### PR TITLE
Feature/on demand vae cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+multidatabackend*json
 # Python and virtual environment files
 temp/
 env.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.code-workspace
 multidatabackend*json
 # Python and virtual environment files
 temp/

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -41,10 +41,10 @@ This guide provides a user-friendly breakdown of the command-line options availa
 - **What**: When provided, will allow SimpleTuner to ignore differences between the cached config inside the dataset and the current values.
 - **Why**: When SimplerTuner is run for the first time on a dataset, it will create a cache document containing information about everything in that dataset. This includes the dataset config, including its "crop" and "resolution" related configuration values. Changing these arbitrarily or by accident could result in your training jobs crashing randomly, so it's highly recommended to not use this parameter, and instead resolve the differences you'd like to apply in your dataset some other way.
 
-### `--vae_cache_behaviour`
+### `--vae_cache_scan_behaviour`
 
 - **What**: Configure the behaviour of the integrity scan check.
-- **Why**: A dataset could have incorrect settings applied at multiple points of training, eg. if you accidentally delete the `.json` cache files from your dataset and switch the data backend config to use square images rather than aspect-crops. This will result in an inconsistent data cache, which can be corrected by setting `scan_for_errors` to `true` in your `multidatabackend.json` configuration file. When this scan runs, it relies on the setting of `--vae_cache_behaviour` to determine how to resolve the inconsistency: `recreate` (the default) will remove the offending cache entry so that it can be recreated, and `sync` will update the bucket metadata to reflect the reality of the real training sample. Recommended value: `recreate`.
+- **Why**: A dataset could have incorrect settings applied at multiple points of training, eg. if you accidentally delete the `.json` cache files from your dataset and switch the data backend config to use square images rather than aspect-crops. This will result in an inconsistent data cache, which can be corrected by setting `scan_for_errors` to `true` in your `multidatabackend.json` configuration file. When this scan runs, it relies on the setting of `--vae_cache_scan_behaviour` to determine how to resolve the inconsistency: `recreate` (the default) will remove the offending cache entry so that it can be recreated, and `sync` will update the bucket metadata to reflect the reality of the real training sample. Recommended value: `recreate`.
 
 ---
 
@@ -179,7 +179,7 @@ usage: train_sdxl.py [-h] [--snr_gamma SNR_GAMMA] [--model_type {full,lora}]
                      [--timestep_bias_portion TIMESTEP_BIAS_PORTION]
                      [--rescale_betas_zero_snr] [--vae_dtype VAE_DTYPE]
                      [--vae_batch_size VAE_BATCH_SIZE]
-                     [--vae_cache_behaviour {recreate,sync}]
+                     [--vae_cache_scan_behaviour {recreate,sync}]
                      [--keep_vae_loaded]
                      [--skip_file_discovery SKIP_FILE_DISCOVERY]
                      [--revision REVISION] [--preserve_data_backend_cache]
@@ -374,7 +374,7 @@ options:
                         issues, but if you are at that point of contention,
                         it's possible that your GPU has too little RAM.
                         Default: 4.
-  --vae_cache_behaviour {recreate,sync}
+  --vae_cache_scan_behaviour {recreate,sync}
                         When a mismatched latent vector is detected, a scan
                         will be initiated to locate inconsistencies and
                         resolve them. The default setting 'recreate' will

