### PR TITLE
Load images preferentially with CV2, fall back to PIL only if that fails

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -100,3 +100,7 @@ bash train_sdxl.sh > /path/to/training-$(date +%s).log 2>&1
 ```
 
 > ⚠️ At this point, the commands will work, but further configuration is required. See [the tutorial](/TUTORIAL.md) for more information.
+
+### Run unit tests
+
+To run unit tests to ensure that installation has completed successfully, execute the command `poetry run python -m unittest discover tests/`.

--- a/helpers/data_backend/aws.py
+++ b/helpers/data_backend/aws.py
@@ -10,7 +10,7 @@ from pathlib import PosixPath
 import concurrent.futures
 from botocore.config import Config
 from helpers.data_backend.base import BaseDataBackend
-from PIL import Image
+from helpers.image_manipulation.load import load_image
 from io import BytesIO
 
 loggers_to_silence = [
@@ -247,7 +247,7 @@ class S3DataBackend(BaseDataBackend):
         return results
 
     def read_image(self, s3_key):
-        return Image.open(BytesIO(self.read(s3_key)))
+        return load_image(BytesIO(self.read(s3_key)))
 
     def read_image_batch(self, s3_keys: list, delete_problematic_images: bool = False):
         """
@@ -265,7 +265,7 @@ class S3DataBackend(BaseDataBackend):
         available_keys = []
         for s3_key, data in zip(s3_keys, batch):
             try:
-                image_data = Image.open(BytesIO(data))
+                image_data = load_image(BytesIO(data))
                 if image_data is None:
                     logger.warning(f"Unable to load image '{s3_key}', skipping.")
                     continue

--- a/helpers/data_backend/local.py
+++ b/helpers/data_backend/local.py
@@ -1,9 +1,9 @@
 from helpers.data_backend.base import BaseDataBackend
+from helpers.image_manipulation.load import load_image
 from pathlib import Path
 from io import BytesIO
 import os, logging, torch, gzip
 from typing import Any
-from PIL import Image
 
 logger = logging.getLogger("LocalDataBackend")
 logger.setLevel(os.environ.get("SIMPLETUNER_LOG_LEVEL", "INFO"))
@@ -114,7 +114,7 @@ class LocalDataBackend(BaseDataBackend):
         # Remove embedded null byte:
         filepath = filepath.replace("\x00", "")
         try:
-            image = Image.open(filepath)
+            image = load_image(filepath)
             return image
         except Exception as e:
             import traceback

--- a/helpers/image_manipulation/load.py
+++ b/helpers/image_manipulation/load.py
@@ -1,0 +1,82 @@
+import logging
+
+from io import BytesIO
+from typing import Union, IO, Any
+
+import cv2
+import numpy as np
+
+from PIL import Image, PngImagePlugin
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
+
+
+LARGE_ENOUGH_NUMBER = 100
+PngImagePlugin.MAX_TEXT_CHUNK = LARGE_ENOUGH_NUMBER * (1024**2)
+
+
+def decode_image_with_opencv(nparr: np.ndarray) -> Union[Image.Image, None]:
+    img_cv = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
+    if img_cv is not None:
+        img_cv = cv2.cvtColor(img_cv, cv2.COLOR_BGR2RGB)
+        # Ensuring we only convert to RGB if needed.
+        if len(img_cv.shape) == 2 or (img_cv.shape[2] != 3 and img_cv.shape[2] == 1):
+            img_cv = cv2.cvtColor(img_cv, cv2.COLOR_GRAY2RGB)
+    return img_cv if img_cv is None else Image.fromarray(img_cv)
+
+
+def decode_image_with_pil(img_data: bytes) -> Image.Image:
+    try:
+        if isinstance(img_data, bytes):
+            img_pil = Image.open(BytesIO(img_data))
+        else:
+            img_pil = Image.open(img_data)
+
+        if img_pil.mode not in ["RGB", "RGBA"] and "transparency" in img_pil.info:
+            img_pil = img_pil.convert("RGBA")
+
+        # For transparent images, add a white background as this is correct
+        # most of the time.
+        if img_pil.mode == 'RGBA':
+            canvas = Image.new("RGBA", img_pil.size, (255, 255, 255))
+            canvas.alpha_composite(img_pil)
+            img_pil = canvas.convert("RGB")
+        else:
+            img_pil = img_pil.convert('RGB')
+    except (OSError, Image.DecompressionBombError, ValueError) as e:
+        logger.warning(f'Error decoding image: {e}')
+        raise
+    return img_pil
+
+
+def load_image(img_data: Union[bytes, IO[Any], str]) -> Image.Image:
+    '''
+    Load an image using CV2. If that fails, fall back to PIL.
+
+    The image is returned as a PIL object.
+    '''
+    if isinstance(img_data, str):
+        with open(img_data, 'rb') as file:
+            img_data = file.read()
+    elif hasattr(img_data, 'read'):
+        # Check if it's file-like object.
+        img_data = img_data.read()
+
+    # Preload the image bytes with channels unchanged and ensure determine
+    # if the image has an alpha channel. If it does we should add a white
+    # background to it using PIL.
+    nparr = np.frombuffer(img_data, np.uint8)
+    image_preload = cv2.imdecode(nparr, cv2.IMREAD_UNCHANGED)
+    has_alpha = False
+    if image_preload is not None and image_preload.shape[2] == 4:
+        has_alpha = True
+    del image_preload
+
+    img = None
+    if not has_alpha:
+        img = decode_image_with_opencv(nparr)
+    if img is None:
+        img = decode_image_with_pil(img_data)
+    return img

--- a/helpers/metadata/backends/json.py
+++ b/helpers/metadata/backends/json.py
@@ -3,10 +3,10 @@ from helpers.multiaspect.image import MultiaspectImage
 from helpers.data_backend.base import BaseDataBackend
 from helpers.metadata.backends.base import MetadataBackend
 from helpers.image_manipulation.training_sample import TrainingSample
+from helpers.image_manipulation.load import load_image
 from pathlib import Path
 import json, logging, os, traceback
 from multiprocessing import Manager
-from PIL import Image
 from tqdm import tqdm
 from multiprocessing import Process, Queue
 import numpy as np
@@ -220,7 +220,7 @@ class JsonMetadataBackend(MetadataBackend):
                 statistics["skipped"]["not_found"] += 1
                 return aspect_ratio_bucket_indices
 
-            with Image.open(BytesIO(image_data)) as image:
+            with load_image(BytesIO(image_data)) as image:
                 if not self.meets_resolution_requirements(image=image):
                     if not self.delete_unwanted_images:
                         logger.debug(


### PR DESCRIPTION
cv2 is faster and more tolerant of corruption than PIL. Also adds a fallback for transparent images that adds a white background, instead of the default which is usually black and looks bad.

I only ran the unit tests, which passed.