### PR TITLE
implement Aura Diffusion training

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -27,6 +27,11 @@ This guide provides a user-friendly breakdown of the command-line options availa
 - **What**: Enable PixArt Sigma training quirks/overrides.
 - **Why**: PixArt is similar to SD3 and DeepFloyd in one way or another, and needs special treatment at validation, training, and inference time. Use this option to enable PixArt training support. PixArt does not support ControlNet, LoRA, or `--validation_using_datasets`
 
+### `--aura_flow`
+
+- **What**: Enable AuraFlow training quirks/overrides.
+- **Why**: As a flow-matching model, AuraFlow has several unique needs. This option must be enabled to load and train an AuraFlow model.
+
 **Note:** Like SDXL and SD3, PixArt Sigma **also** uses the `train_sdxl.sh`/`train_sdxl.py` training script, `sdxl-env.sh` configuration file.
 
 ### `--pretrained_model_name_or_path`
@@ -243,7 +248,8 @@ This is a basic overview meant to help you get started. For a complete list of o
 usage: train_sdxl.py [-h] [--snr_gamma SNR_GAMMA] [--use_soft_min_snr]
                      [--soft_min_snr_sigma_data SOFT_MIN_SNR_SIGMA_DATA]
                      [--model_type {full,lora,deepfloyd-full,deepfloyd-lora,deepfloyd-stage2,deepfloyd-stage2-lora}]
-                     [--pixart_sigma] [--sd3] [--sd3_uses_diffusion]
+                     [--aura_flow] [--pixart_sigma] [--sd3]
+                     [--sd3_uses_diffusion]
                      [--weighting_scheme {sigma_sqrt,logit_normal,mode}]
                      [--logit_mean LOGIT_MEAN] [--logit_std LOGIT_STD]
                      [--mode_scale MODE_SCALE] [--lora_type {Standard}]
@@ -280,7 +286,9 @@ usage: train_sdxl.py [-h] [--snr_gamma SNR_GAMMA] [--use_soft_min_snr]
                      [--cache_dir_text CACHE_DIR_TEXT]
                      [--cache_dir_vae CACHE_DIR_VAE] --data_backend_config
                      DATA_BACKEND_CONFIG [--write_batch_size WRITE_BATCH_SIZE]
-                     [--enable_multiprocessing] [--dataloader_prefetch]
+                     [--enable_multiprocessing]
+                     [--torch_num_threads TORCH_NUM_THREADS]
+                     [--dataloader_prefetch]
                      [--dataloader_prefetch_qlen DATALOADER_PREFETCH_QLEN]
                      [--aspect_bucket_worker_count ASPECT_BUCKET_WORKER_COUNT]
                      [--cache_dir CACHE_DIR]
@@ -403,6 +411,7 @@ options:
                         The training type to use. 'full' will train the full
                         model, while 'lora' will train the LoRA model. LoRA is
                         a smaller model that can be used for faster training.
+  --aura_flow      This must be set when training an AuraFlow model.
   --pixart_sigma        This must be set when training a PixArt Sigma model.
   --sd3                 This option must be provided when training a Stable
                         Diffusion 3 model.
@@ -664,6 +673,10 @@ options:
                         multiprocessing may be faster than threading, but will
                         consume a lot more memory. Use this option with
                         caution, and monitor your system's memory usage.
+  --torch_num_threads TORCH_NUM_THREADS
+                        The number of threads to use for PyTorch operations.
+                        This is not the same as the number of workers.
+                        Default: 8.
   --dataloader_prefetch
                         When provided, the dataloader will read-ahead and
                         attempt to retrieve latents, text embeds, and other
@@ -1013,7 +1026,8 @@ options:
                         better speed, and Euler A can put up with
                         instabilities a bit better. For zero-terminal SNR
                         models, DDIM is the best choice. Choices: ['ddim',
-                        'ddpm', 'euler', 'euler-a', 'unipc'], Default: ddim
+                        'ddpm', 'euler', 'euler-a', 'unipc'], Default: None
+                        (use the model default)
   --validation_disable_unconditional
                         When set, the validation pipeline will not generate
                         unconditional samples. This is useful to speed up

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Simply point your base model to a Stable Diffusion 3 checkpoint and set `STABLE_
 
 > ⚠️ In the current source release of Diffusers, gradient checkpointing is broken for Stable Diffusion 3 models. This will result in much, much higher memory use.
 
+### Aura Diffusion
+
+<!-- Placeholder text -->
+
 ## Hardware Requirements
 
 EMA (exponential moving average) weights are a memory-heavy affair, but provide fantastic results at the end of training. Options like `--ema_cpu_only` can improve this situation by loading EMA weights onto the CPU and then keeping them there.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ For a quick start without reading the full documentation, you can use the [Quick
 
 For memory-constrained systems, see the [DeepSpeed document](/documentation/DEEPSPEED.md) which explains how to use 🤗Accelerate to configure Microsoft's DeepSpeed for optimiser state offload.
 
+---
+
 ## Features
 
 - Precomputed VAE (latents) outputs saved to storage, eliminating the need to invoke the VAE during training.
@@ -80,9 +82,27 @@ Simply point your base model to a Stable Diffusion 3 checkpoint and set `STABLE_
 
 > ⚠️ In the current source release of Diffusers, gradient checkpointing is broken for Stable Diffusion 3 models. This will result in much, much higher memory use.
 
-### Aura Diffusion
+### AuraFlow
 
-<!-- Placeholder text -->
+AuraFlow is a novel, open-source implementation of a flow-matching text-to-image model using a simplified architecture compared to SD3, with a greater number of parameters.
+
+Currently, AuraFlow v0.1 has limited support for SimpleTuner:
+- All limitations that apply to Stable Diffusion 3 also apply to AuraFlow
+- LoRA is not available yet for AuraFlow training
+
+This model is very large, and will require more resources to train than PixArt or SDXL.
+
+AuraFlow has some distinct advantages that make it worth investigating over Stable Diffusion 3:
+
+- It is the largest open text-to-image model with a truly open license
+- It uses the SDXL 4ch VAE which arguably provides an easier learning objective over the 16ch VAE from Stable Diffusion 3
+  - Though small newspaper or book print text suffers at 4ch compression levels, the overall fine details makes this approach viable.
+- It uses just a single text encoder versus Stable Diffusion's three text encoders
+  - AuraFlow leverages EleutherAI's **Pile-T5** which was trained on **twice as much data** with **fewer parameters** than Stable Diffusion 3, DeepFloyd, and PixArt's **T5-XXL v1.1**
+  - Pile-T5 has gone through less content prefiltering than OpenCLIP or T5 v1.1, and has "consumed more of the Internet" than T5 v1.1
+  - With a large data corpus, it has potential for subtle semantic understanding of linguistic oddities, and understanding of more modern concepts without finetuning the text encoder
+
+---
 
 ## Hardware Requirements
 

--- a/documentation/QUICKSTART.md
+++ b/documentation/QUICKSTART.md
@@ -1,13 +1,17 @@
 # Quickstart Guide
 
-> ⚠️ This tutorial is a work-in-progress.
+> ⚠️ These tutorials are a work-in-progress. They contain full end-to-end instructions for a basic training session.
 
-**Note**: This tutorial is very basic, step-by-step guide to get a basic, minimal training run up and running. For more advanced configurations, see the [tutorial](/TUTORIAL.md), [dataloader configuration guide](/documentation/DATALOADER.md), and the [options breakdown](/OPTIONS.md) pages.
+**Note**: For more advanced configurations, see the [tutorial](/TUTORIAL.md), [dataloader configuration guide](/documentation/DATALOADER.md), and the [options breakdown](/OPTIONS.md) pages.
+
+## PixArt Sigma (1K, 2K & 4K)
+
+For a fun and lightweight model, see [this quickstart guide](/documentation/quickstart/SIGMA.md)
+
+## AuraFlow
+
+A full tutorial to start training an AuraFlow model is available in [this quickstart guide](/documentation/quickstart/AURAFLOW.md)
 
 ## Stable Diffusion 3
 
 For personalisation of the Stable Diffusion 3 model family, see [this quickstart guide](/documentation/quickstart/SD3.md)
-
-## PixArt Sigma (1K, 2K & 4K)
-
-For personalisation of the PixArt Sigma model family, see [this quickstart guide](/documentation/quickstart/SIGMA.md)

