### PR TITLE
SDXL: Support for target/original size when resizing images

### DIFF
--- a/helpers/caching/vae.py
+++ b/helpers/caching/vae.py
@@ -18,7 +18,7 @@ class VAECache:
         accelerator,
         data_backend: BaseDataBackend,
         cache_dir="vae_cache",
-        resolution: int = 1024,
+        resolution: float = 1024,
         delete_problematic_images: bool = False,
         write_batch_size: int = 25,
         vae_batch_size: int = 4,

--- a/helpers/caching/vae.py
+++ b/helpers/caching/vae.py
@@ -160,7 +160,10 @@ class VAECache:
             latents = self.encode_image(pixel_values, filepath)
             return latents
         except Exception as e:
+            import traceback
+
             logger.error(f"Error processing image {filepath}: {e}")
+            logging.debug(f"Error traceback: {traceback.format_exc()}")
             if self.delete_problematic_images:
                 self.data_backend.delete(filepath)
             else:
@@ -236,7 +239,10 @@ class VAECache:
                     logger.error(f"Received fatal error: {e}")
                     raise e
                 except Exception as e:
+                    import traceback
+
                     logger.error(f"Error processing image {filepath}: {e}")
+                    logging.debug(f"Error traceback: {traceback.format_exc()}")
                     if self.delete_problematic_images:
                         self.data_backend.delete(filepath)
                     else:

--- a/helpers/multiaspect/image.py
+++ b/helpers/multiaspect/image.py
@@ -126,7 +126,7 @@ class MultiaspectImage:
             )
         else:
             W = H = MultiaspectImage._round_to_nearest_multiple(resolution, 64)
-        return MultiaspectImage._resize_image(input_image, W, H)
+        return MultiaspectImage._resize_image(input_image, int(W), int(H))
 
     @staticmethod
     def resize_by_pixel_area(input_image: Image, megapixels: float) -> Image:

--- a/helpers/multiaspect/image.py
+++ b/helpers/multiaspect/image.py
@@ -45,7 +45,10 @@ class MultiaspectImage:
                 aspect_ratio_bucket_indices[str(aspect_ratio)] = []
             aspect_ratio_bucket_indices[str(aspect_ratio)].append(image_path_str)
         except Exception as e:
-            logger.error(f"Error processing image {image_path_str}.")
+            import traceback
+
+            logger.error(f"Error processing image: {e}")
+            logging.debug(f"Error traceback: {traceback.format_exc()}")
             logger.error(e)
         return aspect_ratio_bucket_indices
 
@@ -55,7 +58,7 @@ class MultiaspectImage:
 
         Args:
             image (Image): A Pillow image.
-            resolution (int): An integer for the image size.
+            resolution (float): A float for the image size.
             resolution_type (str, optional): Whether to use the size as pixel edge or area. If area, the image will be resized overall area. Defaults to "pixel".
 
         Raises:

--- a/train_sdxl.py
+++ b/train_sdxl.py
@@ -493,7 +493,7 @@ def main():
         # The target_size needs to have the current latent shape divided by vae.config.scaling_factor.
         batch_time_ids_list = [
             compute_time_ids(
-                original_size=example.size,
+                original_size=example["instance_images"].size,
                 target_size=latents[idx].shape[
                     2:
                 ],  # Using the spatial dimensions of the latent tensor


### PR DESCRIPTION
Images are only resized when the latents are cached, so, we still have access to the original.

We'll use the original image dimensions and the latent dimensions in combination with the VAE's scaling factor of 8, to mark those correctly.

Previously, the target and original size were identical. We were losing this information and setting the original size to the target.

Now, we'll correctly set it.