### PR TITLE
Make Docker foolproof

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,21 +47,12 @@ RUN apt-get update -y && apt-get install -y python3 python3-pip
 RUN python3 -m pip install pip --upgrade
 
 # HF
-ARG HUGGING_FACE_HUB_TOKEN
-ENV HUGGING_FACE_HUB_TOKEN=$HUGGING_FACE_HUB_TOKEN
-ENV HF_HOME=/workspace/huggingface
+ENV HF_HOME=$PWD/huggingface
 
 RUN pip3 install "huggingface_hub[cli]"
 
-RUN if [ -n "$HUGGING_FACE_HUB_TOKEN" ]; then huggingface-cli login --token "$HUGGING_FACE_HUB_TOKEN" --add-to-git-credential; else echo "HUGGING_FACE_HUB_TOKEN not set; skipping login"; fi
-
 # WanDB
-ARG WANDB_TOKEN
-ENV WANDB_TOKEN=$WANDB_TOKEN
-
 RUN pip3 install wandb
-
-RUN if [ -n "$WANDB_TOKEN" ]; then wandb login "$WANDB_TOKEN"; else echo "WANDB_TOKEN not set; skipping login"; fi
 
 # Clone SimpleTuner
 RUN git clone https://github.com/bghira/SimpleTuner --branch release

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update -y && apt-get install -y python3 python3-pip
 RUN python3 -m pip install pip --upgrade
 
 # HF
-ENV HF_HOME=$PWD/huggingface
+ENV HF_HOME=/workspace/huggingface
 
 RUN pip3 install "huggingface_hub[cli]"
 

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -26,5 +26,9 @@ fi
 # Start SSH server
 service ssh start
 
+# Load HF, WanDB tokens
+if [ -n "$HUGGING_FACE_HUB_TOKEN" ]; then huggingface-cli login --token "$HUGGING_FACE_HUB_TOKEN" --add-to-git-credential; else echo "HUGGING_FACE_HUB_TOKEN not set; skipping login"; fi
+if [ -n "$WANDB_TOKEN" ]; then wandb login "$WANDB_TOKEN"; else echo "WANDB_TOKEN not set; skipping login"; fi
+
 # 🫡
 sleep infinity


### PR DESCRIPTION
Moves loading of ENVs to docker start so they can't be baked into the image and accidentally leaked on public registries.

----

@bghira Since this repo is getting more traction, and people seem to be using Docker, I highly recommend we create a CD pipeline to build and deploy the latest tag to a registry. If you're on board, I'll create it in a way where I don't have any access over any part of the process.

Then, we can offer one-click deployment to the major cloud hosts. Manually building the image can get annoying. On my (slow) internet connection, it takes around 3 hours to pull, build and push it (assuming no cache).

----

And the final step would be to build a small web app so that users can interact with SImpleTuner via a UI instead of SSH'ing into the container. I know you've been negative on that in the past, but if you ever change your mind, I'll get it done.