### PR TITLE
Fix cached text embeds not getting loaded from the disk with local backend and relative path in cache_dir

### DIFF
--- a/helpers/caching/sdxl_embeds.py
+++ b/helpers/caching/sdxl_embeds.py
@@ -119,6 +119,8 @@ class TextEmbeddingCache:
         self.text_encoder_batch_size = text_encoder_batch_size
         self.max_workers = max_workers
         self.rank_info = rank_info()
+        if self.data_backend.type == "local":
+            self.cache_dir = os.path.abspath(self.cache_dir)
         self.data_backend.create_directory(self.cache_dir)
         self.write_queue = Queue()
         self.process_write_batches = True

--- a/helpers/data_backend/aws.py
+++ b/helpers/data_backend/aws.py
@@ -67,6 +67,7 @@ class S3DataBackend(BaseDataBackend):
         self.write_retry_limit = write_retry_limit
         self.write_retry_interval = write_retry_interval
         self.compress_cache = compress_cache
+        self.type = "aws"
         if compress_cache:
             logging.warning(
                 f"Torch cache compression is untested for AWS backends. Open an issue report at https://github.com/bghira/simpletuner/issues/new if you encounter any problems."

--- a/helpers/data_backend/local.py
+++ b/helpers/data_backend/local.py
@@ -14,6 +14,7 @@ class LocalDataBackend(BaseDataBackend):
         self.accelerator = accelerator
         self.id = id
         self.compress_cache = compress_cache
+        self.type = "local"
 
     def read(self, filepath, as_byteIO: bool = False):
         """Read and return the content of the file."""


### PR DESCRIPTION
Loading of cached text embeds from local disk was broken by commit 20bcf68a215c16d5c6cdd084882f079b7cddcaab. When `cache_dir` is a relative path in multidatabackend.json, the cached text embeds always get regenerated.

Here's an example multidatabackend.json that suffers from this problem:
```
[
  {
    "id": "pseudo-camera-10k-sd3",
    "type": "local",
    "crop": false,
    "crop_aspect": "square",
    "crop_style": "random",
    "resolution": 1.0,
    "minimum_image_size": 0.25,
    "maximum_image_size": 1.0,
    "target_downsample_size": 1.0,
    "resolution_type": "area",
    "cache_dir_vae": "cache/vae/sd3/pseudo-camera-10k",
    "instance_data_dir": "/home/mikaelh/Stable Diffusion/datasets/ptx0/pseudo-camera-10k/train",
    "disabled": false,
    "skip_file_discovery": "",
    "caption_strategy": "filename",
    "metadata_backend": "json"
  },
  {
    "id": "text-embeds",
    "type": "local",
    "dataset_type": "text_embeds",
    "default": true,
    "cache_dir": "cache/text/sd3/pseudo-camera-10k",
    "disabled": false,
    "write_batch_size": 128
  }
]
```

The problem can be worked around by using an absolute path for `cache_dir`:
```
[
  {
    "id": "pseudo-camera-10k-sd3",
    "type": "local",
    "crop": false,
    "crop_aspect": "square",
    "crop_style": "random",
    "resolution": 1.0,
    "minimum_image_size": 0.25,
    "maximum_image_size": 1.0,
    "target_downsample_size": 1.0,
    "resolution_type": "area",
    "cache_dir_vae": "cache/vae/sd3/pseudo-camera-10k",
    "instance_data_dir": "/home/mikaelh/Stable Diffusion/datasets/ptx0/pseudo-camera-10k/train",
    "disabled": false,
    "skip_file_discovery": "",
    "caption_strategy": "filename",
    "metadata_backend": "json"
  },
  {
    "id": "text-embeds",
    "type": "local",
    "dataset_type": "text_embeds",
    "default": true,
    "cache_dir": "/nvme/home/mikaelh/Stable_Diffusion/bghira/SimpleTuner/cache/text/sd3/pseudo-camera-10k",
    "disabled": false,
    "write_batch_size": 128
  }
]
```

With this fix, such a workaround is no longer necessary.