### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get install -y python3.10-venv
 EXPOSE 22/tcp
 
 # CUDNN9
-RUN cudnn9-cuda-12 libcudnn9 libcudnn9-dev
+RUN libcudnn9 libcudnn9-dev
 
 # Python
 RUN apt-get update -y && apt-get install -y python3 python3-pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# SimpleTuner needs CU118
-FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
+# SimpleTuner needs CU141
+FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04
 
 # /workspace is the default volume for Runpod & other hosts
 WORKDIR /workspace
@@ -11,28 +11,26 @@ RUN apt-get update -y
 # on user input during build
 ENV DEBIAN_FRONTEND noninteractive
 
-# Install openssh & git
+# Install misc unix libraries
 RUN apt-get install -y --no-install-recommends openssh-server \
                                                openssh-client \
                                                git \
-                                               git-lfs
-
-# Installl misc unix libraries
-RUN apt-get install -y wget \
-                       curl \
-                       tmux \
-                       tldr \
-                       nvtop \
-                       vim \
-                       rsync \
-                       net-tools \
-                       less \
-                       iputils-ping \
-                       7zip \
-                       zip \
-                       unzip \
-                       htop \
-                       inotify-tools
+                                               git-lfs \
+                                               wget \
+                                               curl \
+                                               tmux \
+                                               tldr \
+                                               nvtop \
+                                               vim \
+                                               rsync \
+                                               net-tools \
+                                               less \
+                                               iputils-ping \
+                                               7zip \
+                                               zip \
+                                               unzip \
+                                               htop \
+                                               inotify-tools
 
 # Set up git to support LFS, and to store credentials; useful for Huggingface Hub
 RUN git config --global credential.helper store && \
@@ -44,8 +42,11 @@ RUN apt-get install -y python3.10-venv
 # Ensure SSH access. Not needed for Runpod but is required on Vast and other Docker hosts
 EXPOSE 22/tcp
 
-# Install misc Python & CUDA Libraries
-RUN apt-get update -y && apt-get install -y python3 python3-pip libcudnn8 libcudnn8-dev
+# CUDNN9
+RUN cudnn9-cuda-12 libcudnn9 libcudnn9-dev
+
+# Python
+RUN apt-get update -y && apt-get install -y python3 python3-pip
 RUN python3 -m pip install pip --upgrade
 
 # HF
@@ -55,7 +56,7 @@ ENV HF_HOME=/workspace/huggingface
 
 RUN pip3 install "huggingface_hub[cli]"
 
-RUN huggingface-cli login --token "$HUGGING_FACE_HUB_TOKEN" --add-to-git-credential
+RUN if [ -n "$HUGGING_FACE_HUB_TOKEN" ]; then huggingface-cli login --token "$HUGGING_FACE_HUB_TOKEN" --add-to-git-credential; else echo "HUGGING_FACE_HUB_TOKEN not set; skipping login"; fi
 
 # WanDB
 ARG WANDB_TOKEN
@@ -63,7 +64,7 @@ ENV WANDB_TOKEN=$WANDB_TOKEN
 
 RUN pip3 install wandb
 
-RUN wandb login "$WANDB_TOKEN"
+RUN if [ -n "$WANDB_TOKEN" ]; then wandb login "$WANDB_TOKEN"; else echo "WANDB_TOKEN not set; skipping login"; fi
 
 # Clone SimpleTuner
 RUN git clone https://github.com/bghira/SimpleTuner --branch release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # SimpleTuner needs CU141
-FROM 12.4.1-cudnn-devel-ubuntu22.04
+FROM nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04
 
 # /workspace is the default volume for Runpod & other hosts
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # SimpleTuner needs CU141
-FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04
+FROM 12.4.1-cudnn-devel-ubuntu22.04
 
 # /workspace is the default volume for Runpod & other hosts
 WORKDIR /workspace
@@ -41,9 +41,6 @@ RUN apt-get install -y python3.10-venv
 
 # Ensure SSH access. Not needed for Runpod but is required on Vast and other Docker hosts
 EXPOSE 22/tcp
-
-# CUDNN9
-RUN libcudnn9 libcudnn9-dev
 
 # Python
 RUN apt-get update -y && apt-get install -y python3 python3-pip


### PR DESCRIPTION
Now it's using cu141 & cudnn9 (instead of cu118 & cudnn8). I kept Python 3.10 since that doesn't seem to have changed.

I was able to test torch on Runpod via:
```
(.venv) root@43cd66d74b66:/workspace/SimpleTuner# python3
Python 3.10.12 (main, Jul 29 2024, 16:56:48) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch
>>> print(torch.cuda.is_available())
True
>>> print(torch.version.cuda)
12.4
>>> print(torch.backends.cudnn.version())
90100
>>>
```

However, there have been breaking changes to the code, and I'm not able to test simpletuner using my old datasets. If you have a dummy dataset using the new format, I can also give that a try.

I saw you already edited it to use the new `train.sh` script. So i think that's it.

If you're willing to build it on a DockerHub account ([like so](https://hub.docker.com/r/orionkomninos/simpletuner)), we can offer one-click deployment to Runpod.