--- a/helpers/arguments.py
+++ b/helpers/arguments.py
@@ -190,7 +190,7 @@ def parse_args(input_args=None):
         ),
     )
     parser.add_argument(
-        "--vae_cache_behaviour",
+        "--vae_cache_scan_behaviour",
         type=str,
         choices=["recreate", "sync"],
         default="recreate",

--- a/helpers/arguments.py
+++ b/helpers/arguments.py
@@ -202,6 +202,17 @@ def parse_args(input_args=None):
         ),
     )
     parser.add_argument(
+        "--encode_during_training",
+        action="store_true",
+        default=False,
+        help=(
+            "If set, will encode images during training. This is not recommended, as it will slow down training."
+            " The recommended behaviour is to cache the latents before training. However, extremely-large datasets may take"
+            " an excessive amount of time for the first cache run. It is recommended to combine this with crop=false and"
+            " vae_cache_clear_each_epoch=false, because they are counter-productive with an on-demand cache generation."
+        ),
+    )
+    parser.add_argument(
         "--keep_vae_loaded",
         action="store_true",
         default=False,

--- a/helpers/arguments.py
+++ b/helpers/arguments.py
@@ -203,13 +203,11 @@ def parse_args(input_args=None):
     )
     parser.add_argument(
         "--encode_during_training",
-        action="store_true",
-        default=False,
+        type=bool,
+        default=True,
         help=(
-            "If set, will encode images during training. This is not recommended, as it will slow down training."
-            " The recommended behaviour is to cache the latents before training. However, extremely-large datasets may take"
-            " an excessive amount of time for the first cache run. It is recommended to combine this with crop=false and"
-            " vae_cache_clear_each_epoch=false, because they are counter-productive with an on-demand cache generation."
+            "By default, will encode images during training. For some situations, pre-processing may be desired."
+            " To revert to the old behaviour, supply --encode_during_training=false."
         ),
     )
     parser.add_argument(

--- a/helpers/caching/vae.py
+++ b/helpers/caching/vae.py
@@ -45,6 +45,7 @@ class VAECache:
         resolution_type: str = "pixel",
         minimum_image_size: int = None,
         max_workers: int = 32,
+        encode_during_training: bool = False,
     ):
         self.id = id
         if data_backend.id != id:
@@ -73,6 +74,8 @@ class VAECache:
         self.metadata_backend = metadata_backend
         if not self.metadata_backend.image_metadata_loaded:
             self.metadata_backend.load_image_metadata()
