### PR TITLE
Fix text encoder unload reporting

### DIFF
--- a/train_sdxl.py
+++ b/train_sdxl.py
@@ -740,6 +740,9 @@ def main():
         text_encoder_2 = None
         text_encoder_3 = None
         text_encoders = []
+        for backend_id, backend in StateTracker.get_data_backends().items():
+            if "text_embed_cache" in backend:
+                backend["text_embed_cache"].text_encoders = None
         reclaim_memory()
         memory_after_unload = torch.cuda.memory_allocated() / 1024**3
         memory_saved = memory_after_unload - memory_before_unload
@@ -1215,10 +1218,6 @@ def main():
         logger.info(
             f"After the VAE from orbit, we freed {abs(round(memory_saved, 2)) * 1024} MB of VRAM."
         )
-
-    for backend_id, backend in StateTracker.get_data_backends().items():
-        if "text_embed_cache" in backend:
-            backend["text_embed_cache"].text_encoders = None
 
     # Train!
     total_batch_size = (


### PR DESCRIPTION
SD3 text encoder unloading was fixed in commit 7c749772e54434eec3403412b3d1d4e31288fa23 to address issue #457. However, the amount of the freed memory is reported as 0.0 GB because the fix was applied just before the actual training starts.

```
2024-07-07 10:52:57,669 [INFO] (__main__) Unloading text encoders, as they are not being trained.
2024-07-07 10:52:57,753 [INFO] (__main__) After nuking text encoders from orbit, we freed 0.0 GB of VRAM. The real memories were the friends we trained a model on along the way.
```

After moving the code around the amount of memory freed is reported correctly:

```
2024-07-07 11:00:03,781 [INFO] (__main__) Unloading text encoders, as they are not being trained.
2024-07-07 11:00:04,063 [INFO] (__main__) After nuking text encoders from orbit, we freed 10.4 GB of VRAM. The real memories were the friends we trained a model on along the way.
```

I was able to increase `TRAIN_BATCH_SIZE` to 3 both before and after moving the code around (when doing full SD3 finetuning on my RTX 3090). So the unload fix seems to have been working despite not getting reported correctly.