### PR TITLE
Fix crash when using jsonl files

### DIFF
--- a/helpers/data_backend/factory.py
+++ b/helpers/data_backend/factory.py
@@ -247,7 +247,11 @@ def configure_parquet_database(backend: dict, args, data_backend: BaseDataBacken
 
     bytes_string = data_backend.read(parquet_path)
     pq = io.BytesIO(bytes_string)
-    df = pd.read_parquet(pq)
+    if parquet_path.endswith(".jsonl"):
+        df = pd.read_json(pq, lines=True)
+    else:
+        df = pd.read_parquet(pq)
+
     caption_column = parquet_config.get(
         "caption_column", args.parquet_caption_column or "description"
     )


### PR DESCRIPTION
Thanks for supporting jsonl, btw jsonl file crashes here.

Followed similar pattern in `parquet.py`. 