### PR TITLE
(#273) add a check for cache load failure during validations preparation

### DIFF
--- a/helpers/legacy/validation.py
+++ b/helpers/legacy/validation.py
@@ -70,7 +70,7 @@ def prepare_validation_prompt_list(args, embed_cache):
             (
                 validation_negative_prompt_embeds,
                 validation_negative_pooled_embeds,
-            ) = embed_cache.compute_embeddings_for_sdxl_prompts(
+            ) = embed_cache.compute_embeddings_for_prompts(
                 [StateTracker.get_args().validation_negative_prompt], is_validation=True
             )
             return (
@@ -81,7 +81,7 @@ def prepare_validation_prompt_list(args, embed_cache):
             )
         elif model_type == "legacy":
             validation_negative_prompt_embeds = (
-                embed_cache.compute_embeddings_for_legacy_prompts(
+                embed_cache.compute_embeddings_for_prompts(
                     [StateTracker.get_args().validation_negative_prompt]
                 )
             )


### PR DESCRIPTION
Fixes #273 by:

* Using the common `compute_embeddings_for_prompts` instead of the private methods `comptue_embeddings_for_sdxl_prompts`, as those do not do the same level of error checking

* Added logic to the caching mechanism that detects errors in the cache load, to then encode the prompt. It's possible we want to do this only when we're still preparing the training run, since running the text encoder during training will be slow.