### PR TITLE
quanto: allow further vram reduction with bf16 base weights, reorder model loading operations to evacuate text encoders before DiT loads

### DIFF
--- a/config/config.env.example
+++ b/config/config.env.example
@@ -5,6 +5,8 @@
 # full - requires lots of vram, trains very slowly, needs a lot of data and concepts.
 export MODEL_TYPE='lora'
 
+# SDXL is trained by default, but you will need to enable one of these options for anything else.
+
 # Set this to 'true' if you are training a Stable Diffusion 3 checkpoint.
 # Use MODEL_NAME="stabilityai/stable-diffusion-3-medium-diffusers"
 export STABLE_DIFFUSION_3=false
@@ -63,7 +65,7 @@ export MODEL_NAME="stabilityai/stable-diffusion-xl-base-1.0"
 
 # Make DEBUG_EXTRA_ARGS empty to disable wandb.
 export DEBUG_EXTRA_ARGS="--report_to=wandb"
-export TRACKER_PROJECT_NAME="sdxl-training"
+export TRACKER_PROJECT_NAME="${MODEL_TYPE}-training"
 export TRACKER_RUN_NAME="simpletuner-sdxl"
 
 # Max number of steps OR epochs can be used. Not both.

--- a/documentation/quickstart/FLUX.md
+++ b/documentation/quickstart/FLUX.md
@@ -51,13 +51,13 @@ poetry install --no-root -C install/rocm
 
 #### Custom Diffusers build
 
-For LoRA support in Diffusers, the current main branch does not yet have this merged in.
+For LoRA support in Diffusers, the latest release does not yet have Flux LoRA support, so we must install directly from the main branch.
 
 To obtain the correct build, run the following commands:
 
 ```bash
 pip uninstall diffusers
-pip install git+https://github.com/huggingface/diffusers@lora-support-flux
+pip install git+https://github.com/huggingface/diffusers
 ```
 
 ### Setting up the environment
@@ -223,3 +223,5 @@ For more information, see the [dataloader](/documentation/DATALOADER.md) and [tu
   - Undertraining (also), a high-capacity network with too few images
   - Using weird aspect ratios or training data sizes
 - Training for too long on square crops probably won't damage this model. Go nuts, it's great and reliable.
+- We're overriding `--max_grad_norm` on all DiT models currently - providing the flag `--i_know_what_im_doing` will allow you to bypass this limit and experiment with higher gradient norm scales
+  - The low value keeps the model from falling apart too soon, but can also make it very difficult to learn new concepts that venture far from the base model data distribution

--- a/helpers/arguments.py
+++ b/helpers/arguments.py
@@ -162,8 +162,8 @@ def parse_args(input_args=None):
     parser.add_argument(
         "--weighting_scheme",
         type=str,
-        default="none",
-        choices=["sigma_sqrt", "logit_normal", "mode", "none"],
+        default="cosmap",
+        choices=["sigma_sqrt", "logit_normal", "mode", "cosmap", "none"],
         help=(
             "Stable Diffusion 3 used either uniform sampling of timesteps with post-prediction loss weighting, or"
             " a weighted timestep selection by mode or log-normal distribution. The default for SD3 is logit_normal, though"
@@ -1741,7 +1741,8 @@ def parse_args(input_args=None):
         )
 
     model_is_bf16 = (
-        args.base_model_precision == "no_change" and args.mixed_precision == "bf16"
+        args.base_model_precision == "no_change"
+        and (args.mixed_precision == "bf16" or torch.backends.mps.is_available())
     ) or (
         args.base_model_precision != "no_change"
         and args.base_model_default_dtype == "bf16"

--- a/helpers/arguments.py
+++ b/helpers/arguments.py
@@ -105,6 +105,36 @@ def parse_args(input_args=None):
         help=("This option must be provided when training a Flux model."),
     )
     parser.add_argument(
+        "--flux_guidance_mode",
+        type=str,
+        choices=["constant", "random-range"],
+        default="constant",
+        help=(
+            "Flux has a 'guidance' value used during training time that reflects the CFG range of your training samples."
+            " The default mode 'constant' will use a single value for every sample."
+            " The mode 'random-range' will randomly select a value from the range of the CFG for each sample."
+            " Set the range using --flux_guidance_min and --flux_guidance_max."
+        ),
+    )
+    parser.add_argument(
+        "--flux_guidance_value",
+        type=float,
+        default=3.0,
+        help=(
+            "When using --flux_guidance_mode=constant, this value will be used for every input sample."
+        ),
+    )
+    parser.add_argument(
+        "--flux_guidance_min",
+        type=float,
+        default=0.0,
+    )
+    parser.add_argument(
+        "--flux_guidance_max",
+        type=float,
+        default=4.0,
+    )
+    parser.add_argument(
         "--smoldit",
         action="store_true",
         default=False,

--- a/helpers/training/__init__.py
+++ b/helpers/training/__init__.py
@@ -1,7 +1,7 @@
 quantised_precision_levels = [
     "no_change",
-    "fp4-bnb",
-    "fp8-bnb",
+    # "fp4-bnb",
+    # "fp8-bnb",
     "fp8-quanto",
     "int8-quanto",
     "int4-quanto",

--- a/train.py
+++ b/train.py
@@ -736,7 +736,8 @@ def main():
         text_encoder_2 = None
         text_encoder_3 = None
         text_encoders = []
-        prompt_handler.text_encoders = []
+        if prompt_handler is not None:
+            prompt_handler.text_encoders = []
         for backend_id, backend in StateTracker.get_data_backends().items():
             if "text_embed_cache" in backend:
                 backend["text_embed_cache"].text_encoders = None
@@ -947,7 +948,7 @@ def main():
         else:
             transformer.to(accelerator.device, dtype=weight_dtype)
     if args.enable_xformers_memory_efficient_attention and not any(
-        [args.sd3, args.pixart_sigma, args.flux, args.kolors]
+        [args.sd3, args.pixart_sigma, args.flux, args.smoldit]
     ):
         logger.info("Enabling xformers memory-efficient attention.")
         if is_xformers_available():

--- a/train.py
+++ b/train.py
@@ -2024,7 +2024,12 @@ def main():
                             height=latents.shape[2],
                             width=latents.shape[3],
                         )
-                        guidance_scale = 3  # >>> ????? <<<
+                        if args.flux_guidance_mode == "constant":
+                            guidance_scale = float(args.flux_guidance_value)
+                        elif args.flux_guidance_mode == "random-range":
+                            guidance_scale = random.uniform(
+                                args.flux_guidance_min, args.flux_guidance_max
+                            )
                         transformer_config = None
                         if hasattr(transformer, "module"):
                             transformer_config = transformer.module.config

--- a/train.py
+++ b/train.py
@@ -948,7 +948,7 @@ def main():
         else:
             transformer.to(accelerator.device, dtype=weight_dtype)
     if args.enable_xformers_memory_efficient_attention and not any(
-        [args.sd3, args.pixart_sigma, args.flux, args.smoldit]
+        [args.sd3, args.pixart_sigma, args.flux, args.smoldit, args.kolors]
     ):
         logger.info("Enabling xformers memory-efficient attention.")
         if is_xformers_available():


### PR DESCRIPTION
this is kind of an experimental change.

i was investigating how to fix the LoRA loading issue when we try and resume a checkpoint, as that is currently broken upstream in Quanto.

however, i also discovered that if we send the model to its target dtype before quantising it, the weight is reduced and we can train in even less memory.

this requires the adam_bf16 optimiser be used, so the error messages are updated to reflect that.

you can still use adafactor and others, but it's noted as a bit heavier and requires fp32 base default dtype.