### PR TITLE
sd3: Fix random errors when generating validation images. (#546)

### DIFF
--- a/helpers/sd3/pipeline.py
+++ b/helpers/sd3/pipeline.py
@@ -909,6 +909,8 @@ class StableDiffusion3Pipeline(
             generator,
             latents,
         )
+        latents = latents.to(self.transformer.device)
+        timesteps = timesteps.to(self.transformer.device)
 
         # 6. Denoising loop
         with self.progress_bar(total=num_inference_steps) as progress_bar:


### PR DESCRIPTION
I managed to fix the random errors in #546 for myself at least. Debug prints revealed that C<timestep> was randomly either on the CPU or on the GPU. However, after moving C<timesteps> to the GPU, another error happened because C<latents> was also on the CPU. So then I moved C<latents> also to the GPU and the errors were gone.