--- a/documentation/quickstart/AURAFLOW.md
+++ b/documentation/quickstart/AURAFLOW.md
@@ -88,7 +88,7 @@ In your `BASE_DIR` directory, create a multidatabackend.json:
 ```json
 [
   {
-    "id": "pseudo-camera-10k-sd3",
+    "id": "pseudo-camera-10k-aura",
     "type": "local",
     "crop": true,
     "crop_aspect": "square",
@@ -98,7 +98,7 @@ In your `BASE_DIR` directory, create a multidatabackend.json:
     "maximum_image_size": 1.0,
     "target_downsample_size": 1.0,
     "resolution_type": "area",
-    "cache_dir_vae": "cache/vae/sd3/pseudo-camera-10k",
+    "cache_dir_vae": "cache/vae/aura/pseudo-camera-10k",
     "instance_data_dir": "datasets/pseudo-camera-10k",
     "disabled": false,
     "skip_file_discovery": "",
@@ -110,7 +110,7 @@ In your `BASE_DIR` directory, create a multidatabackend.json:
     "type": "local",
     "dataset_type": "text_embeds",
     "default": true,
-    "cache_dir": "cache/text/sd3/pseudo-camera-10k",
+    "cache_dir": "cache/text/aura/pseudo-camera-10k",
     "disabled": false,
     "write_batch_size": 128
   }

--- a/documentation/quickstart/AURAFLOW.md
+++ b/documentation/quickstart/AURAFLOW.md
@@ -1,0 +1,162 @@
+## AuraFlow v0.1
+
+In this example, we'll be running a **full fine-tune** on an AuraFlow model using the SimpleTuner toolkit.
+
+> ⚠️ LoRA is not currently supported for AuraFlow, this will require more resources.
+
+### Prerequisites
+
+Make sure that you have python installed. You can check this by running:
+
+```bash
+python --version
+```
+
+### Installation
+
+Clone the SimpleTuner repository and set up the python venv:
+
+```bash
+git clone --branch=release https://github.com/bghira/SimpleTuner.git
+
+cd SimpleTuner
+
+python -m venv .venv
+
+source .venv/bin/activate
+
+pip install -U poetry pip
+```
+
+Depending on your system, you will run one of 3 commands:
+
+```bash
+# MacOS
+poetry install --no-root -C install/apple
+
+# Linux
+poetry install --no-root
+
+# Linux with ROCM
+poetry install --no-root -C install/rocm
+```
+
+Additionally, because of AuraFlow's preliminary support in the Diffusers project, you will have to manually install a fork that contains the AuraFlow patches already-integrated.
+
+This command should be executed while you are still inside your venv from earlier:
+
+```bash
+pip install git+https://github.com/bghira/diffusers@feature/lavender-flow-complete
+```
+
+For your own security, you may audit the changes between this branch and upstream Diffusers repository [here](https://github.com/bghira/diffusers/tree/feature/lavender-flow-complete).
+
+This page will be updated after full support lands in the Diffusers project, negating the requirement for this part to be done manually. That progress can be viewed [here](https://github.com/huggingface/diffusers/pull/8796). If that issue has been closed and this page has not yet been updated, please take the time to open an issue report on GitHub [here](https://github.com/bghira/SimpleTuner/isssues).
+
+### Setting up the environment
+
+To run SimpleTuner, you will need to set up a configuration file, the dataset and model directories, and a dataloader configuration file.
+
+#### Configuration file
+
+Copy `sdxl-env.sh.example` to `sdxl-env.sh`:
+
+```bash
+cp sdxl-env.sh.example sdxl-env.sh
+```
+
+There, you will need to modify the following variables:
+
+- `MODEL_TYPE` - This should remain set as `full`. **LoRA will not work.**
+- `AURA_FLOW` - Set this to `true`.
+- `MODEL_NAME` - Set this to `AuraDiffusion/auradiffusion-v0.1a0`. Note that you will need to log in to Huggingface and be granted access to download this model. We will go over logging in to Huggingface later in this tutorial.
+- `BASE_DIR` - Set this to the directory where you want to store your outputs and datasets. It's recommended to use a full path here.
+
+There are a few more if using a Mac M-series machine:
+
+- `MIXED_PRECISION` should be set to `no`.
+- `USE_XFORMERS` should be set to `false`.
+
+#### Dataset considerations
+
+It's crucial to have a substantial dataset to train your model on. There are limitations on the dataset size, and you will need to ensure that your dataset is large enough to train your model effectively. Note that the bare minimum dataset size is `TRAIN_BATCH_SIZE * GRADIENT_ACCUMULATION_STEPS`. The dataset will not be useable if it is too small.
+
+Depending on the dataset you have, you will need to set up your dataset directory and dataloader configuration file differently. In this example, we will be using [pseudo-camera-10k](https://huggingface.co/datasets/ptx0/pseudo-camera-10k) as the dataset.
+
+In your `BASE_DIR` directory, create a multidatabackend.json:
+
+```json
+[
+  {
+    "id": "pseudo-camera-10k-sd3",
+    "type": "local",
+    "crop": true,
+    "crop_aspect": "square",
+    "crop_style": "center",
+    "resolution": 0.5,
+    "minimum_image_size": 0.25,
+    "maximum_image_size": 1.0,
+    "target_downsample_size": 1.0,
+    "resolution_type": "area",
+    "cache_dir_vae": "cache/vae/sd3/pseudo-camera-10k",
+    "instance_data_dir": "datasets/pseudo-camera-10k",
+    "disabled": false,
+    "skip_file_discovery": "",
+    "caption_strategy": "filename",
+    "metadata_backend": "json"
+  },
+  {
+    "id": "text-embeds",
+    "type": "local",
+    "dataset_type": "text_embeds",
+    "default": true,
+    "cache_dir": "cache/text/sd3/pseudo-camera-10k",
+    "disabled": false,
+    "write_batch_size": 128
+  }
+]
+```
+
+Then, navigate to the `BASE_DIR` directory and create a `datasets` directory:
+
+```bash
+apt -y install git-lfs
+mkdir -p datasets
+pushd datasets
+    git clone https://huggingface.co/datasets/ptx0/pseudo-camera-10k
+popd
+```
+
+This will download about 10k photograph samples to your `datasets/pseudo-camera-10k` directory, which will be automatically created for you.
+
+#### Login to WandB and Huggingface Hub
+
+You'll want to login to WandB and HF Hub before beginning training, especially if you're using `PUSH_TO_HUB=true` and `--report_to=wandb`.
+
+If you're going to be pushing items to a Git LFS repository manually, you should also run `git config --global credential.helper store`
+
+Run the following commands:
+
+```bash
+wandb login
+```
+
+and
+
+```bash
+huggingface-cli login
+```
+
+Follow the instructions to log in to both services.
+
+### Executing the training run
+
+From the SimpleTuner directory, one simply has to run:
+
+```bash
+bash train_sdxl.sh
+```
+
+This will begin the text embed and VAE output caching to disk.
+
+For more information, see the [dataloader](/documentation/DATALOADER.md) and [tutorial](/TUTORIAL.md) documents.

--- a/helpers/arguments.py
+++ b/helpers/arguments.py
@@ -1666,12 +1666,12 @@ def parse_args(input_args=None):
         )
         info_log(f"Default VAE Cache location: {args.cache_dir_vae}")
         info_log(f"Text Cache location: {args.cache_dir_text}")
-    elif args.sd3 or args.aura_diffusion:
+    if args.sd3 or args.aura_diffusion:
         warning_log(
             "MM-DiT requires an alignment value of 64px. Overriding the value of --aspect_bucket_alignment."
         )
         args.aspect_bucket_alignment = 64
-    else:
+    elif "deepfloyd" in args.model_type:
         deepfloyd_pixel_alignment = 8
         if args.aspect_bucket_alignment != deepfloyd_pixel_alignment:
             warning_log(

--- a/helpers/arguments.py
+++ b/helpers/arguments.py
@@ -79,10 +79,10 @@ def parse_args(input_args=None):
         ),
     )
     parser.add_argument(
-        "--aura_diffusion",
+        "--aura_flow",
         action="store_true",
         default=False,
-        help=("This must be set when training an Aura Diffusion model."),
+        help=("This must be set when training an AuraFlow model."),
     )
     parser.add_argument(
         "--pixart_sigma",
@@ -1666,7 +1666,7 @@ def parse_args(input_args=None):
         )
         info_log(f"Default VAE Cache location: {args.cache_dir_vae}")
         info_log(f"Text Cache location: {args.cache_dir_text}")
-    if args.sd3 or args.aura_diffusion:
+    if args.sd3 or args.aura_flow:
         warning_log(
             "MM-DiT requires an alignment value of 64px. Overriding the value of --aspect_bucket_alignment."
         )
@@ -1738,13 +1738,13 @@ def parse_args(input_args=None):
             args.disable_compel = True
 
     t5_max_length = 512
-    if args.aura_diffusion and (
+    if args.aura_flow and (
         args.tokenizer_max_length is None
         or int(args.tokenizer_max_length) > t5_max_length
     ):
         if not args.i_know_what_i_am_doing:
             warning_log(
-                f"Updating Pile-T5 tokeniser max length to {t5_max_length} for Aura Diffusion."
+                f"Updating Pile-T5 tokeniser max length to {t5_max_length} for AuraFlow."
             )
             args.tokenizer_max_length = t5_max_length
         else:
@@ -1759,7 +1759,7 @@ def parse_args(input_args=None):
         args.ema_device = "cpu"
 
     if not args.i_know_what_i_am_doing:
-        if args.pixart_sigma or args.sd3 or args.aura_diffusion:
+        if args.pixart_sigma or args.sd3 or args.aura_flow:
             if args.max_grad_norm is None or float(args.max_grad_norm) > 0.01:
                 warning_log(
                     f"{'PixArt Sigma' if args.pixart_sigma else 'Stable Diffusion 3'} requires --max_grad_norm=0.01 to prevent model collapse. Overriding value. Set this value manually to disable this warning."

--- a/helpers/arguments.py
+++ b/helpers/arguments.py
@@ -79,6 +79,12 @@ def parse_args(input_args=None):
         ),
     )
     parser.add_argument(
+        "--aura_diffusion",
+        action="store_true",
+        default=False,
+        help=("This must be set when training an Aura Diffusion model."),
+    )
+    parser.add_argument(
         "--pixart_sigma",
         action="store_true",
         default=False,
@@ -1735,7 +1741,7 @@ def parse_args(input_args=None):
         args.ema_device = "cpu"
 
     if not args.i_know_what_i_am_doing:
-        if args.pixart_sigma or args.sd3:
+        if args.pixart_sigma or args.sd3 or args.aura_diffusion:
             if args.max_grad_norm is None or float(args.max_grad_norm) > 0.01:
                 warning_log(
                     f"{'PixArt Sigma' if args.pixart_sigma else 'Stable Diffusion 3'} requires --max_grad_norm=0.01 to prevent model collapse. Overriding value. Set this value manually to disable this warning."

--- a/helpers/arguments.py
+++ b/helpers/arguments.py
@@ -1660,24 +1660,24 @@ def parse_args(input_args=None):
     ):
         args.pretrained_vae_model_name_or_path = None
 
-    if "deepfloyd" not in args.model_type and not args.sd3:
+    if "deepfloyd" not in args.model_type:
         info_log(
             f"VAE Model: {args.pretrained_vae_model_name_or_path or args.pretrained_model_name_or_path}"
         )
         info_log(f"Default VAE Cache location: {args.cache_dir_vae}")
         info_log(f"Text Cache location: {args.cache_dir_text}")
+    elif args.sd3 or args.aura_diffusion:
+        warning_log(
+            "MM-DiT requires an alignment value of 64px. Overriding the value of --aspect_bucket_alignment."
+        )
+        args.aspect_bucket_alignment = 64
     else:
         deepfloyd_pixel_alignment = 8
-        if not args.sd3 and args.aspect_bucket_alignment != deepfloyd_pixel_alignment:
+        if args.aspect_bucket_alignment != deepfloyd_pixel_alignment:
             warning_log(
                 f"Overriding aspect bucket alignment pixel interval to {deepfloyd_pixel_alignment}px instead of {args.aspect_bucket_alignment}px."
             )
             args.aspect_bucket_alignment = deepfloyd_pixel_alignment
-        elif args.sd3:
-            warning_log(
-                "Stable Diffusion 3 requires a pixel alignment interval of 64px. Updating value."
-            )
-            args.aspect_bucket_alignment = 64
 
     if "deepfloyd-stage2" in args.model_type and args.resolution < 256:
         warning_log(
@@ -1736,6 +1736,10 @@ def parse_args(input_args=None):
                 "Disabling Compel long-prompt weighting for SD3 inference, as it does not support Stable Diffusion 3."
             )
             args.disable_compel = True
+
+    if args.aura_diffusion:
+        warning_log("Updating Pile-T5 tokeniser max length to 512 for Aura Diffusion")
+        args.tokenizer_max_length = 512
 
     if args.use_ema and args.ema_cpu_only:
         args.ema_device = "cpu"

--- a/helpers/arguments.py
+++ b/helpers/arguments.py
@@ -1737,9 +1737,23 @@ def parse_args(input_args=None):
             )
             args.disable_compel = True
 
-    if args.aura_diffusion:
-        warning_log("Updating Pile-T5 tokeniser max length to 512 for Aura Diffusion")
-        args.tokenizer_max_length = 512
+    t5_max_length = 512
+    if args.aura_diffusion and (
+        args.tokenizer_max_length is None
+        or int(args.tokenizer_max_length) > t5_max_length
+    ):
+        if not args.i_know_what_i_am_doing:
+            warning_log(
+                f"Updating Pile-T5 tokeniser max length to {t5_max_length} for Aura Diffusion."
+            )
+            args.tokenizer_max_length = t5_max_length
+        else:
+            warning_log(
+                f"-!- T5 supports a max length of {t5_max_length} tokens, but you have supplied `--i_know_what_i_am_doing`, so this limit will not be enforced. -!-"
+            )
+            warning_log(
+                f"Your outputs will possibly look incoherent if the model you are continuing from has not been tuned beyond {t5_max_length} tokens."
+            )
 
     if args.use_ema and args.ema_cpu_only:
         args.ema_device = "cpu"

--- a/helpers/aura_diffusion/pipeline.py
+++ b/helpers/aura_diffusion/pipeline.py
@@ -1,0 +1,582 @@
+# Copyright 2024 AuraFlow Authors and The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import inspect
+from typing import Callable, List, Optional, Tuple, Union
+
+import torch
+from transformers import T5Tokenizer, UMT5EncoderModel
+
+from diffusers.image_processor import VaeImageProcessor
+from diffusers.models import AuraFlowTransformer2DModel, AutoencoderKL
+from diffusers.models.attention_processor import (
+    AttnProcessor2_0,
+    FusedAttnProcessor2_0,
+    XFormersAttnProcessor,
+)
+from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
+from diffusers.utils import logging
+from diffusers.utils.torch_utils import randn_tensor
+from diffusers.pipelines.pipeline_utils import DiffusionPipeline, ImagePipelineOutput
+
+
+logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
+
+
+# Copied from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion.retrieve_timesteps
+def retrieve_timesteps(
+    scheduler,
+    num_inference_steps: Optional[int] = None,
+    device: Optional[Union[str, torch.device]] = None,
+    timesteps: Optional[List[int]] = None,
+    sigmas: Optional[List[float]] = None,
+    **kwargs,
+):
+    """
+    Calls the scheduler's `set_timesteps` method and retrieves timesteps from the scheduler after the call. Handles
+    custom timesteps. Any kwargs will be supplied to `scheduler.set_timesteps`.
+
+    Args:
+        scheduler (`SchedulerMixin`):
+            The scheduler to get timesteps from.
+        num_inference_steps (`int`):
+            The number of diffusion steps used when generating samples with a pre-trained model. If used, `timesteps`
+            must be `None`.
+        device (`str` or `torch.device`, *optional*):
+            The device to which the timesteps should be moved to. If `None`, the timesteps are not moved.
+        timesteps (`List[int]`, *optional*):
+            Custom timesteps used to override the timestep spacing strategy of the scheduler. If `timesteps` is passed,
+            `num_inference_steps` and `sigmas` must be `None`.
+        sigmas (`List[float]`, *optional*):
+            Custom sigmas used to override the timestep spacing strategy of the scheduler. If `sigmas` is passed,
+            `num_inference_steps` and `timesteps` must be `None`.
+
+    Returns:
+        `Tuple[torch.Tensor, int]`: A tuple where the first element is the timestep schedule from the scheduler and the
+        second element is the number of inference steps.
+    """
+    if timesteps is not None and sigmas is not None:
+        raise ValueError(
+            "Only one of `timesteps` or `sigmas` can be passed. Please choose one to set custom values"
+        )
+    if timesteps is not None:
+        accepts_timesteps = "timesteps" in set(
+            inspect.signature(scheduler.set_timesteps).parameters.keys()
+        )
+        if not accepts_timesteps:
+            raise ValueError(
+                f"The current scheduler class {scheduler.__class__}'s `set_timesteps` does not support custom"
+                f" timestep schedules. Please check whether you are using the correct scheduler."
+            )
+        scheduler.set_timesteps(timesteps=timesteps, device=device, **kwargs)
+        timesteps = scheduler.timesteps
+        num_inference_steps = len(timesteps)
+    elif sigmas is not None:
+        accept_sigmas = "sigmas" in set(
+            inspect.signature(scheduler.set_timesteps).parameters.keys()
+        )
+        if not accept_sigmas:
+            raise ValueError(
+                f"The current scheduler class {scheduler.__class__}'s `set_timesteps` does not support custom"
+                f" sigmas schedules. Please check whether you are using the correct scheduler."
+            )
+        scheduler.set_timesteps(sigmas=sigmas, device=device, **kwargs)
+        timesteps = scheduler.timesteps
+        num_inference_steps = len(timesteps)
+    else:
+        scheduler.set_timesteps(num_inference_steps, device=device, **kwargs)
+        timesteps = scheduler.timesteps
+    return timesteps, num_inference_steps
+
+
+class AuraFlowPipeline(DiffusionPipeline):
+    _optional_components = ["tokenizer", "text_encoder"]
+    model_cpu_offload_seq = "text_encoder->transformer->vae"
+
+    def __init__(
+        self,
+        tokenizer: T5Tokenizer,
+        text_encoder: UMT5EncoderModel,
+        vae: AutoencoderKL,
+        transformer: AuraFlowTransformer2DModel,
+        scheduler: FlowMatchEulerDiscreteScheduler,
+    ):
+        super().__init__()
+
+        self.register_modules(
+            tokenizer=tokenizer,
+            text_encoder=text_encoder,
+            vae=vae,
+            transformer=transformer,
+            scheduler=scheduler,
+        )
+
+        self.vae_scale_factor = 2 ** (len(self.vae.config.block_out_channels) - 1)
+        self.image_processor = VaeImageProcessor(vae_scale_factor=self.vae_scale_factor)
+
+    # Copied from diffusers.pipelines.pixart_alpha.pipeline_pixart_alpha.PixArtAlphaPipeline.check_inputs
+    def check_inputs(
+        self,
+        prompt,
+        height,
+        width,
+        negative_prompt,
+        callback_steps,
+        prompt_embeds=None,
+        negative_prompt_embeds=None,
+        prompt_attention_mask=None,
+        negative_prompt_attention_mask=None,
+    ):
+        if height % 8 != 0 or width % 8 != 0:
+            raise ValueError(
+                f"`height` and `width` have to be divisible by 8 but are {height} and {width}."
+            )
+
+        if (callback_steps is None) or (
+            callback_steps is not None
+            and (not isinstance(callback_steps, int) or callback_steps <= 0)
+        ):
+            raise ValueError(
+                f"`callback_steps` has to be a positive integer but is {callback_steps} of type"
+                f" {type(callback_steps)}."
+            )
+
+        if prompt is not None and prompt_embeds is not None:
+            raise ValueError(
+                f"Cannot forward both `prompt`: {prompt} and `prompt_embeds`: {prompt_embeds}. Please make sure to"
+                " only forward one of the two."
+            )
+        elif prompt is None and prompt_embeds is None:
+            raise ValueError(
+                "Provide either `prompt` or `prompt_embeds`. Cannot leave both `prompt` and `prompt_embeds` undefined."
+            )
+        elif prompt is not None and (
+            not isinstance(prompt, str) and not isinstance(prompt, list)
+        ):
+            raise ValueError(
+                f"`prompt` has to be of type `str` or `list` but is {type(prompt)}"
+            )
+
+        if prompt is not None and negative_prompt_embeds is not None:
+            raise ValueError(
+                f"Cannot forward both `prompt`: {prompt} and `negative_prompt_embeds`:"
+                f" {negative_prompt_embeds}. Please make sure to only forward one of the two."
+            )
+
+        if negative_prompt is not None and negative_prompt_embeds is not None:
+            raise ValueError(
+                f"Cannot forward both `negative_prompt`: {negative_prompt} and `negative_prompt_embeds`:"
+                f" {negative_prompt_embeds}. Please make sure to only forward one of the two."
+            )
+
+        if prompt_embeds is not None and prompt_attention_mask is None:
+            raise ValueError(
+                "Must provide `prompt_attention_mask` when specifying `prompt_embeds`."
+            )
+
+        if (
+            negative_prompt_embeds is not None
+            and negative_prompt_attention_mask is None
+        ):
+            raise ValueError(
+                "Must provide `negative_prompt_attention_mask` when specifying `negative_prompt_embeds`."
+            )
+
+        if prompt_embeds is not None and negative_prompt_embeds is not None:
+            if prompt_embeds.shape != negative_prompt_embeds.shape:
+                raise ValueError(
+                    "`prompt_embeds` and `negative_prompt_embeds` must have the same shape when passed directly, but"
+                    f" got: `prompt_embeds` {prompt_embeds.shape} != `negative_prompt_embeds`"
+                    f" {negative_prompt_embeds.shape}."
+                )
+            if prompt_attention_mask.shape != negative_prompt_attention_mask.shape:
+                raise ValueError(
+                    "`prompt_attention_mask` and `negative_prompt_attention_mask` must have the same shape when passed directly, but"
+                    f" got: `prompt_attention_mask` {prompt_attention_mask.shape} != `negative_prompt_attention_mask`"
+                    f" {negative_prompt_attention_mask.shape}."
+                )
+
+    def encode_prompt(
+        self,
+        prompt: Union[str, List[str]],
+        do_classifier_free_guidance: bool = True,
+        negative_prompt: str = "This is watermark, jpeg image white background, web image",
+        num_images_per_prompt: int = 1,
+        device: Optional[torch.device] = None,
+        prompt_embeds: Optional[torch.Tensor] = None,
+        negative_prompt_embeds: Optional[torch.Tensor] = None,
+        prompt_attention_mask: Optional[torch.Tensor] = None,
+        negative_prompt_attention_mask: Optional[torch.Tensor] = None,
+        max_sequence_length: int = 256,
+    ):
+        r"""
+        Encodes the prompt into text encoder hidden states.
+
+        Args:
+            prompt (`str` or `List[str]`, *optional*):
+                prompt to be encoded
+            negative_prompt (`str` or `List[str]`, *optional*):
+                The prompt not to guide the image generation. If not defined, one has to pass `negative_prompt_embeds`
+                instead. Ignored when not using guidance (i.e., ignored if `guidance_scale` is less than `1`).
+            do_classifier_free_guidance (`bool`, *optional*, defaults to `True`):
+                whether to use classifier free guidance or not
+            num_images_per_prompt (`int`, *optional*, defaults to 1):
+                number of images that should be generated per prompt
+            device: (`torch.device`, *optional*):
+                torch device to place the resulting embeddings on
+            prompt_embeds (`torch.Tensor`, *optional*):
+                Pre-generated text embeddings. Can be used to easily tweak text inputs, *e.g.* prompt weighting. If not
+                provided, text embeddings will be generated from `prompt` input argument.
+            negative_prompt_embeds (`torch.Tensor`, *optional*):
+                Pre-generated negative text embeddings.
+            max_sequence_length (`int`, defaults to 256): Maximum sequence length to use for the prompt.
+        """
+        if device is None:
+            device = self._execution_device
+
+        if prompt is not None and isinstance(prompt, str):
+            batch_size = 1
+        elif prompt is not None and isinstance(prompt, list):
+            batch_size = len(prompt)
+        else:
+            batch_size = prompt_embeds.shape[0]
+
+        max_length = max_sequence_length
+        if prompt_embeds is None:
+            text_inputs = self.tokenizer(
+                prompt,
+                truncation=True,
+                max_length=max_length,
+                padding="max_length",
+                return_tensors="pt",
+            )
+            text_inputs = {k: v.to(device) for k, v in text_inputs.items()}
+            text_input_ids = text_inputs["input_ids"]
+            untruncated_ids = self.tokenizer(
+                prompt, padding="longest", return_tensors="pt"
+            ).input_ids
+
+            if untruncated_ids.shape[-1] >= text_input_ids.shape[
+                -1
+            ] and not torch.equal(text_input_ids, untruncated_ids):
+                removed_text = self.tokenizer.batch_decode(
+                    untruncated_ids[:, max_length - 1 : -1]
+                )
+                logger.warning(
+                    "The following part of your input was truncated because T5 can only handle sequences up to"
+                    f" {max_length} tokens: {removed_text}"
+                )
+
+            prompt_embeds = self.text_encoder(**text_inputs)[0]
+            prompt_attention_mask = (
+                text_inputs["attention_mask"].unsqueeze(-1).expand(prompt_embeds.shape)
+            )
+            prompt_embeds = prompt_embeds * prompt_attention_mask
+
+        if self.text_encoder is not None:
+            dtype = self.text_encoder.dtype
+        elif self.transformer is not None:
+            dtype = self.transformer.dtype
+        else:
+            dtype = None
+
+        prompt_embeds = prompt_embeds.to(dtype=dtype, device=device)
+
+        bs_embed, seq_len, _ = prompt_embeds.shape
+        # duplicate text embeddings and attention mask for each generation per prompt, using mps friendly method
+        prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
+        prompt_embeds = prompt_embeds.view(
+            bs_embed * num_images_per_prompt, seq_len, -1
+        )
+        prompt_attention_mask = prompt_attention_mask.reshape(bs_embed, -1)
+        prompt_attention_mask = prompt_attention_mask.repeat(num_images_per_prompt, 1)
+
+        # get unconditional embeddings for classifier free guidance
+        if do_classifier_free_guidance and negative_prompt_embeds is None:
+            uncond_tokens = (
+                [negative_prompt] * batch_size
+                if isinstance(negative_prompt, str)
+                else negative_prompt
+            )
+            max_length = prompt_embeds.shape[1]
+            uncond_input = self.tokenizer(
+                uncond_tokens,
+                truncation=True,
+                max_length=max_length,
+                padding="max_length",
+                return_tensors="pt",
+            )
+            uncond_input = {k: v.to(device) for k, v in uncond_input.items()}
+            negative_prompt_embeds = self.text_encoder(**uncond_input)[0]
+            negative_prompt_attention_mask = (
+                uncond_input["attention_mask"]
+                .unsqueeze(-1)
+                .expand(negative_prompt_embeds.shape)
+            )
+            negative_prompt_embeds = (
+                negative_prompt_embeds * negative_prompt_attention_mask
+            )
+
+        if do_classifier_free_guidance:
+            # duplicate unconditional embeddings for each generation per prompt, using mps friendly method
+            seq_len = negative_prompt_embeds.shape[1]
+
+            negative_prompt_embeds = negative_prompt_embeds.to(
+                dtype=dtype, device=device
+            )
+
+            negative_prompt_embeds = negative_prompt_embeds.repeat(
+                1, num_images_per_prompt, 1
+            )
+            negative_prompt_embeds = negative_prompt_embeds.view(
+                batch_size * num_images_per_prompt, seq_len, -1
+            )
+
+            negative_prompt_attention_mask = negative_prompt_attention_mask.reshape(
+                bs_embed, -1
+            )
+            negative_prompt_attention_mask = negative_prompt_attention_mask.repeat(
+                num_images_per_prompt, 1
+            )
+        else:
+            negative_prompt_embeds = None
+            negative_prompt_attention_mask = None
+
+        return (
+            prompt_embeds,
+            prompt_attention_mask,
+            negative_prompt_embeds,
+            negative_prompt_attention_mask,
+        )
+
+    # Copied from diffusers.pipelines.stable_diffusion_3.pipeline_stable_diffusion_3.StableDiffusion3Pipeline.prepare_latents
+    def prepare_latents(
+        self,
+        batch_size,
+        num_channels_latents,
+        height,
+        width,
+        dtype,
+        device,
+        generator,
+        latents=None,
+    ):
+        if latents is not None:
+            return latents.to(device=device, dtype=dtype)
+
+        shape = (
+            batch_size,
+            num_channels_latents,
+            int(height) // self.vae_scale_factor,
+            int(width) // self.vae_scale_factor,
+        )
+
+        if isinstance(generator, list) and len(generator) != batch_size:
+            raise ValueError(
+                f"You have passed a list of generators of length {len(generator)}, but requested an effective batch"
+                f" size of {batch_size}. Make sure the batch size matches the length of the generators."
+            )
+
+        latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
+
+        return latents
+
+    # Copied from diffusers.pipelines.stable_diffusion_xl.pipeline_stable_diffusion_xl.StableDiffusionXLPipeline.upcast_vae
+    def upcast_vae(self):
+        dtype = self.vae.dtype
+        self.vae.to(dtype=torch.float32)
+        use_torch_2_0_or_xformers = isinstance(
+            self.vae.decoder.mid_block.attentions[0].processor,
+            (
+                AttnProcessor2_0,
+                XFormersAttnProcessor,
+                FusedAttnProcessor2_0,
+            ),
+        )
+        # if xformers or torch_2_0 is used attention block does not need
+        # to be in float32 which can save lots of memory
+        if use_torch_2_0_or_xformers:
+            self.vae.post_quant_conv.to(dtype)
+            self.vae.decoder.conv_in.to(dtype)
+            self.vae.decoder.mid_block.to(dtype)
+
+    @torch.no_grad()
+    def __call__(
+        self,
+        prompt: Union[str, List[str]] = None,
+        negative_prompt: str = "This is watermark, jpeg image white background, web image",
+        num_inference_steps: int = 50,
+        timesteps: List[int] = None,
+        sigmas: List[float] = None,
+        guidance_scale: float = 3.5,
+        num_images_per_prompt: Optional[int] = 1,
+        height: Optional[int] = 512,
+        width: Optional[int] = 512,
+        generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
+        latents: Optional[torch.Tensor] = None,
+        prompt_embeds: Optional[torch.Tensor] = None,
+        prompt_attention_mask: Optional[torch.Tensor] = None,
+        negative_prompt_embeds: Optional[torch.Tensor] = None,
+        negative_prompt_attention_mask: Optional[torch.Tensor] = None,
+        output_type: Optional[str] = "pil",
+        return_dict: bool = True,
+        callback: Optional[Callable[[int, int, torch.Tensor], None]] = None,
+        callback_steps: int = 1,
+        max_sequence_length: int = 256,
+    ) -> Union[ImagePipelineOutput, Tuple]:
+        # 1. Check inputs. Raise error if not correct
+        height = height or self.transformer.config.sample_size * self.vae_scale_factor
+        width = width or self.transformer.config.sample_size * self.vae_scale_factor
+
+        self.check_inputs(
+            prompt,
+            height,
+            width,
+            negative_prompt,
+            callback_steps,
+            prompt_embeds,
+            negative_prompt_embeds,
+            prompt_attention_mask,
+            negative_prompt_attention_mask,
+        )
+
+        # 2. Determine batch size.
+        if prompt is not None and isinstance(prompt, str):
+            batch_size = 1
+        elif prompt is not None and isinstance(prompt, list):
+            batch_size = len(prompt)
+        else:
+            batch_size = prompt_embeds.shape[0]
+
+        device = self._execution_device
+
+        # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
+        # of the Imagen paper: https://arxiv.org/pdf/2205.11487.pdf . `guidance_scale = 1`
+        # corresponds to doing no classifier free guidance.
+        do_classifier_free_guidance = guidance_scale > 1.0
+
+        # 3. Encode input prompt
+        (
+            prompt_embeds,
+            prompt_attention_mask,
+            negative_prompt_embeds,
+            negative_prompt_attention_mask,
+        ) = self.encode_prompt(
+            prompt,
+            do_classifier_free_guidance,
+            negative_prompt=negative_prompt,
+            num_images_per_prompt=num_images_per_prompt,
+            device=device,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            prompt_attention_mask=prompt_attention_mask,
+            negative_prompt_attention_mask=negative_prompt_attention_mask,
+            max_sequence_length=max_sequence_length,
+        )
+        if do_classifier_free_guidance:
+            prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
+
+        # 4. Prepare timesteps
+        timesteps, num_inference_steps = retrieve_timesteps(
+            self.scheduler, num_inference_steps, device, timesteps, sigmas
+        )
+
+        # 5. Prepare latents.
+        latent_channels = self.transformer.config.in_channels
+        effective_batch_size = batch_size * num_images_per_prompt
+        latents = self.prepare_latents(
+            batch_size * num_images_per_prompt,
+            latent_channels,
+            height,
+            width,
+            prompt_embeds.dtype,
+            device,
+            generator,
+            latents,
+        )
+
+        # 6. Denoising loop
+        num_warmup_steps = max(
+            len(timesteps) - num_inference_steps * self.scheduler.order, 0
+        )
+        dt = 1.0 / num_inference_steps
+        dt = (
+            torch.tensor([dt] * effective_batch_size)
+            .to(self.device)
+            .view([effective_batch_size, *([1] * len(latents.shape[1:]))])
+        )
+        with self.progress_bar(total=num_inference_steps) as progress_bar:
+            for i, t in enumerate(range(num_inference_steps, 0, -1)):
+                # expand the latents if we are doing classifier free guidance
+                latent_model_input = (
+                    torch.cat([latents] * 2) if do_classifier_free_guidance else latents
+                )
+                # broadcast to batch dimension in a way that's compatible with ONNX/Core ML
+                t = t / num_inference_steps
+                timestep = (
+                    torch.tensor([t])
+                    .expand(latent_model_input.shape[0])
+                    .to(latents.device, dtype=latents.dtype)
+                )
+
+                # predict noise model_output
+                noise_pred = self.transformer(
+                    latent_model_input,
+                    encoder_hidden_states=prompt_embeds,
+                    timestep=timestep,
+                    return_dict=False,
+                )[0]
+
+                # perform guidance
+                if do_classifier_free_guidance:
+                    noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+                    noise_pred = noise_pred_uncond + guidance_scale * (
+                        noise_pred_text - noise_pred_uncond
+                    )
+
+                # compute the previous noisy sample x_t -> x_t-1
+                latents = (latents - dt * noise_pred).to(latents.dtype)
+
+                # call the callback, if provided
+                if i == len(timesteps) - 1 or (
+                    (i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0
+                ):
+                    progress_bar.update()
+                    if callback is not None and i % callback_steps == 0:
+                        step_idx = i // getattr(self.scheduler, "order", 1)
+                        callback(step_idx, t, latents)
+
+        if output_type == "latent":
+            image = latents
+        else:
+            # make sure the VAE is in float32 mode, as it overflows in float16
+            needs_upcasting = (
+                self.vae.dtype == torch.float16 and self.vae.config.force_upcast
+            )
+            if needs_upcasting:
+                self.upcast_vae()
+                latents = latents.to(
+                    next(iter(self.vae.post_quant_conv.parameters())).dtype
+                )
+            image = self.vae.decode(
+                latents / self.vae.config.scaling_factor, return_dict=False
+            )[0]
+            image = self.image_processor.postprocess(image, output_type=output_type)
+
+        # Offload all models
+        self.maybe_free_model_hooks()
+
+        if not return_dict:
+            return (image,)
+
+        return ImagePipelineOutput(images=image)

--- a/helpers/aura_diffusion/pipeline.py
+++ b/helpers/aura_diffusion/pipeline.py
@@ -241,9 +241,8 @@ class AuraFlowPipeline(DiffusionPipeline):
                 Pre-generated negative text embeddings.
             max_sequence_length (`int`, defaults to 256): Maximum sequence length to use for the prompt.
         """
-        if device is None:
-            device = self._execution_device
-
+        device = self.transformer.device
+        dtype = self.transformer.dtype
         if prompt is not None and isinstance(prompt, str):
             batch_size = 1
         elif prompt is not None and isinstance(prompt, list):
@@ -251,47 +250,7 @@ class AuraFlowPipeline(DiffusionPipeline):
         else:
             batch_size = prompt_embeds.shape[0]
 
-        max_length = max_sequence_length
-        if prompt_embeds is None:
-            text_inputs = self.tokenizer(
-                prompt,
-                truncation=True,
-                max_length=max_length,
-                padding="max_length",
-                return_tensors="pt",
-            )
-            text_inputs = {k: v.to(device) for k, v in text_inputs.items()}
-            text_input_ids = text_inputs["input_ids"]
-            untruncated_ids = self.tokenizer(
-                prompt, padding="longest", return_tensors="pt"
-            ).input_ids
-
-            if untruncated_ids.shape[-1] >= text_input_ids.shape[
-                -1
-            ] and not torch.equal(text_input_ids, untruncated_ids):
-                removed_text = self.tokenizer.batch_decode(
-                    untruncated_ids[:, max_length - 1 : -1]
-                )
-                logger.warning(
-                    "The following part of your input was truncated because T5 can only handle sequences up to"
-                    f" {max_length} tokens: {removed_text}"
-                )
-
-            prompt_embeds = self.text_encoder(**text_inputs)[0]
-            prompt_attention_mask = (
-                text_inputs["attention_mask"].unsqueeze(-1).expand(prompt_embeds.shape)
-            )
-            prompt_embeds = prompt_embeds * prompt_attention_mask
-
-        if self.text_encoder is not None:
-            dtype = self.text_encoder.dtype
-        elif self.transformer is not None:
-            dtype = self.transformer.dtype
-        else:
-            dtype = None
-
         prompt_embeds = prompt_embeds.to(dtype=dtype, device=device)
-
         bs_embed, seq_len, _ = prompt_embeds.shape
         # duplicate text embeddings and attention mask for each generation per prompt, using mps friendly method
         prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
@@ -300,32 +259,6 @@ class AuraFlowPipeline(DiffusionPipeline):
         )
         prompt_attention_mask = prompt_attention_mask.reshape(bs_embed, -1)
         prompt_attention_mask = prompt_attention_mask.repeat(num_images_per_prompt, 1)
-
-        # get unconditional embeddings for classifier free guidance
-        if do_classifier_free_guidance and negative_prompt_embeds is None:
-            uncond_tokens = (
-                [negative_prompt] * batch_size
-                if isinstance(negative_prompt, str)
-                else negative_prompt
-            )
-            max_length = prompt_embeds.shape[1]
-            uncond_input = self.tokenizer(
-                uncond_tokens,
-                truncation=True,
-                max_length=max_length,
-                padding="max_length",
-                return_tensors="pt",
-            )
-            uncond_input = {k: v.to(device) for k, v in uncond_input.items()}
-            negative_prompt_embeds = self.text_encoder(**uncond_input)[0]
-            negative_prompt_attention_mask = (
-                uncond_input["attention_mask"]
-                .unsqueeze(-1)
-                .expand(negative_prompt_embeds.shape)
-            )
-            negative_prompt_embeds = (
-                negative_prompt_embeds * negative_prompt_attention_mask
-            )
 
         if do_classifier_free_guidance:
             # duplicate unconditional embeddings for each generation per prompt, using mps friendly method
@@ -414,7 +347,7 @@ class AuraFlowPipeline(DiffusionPipeline):
     def __call__(
         self,
         prompt: Union[str, List[str]] = None,
-        negative_prompt: str = "This is watermark, jpeg image white background, web image",
+        negative_prompt: str = "",
         num_inference_steps: int = 50,
         timesteps: List[int] = None,
         sigmas: List[float] = None,

--- a/helpers/aura_diffusion/pipeline.py
+++ b/helpers/aura_diffusion/pipeline.py
@@ -569,7 +569,9 @@ class AuraFlowPipeline(DiffusionPipeline):
                     next(iter(self.vae.post_quant_conv.parameters())).dtype
                 )
             image = self.vae.decode(
-                latents / self.vae.config.scaling_factor, return_dict=False
+                latents.to(device=self.vae.device, dtype=self.vae.dtype)
+                / self.vae.config.scaling_factor,
+                return_dict=False,
             )[0]
             image = self.image_processor.postprocess(image, output_type=output_type)
 

--- a/helpers/caching/sdxl_embeds.py
+++ b/helpers/caching/sdxl_embeds.py
@@ -711,6 +711,8 @@ class TextEmbeddingCache:
                 filename = os.path.join(self.cache_dir, self.hash_prompt(prompt))
                 if prompt != "":
                     prompt = PromptHandler.filter_caption(self.data_backend, prompt)
+                if prompt is None:
+                    continue
 
                 if return_concat and load_from_cache:
                     try:
@@ -756,7 +758,9 @@ class TextEmbeddingCache:
                         prompt_embeds, attention_mask = self.compute_t5_prompt(prompt)
                         if "deepfloyd" not in StateTracker.get_args().model_type:
                             # we have to store the attn mask with the embed for pixart.
-                            # does aura diffusion require the attn mask be available? oh well.
+                            # aura doesn't require it, but it's just easier to keep.
+                            if self.model_type == "aura_diffusion":
+                                prompt_embeds = prompt_embeds.squeeze(0)
                             prompt_embeds = (prompt_embeds, attention_mask)
                     else:
                         prompt_embeds = self.encode_legacy_prompt(

--- a/helpers/caching/sdxl_embeds.py
+++ b/helpers/caching/sdxl_embeds.py
@@ -414,7 +414,9 @@ class TextEmbeddingCache:
 
         return text_inputs
 
-    def encode_t5_prompt(self, input_ids, attention_mask, apply_attn_mask: bool = False):
+    def encode_t5_prompt(
+        self, input_ids, attention_mask, apply_attn_mask: bool = False
+    ):
         text_input_ids = input_ids.to(self.text_encoders[0].device)
         attention_mask = attention_mask.to(self.text_encoders[0].device)
         prompt_embeds = self.text_encoders[0](
@@ -424,8 +426,8 @@ class TextEmbeddingCache:
         )[0]
         if apply_attn_mask:
             # then we'll mangle the attention mask to be a bit more useful.
-            prompt_attention_mask = (
-                attention_mask.unsqueeze(-1).expand(prompt_embeds.shape)
+            prompt_attention_mask = attention_mask.unsqueeze(-1).expand(
+                prompt_embeds.shape
             )
             prompt_embeds = prompt_embeds * prompt_attention_mask
         prompt_embeds = prompt_embeds.to("cpu")
@@ -438,7 +440,7 @@ class TextEmbeddingCache:
 
         Args:
             prompt: The prompt to encode.
-            apply_attn_mask: Whether to apply the attention mask to the embeddings. This is required for Aura Diffusion, and might also improve disk space efficiency.
+            apply_attn_mask: Whether to apply the attention mask to the embeddings. This is required for AuraFlow, and might also improve disk space efficiency.
         Returns:
             Tuple of (prompt_embeds, attention_mask)
         """
@@ -449,7 +451,7 @@ class TextEmbeddingCache:
         result = self.encode_t5_prompt(
             text_inputs.input_ids,
             text_inputs.attention_mask,
-            apply_attn_mask=apply_attn_mask
+            apply_attn_mask=apply_attn_mask,
         )
         attn_mask = text_inputs.attention_mask
         del text_inputs
@@ -515,7 +517,7 @@ class TextEmbeddingCache:
         elif (
             self.model_type == "legacy"
             or self.model_type == "pixart_sigma"
-            or self.model_type == "aura_diffusion"
+            or self.model_type == "aura_flow"
         ):
             # both sd1.x/2.x and t5 style models like pixart use this flow.
             output = self.compute_embeddings_for_legacy_prompts(
@@ -768,12 +770,14 @@ class TextEmbeddingCache:
                     if (
                         "deepfloyd" in StateTracker.get_args().model_type
                         or self.model_type == "pixart_sigma"
-                        or self.model_type == "aura_diffusion"
+                        or self.model_type == "aura_flow"
                     ):
                         # TODO: Batch this
                         prompt_embeds, attention_mask = self.compute_t5_prompt(
                             prompt=prompt,
-                            apply_attn_mask=True if self.model_type == "aura_diffusion" else False,
+                            apply_attn_mask=(
+                                True if self.model_type == "aura_flow" else False
+                            ),
                         )
                         if "deepfloyd" not in StateTracker.get_args().model_type:
                             # we have to store the attn mask with the embed for pixart.

--- a/helpers/caching/sdxl_embeds.py
+++ b/helpers/caching/sdxl_embeds.py
@@ -749,13 +749,14 @@ class TextEmbeddingCache:
                             time.sleep(5)
                     if (
                         "deepfloyd" in StateTracker.get_args().model_type
-                        or StateTracker.get_model_type() == "pixart_sigma"
-                        or StateTracker.get_model_type() == "aura_diffusion"
+                        or self.model_type == "pixart_sigma"
+                        or self.model_type == "aura_diffusion"
                     ):
                         # TODO: Batch this
                         prompt_embeds, attention_mask = self.compute_t5_prompt(prompt)
-                        if self.model_type == "pixart_sigma":
+                        if "deepfloyd" not in StateTracker.get_args().model_type:
                             # we have to store the attn mask with the embed for pixart.
+                            # does aura diffusion require the attn mask be available? oh well.
                             prompt_embeds = (prompt_embeds, attention_mask)
                     else:
                         prompt_embeds = self.encode_legacy_prompt(

--- a/helpers/caching/sdxl_embeds.py
+++ b/helpers/caching/sdxl_embeds.py
@@ -496,7 +496,11 @@ class TextEmbeddingCache:
                 is_validation=is_validation,
                 load_from_cache=load_from_cache,
             )
-        elif self.model_type == "legacy" or self.model_type == "pixart_sigma":
+        elif (
+            self.model_type == "legacy"
+            or self.model_type == "pixart_sigma"
+            or self.model_type == "aura_diffusion"
+        ):
             # both sd1.x/2.x and t5 style models like pixart use this flow.
             output = self.compute_embeddings_for_legacy_prompts(
                 raw_prompts,
@@ -746,6 +750,7 @@ class TextEmbeddingCache:
                     if (
                         "deepfloyd" in StateTracker.get_args().model_type
                         or StateTracker.get_model_type() == "pixart_sigma"
+                        or StateTracker.get_model_type() == "aura_diffusion"
                     ):
                         # TODO: Batch this
                         prompt_embeds, attention_mask = self.compute_t5_prompt(prompt)

--- a/helpers/data_backend/aws.py
+++ b/helpers/data_backend/aws.py
@@ -303,6 +303,8 @@ class S3DataBackend(BaseDataBackend):
                         logger.error(
                             f"Failed to decompress torch file, falling back to passthrough: {e}"
                         )
+                if hasattr(stored_tensor, "seek"):
+                    stored_tensor.seek(0)
 
                 obj = torch.load(stored_tensor, map_location="cpu")
                 # logger.debug(f"torch.load found: {obj}")

--- a/helpers/data_backend/local.py
+++ b/helpers/data_backend/local.py
@@ -177,11 +177,12 @@ class LocalDataBackend(BaseDataBackend):
         if self.compress_cache:
             try:
                 stored_tensor = self._decompress_torch(stored_tensor)
-                stored_tensor.seek(0)
             except Exception as e:
                 logger.error(
                     f"Failed to decompress torch file, falling back to passthrough: {e}"
                 )
+        if hasattr(stored_tensor, "seek"):
+            stored_tensor.seek(0)
         try:
             loaded_tensor = torch.load(stored_tensor, map_location="cpu")
         except Exception as e:

--- a/helpers/legacy/validation.py
+++ b/helpers/legacy/validation.py
@@ -205,7 +205,7 @@ def prepare_validation_prompt_list(args, embed_cache):
                 validation_shortnames,
                 validation_negative_prompt_embeds,
             )
-        elif model_type == "pixart_sigma":
+        elif model_type == "pixart_sigma" or model_type == "aura_diffusion":
             # we use the legacy encoder but we return no pooled embeds.
             validation_negative_prompt_embeds = (
                 embed_cache.compute_embeddings_for_prompts(
@@ -219,10 +219,6 @@ def prepare_validation_prompt_list(args, embed_cache):
                 validation_shortnames,
                 validation_negative_prompt_embeds,
                 None,
-            )
-        elif model_type == "aura_diffusion":
-            raise NotImplementedError(
-                "Aura Diffusion validation prompt preparation is not yet implemented."
             )
         else:
             raise ValueError(f"Unknown model type '{model_type}'")

--- a/helpers/legacy/validation.py
+++ b/helpers/legacy/validation.py
@@ -205,7 +205,7 @@ def prepare_validation_prompt_list(args, embed_cache):
                 validation_shortnames,
                 validation_negative_prompt_embeds,
             )
-        elif model_type == "pixart_sigma" or model_type == "aura_diffusion":
+        elif model_type == "pixart_sigma" or model_type == "aura_flow":
             # we use the legacy encoder but we return no pooled embeds.
             validation_negative_prompt_embeds = (
                 embed_cache.compute_embeddings_for_prompts(

--- a/helpers/legacy/validation.py
+++ b/helpers/legacy/validation.py
@@ -220,6 +220,10 @@ def prepare_validation_prompt_list(args, embed_cache):
                 validation_negative_prompt_embeds,
                 None,
             )
+        elif model_type == "aura_diffusion":
+            raise NotImplementedError(
+                "Aura Diffusion validation prompt preparation is not yet implemented."
+            )
         else:
             raise ValueError(f"Unknown model type '{model_type}'")
 

--- a/helpers/sdxl/save_hooks.py
+++ b/helpers/sdxl/save_hooks.py
@@ -122,8 +122,6 @@ class SDXLSaveHook:
                 self.ema_model_cls = SD3Transformer2DModel
             elif self.args.pixart_sigma:
                 self.ema_model_cls = PixArtTransformer2DModel
-            elif self.args.hunyuan_dit:
-                self.ema_model_cls = HunyuanDiT2DModel
             elif self.args.aura_diffusion:
                 self.ema_model_cls = AuraFlowTransformer2DModel
 

--- a/helpers/sdxl/save_hooks.py
+++ b/helpers/sdxl/save_hooks.py
@@ -41,10 +41,10 @@ except Exception as e:
     raise e
 
 try:
-    from diffusers.models import AuraMMDiT2DModel
+    from diffusers.models import AuraFlowTransformer2DModel
 except Exception as e:
     logger.error(
-        f"Can not load AuraMMDiT2DModel class. This release requires the latest version of Diffusers: {e}"
+        f"Can not load AuraFlowTransformer2DModel class. This release requires the latest version of Diffusers: {e}"
     )
     raise e
 
@@ -125,7 +125,7 @@ class SDXLSaveHook:
             elif self.args.hunyuan_dit:
                 self.ema_model_cls = HunyuanDiT2DModel
             elif self.args.aura_diffusion:
-                self.ema_model_cls = AuraMMDiT2DModel
+                self.ema_model_cls = AuraFlowTransformer2DModel
 
     def _save_lora(self, models, weights, output_dir):
         # for SDXL/others, there are only two options here. Either are just the unet attn processor layers
@@ -383,7 +383,7 @@ class SDXLSaveHook:
                             input_dir, subfolder="transformer"
                         )
                     elif self.args.aura_diffusion:
-                        load_model = AuraMMDiT2DModel.from_pretrained(
+                        load_model = AuraFlowTransformer2DModel.from_pretrained(
                             input_dir, subfolder="transformer"
                         )
                     elif self.unet is not None:

--- a/helpers/sdxl/save_hooks.py
+++ b/helpers/sdxl/save_hooks.py
@@ -376,7 +376,7 @@ class SDXLSaveHook:
                         load_model = PixArtTransformer2DModel.from_pretrained(
                             input_dir, subfolder="transformer"
                         )
-                    elif self.args.hunyuan_dit:
+                    elif hasattr(self.args, "hunyuan_dit") and self.args.hunyuan_dit:
                         load_model = HunyuanDiT2DModel.from_pretrained(
                             input_dir, subfolder="transformer"
                         )

--- a/helpers/sdxl/save_hooks.py
+++ b/helpers/sdxl/save_hooks.py
@@ -122,7 +122,7 @@ class SDXLSaveHook:
                 self.ema_model_cls = SD3Transformer2DModel
             elif self.args.pixart_sigma:
                 self.ema_model_cls = PixArtTransformer2DModel
-            elif self.args.aura_diffusion:
+            elif self.args.aura_flow:
                 self.ema_model_cls = AuraFlowTransformer2DModel
 
     def _save_lora(self, models, weights, output_dir):
@@ -380,7 +380,7 @@ class SDXLSaveHook:
                         load_model = HunyuanDiT2DModel.from_pretrained(
                             input_dir, subfolder="transformer"
                         )
-                    elif self.args.aura_diffusion:
+                    elif self.args.aura_flow:
                         load_model = AuraFlowTransformer2DModel.from_pretrained(
                             input_dir, subfolder="transformer"
                         )

--- a/helpers/sdxl/save_hooks.py
+++ b/helpers/sdxl/save_hooks.py
@@ -44,7 +44,7 @@ try:
     from diffusers.models import AuraMMDiT2DModel
 except Exception as e:
     logger.error(
-        f"Can not load Hunyuan DiT model class. This release requires the latest version of Diffusers: {e}"
+        f"Can not load AuraMMDiT2DModel class. This release requires the latest version of Diffusers: {e}"
     )
     raise e
 

--- a/helpers/training/collate.py
+++ b/helpers/training/collate.py
@@ -426,12 +426,7 @@ def collate_fn(batch):
         )
         attn_mask = add_text_embeds_all
     elif StateTracker.get_model_type() == "aura_diffusion":
-        debug_log(
-            "Reached the collate_fn portion for computing microcondition inputs for the model."
-        )
-        raise NotImplementedError(
-            "Aura Diffusion microconditioning inputs are not yet implemented."
-        )
+        attn_mask = add_text_embeds_all
 
     return {
         "latent_batch": latent_batch,

--- a/helpers/training/collate.py
+++ b/helpers/training/collate.py
@@ -245,6 +245,9 @@ def compute_prompt_embeddings(captions, text_embed_cache):
         for embed in embeddings:
             prompt_embeds.append(embed[0][0])
             attn_masks.append(embed[1][0])
+        if len(prompt_embeds[0].shape) == 3:
+            # some tensors are already expanded due to the way they were saved
+            prompt_embeds = [t.squeeze(0) for t in prompt_embeds]
         return (torch.stack(prompt_embeds), torch.stack(attn_masks))
     else:
         # Separate the tuples

--- a/helpers/training/collate.py
+++ b/helpers/training/collate.py
@@ -183,7 +183,7 @@ def compute_single_embedding(caption, text_embed_cache, is_sdxl, is_sd3: bool = 
         if type(prompt_embeds) == tuple:
             if (
                 StateTracker.get_args().pixart_sigma
-                or StateTracker.get_args().aura_diffusion
+                or StateTracker.get_args().aura_flow
             ):
                 # PixArt requires the attn mask be returned, too.
                 prompt_embeds, attn_mask = prompt_embeds
@@ -213,7 +213,7 @@ def compute_prompt_embeddings(captions, text_embed_cache):
     is_sdxl = text_embed_cache.model_type == "sdxl"
     is_sd3 = text_embed_cache.model_type == "sd3"
     is_pixart_sigma = text_embed_cache.model_type == "pixart_sigma"
-    is_aura_diffusion = text_embed_cache.model_type == "aura_diffusion"
+    is_aura_flow = text_embed_cache.model_type == "aura_flow"
 
     # Use a thread pool to compute embeddings concurrently
     with ThreadPoolExecutor() as executor:
@@ -238,9 +238,9 @@ def compute_prompt_embeddings(captions, text_embed_cache):
         prompt_embeds = [t[0] for t in embeddings]
         add_text_embeds = [t[1] for t in embeddings]
         return (torch.stack(prompt_embeds), torch.stack(add_text_embeds))
-    elif is_pixart_sigma or is_aura_diffusion:
+    elif is_pixart_sigma or is_aura_flow:
         # the tuples here are the text encoder hidden states and the attention masks
-        # TODO: determine whether aura diffusion requires these conjoined
+        # TODO: determine whether AuraFlow requires these conjoined
         prompt_embeds, attn_masks = [], []
         for embed in embeddings:
             prompt_embeds.append(embed[0][0])
@@ -428,7 +428,7 @@ def collate_fn(batch):
             examples, latent_batch, StateTracker.get_weight_dtype()
         )
         attn_mask = add_text_embeds_all
-    elif StateTracker.get_model_type() == "aura_diffusion":
+    elif StateTracker.get_model_type() == "aura_flow":
         attn_mask = add_text_embeds_all
 
     return {

--- a/helpers/training/collate.py
+++ b/helpers/training/collate.py
@@ -181,7 +181,10 @@ def compute_single_embedding(caption, text_embed_cache, is_sdxl, is_sd3: bool = 
             [caption]
         )
         if type(prompt_embeds) == tuple:
-            if StateTracker.get_args().pixart_sigma:
+            if (
+                StateTracker.get_args().pixart_sigma
+                or StateTracker.get_args().aura_diffusion
+            ):
                 # PixArt requires the attn mask be returned, too.
                 prompt_embeds, attn_mask = prompt_embeds
 
@@ -210,6 +213,7 @@ def compute_prompt_embeddings(captions, text_embed_cache):
     is_sdxl = text_embed_cache.model_type == "sdxl"
     is_sd3 = text_embed_cache.model_type == "sd3"
     is_pixart_sigma = text_embed_cache.model_type == "pixart_sigma"
+    is_aura_diffusion = text_embed_cache.model_type == "aura_diffusion"
 
     # Use a thread pool to compute embeddings concurrently
     with ThreadPoolExecutor() as executor:
@@ -234,8 +238,9 @@ def compute_prompt_embeddings(captions, text_embed_cache):
         prompt_embeds = [t[0] for t in embeddings]
         add_text_embeds = [t[1] for t in embeddings]
         return (torch.stack(prompt_embeds), torch.stack(add_text_embeds))
-    elif is_pixart_sigma:
+    elif is_pixart_sigma or is_aura_diffusion:
         # the tuples here are the text encoder hidden states and the attention masks
+        # TODO: determine whether aura diffusion requires these conjoined
         prompt_embeds, attn_masks = [], []
         for embed in embeddings:
             prompt_embeds.append(embed[0][0])
@@ -420,6 +425,13 @@ def collate_fn(batch):
             examples, latent_batch, StateTracker.get_weight_dtype()
         )
         attn_mask = add_text_embeds_all
+    elif StateTracker.get_model_type() == "aura_diffusion":
+        debug_log(
+            "Reached the collate_fn portion for computing microcondition inputs for the model."
+        )
+        raise NotImplementedError(
+            "Aura Diffusion microconditioning inputs are not yet implemented."
+        )
 
     return {
         "latent_batch": latent_batch,

--- a/helpers/training/state_tracker.py
+++ b/helpers/training/state_tracker.py
@@ -95,7 +95,13 @@ class StateTracker:
 
     @classmethod
     def set_model_type(cls, model_type: str):
-        if model_type not in ["legacy", "sdxl", "sd3", "pixart_sigma"]:
+        if model_type not in [
+            "legacy",
+            "sdxl",
+            "sd3",
+            "pixart_sigma",
+            "aura_diffusion",
+        ]:
             raise ValueError(f"Unknown model type: {model_type}")
         cls.model_type = model_type
 

--- a/helpers/training/state_tracker.py
+++ b/helpers/training/state_tracker.py
@@ -100,7 +100,7 @@ class StateTracker:
             "sdxl",
             "sd3",
             "pixart_sigma",
-            "aura_diffusion",
+            "aura_flow",
         ]:
             raise ValueError(f"Unknown model type: {model_type}")
         cls.model_type = model_type

--- a/helpers/training/validation.py
+++ b/helpers/training/validation.py
@@ -162,7 +162,7 @@ class Validation:
         self.tokenizer_3 = tokenizer_3
         self.flow_matching = (
             self.args.sd3 and not self.args.sd3_uses_diffusion
-        ) or self.args.aura_diffusion
+        ) or self.args.aura_flow
 
         self._update_state()
 
@@ -269,22 +269,22 @@ class Validation:
             from helpers.pixart.pipeline import PixArtSigmaPipeline
 
             return PixArtSigmaPipeline
-        elif model_type == "aura_diffusion":
+        elif model_type == "aura_flow":
             if self.args.controlnet:
                 raise Exception(
-                    "Aura Diffusion ControlNet inference validation is not yet supported."
+                    "AuraFlow ControlNet inference validation is not yet supported."
                 )
             if self.args.validation_using_datasets:
                 raise Exception(
-                    "Aura Diffusion inference validation using img2img is not yet supported. Please remove --validation_using_datasets."
+                    "AuraFlow inference validation using img2img is not yet supported. Please remove --validation_using_datasets."
                 )
             try:
-                from helpers.aura_diffusion.pipeline import AuraFlowPipeline
+                from helpers.aura_flow.pipeline import AuraFlowPipeline
             except Exception as e:
                 logger.error(
-                    f"Could not import Aura Diffusion pipeline. Perhaps you need a git-source version of Diffusers."
+                    f"Could not import AuraFlow pipeline. Perhaps you need a git-source version of Diffusers."
                 )
-                raise NotImplementedError("Aura Diffusion pipeline not available.")
+                raise NotImplementedError("AuraFlow pipeline not available.")
 
             return AuraFlowPipeline
 
@@ -337,14 +337,14 @@ class Validation:
         elif (
             StateTracker.get_model_type() == "legacy"
             or StateTracker.get_model_type() == "pixart_sigma"
-            or StateTracker.get_model_type() == "aura_diffusion"
+            or StateTracker.get_model_type() == "aura_flow"
         ):
             self.validation_negative_pooled_embeds = None
             current_validation_pooled_embeds = None
             current_validation_prompt_embeds = (
                 self.embed_cache.compute_embeddings_for_prompts([validation_prompt])
             )
-            if self.args.pixart_sigma or self.args.aura_diffusion:
+            if self.args.pixart_sigma or self.args.aura_flow:
                 current_validation_prompt_embeds, current_validation_prompt_mask = (
                     current_validation_prompt_embeds
                 )
@@ -416,7 +416,7 @@ class Validation:
         prompt_embeds["negative_prompt_embeds"] = self.validation_negative_prompt_embeds
         if (
             StateTracker.get_model_type() == "pixart_sigma"
-            or StateTracker.get_model_type() == "aura_diffusion"
+            or StateTracker.get_model_type() == "aura_flow"
         ):
             prompt_embeds["prompt_mask"] = current_validation_prompt_mask
             prompt_embeds["negative_mask"] = self.validation_negative_prompt_mask
@@ -560,7 +560,7 @@ class Validation:
                     extra_pipeline_kwargs["text_encoder_2"] = None
                     extra_pipeline_kwargs["tokenizer_2"] = None
 
-            if self.args.aura_diffusion:
+            if self.args.aura_flow:
                 extra_pipeline_kwargs["tokenizer"] = None
                 extra_pipeline_kwargs["text_encoder"] = None
 
@@ -792,7 +792,7 @@ class Validation:
                         logger.debug(f"Device for {key}: {value.device}")
                 if (
                     StateTracker.get_model_type() == "pixart_sigma"
-                    or StateTracker.get_model_type() == "aura_diffusion"
+                    or StateTracker.get_model_type() == "aura_flow"
                 ):
                     if pipeline_kwargs.get("negative_prompt") is not None:
                         del pipeline_kwargs["negative_prompt"]

--- a/helpers/training/validation.py
+++ b/helpers/training/validation.py
@@ -276,14 +276,14 @@ class Validation:
                     "Aura Diffusion inference validation using img2img is not yet supported. Please remove --validation_using_datasets."
                 )
             try:
-                from helpers.aura_diffusion.pipeline import AuraDiffusionPipeline
+                from helpers.aura_diffusion.pipeline import AuraFlowPipeline
             except Exception as e:
                 logger.error(
                     f"Could not import Aura Diffusion pipeline. Perhaps you need a git-source version of Diffusers."
                 )
                 raise NotImplementedError("Aura Diffusion pipeline not available.")
 
-            return AuraDiffusionPipeline
+            return AuraFlowPipeline
 
     def _gather_prompt_embeds(self, validation_prompt: str):
         prompt_embeds = {}

--- a/helpers/training/validation.py
+++ b/helpers/training/validation.py
@@ -73,20 +73,18 @@ def parse_validation_resolution(input_str: str) -> tuple:
      - if it has an x in it, we will split and treat as WIDTHxHEIGHT
      - if it has comma, we will split and treat each value as above
     """
+    is_df_ii = (
+        True if "deepfloyd-stage2" in StateTracker.get_args().model_type else False
+    )
     if isinstance(input_str, int) or input_str.isdigit():
-        if (
-            "deepfloyd-stage2" in StateTracker.get_args().model_type
-            and int(input_str) < 256
-        ):
+        if is_df_ii and int(input_str) < 256:
             raise ValueError(
                 "Cannot use less than 256 resolution for DeepFloyd stage 2."
             )
         return (input_str, input_str)
     if "x" in input_str:
         pieces = input_str.split("x")
-        if "deepfloyd-stage2" in StateTracker.get_args().model_type and (
-            int(pieces[0]) < 256 or int(pieces[1]) < 256
-        ):
+        if is_df_ii and (int(pieces[0]) < 256 or int(pieces[1]) < 256):
             raise ValueError(
                 "Cannot use less than 256 resolution for DeepFloyd stage 2."
             )
@@ -152,14 +150,19 @@ class Validation:
         self.ema_model = ema_model
         self.vae = vae
         self.pipeline = None
+        self.deepfloyd = True if "deepfloyd" in self.args.model_type else False
+        self.deepfloyd_stage2 = (
+            True if "deepfloyd-stage2" in self.args.model_type else False
+        )
         self._discover_validation_input_samples()
         self.validation_resolutions = (
-            get_validation_resolutions()
-            if "deepfloyd-stage2" not in args.model_type
-            else ["base-256"]
+            get_validation_resolutions() if not self.deepfloyd_stage2 else ["base-256"]
         )
         self.text_encoder_3 = text_encoder_3
         self.tokenizer_3 = tokenizer_3
+        self.flow_matching = (
+            self.args.sd3 and not self.args.sd3_uses_diffusion
+        ) or self.args.aura_diffusion
 
         self._update_state()
 
@@ -221,7 +224,7 @@ class Validation:
         """
         self.validation_image_inputs = None
         if (
-            "deepfloyd-stage2" in self.args.model_type
+            self.deepfloyd_stage2
             or self.args.validation_using_datasets
             or self.args.controlnet
         ):
@@ -243,7 +246,7 @@ class Validation:
                 return StableDiffusionXLImg2ImgPipeline
             return StableDiffusionXLPipeline
         elif model_type == "legacy":
-            if "deepfloyd-stage2" in self.args.model_type:
+            if self.deepfloyd_stage2:
                 from diffusers.pipelines import IFSuperResolutionPipeline
 
                 return IFSuperResolutionPipeline
@@ -365,9 +368,11 @@ class Validation:
             # )
             if (
                 self.prompt_handler is not None
-                and "deepfloyd" not in self.args.model_type
-                and "pixart" not in self.args.model_type
+                and not self.deepfloyd
+                and not self.args.pixart_sigma
+                and not self.flow_matching
             ):
+                # for SDXL and earlier SD models we optionally use Compel for prompt upweighting/long prompt parsing.
                 for text_encoder in self.prompt_handler.text_encoders:
                     if text_encoder:
                         text_encoder = text_encoder.to(
@@ -403,16 +408,12 @@ class Validation:
                 device=self.accelerator.device, dtype=self.weight_dtype
             )
         )
+        # when sampling unconditional guidance, you should only zero one or the other prompt, and not both.
+        # we'll assume that the user has a negative prompt, so that the unconditional sampling works.
+        # the positive prompt embed is zeroed out for SDXL at the time of it being placed into the cache.
+        # the embeds are not zeroed out for any other model, including Stable Diffusion 3.
         prompt_embeds["prompt_embeds"] = current_validation_prompt_embeds
         prompt_embeds["negative_prompt_embeds"] = self.validation_negative_prompt_embeds
-        # If the prompt is an empty string, zero out all of the embeds:
-        if validation_prompt == "" and "deepfloyd" not in self.args.model_type:
-            prompt_embeds = {
-                key: torch.zeros_like(value).to(
-                    device=self.accelerator.device, dtype=self.weight_dtype
-                )
-                for key, value in prompt_embeds.items()
-            }
         if (
             StateTracker.get_model_type() == "pixart_sigma"
             or StateTracker.get_model_type() == "aura_diffusion"
@@ -437,7 +438,7 @@ class Validation:
         self._update_state()
         should_validate = self.should_perform_validation(
             step, self.validation_prompts, validation_type
-        )
+        ) or (step == 0 and validation_type == "base_model")
         logger.debug(
             f"Should evaluate: {should_validate}, force evaluation: {force_evaluation}, skip execution: {skip_execution}"
         )
@@ -494,9 +495,9 @@ class Validation:
                 variance_type = "fixed_small"
 
             scheduler_args["variance_type"] = variance_type
-        if "deepfloyd" in self.args.model_type:
+        if self.deepfloyd:
             self.args.validation_noise_scheduler = "ddpm"
-        if self.args.sd3 and not self.args.sd3_uses_diffusion:
+        if self.flow_matching:
             # NO TOUCHIE FOR FLOW-MATCHING.
             # Touchie for diffusion though.
             return
@@ -558,6 +559,10 @@ class Validation:
                     extra_pipeline_kwargs["tokenizer_1"] = None
                     extra_pipeline_kwargs["text_encoder_2"] = None
                     extra_pipeline_kwargs["tokenizer_2"] = None
+
+            if self.args.aura_diffusion:
+                extra_pipeline_kwargs["tokenizer"] = None
+                extra_pipeline_kwargs["text_encoder"] = None
 
             if self.args.controlnet:
                 # ControlNet training has an additional adapter thingy.
@@ -713,7 +718,7 @@ class Validation:
                 )
             if validation_input_image is not None:
                 extra_validation_kwargs["image"] = validation_input_image
-                if "deepfloyd-stage2" in self.args.model_type:
+                if self.deepfloyd_stage2:
                     validation_resolution_width, validation_resolution_height = (
                         val * 4 for val in extra_validation_kwargs["image"].size
                     )
@@ -728,10 +733,15 @@ class Validation:
             else:
                 validation_resolution_width, validation_resolution_height = resolution
 
-            if "deepfloyd" not in self.args.model_type and not self.args.sd3:
+            if (
+                not self.deepfloyd
+                and not self.args.pixart_sigma
+                and not self.flow_matching
+            ):
                 extra_validation_kwargs["guidance_rescale"] = (
                     self.args.validation_guidance_rescale
                 )
+
             if StateTracker.get_args().validation_using_datasets:
                 extra_validation_kwargs["strength"] = getattr(
                     self.args, "validation_strength", 0.2
@@ -754,8 +764,11 @@ class Validation:
                     f"Error gathering text embed for validation prompt {prompt}: {e}, traceback: {traceback.format_exc()}"
                 )
                 continue
+
             try:
                 pipeline_kwargs = {
+                    "prompt": None,
+                    "negative_prompt": None,
                     "num_images_per_prompt": self.args.num_validation_images,
                     "num_inference_steps": self.args.validation_num_inference_steps,
                     "guidance_scale": self.args.validation_guidance,

--- a/sdxl-env.sh.example
+++ b/sdxl-env.sh.example
@@ -11,6 +11,9 @@ export STABLE_DIFFUSION_3=false
 # Similarly, this is to train PixArt Sigma (1K or 2K) models.
 # Use MODEL_NAME="PixArt-alpha/PixArt-Sigma-XL-2-1024-MS"
 export PIXART_SIGMA=false
+# Similarly, this is to train Aura Diffusion family of models.
+# Use MODEL_NAME="internal-models/aura-diffusion-400B"
+export AURA_DIFFUSION=false
 
 # ControlNet model training is only supported when MODEL_TYPE='full'
 # See this document for more information: https://github.com/bghira/SimpleTuner/blob/main/documentation/CONTROLNET.md

--- a/sdxl-env.sh.example
+++ b/sdxl-env.sh.example
@@ -11,9 +11,9 @@ export STABLE_DIFFUSION_3=false
 # Similarly, this is to train PixArt Sigma (1K or 2K) models.
 # Use MODEL_NAME="PixArt-alpha/PixArt-Sigma-XL-2-1024-MS"
 export PIXART_SIGMA=false
-# Similarly, this is to train Aura Diffusion family of models.
-# Use MODEL_NAME="internal-models/aura-diffusion-400B"
-export AURA_DIFFUSION=false
+# Similarly, this is to train AuraFlow family of models.
+# Use MODEL_NAME="auradiffusion/auradiffusion-v0.1a0"
+export AURA_FLOW=false
 
 # ControlNet model training is only supported when MODEL_TYPE='full'
 # See this document for more information: https://github.com/bghira/SimpleTuner/blob/main/documentation/CONTROLNET.md

--- a/train_sdxl.py
+++ b/train_sdxl.py
@@ -481,7 +481,7 @@ def main():
                 variant=args.variant,
             )
 
-        logger.info("Load VAE..")
+        logger.info(f"Load VAE: {vae_path}")
         vae = AutoencoderKL.from_pretrained(
             vae_path,
             subfolder="vae" if args.pretrained_vae_model_name_or_path is None else None,
@@ -1786,6 +1786,19 @@ def main():
                     elif args.aura_diffusion:
                         # Aura Diffusion also uses a MM-DiT model where the VAE-produced
                         #  image embeds are passed in with the TE-produced text embeds.
+                        # Print the dtypes/shapes:
+                        print(
+                            "Dtypes:"
+                            f" noisy_latents: {noisy_latents.dtype},"
+                            f" timesteps: {timesteps.dtype},"
+                            f" encoder_hidden_states: {encoder_hidden_states.dtype},"
+                        )
+                        print(
+                            "Shapes:"
+                            f" noisy_latents: {noisy_latents.shape},"
+                            f" timesteps: {timesteps.shape},"
+                            f" encoder_hidden_states: {encoder_hidden_states.shape},"
+                        )
                         model_pred = transformer(
                             hidden_states=noisy_latents,
                             encoder_hidden_states=encoder_hidden_states,
@@ -1845,7 +1858,9 @@ def main():
                     )
                     loss = loss.mean()
 
-                elif args.snr_gamma is None or args.snr_gamma == 0:
+                elif args.aura_diffusion or (
+                    args.snr_gamma is None or args.snr_gamma == 0
+                ):
                     training_logger.debug(f"Calculating loss")
                     loss = args.snr_weight * F.mse_loss(
                         model_pred.float(), target.float(), reduction="mean"

--- a/train_sdxl.py
+++ b/train_sdxl.py
@@ -539,10 +539,10 @@ def main():
             "Loading Aura Diffusion models is not yet implemented."
         )
 
-        # from diffusers.models import AuraTransformer2DModel
+        # from diffusers.models import AuraMMDiT2DModel
 
         # unet = None
-        # transformer = AuraTransformer2DModel.from_pretrained(
+        # transformer = AuraMMDiT2DModel.from_pretrained(
         #     args.pretrained_model_name_or_path,
         #     subfolder="transformer",
         #     **pretrained_load_args,
@@ -1109,7 +1109,7 @@ def main():
                         else (
                             PixArtTransformer2DModel
                             if args.pixart_sigma
-                            else AuraTransformer2DModel if args.aura_diffusion else None
+                            else AuraMMDiT2DModel if args.aura_diffusion else None
                         )
                     )
                 ),

--- a/train_sdxl.py
+++ b/train_sdxl.py
@@ -1709,10 +1709,6 @@ def main():
                     batch["encoder_attention_mask"] = batch[
                         "encoder_attention_mask"
                     ].to(device=accelerator.device, dtype=weight_dtype)
-                elif args.aura_diffusion:
-                    raise NotImplementedError(
-                        "Aura Diffusion noise residual predictions are not yet implemented."
-                    )
 
                 training_logger.debug("Predicting noise residual.")
 

--- a/train_sdxl.py
+++ b/train_sdxl.py
@@ -535,18 +535,14 @@ def main():
             **pretrained_load_args,
         )
     elif args.aura_diffusion:
-        raise NotImplementedError(
-            "Loading Aura Diffusion models is not yet implemented."
+        from diffusers.models import AuraFlowTransformer2DModel
+
+        unet = None
+        transformer = AuraFlowTransformer2DModel.from_pretrained(
+            args.pretrained_model_name_or_path,
+            subfolder="transformer",
+            **pretrained_load_args,
         )
-
-        # from diffusers.models import AuraMMDiT2DModel
-
-        # unet = None
-        # transformer = AuraMMDiT2DModel.from_pretrained(
-        #     args.pretrained_model_name_or_path,
-        #     subfolder="transformer",
-        #     **pretrained_load_args,
-        # )
     else:
         logger.info(f"Loading SDXL U-net..")
         transformer = None
@@ -1778,12 +1774,10 @@ def main():
                     elif args.aura_diffusion:
                         # Aura Diffusion also uses a MM-DiT model where the VAE-produced
                         #  image embeds are passed in with the TE-produced text embeds.
-                        raise NotImplementedError(
-                            "Aura Diffusion prediction is not currently implemented."
-                        )
                         model_pred = transformer(
                             hidden_states=noisy_latents,
                             encoder_hidden_states=encoder_hidden_states,
+                            timestep=timesteps,
                             return_dict=False,
                         )[0]
                     elif args.pixart_sigma:

--- a/train_sdxl.py
+++ b/train_sdxl.py
@@ -668,7 +668,7 @@ def main():
             raise ValueError(
                 "xformers is not available. Make sure it is installed correctly"
             )
-    elif args.enable_xformers_memory_attention:
+    elif args.enable_xformers_memory_efficient_attention:
         logger.warning(
             "xformers is not enabled, as it is incompatible with this model type."
         )

--- a/train_sdxl.py
+++ b/train_sdxl.py
@@ -1105,7 +1105,11 @@ def main():
                         else (
                             PixArtTransformer2DModel
                             if args.pixart_sigma
-                            else AuraMMDiT2DModel if args.aura_diffusion else None
+                            else (
+                                AuraFlowTransformer2DModel
+                                if args.aura_diffusion
+                                else None
+                            )
                         )
                     )
                 ),

--- a/train_sdxl.py
+++ b/train_sdxl.py
@@ -1030,9 +1030,9 @@ def main():
                 filter(lambda p: p.requires_grad, transformer.parameters())
             )
         if args.train_text_encoder:
-            if args.sd3:
+            if args.sd3 or args.aura_diffusion or args.pixart_sigma:
                 raise ValueError(
-                    "Stable Diffusion 3 does not support finetuning the text encoders, as it is a multimodal transformer model that does not benefit from it."
+                    f"{model_type_label} does not support finetuning the text encoders, as T5 does not benefit from it."
                 )
             else:
                 params_to_optimize = (

--- a/train_sdxl.sh
+++ b/train_sdxl.sh
@@ -163,6 +163,9 @@ fi
 if [ -n "$PIXART_SIGMA" ] && [[ "$PIXART_SIGMA" == "true" ]]; then
     export TRAINER_EXTRA_ARGS="${TRAINER_EXTRA_ARGS} --pixart_sigma"
 fi
+if [ -n "$AURA_DIFFUSION" ] && [[ "$AURA_DIFFUSION" == "true" ]]; then
+    export TRAINER_EXTRA_ARGS="${TRAINER_EXTRA_ARGS} --aura_diffusion"
+fi
 
 
 export EMA_ARGS=""

--- a/train_sdxl.sh
+++ b/train_sdxl.sh
@@ -163,8 +163,8 @@ fi
 if [ -n "$PIXART_SIGMA" ] && [[ "$PIXART_SIGMA" == "true" ]]; then
     export TRAINER_EXTRA_ARGS="${TRAINER_EXTRA_ARGS} --pixart_sigma"
 fi
-if [ -n "$AURA_DIFFUSION" ] && [[ "$AURA_DIFFUSION" == "true" ]]; then
-    export TRAINER_EXTRA_ARGS="${TRAINER_EXTRA_ARGS} --aura_diffusion"
+if [ -n "$AURA_FLOW" ] && [[ "$AURA_FLOW" == "true" ]]; then
+    export TRAINER_EXTRA_ARGS="${TRAINER_EXTRA_ARGS} --aura_flow"
 fi
 
 


### PR DESCRIPTION
This issue encompasses the plan to support Aura Diffusion.

If you wish to take one of the components, simply comment here and open a pull request to this branch (`feature/aura-diffusion`). Please do not open your pull request to the main branch.

- [x] a `--aura_diffusion` argment is added
  - this occurs in multiple places. look for `pixart_sigma` to get an idea of where these occur.
  - leave things like text embed cache broken, until they are properly implemented - so that a ValueError etc is raised when something still needs to be "plugged in".
  - we have to then `StateTracker.set_model_type("aura_diffusion")`
- [x] model_type gets updated to include aura_diffusion value alongside sdxl, sd3, pixart_sigma, etc
  - this applies when `--aura_diffusion` argument is provided
  - a `AURA_DIFFUSION=false` variable export should be added to `sdxl-env.sh.example`
  - `train_sdxl.sh` should be updated to address this variable by setting `--aura_diffusion` when AURA_DIFFUSION=true. see `PIXART_SIGMA` in there for info.
- [x] initial model loading for the trained transformer must be added or included alongside eg. pixart's loading, if the two are compatible and can be shared
  - this occurs at the top of `train_sdxl.py` where we load `PixArtTransformer2DModel` etc
- [x] text embed caching then needs n aura_diffusion codepath added, which can probably be shared with pixart depending on how it expects the embeds to be used. for example, DeepFloyd's T5 embeds don't return the attn mask, they just encode the embeds with it. but PixArt Sigma requires the attn mask as an input to the transformer itself.
- [x] checkpoint save/load should be enhanced to include the logic for aura_diffusion or share with pixart where appropriate
  - these occur inside `helpers/sdxl/save_hooks.py`, and LoRA vs Full models are handled differently
- [x] any kind of specific loss augmentation - scaling, weighting, masking, must be added to the training loop if required
- [x] validations must load the Aura Diffusion pipeline classes (`helpers/training/validation.py`)
  - more than likely this will require wholesale copy-pasting the Aura pipeline from Diffusers into `helpers/aura_diffusion/pipeline.py` so that we can apply dtype/device assignment corrections. see `helpers/sdxl/pipeline.py` and `helpers/sd3/pipeline.py` for more information.
- [x] documentation must be produced and included, eg. a quickstart guide w/ a functional dataset is required for all new models added
- [x] update model card metadata to include Aura Diffusion details for code example
- [x] block access to controlnet training
- [x] block access to LoRA training
- [x] block access to text encoder training
- [x] block access to `--validation_using_datasets` if Aura Diffusion does not have img2img pipeline

## nice-to-have, but not needed

- [ ] controlnet training / inference validations
- [ ] LoRA training
- [ ] refiner validations, eg. `denoising_start` support in pipeline

## testing

- [x] loading initial model
- [x] saving a checkpoint
- [x] loading a checkpoint
- [ ] final pipeline export
- [x] text2img validations
- [ ] img2img validations
- [ ] if implemented, refiner-based partial denoising validations (uses PIL inputs, sorry)
- [x] i think the vae cache works just fine as-is, but it should be tested
- [ ] ~~min-snr-gamma compatibility~~
- [ ] ~~whether offset noise should be allowed~~
- [ ] ~~noise scheduler changes at validation time via `--validation_noise_scheduler`~~

cc @sayakpaul should we pull your save/load lora refactor into a separate PR so that this can build on it?