### PR TITLE
BucketManager: allow removing of images that are too small. Rename --center_crop to --crop, since it never center-cropped. Alter minimum_image_size logic to work with megapixel values for 'area' resolution_type.

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -175,7 +175,7 @@ usage: train_sdxl.py [-h] [--snr_gamma SNR_GAMMA]
                      [--seed_for_each_device SEED_FOR_EACH_DEVICE]
                      [--resolution RESOLUTION]
                      [--resolution_type {pixel,area}]
-                     [--minimum_image_size MINIMUM_IMAGE_SIZE] [--center_crop]
+                     [--minimum_image_size MINIMUM_IMAGE_SIZE] [--crop]
                      [--train_text_encoder]
                      [--train_batch_size TRAIN_BATCH_SIZE]
                      [--num_train_epochs NUM_TRAIN_EPOCHS]
@@ -454,7 +454,7 @@ options:
                         The minimum resolution for both sides of input images.
                         If --delete_unwanted_images is set, images smaller
                         than this will be DELETED.
-  --center_crop         Whether to center crop the input images to the
+  --crop                Whether to center crop the input images to the
                         resolution. If not set, the images will be randomly
                         cropped. The images will be resized to the resolution
                         first before cropping. If training SDXL, the VAE cache

--- a/helpers/arguments.py
+++ b/helpers/arguments.py
@@ -378,19 +378,21 @@ def parse_args(input_args=None):
     parser.add_argument(
         "--minimum_image_size",
         type=int,
-        default=768,
+        default=None,
         help=(
             "The minimum resolution for both sides of input images."
             " If --delete_unwanted_images is set, images smaller than this will be DELETED."
+            " The default value is None, which means no minimum resolution is enforced."
+            " If this option is not provided, it is possible that images will be destructively resized, harming model performance."
         ),
     )
     parser.add_argument(
-        "--center_crop",
+        "--crop",
         default=False,
-        action="store_true",
+        type=bool,
         help=(
-            "Whether to center crop the input images to the resolution. If not set, the images will be randomly"
-            " cropped. The images will be resized to the resolution first before cropping. If training SDXL,"
+            "Whether to crop the input images to the resolution. If not set, the images will be randomly"
+            " cropped. The images will not be resized to the resolution first before cropping. If training SDXL,"
             " the VAE cache and aspect bucket cache will need to be (re)built so they include crop coordinates."
         ),
     )

--- a/train_sd21.py
+++ b/train_sd21.py
@@ -479,6 +479,7 @@ def main(args):
         batch_size=args.train_batch_size,
         resolution=args.resolution,
         resolution_type=args.resolution_type,
+        minimum_image_size=args.minimum_image_size,
         cache_file=os.path.join(
             args.instance_data_dir, "aspect_ratio_bucket_indices.json"
         ),
@@ -552,7 +553,6 @@ def main(args):
         state_path=args.state_path,
         debug_aspect_buckets=args.debug_aspect_buckets,
         delete_unwanted_images=args.delete_unwanted_images,
-        minimum_image_size=args.minimum_image_size,
         resolution=args.resolution,
         resolution_type=args.resolution_type,
     )
@@ -773,6 +773,7 @@ def main(args):
         resolution_type=args.resolution_type,
         vae_batch_size=args.vae_batch_size,
         write_batch_size=args.write_batch_size,
+        minimum_image_size=args.minimum_image_size
     )
     StateTracker.set_vaecache(vaecache)
     StateTracker.set_vae_dtype(vae_dtype)

--- a/train_sdxl.py
+++ b/train_sdxl.py
@@ -284,6 +284,7 @@ def main():
         data_backend=data_backend,
         accelerator=accelerator,
         resolution=args.resolution,
+        minimum_image_size=args.minimum_image_size,
         resolution_type=args.resolution_type,
         batch_size=args.train_batch_size,
         metadata_update_interval=args.metadata_update_interval,
@@ -441,7 +442,6 @@ def main():
         state_path=args.state_path,
         debug_aspect_buckets=args.debug_aspect_buckets,
         delete_unwanted_images=args.delete_unwanted_images,
-        minimum_image_size=args.minimum_image_size,
         resolution=args.resolution,
         resolution_type=args.resolution_type,
     )
@@ -832,6 +832,7 @@ def main():
         delete_problematic_images=args.delete_problematic_images,
         resolution=args.resolution,
         resolution_type=args.resolution_type,
+        minimum_image_size=args.minimum_image_size
         vae_batch_size=args.vae_batch_size,
         write_batch_size=args.write_batch_size,
         cache_dir=args.cache_dir_vae,


### PR DESCRIPTION
…