### PR TITLE
Flux: Purge text encoders from system RAM.

### DIFF
--- a/train.py
+++ b/train.py
@@ -742,6 +742,7 @@ def main():
         for backend_id, backend in StateTracker.get_data_backends().items():
             if "text_embed_cache" in backend:
                 backend["text_embed_cache"].text_encoders = None
+                backend["text_embed_cache"].pipeline = None
         reclaim_memory()
         if torch.cuda.is_available():
             memory_after_unload = torch.cuda.memory_allocated() / 1024**3


### PR DESCRIPTION
Get rid of FluxPipeline inside TextEmbeddingCache that is keeping text encoders in system RAM. This frees up RAM for other things like quantization. Peak RAM usage during fp8 quantization is about 45.4 GB after this change.