+
+        self.encode_during_training = encode_during_training
 
         self.max_workers = max_workers
         if (maximum_image_size and not target_downsample_size) or (
@@ -139,7 +142,9 @@ class VAECache:
             return True
         return False
 
-    def _read_from_storage(self, filename: str) -> torch.Tensor:
+    def _read_from_storage(
+        self, filename: str, hide_errors: bool = False
+    ) -> torch.Tensor:
         """Read a cache object from the storage backend.
 
         Args:
@@ -148,13 +153,29 @@ class VAECache:
         Returns:
             torch.Tensor: The cached Tensor object.
         """
-        return self.data_backend.torch_load(filename).to("cpu")
+        if os.path.splitext(filename)[1] != ".pt":
+            return self.data_backend.read_image(filename)
+        try:
+            return self.data_backend.torch_load(filename).to("cpu")
+        except Exception as e:
+            if hide_errors:
+                logger.debug(
+                    f"Filename: {filename}, returning None even though read_from_storage found no object, since hide_errors is True: {e}"
+                )
+                return None
+            raise e
 
     def retrieve_from_cache(self, filepath: str):
         """
         Use the encode_images method to emulate a single image encoding.
         """
         return self.encode_images([None], [filepath])[0]
+
+    def retreve_batch_from_cache(self, filepaths: list):
+        """
+        Use the encode_images method to emulate a batch of image encodings.
+        """
+        return self.encode_images([None] * len(filepaths), filepaths)
 
     def discover_all_files(self):
         """Identify all files in the data backend."""
@@ -360,6 +381,9 @@ class VAECache:
         If load_from_cache=True, we read from the VAE cache rather than encode.
         If load_from_cache=True, we will throw an exception if the entry is not found.
         """
+        logger.debug(
+            f"Begin call to encode_images, images: {type(images)}, filepaths: {type(filepaths)}, load_from_cache: {load_from_cache}"
+        )
         batch_size = len(images)
         if batch_size != len(filepaths):
             raise ValueError("Mismatch between number of images and filepaths.")
@@ -380,26 +404,90 @@ class VAECache:
             for i, filename in enumerate(full_filenames)
             if i in uncached_image_indices
         ]
-        # if len(uncached_image_indices) > 0:
-        #     self.debug_log(
-        #         f"Found {len(uncached_image_indices)} uncached images (truncated): {uncached_image_indices[:5]}"
-        #     )
-        #     self.debug_log(
-        #         f"Received full filenames {len(full_filenames)} (truncated): {full_filenames[:5]}"
-        #     )
-        uncached_images = [images[i] for i in uncached_image_indices]
+        if len(uncached_image_indices) > 0:
+            self.debug_log(
+                f"Found {len(uncached_image_indices)} uncached images (truncated): {uncached_image_indices[:5]}"
+            )
+            self.debug_log(
+                f"Received full filenames {len(full_filenames)} (truncated): {full_filenames[:5]}"
+            )
 
-        if len(uncached_image_indices) > 0 and load_from_cache:
+        # We need to populate any uncached images with the actual image data if they are None.
+        missing_images = [
+            i
+            for i, image in enumerate(images)
+            if i in uncached_image_indices and image is None
+        ]
+        logger.debug(
+            f"Encoding during training: {self.encode_during_training}, load_from_cache: {load_from_cache}, uncached_image_indices: {uncached_image_indices}, missing_images: {missing_images}"
+        )
+        missing_image_pixel_values = []
+        written_latents = []
+        if len(missing_images) > 0 and self.encode_during_training:
+            missing_image_paths = [filepaths[i] for i in missing_images]
+            logger.debug(f"Missing image paths: {missing_image_paths}")
+            missing_image_data = [
+                self._read_from_storage_concurrently(
+                    missing_image_paths, hide_errors=True
+                ).__next__()[1]
+                for i in missing_images
+            ]
+            logger.debug(f"Missing image data: {missing_image_data}")
+            missing_image_pixel_values = self._process_images_in_batch(
+                missing_image_paths, missing_image_data, disable_queue=True
+            )
+            logger.debug(
+                f"Missing image pixel values: {type(missing_image_pixel_values)}"
+            )
+            missing_image_vae_outputs = self._encode_images_in_batch(
+                image_pixel_values=missing_image_pixel_values, disable_queue=True
+            )
+            logger.debug(f"Missing image VAE outputs: {missing_image_vae_outputs}")
+            written_latents = self._write_latents_in_batch(missing_image_vae_outputs)
+            logger.debug(f"Returning written latents: {written_latents}")
+
+            return written_latents
+
+        if len(uncached_image_indices) > 0:
+            uncached_images = [images[i] for i in uncached_image_indices]
+            logger.debug(
+                f"Running vanilla encode_images, all images are available: {uncached_images}"
+            )
+        elif len(missing_images) > 0 and len(missing_image_pixel_values) > 0:
+            uncached_images = []
+            for i in uncached_image_indices:
+                if images[i] is not None:
+                    uncached_images.append(images[i])
+                elif i in missing_image_pixel_values:
+                    uncached_images.append(missing_image_pixel_values[i])
+            logger.debug(
+                f"Running encode_images with missing images: {uncached_images}"
+            )
+
+        if (
+            len(uncached_image_indices) > 0
+            and load_from_cache
+            and not self.encode_during_training
+        ):
             # We wanted only uncached images. Something went wrong.
             raise Exception(
                 f"(id={self.id}) Some images were not correctly cached during the VAE Cache operations. Ensure --skip_file_discovery=vae is not set.\nProblematic images: {uncached_image_paths}"
             )
 
+        latents = []
         if load_from_cache:
             # If all images are cached, simply load them
-            latents = [self._read_from_storage(filename) for filename in full_filenames]
-        elif len(uncached_images) > 0:
-            # Only process images not found in cache
+            logger.debug(f"Attempting to read latents from storage: {full_filenames}")
+            latents = [
+                self._read_from_storage(
+                    filename, hide_errors=self.encode_during_training
+                )
+                for filename in full_filenames
+                if filename not in uncached_images
+            ]
+
+        if len(uncached_images) > 0:
+            # Process images not found in cache
             with torch.no_grad():
                 # Debug log the size of each image:
                 for image in uncached_images:
@@ -413,7 +501,6 @@ class VAECache:
                 latents_uncached = latents_uncached * self.vae.config.scaling_factor
 
             # Prepare final latents list by combining cached and newly computed latents
-            latents = []
             cached_idx, uncached_idx = 0, 0
             for i in range(batch_size):
                 if i in uncached_image_indices:
@@ -423,16 +510,27 @@ class VAECache:
                     latents.append(self._read_from_storage(full_filenames[i]))
                     cached_idx += 1
         else:
-            return None
+            logger.debug(
+                f"No uncached images to retrieve, {uncached_images} or missing images: {missing_images}"
+            )
+        logger.debug(f"completed encode_images, returning latents: {latents}")
         return latents
 
-    def _write_latents_in_batch(self):
+    def _write_latents_in_batch(self, input_latents: list = None):
         # Pull the 'filepaths' and 'latents' from self.write_queue
         filepaths, latents = [], []
-        qlen = self.write_queue.qsize()
-        self.debug_log(f"We have {qlen} latents to write to disk.")
+        if input_latents is not None:
+            qlen = len(input_latents)
+            self.debug_log(f"We have {len(input_latents)} latents to write to disk.")
+        else:
+            qlen = self.write_queue.qsize()
+            self.debug_log(f"We have {qlen} latents to write to disk.")
+
         for idx in range(0, qlen):
-            output_file, filepath, latent_vector = self.write_queue.get()
+            if input_latents:
+                output_file, filepath, latent_vector = input_latents.pop()
+            else:
+                output_file, filepath, latent_vector = self.write_queue.get()
             file_extension = os.path.splitext(output_file)[1]
             if (
                 file_extension == ".png"
@@ -447,20 +545,44 @@ class VAECache:
         self.metadata_backend.save_image_metadata()
         self.data_backend.write_batch(filepaths, latents)
 
-    def _process_images_in_batch(self) -> None:
+        return latents
+
+    def _process_images_in_batch(
+        self,
+        image_paths: list = None,
+        image_data: list = None,
+        disable_queue: bool = False,
+    ) -> None:
         """Process a queue of images. This method assumes our batch size has been reached.
+
+        Args:
+            image_paths: list If given, image_data must also be supplied. This will avoid the use of the Queues.
+            image_data: list Provided Image objects for corresponding image_paths.
 
         Returns:
             None
         """
         try:
+            logger.debug(
+                f"Processing batch of images into VAE embeds. image_paths: {type(image_paths)}, image_data: {type(image_data)}"
+            )
             initial_data = []
             filepaths = []
-            qlen = self.process_queue.qsize()
+            if image_paths is not None and image_data is not None:
+                qlen = len(image_paths)
+            else:
+                qlen = self.process_queue.qsize()
+            logger.debug(f"we have {qlen} images to process.")
 
             # First Loop: Preparation and Filtering
             for _ in range(qlen):
-                filepath, image, aspect_bucket = self.process_queue.get()
+                if image_paths:
+                    # retrieve image data from Generator, image_data:
+                    filepath = image_paths.pop()
+                    image = image_data.pop()
+                    aspect_bucket = MultiaspectImage.calculate_image_aspect_ratio(image)
+                else:
+                    filepath, image, aspect_bucket = self.process_queue.get()
                 if self.minimum_image_size is not None:
                     if not self.metadata_backend.meets_resolution_requirements(
                         image_path=filepath
@@ -493,41 +615,30 @@ class VAECache:
                         if result:  # Ensure result is not None or invalid
                             processed_images.append(result)
                     except Exception as e:
-                        import traceback
-
                         self.debug_log(
                             f"Error processing image in pool: {e}, traceback: {traceback.format_exc()}"
                         )
 
             # Second Loop: Final Processing
             is_final_sample = False
+            output_values = []
             for idx, (image, crop_coordinates, new_aspect_ratio) in enumerate(
                 processed_images
             ):
                 if idx == len(processed_images) - 1:
                     is_final_sample = True
                 filepath, _, aspect_bucket = initial_data[idx]
-
-                # We need to validate that the image dimensions match the aspect bucket, because EXIF data is dumb.
-                actual_aspect_bucket = MultiaspectImage.calculate_image_aspect_ratio(
-                    image
-                )
-                # if str(aspect_bucket) != str(actual_aspect_bucket):
-                #     logger.warning(
-                #         f"Image {filepath} has an incorrect aspect ratio recorded, seen in {aspect_bucket} but actually is {actual_aspect_bucket}."
-                #     )
-                #     self.metadata_backend.handle_incorrect_bucket(
-                #         filepath, aspect_bucket, actual_aspect_bucket, save_cache=False
-                #     )
-                #     continue
                 filepaths.append(filepath)
 
                 pixel_values = self.transform(image).to(
                     self.accelerator.device, dtype=self.vae.dtype
                 )
-                self.vae_input_queue.put(
-                    (pixel_values, filepath, aspect_bucket, is_final_sample)
-                )
+                output_value = (pixel_values, filepath, aspect_bucket, is_final_sample)
+                output_values.append(output_value)
+                if not disable_queue:
+                    self.vae_input_queue.put(
+                        (pixel_values, filepath, aspect_bucket, is_final_sample)
+                    )
                 # Update the crop_coordinates in the metadata document
                 self.metadata_backend.set_metadata_attribute_by_filepath(
                     filepath=filepath,
@@ -535,29 +646,46 @@ class VAECache:
                     value=crop_coordinates,
                     update_json=False,
                 )
-                self.debug_log(f"Completed processing {filepath}")
+                self.debug_log(
+                    f"Completed processing {filepath}, gathered {len(output_values)} output values."
+                )
         except Exception as e:
-            logger.error(f"Error processing images {filepaths}: {e}")
+            logger.error(
+                f"Error processing images {filepaths if len(filepaths) > 0 else image_paths}: {e}"
+            )
             self.debug_log(f"Error traceback: {traceback.format_exc()}")
             raise e
+        return output_values
 
-    def _encode_images_in_batch(self) -> None:
+    def _encode_images_in_batch(
+        self, image_pixel_values: list = None, disable_queue: bool = False
+    ) -> None:
         """Encode the batched Image objects using the VAE model.
 
         Raises:
             ValueError: If we receive any invalid results.
         """
         try:
-            qlen = self.vae_input_queue.qsize()
+            if image_pixel_values is not None:
+                qlen = len(image_pixel_values)
+            else:
+                qlen = self.vae_input_queue.qsize()
+
             if qlen == 0:
                 return
+            output_values = []
             while qlen > 0:
                 vae_input_images, vae_input_filepaths, vae_output_filepaths = [], [], []
                 batch_aspect_bucket = None
                 for idx in range(0, min(qlen, self.vae_batch_size)):
-                    pixel_values, filepath, aspect_bucket, is_final_sample = (
-                        self.vae_input_queue.get()
-                    )
+                    if image_pixel_values:
+                        pixel_values, filepath, aspect_bucket, is_final_sample = (
+                            image_pixel_values.pop()
+                        )
+                    else:
+                        pixel_values, filepath, aspect_bucket, is_final_sample = (
+                            self.vae_input_queue.get()
+                        )
                     self.debug_log(
                         f"Queue values: {pixel_values.shape}, {filepath}, {aspect_bucket}, {is_final_sample}"
                     )
@@ -585,8 +713,14 @@ class VAECache:
                         raise ValueError(
                             f"Latent vector is None for filepath {filepath}"
                         )
-                    self.write_queue.put((output_file, filepath, latent_vector))
-                qlen = self.vae_input_queue.qsize()
+                    output_value = (output_file, filepath, latent_vector)
+                    output_values.append(output_value)
+                    if not disable_queue:
+                        self.write_queue.put(output_value)
+                if image_pixel_values is not None:
+                    qlen = len(image_pixel_values) - 1
+                else:
+                    qlen = self.vae_input_queue.qsize()
         except Exception as e:
             logger.error(f"Error encoding images {vae_input_filepaths}: {e}")
             # Remove all of the errored images from the bucket. They will be captured on restart.
@@ -596,8 +730,9 @@ class VAECache:
             raise Exception(
                 f"Error encoding images {vae_input_filepaths}: {e}, traceback: {traceback.format_exc()}"
             )
+        return output_values
 
-    def _read_from_storage_concurrently(self, paths):
+    def _read_from_storage_concurrently(self, paths, hide_errors: bool = False):
         """
         A helper method to read files from storage concurrently, without Queues.
 
@@ -610,9 +745,13 @@ class VAECache:
 
         def read_file(path):
             try:
-                return path, self._read_from_storage(path)
+                return path, self._read_from_storage(path, hide_errors=hide_errors)
             except Exception as e:
-                logger.error(f"Error reading {path}: {e}")
+                import traceback
+
+                logger.error(
+                    f"Error reading {path}: {e}, traceback: {traceback.format_exc()}"
+                )
                 return path, None
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:

--- a/helpers/data_backend/factory.py
+++ b/helpers/data_backend/factory.py
@@ -632,7 +632,7 @@ def configure_multi_databackend(
             init_backend["metadata_backend"].handle_vae_cache_inconsistencies(
                 vae_cache=init_backend["vaecache"],
                 vae_cache_behavior=backend.get(
-                    "vae_cache_behaviour", args.vae_cache_behaviour
+                    "vae_cache_scan_behaviour", args.vae_cache_scan_behaviour
                 ),
             )
             init_backend["metadata_backend"].scan_for_metadata()

--- a/helpers/data_backend/local.py
+++ b/helpers/data_backend/local.py
@@ -6,7 +6,7 @@ from typing import Any
 from PIL import Image
 
 logger = logging.getLogger("LocalDataBackend")
-logger.setLevel(os.environ.get("SIMPLETUNER_LOG_LEVEL", "WARNING"))
+logger.setLevel(os.environ.get("SIMPLETUNER_LOG_LEVEL", "INFO"))
 
 
 class LocalDataBackend(BaseDataBackend):

--- a/helpers/metadata/backends/base.py
+++ b/helpers/metadata/backends/base.py
@@ -389,11 +389,11 @@ class MetadataBackend:
         for bucket in list(
             self.aspect_ratio_bucket_indices.keys()
         ):  # Safe iteration over keys
-            # Prune the smaller buckets so that we don't enforce resolution constraints on them unnecessarily.
-            self._prune_small_buckets(bucket)
+            # # Prune the smaller buckets so that we don't enforce resolution constraints on them unnecessarily.
+            # self._prune_small_buckets(bucket)
             self._enforce_resolution_constraints(bucket)
-            # We do this twice in case there were any new contenders for being too small.
-            self._prune_small_buckets(bucket)
+            # # We do this twice in case there were any new contenders for being too small.
+            # self._prune_small_buckets(bucket)
 
     def _prune_small_buckets(self, bucket):
         """

--- a/helpers/metadata/backends/base.py
+++ b/helpers/metadata/backends/base.py
@@ -14,7 +14,7 @@ import numpy as np
 from threading import Semaphore
 
 logger = logging.getLogger("BaseMetadataBackend")
-logger.setLevel(logging.DEBUG)
+logger.setLevel(os.environ.get("SIMPLETUNER_LOG_LEVEL", "INFO"))
 
 
 class MetadataBackend:
@@ -260,7 +260,7 @@ class MetadataBackend:
                     self.save_image_metadata()
                     last_write_time = current_time
 
-                time.sleep(0.1)
+                time.sleep(0.001)
 
         for worker in workers:
             worker.join()

--- a/helpers/metadata/backends/json.py
+++ b/helpers/metadata/backends/json.py
@@ -14,7 +14,7 @@ from io import BytesIO
 from helpers.image_manipulation.brightness import calculate_luminance
 
 logger = logging.getLogger("JsonMetadataBackend")
-target_level = os.environ.get("SIMPLETUNER_LOG_LEVEL", "WARNING")
+target_level = os.environ.get("SIMPLETUNER_LOG_LEVEL", "INFO")
 logger.setLevel(target_level)
 
 

--- a/helpers/metadata/backends/parquet.py
+++ b/helpers/metadata/backends/parquet.py
@@ -7,7 +7,7 @@ from io import BytesIO
 from PIL import Image
 
 logger = logging.getLogger("ParquetMetadataBackend")
-target_level = os.environ.get("SIMPLETUNER_LOG_LEVEL", "WARNING")
+target_level = os.environ.get("SIMPLETUNER_LOG_LEVEL", "INFO")
 logger.setLevel(target_level)
 
 try:

--- a/helpers/multiaspect/dataset.py
+++ b/helpers/multiaspect/dataset.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import logging, os
 
 logger = logging.getLogger("MultiAspectDataset")
-logger.setLevel(os.environ.get("SIMPLETUNER_LOG_LEVEL", "WARNING"))
+logger.setLevel(os.environ.get("SIMPLETUNER_LOG_LEVEL", "INFO"))
 
 
 class MultiAspectDataset(Dataset):

--- a/helpers/multiaspect/image.py
+++ b/helpers/multiaspect/image.py
@@ -8,7 +8,7 @@ from math import sqrt
 from helpers.training.state_tracker import StateTracker
 
 logger = logging.getLogger("MultiaspectImage")
-logger.setLevel(os.environ.get("SIMPLETUNER_LOG_LEVEL", "WARNING"))
+logger.setLevel(os.environ.get("SIMPLETUNER_LOG_LEVEL", "INFO"))
 
 
 class MultiaspectImage:

--- a/helpers/multiaspect/sampler.py
+++ b/helpers/multiaspect/sampler.py
@@ -56,7 +56,7 @@ class MultiAspectSampler(torch.utils.data.Sampler):
         # Update the logger name with the id:
         self.logger = get_logger(
             f"MultiAspectSampler-{self.id}",
-            os.environ.get("SIMPLETUNER_LOG_LEVEL", "WARNING"),
+            os.environ.get("SIMPLETUNER_LOG_LEVEL", "INFO"),
         )
         self.rank_info = rank_info()
         self.accelerator = accelerator

--- a/helpers/prompts.py
+++ b/helpers/prompts.py
@@ -154,7 +154,7 @@ from tqdm import tqdm
 import os
 
 logger = logging.getLogger("PromptHandler")
-logger.setLevel(os.environ.get("SIMPLETUNER_LOG_LEVEL", "WARNING"))
+logger.setLevel(os.environ.get("SIMPLETUNER_LOG_LEVEL", "INFO"))
 
 
 class PromptHandler:

--- a/helpers/training/state_tracker.py
+++ b/helpers/training/state_tracker.py
@@ -6,6 +6,12 @@ import json, logging
 logger = logging.getLogger("StateTracker")
 logger.setLevel(environ.get("SIMPLETUNER_LOG_LEVEL", "INFO"))
 
+filename_mapping = {
+    "all_image_files": "image",
+    "all_vae_cache_files": "vae",
+    "all_text_cache_files": "text",
+}
+
 
 class StateTracker:
     # Class variables
@@ -37,12 +43,16 @@ class StateTracker:
     args = None
 
     @classmethod
-    def delete_cache_files(cls, data_backend_id: str = None):
+    def delete_cache_files(
+        cls, data_backend_id: str = None, preserve_data_backend_cache=False
+    ):
         for cache_name in [
             "all_image_files",
             "all_vae_cache_files",
             "all_text_cache_files",
         ]:
+            if filename_mapping[cache_name] in str(preserve_data_backend_cache):
+                continue
             data_backend_id_suffix = ""
             if data_backend_id:
                 data_backend_id_suffix = f"_{data_backend_id}"

--- a/train_sd21.py
+++ b/train_sd21.py
@@ -134,7 +134,9 @@ def main():
     args = parse_args()
     StateTracker.set_args(args)
     if not args.preserve_data_backend_cache:
-        StateTracker.delete_cache_files()
+        StateTracker.delete_cache_files(
+            preserve_data_backend_cache=args.preserve_data_backend_cache
+        )
 
     logging_dir = Path(args.output_dir, args.logging_dir)
     accelerator_project_config = ProjectConfiguration(
@@ -802,7 +804,7 @@ def main():
         f" {args.num_train_epochs} epochs and {num_update_steps_per_epoch} steps per epoch."
     )
 
-    if not args.keep_vae_loaded:
+    if not args.keep_vae_loaded and not args.encode_during_training:
         memory_before_unload = torch.cuda.memory_allocated() / 1024**3
         import gc
 

--- a/train_sdxl.py
+++ b/train_sdxl.py
@@ -143,7 +143,9 @@ def main():
     args = parse_args()
     StateTracker.set_args(args)
     if not args.preserve_data_backend_cache:
-        StateTracker.delete_cache_files()
+        StateTracker.delete_cache_files(
+            preserve_data_backend_cache=args.preserve_data_backend_cache
+        )
 
     logging_dir = os.path.join(args.output_dir, args.logging_dir)
     accelerator_project_config = ProjectConfiguration(
@@ -873,7 +875,7 @@ def main():
         f" {args.num_train_epochs} epochs and {num_update_steps_per_epoch} steps per epoch."
     )
 
-    if not args.keep_vae_loaded:
+    if not args.keep_vae_loaded and not args.encode_during_training:
         memory_before_unload = torch.cuda.memory_allocated() / 1024**3
         import gc
 


### PR DESCRIPTION
For absurdly large datasets in the millions of images, pre-caching really doesn't make much sense.

This pull request adds in `--encode_during_training` option that bypasses the pre-processing stage in favour of an on-demand approach.

This will combine batches of ahead-of-time images with just-in-time cached images.