### PR TITLE
bugfix: capture more samples when their intermediary size is smaller than target.

### DIFF
--- a/helpers/image_manipulation/training_sample.py
+++ b/helpers/image_manipulation/training_sample.py
@@ -515,7 +515,7 @@ class TrainingSample:
                 self.target_size = (self.pixel_resolution, self.pixel_resolution)
             if self.crop_aspect != "random" or not self.valid_metadata:
                 logger.debug(
-                    f"We had {'non-random crops' if self.crop_aspect != 'random' else 'invalid metadata: '} {self.image_metadata} and calculated intermediary size {calculated_intermediary_size}"
+                    f"We had {'non-random crops' if self.crop_aspect != 'random' else 'invalid metadata'} and calculated intermediary size {calculated_intermediary_size}"
                 )
                 self.intermediary_size = calculated_intermediary_size
             logger.debug(

--- a/helpers/image_manipulation/training_sample.py
+++ b/helpers/image_manipulation/training_sample.py
@@ -383,6 +383,17 @@ class TrainingSample:
             else:
                 new_width = int(self.current_size[0] * scale_factor)
                 new_height = int(self.current_size[1] * scale_factor)
+
+            # if we're smaller, we have to adjust. this helps us avoid a double-resize later.
+            w_diff = self.target_size[0] - new_width
+            h_diff = self.target_size[1] - new_height
+            if w_diff > 0 and w_diff > h_diff:
+                new_width += w_diff
+                new_height += w_diff
+            elif h_diff > 0 and h_diff > w_diff:
+                new_width += h_diff
+                new_height += h_diff
+
             intermediary_size = (new_width, new_height)
             logger.debug(
                 f"Downsampling image from {self.image.size if self.image is not None else self.current_size} to {intermediary_size} before cropping."


### PR DESCRIPTION
Resolves a condition where a mostly-square-image dataset of 1 million images was reduced by half, only ~500k samples were visible.