### PR TITLE
Convert image to accepted format for calculate_luminance

### DIFF
--- a/helpers/image_manipulation/brightness.py
+++ b/helpers/image_manipulation/brightness.py
@@ -1,10 +1,11 @@
-from PIL import Image
 import multiprocessing
+
 import numpy as np
+from PIL import Image
 
 
-def calculate_luminance(img: Image):
-    np_img = np.array(img)
+def calculate_luminance(img: Image.Image):
+    np_img = np.asarray(img.convert("RGB"))
     r, g, b = np_img[:, :, 0], np_img[:, :, 1], np_img[:, :, 2]
     luminance = 0.299 * r + 0.587 * g + 0.114 * b
     avg_luminance = np.mean(luminance)


### PR DESCRIPTION
Enforces the image being in 8-bit RGB mode for calculate_luminance.