### PR TITLE
end the text embed write thread when it's actually done reduce duplicate calls to create_hash and optimise create_hash fix the issue of missing text embed files for validation prompts. always encode validation prompts at start. fix final validations for LoRA models, as they need to load a full pipeline and have the text encoders moved to GPU

### DIFF
--- a/helpers/caching/vae.py
+++ b/helpers/caching/vae.py
@@ -117,8 +117,8 @@ class VAECache:
         """
         return self.encode_images([None], [filepath])[0]
 
-    def discover_all_files(self, directory: str = None):
-        """Identify all files in a directory."""
+    def discover_all_files(self):
+        """Identify all files in the data backend."""
         all_image_files = StateTracker.get_image_files(
             data_backend_id=self.id
         ) or StateTracker.set_image_files(

--- a/helpers/data_backend/factory.py
+++ b/helpers/data_backend/factory.py
@@ -381,11 +381,12 @@ def configure_multi_databackend(
                     f"Pre-computing text embeds / updating cache. We have {len(captions)} captions to process, though these will be filtered next."
                 )
                 logger.info(
-                    f"(id={init_backend['id']}) Initialise text embed pre-computation."
+                    f"(id={init_backend['id']}) Initialise text embed pre-computation. We have {len(captions)} captions to process."
                 )
                 init_backend["text_embed_cache"].compute_embeddings_for_prompts(
                     captions, return_concat=False
                 )
+
         accelerator.wait_for_everyone()
         logger.info(
             f"(id={init_backend['id']}) Completed processing {len(captions)} captions."

--- a/helpers/legacy/validation.py
+++ b/helpers/legacy/validation.py
@@ -264,6 +264,8 @@ def log_validations(
                                     validation_negative_prompt_embeds,
                                 ]
                             )
+                            for text_encoder in prompt_handler.text_encoders:
+                                text_encoder.to("cpu")
 
                         logger.debug(
                             f"Generating validation image: {validation_prompt}"

--- a/helpers/legacy/validation.py
+++ b/helpers/legacy/validation.py
@@ -253,6 +253,8 @@ def log_validations(
                             [validation_prompt]
                         )
                         if prompt_handler is not None:
+                            for text_encoder in prompt_handler.text_encoders:
+                                text_encoder.to(accelerator.device)
                             [
                                 current_validation_prompt_embeds,
                                 validation_negative_prompt_embeds,

--- a/helpers/legacy/validation.py
+++ b/helpers/legacy/validation.py
@@ -55,7 +55,9 @@ def prepare_validation_prompt_list(args, embed_cache):
             ncols=100,
             desc="Precomputing user prompt library embeddings",
         ):
-            embed_cache.compute_embeddings_for_prompts([prompt], is_validation=True)
+            embed_cache.compute_embeddings_for_prompts(
+                [prompt], is_validation=True, load_from_cache=False
+            )
             validation_prompts.append(prompt)
             validation_shortnames.append(shortname)
     if args.validation_prompt is not None:
@@ -66,12 +68,15 @@ def prepare_validation_prompt_list(args, embed_cache):
 
     # Compute negative embed for validation prompts, if any are set.
     if validation_prompts:
+        logger.info("Precomputing the negative prompt embed for validations.")
         if model_type == "sdxl":
             (
                 validation_negative_prompt_embeds,
                 validation_negative_pooled_embeds,
             ) = embed_cache.compute_embeddings_for_prompts(
-                [StateTracker.get_args().validation_negative_prompt], is_validation=True
+                [StateTracker.get_args().validation_negative_prompt],
+                is_validation=True,
+                load_from_cache=False,
             )
             return (
                 validation_prompts,
@@ -82,7 +87,8 @@ def prepare_validation_prompt_list(args, embed_cache):
         elif model_type == "legacy":
             validation_negative_prompt_embeds = (
                 embed_cache.compute_embeddings_for_prompts(
-                    [StateTracker.get_args().validation_negative_prompt]
+                    [StateTracker.get_args().validation_negative_prompt],
+                    load_from_cache=False,
                 )
             )
 
@@ -116,6 +122,7 @@ def log_validations(
     vae=None,
     SCHEDULER_NAME_MAP: dict = {},
     validation_type: str = "training",
+    pipeline: DiffusionPipeline = None,
 ):
     if accelerator.is_main_process:
         logger.debug(
@@ -167,27 +174,41 @@ def log_validations(
                     force_upcast=False,
                 )
             # The models need unwrapping because for compatibility in distributed training mode.
-            pipeline = StableDiffusionXLPipeline.from_pretrained(
-                args.pretrained_model_name_or_path,
-                unet=unwrap_model(accelerator, unet),
-                text_encoder=text_encoder_1,
-                text_encoder_2=text_encoder_2,
-                tokenizer=None,
-                tokenizer_2=None,
-                vae=vae,
-                revision=args.revision,
-                torch_dtype=weight_dtype,
-                add_watermarker=args.enable_watermark,
-            )
-            pipeline.scheduler = SCHEDULER_NAME_MAP[
-                args.validation_noise_scheduler
-            ].from_pretrained(
-                args.pretrained_model_name_or_path,
-                subfolder="scheduler",
-                prediction_type=args.prediction_type,
-                timestep_spacing=args.inference_scheduler_timestep_spacing,
-                rescale_betas_zero_snr=args.rescale_betas_zero_snr,
-            )
+            if not pipeline:
+                if StateTracker.get_model_type() == "sdxl":
+                    pipeline_cls = StableDiffusionXLPipeline
+                    pipeline = pipeline_cls.from_pretrained(
+                        args.pretrained_model_name_or_path,
+                        unet=unwrap_model(accelerator, unet),
+                        text_encoder=text_encoder_1,
+                        text_encoder_2=text_encoder_2,
+                        tokenizer=None,
+                        tokenizer_2=None,
+                        vae=vae,
+                        revision=args.revision,
+                        torch_dtype=weight_dtype,
+                        add_watermarker=args.enable_watermark,
+                    )
+                elif StateTracker.get_model_type() == "legacy":
+                    pipeline_cls = DiffusionPipeline
+                    pipeline = pipeline_cls.from_pretrained(
+                        args.pretrained_model_name_or_path,
+                        unet=unwrap_model(accelerator, unet),
+                        text_encoder=text_encoder_1,
+                        tokenizer=None,
+                        vae=vae,
+                        revision=args.revision,
+                        torch_dtype=weight_dtype,
+                    )
+                pipeline.scheduler = SCHEDULER_NAME_MAP[
+                    args.validation_noise_scheduler
+                ].from_pretrained(
+                    args.pretrained_model_name_or_path,
+                    subfolder="scheduler",
+                    prediction_type=args.prediction_type,
+                    timestep_spacing=args.inference_scheduler_timestep_spacing,
+                    rescale_betas_zero_snr=args.rescale_betas_zero_snr,
+                )
             if args.validation_torch_compile and not is_compiled_module(pipeline.unet):
                 pipeline.unet = torch.compile(
                     pipeline.unet,

--- a/helpers/prompts.py
+++ b/helpers/prompts.py
@@ -217,6 +217,8 @@ class PromptHandler:
                 device=accelerator.device,
             )
             self.encoder_style = "legacy"
+        self.text_encoders = text_encoders
+        self.tokenizers = tokenizers
 
     @staticmethod
     def prepare_instance_prompt(

--- a/train_sdxl.py
+++ b/train_sdxl.py
@@ -1459,7 +1459,30 @@ def main():
         elif args.model_type == "lora":
             # load attention processors. They were saved earlier.
             pipeline.load_lora_weights(args.output_dir)
-
+            log_validations(
+                accelerator,
+                prompt_handler,
+                None,
+                args,
+                validation_prompts,
+                validation_shortnames,
+                global_step,
+                resume_global_step,
+                step,
+                text_encoder_1,
+                tokenizer=None,
+                vae_path=vae_path,
+                weight_dtype=weight_dtype,
+                embed_cache=StateTracker.get_default_text_embed_cache(),
+                validation_negative_pooled_embeds=validation_negative_pooled_embeds,
+                validation_negative_prompt_embeds=validation_negative_prompt_embeds,
+                text_encoder_2=text_encoder_2,
+                tokenizer_2=None,
+                vae=vae,
+                SCHEDULER_NAME_MAP=SCHEDULER_NAME_MAP,
+                validation_type="finish",
+                pipeline=pipeline,
+            )
         if args.push_to_hub:
             upload_folder(
                 repo_id=repo_id,

--- a/train_sdxl.py
+++ b/train_sdxl.py
@@ -1399,17 +1399,25 @@ def main():
                     force_upcast=False,
                 )
             )
-        pipeline = StableDiffusionXLPipeline.from_pretrained(
-            args.pretrained_model_name_or_path,
-            text_encoder=text_encoder_1,
-            text_encoder_2=text_encoder_2,
-            tokenizer=tokenizer_1,
-            tokenizer_2=tokenizer_2,
-            vae=StateTracker.get_vae(),
-            unet=unet,
-            revision=args.revision,
-            add_watermarker=args.enable_watermark,
-        )
+        if args.model_type == "full":
+            pipeline = StableDiffusionXLPipeline.from_pretrained(
+                args.pretrained_model_name_or_path,
+                text_encoder=text_encoder_1,
+                text_encoder_2=text_encoder_2,
+                tokenizer=tokenizer_1,
+                tokenizer_2=tokenizer_2,
+                vae=StateTracker.get_vae(),
+                unet=unet,
+                revision=args.revision,
+                add_watermarker=args.enable_watermark,
+            )
+        else:
+            pipeline = StableDiffusionXLPipeline.from_pretrained(
+                args.pretrained_model_name_or_path,
+                vae=StateTracker.get_vae(),
+                revision=args.revision,
+                add_watermarker=args.enable_watermark,
+            )
         pipeline.set_progress_bar_config(disable=True)
         pipeline.scheduler = SCHEDULER_NAME_MAP[
             args.validation_noise_scheduler
@@ -1424,9 +1432,33 @@ def main():
             pipeline.save_pretrained(
                 os.path.join(args.output_dir, "pipeline"), safe_serialization=True
             )
+            log_validations(
+                accelerator,
+                prompt_handler,
+                unet,
+                args,
+                validation_prompts,
+                validation_shortnames,
+                global_step,
+                resume_global_step,
+                step,
+                text_encoder_1,
+                tokenizer=None,
+                vae_path=vae_path,
+                weight_dtype=weight_dtype,
+                embed_cache=StateTracker.get_default_text_embed_cache(),
+                validation_negative_pooled_embeds=validation_negative_pooled_embeds,
+                validation_negative_prompt_embeds=validation_negative_prompt_embeds,
+                text_encoder_2=text_encoder_2,
+                tokenizer_2=None,
+                vae=vae,
+                SCHEDULER_NAME_MAP=SCHEDULER_NAME_MAP,
+                validation_type="finish",
+                pipeline=pipeline,
+            )
         elif args.model_type == "lora":
-            # load attention processors
-            pipeline.save_lora_weights(args.output_dir)
+            # load attention processors. They were saved earlier.
+            pipeline.load_lora_weights(args.output_dir)
 
         if args.push_to_hub:
             upload_folder(
@@ -1437,31 +1469,6 @@ def main():
                 commit_message="End of training",
                 ignore_patterns=["step_*", "epoch_*"],
             )
-
-        log_validations(
-            accelerator,
-            prompt_handler,
-            unet,
-            args,
-            validation_prompts,
-            validation_shortnames,
-            global_step,
-            resume_global_step,
-            step,
-            text_encoder_1,
-            tokenizer=None,
-            vae_path=vae_path,
-            weight_dtype=weight_dtype,
-            embed_cache=StateTracker.get_default_text_embed_cache(),
-            validation_negative_pooled_embeds=validation_negative_pooled_embeds,
-            validation_negative_prompt_embeds=validation_negative_prompt_embeds,
-            text_encoder_2=text_encoder_2,
-            tokenizer_2=None,
-            vae=vae,
-            SCHEDULER_NAME_MAP=SCHEDULER_NAME_MAP,
-            validation_type="finish",
-        )
-
     accelerator.end_training()
 
 


### PR DESCRIPTION
* end the text embed write thread when it's actually done
* reduce duplicate calls to create_hash and optimise create_hash
* fix the issue of missing text embed files for validation prompts. always encode validation prompts at start.
* fix final validations for LoRA models, as they need to load a full pipeline and have the text encoders moved to GPU