### PR TITLE
Add input perturbation

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -1312,7 +1312,8 @@ options:
                         work with flow-matching (e.g. SD3 and Flux).
   --input_perturbation_steps INPUT_PERTURBATION_STEPS
                         Only apply input perturbation over the first N steps
-                        with linear decay.
+                        with linear decay. This should prevent artifacts from
+                        showing up in longer training runs.
   --lr_end LR_END       A polynomial learning rate will end up at this value
                         after the specified number of warmup steps. A sine or
                         cosine wave will use this value as its lower bound for

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -393,7 +393,9 @@ usage: train.py [-h] [--snr_gamma SNR_GAMMA] [--use_soft_min_snr]
                 [--sdxl_refiner_uses_full_range]
                 [--caption_dropout_probability CAPTION_DROPOUT_PROBABILITY]
                 [--delete_unwanted_images] [--delete_problematic_images]
-                [--offset_noise] [--lr_end LR_END] [--i_know_what_i_am_doing]
+                [--offset_noise] [--input_perturbation INPUT_PERTURBATION]
+                [--input_perturbation_steps INPUT_PERTURBATION_STEPS]
+                [--lr_end LR_END] [--i_know_what_i_am_doing]
                 [--accelerator_cache_clear_interval ACCELERATOR_CACHE_CLEAR_INTERVAL]
 
 The following SimpleTuner command-line options are available:
@@ -1302,6 +1304,15 @@ options:
   --offset_noise        Fine-tuning against a modified noise See:
                         https://www.crosslabs.org//blog/diffusion-with-offset-
                         noise for more information.
+  --input_perturbation INPUT_PERTURBATION
+                        Add additional noise only to the inputs fed to the
+                        model during training. This will make the training
+                        converge faster. A value of 0.1 is suggested if you
+                        want to enable this. Input perturbation seems to also
+                        work with flow-matching (e.g. SD3 and Flux).
+  --input_perturbation_steps INPUT_PERTURBATION_STEPS
+                        Only apply input perturbation over the first N steps
+                        with linear decay.
   --lr_end LR_END       A polynomial learning rate will end up at this value
                         after the specified number of warmup steps. A sine or
                         cosine wave will use this value as its lower bound for

--- a/helpers/arguments.py
+++ b/helpers/arguments.py
@@ -1700,6 +1700,14 @@ def parse_args(input_args=None):
         ),
     )
     parser.add_argument(
+        "--input_perturbation_steps",
+        type=float,
+        default=0,
+        help=(
+            "Only apply input perturbation over the first N steps with linear decay."
+        ),
+    )
+    parser.add_argument(
         "--lr_end",
         type=str,
         default="4e-7",

--- a/helpers/arguments.py
+++ b/helpers/arguments.py
@@ -1705,6 +1705,7 @@ def parse_args(input_args=None):
         default=0,
         help=(
             "Only apply input perturbation over the first N steps with linear decay."
+            " This should prevent artifacts from showing up in longer training runs."
         ),
     )
     parser.add_argument(

--- a/helpers/arguments.py
+++ b/helpers/arguments.py
@@ -1690,6 +1690,16 @@ def parse_args(input_args=None):
         ),
     )
     parser.add_argument(
+        "--input_perturbation",
+        type=float,
+        default=0.0,
+        help=(
+            "Add additional noise only to the inputs fed to the model during training."
+            " This will make the training converge faster. A value of 0.1 is suggested if you want to enable this."
+            " Input perturbation seems to also work with flow-matching (e.g. SD3 and Flux)."
+        ),
+    )
+    parser.add_argument(
         "--lr_end",
         type=str,
         default="4e-7",

--- a/train.py
+++ b/train.py
@@ -1588,7 +1588,10 @@ def main():
                 for timestep in timesteps.tolist():
                     timesteps_buffer.append((global_step, timestep))
 
-                if args.input_perturbation != 0:
+                if args.input_perturbation != 0 and (not args.input_perturbation_steps or global_step < args.input_perturbation_steps):
+                    input_perturbation = args.input_perturbation
+                    if args.input_perturbation_steps:
+                        input_perturbation *= 1.0 - (global_step / args.input_perturbation_steps)
                     input_noise = noise + args.input_perturbation * torch.randn_like(latents)
                 else:
                     input_noise = noise

--- a/train.py
+++ b/train.py
@@ -1588,13 +1588,18 @@ def main():
                 for timestep in timesteps.tolist():
                     timesteps_buffer.append((global_step, timestep))
 
+                if args.input_perturbation != 0:
+                    input_noise = noise + args.input_perturbation * torch.randn_like(latents)
+                else:
+                    input_noise = noise
+
                 if flow_matching:
-                    noisy_latents = (1 - sigmas) * latents + sigmas * noise
+                    noisy_latents = (1 - sigmas) * latents + sigmas * input_noise
                 else:
                     # Add noise to the latents according to the noise magnitude at each timestep
                     # (this is the forward diffusion process)
                     noisy_latents = noise_scheduler.add_noise(
-                        latents.float(), noise.float(), timesteps
+                        latents.float(), input_noise.float(), timesteps
                     ).to(device=accelerator.device, dtype=weight_dtype)
 
                 encoder_hidden_states = batch["prompt_embeds"].to(


### PR DESCRIPTION
Input perturbation is a simple trick to speed up training convergence. We just add a little bit of extra noise to the inputs fed to the model.

Input perturbation has already been added to diffusers before:
https://github.com/huggingface/diffusers/issues/3293

Kohya calls this --ip_noise_gamma:
https://github.com/kohya-ss/sd-scripts/pull/798

The original research paper is here:
https://arxiv.org/pdf/2301.11706

I tested input perturbation with Flux LoRA training and it seems to work quite well. I did a little test run at 512px resolution and adamw_bf16 optimizer with 4e-4 learning rate.

500 steps without input perturbation:
![step_500_validation_(512, 512)](https://github.com/user-attachments/assets/1d0811c8-7168-4b64-9b6f-05471ae92fcb)

500 steps with input perturbation set to 0.1:
![step_500_validation_(512, 512)](https://github.com/user-attachments/assets/93918756-c7f4-4517-a498-656ce21e6a28)

I'd say the latter image is already starting look almost fully converged at just 500 steps.

Also, there seems to be less bleeding into the unconditional validation images.