### PR TITLE
Fix --input_perturbation_steps so that it actually has an effect

### DIFF
--- a/train.py
+++ b/train.py
@@ -1469,7 +1469,7 @@ def main():
                         input_perturbation *= 1.0 - (
                             global_step / args.input_perturbation_steps
                         )
-                    input_noise = noise + args.input_perturbation * torch.randn_like(
+                    input_noise = noise + input_perturbation * torch.randn_like(
                         latents
                     )
                 else:


### PR DESCRIPTION
Fix a mistake in my previous pull request #723. Below is a comparison with 'Before' column having input perturbation at 0.1 all the time and 'After' column having working linear decay. I'm still running main branch code from Sunday (commit 166d905a4506241ab9bb663f96df0bb2d49bdd3d) for these comparisons. There is a clear difference between 'Before' and 'After' but it's hard to tell which is actually better. 'Before' seems to maintain the same pose more consistently.

| Steps | Before (constant input perturbation) | After (linear decay fixed) |
| --- | --- | --- |
| 500 | ![step_500_validation_(512, 512)](https://github.com/user-attachments/assets/49977ecf-df71-4b38-8f65-6c82f3362721) | ![step_500_validation_(512, 512)](https://github.com/user-attachments/assets/e8249376-e6e4-406a-a6ad-a3bc192136e0) |
| 1000 | ![step_1000_validation_(512, 512)](https://github.com/user-attachments/assets/db50e51f-0981-4398-8fc9-362f83c247bd) | ![step_1000_validation_(512, 512)](https://github.com/user-attachments/assets/0842ddfd-0990-4c27-8feb-7c2c47bc0123) |
| 1500 | ![step_1500_validation_(512, 512)](https://github.com/user-attachments/assets/9be04879-6410-4c3a-a39e-96a4c9383b5b) | ![step_1500_unconditional_(512, 512)](https://github.com/user-attachments/assets/8717966b-0215-4658-9a16-d2c7fd7aaedb) |
| 2000 | ![step_2000_validation_(512, 512)](https://github.com/user-attachments/assets/e586be93-2b09-4328-aa6c-b73840d9245b) | ![step_2000_validation_(512, 512)](https://github.com/user-attachments/assets/aa2abb5b-39d9-4992-85b7-90279692311d) |
| 2500 | ![step_2500_validation_(512, 512)](https://github.com/user-attachments/assets/17419e91-dbfe-4187-a51a-de861bd42072) | ![step_2500_validation_(512, 512)](https://github.com/user-attachments/assets/03c38921-725b-4a86-a26c-2a3b2aa5bfec) |
| 3000 | ![step_3000_validation_(512, 512)](https://github.com/user-attachments/assets/c1f83341-1625-4129-b593-c636c090cbad) | ![step_3000_validation_(512, 512)](https://github.com/user-attachments/assets/cb3f74a4-80b5-4e22-8df8-97c1cedc9f5d) |
| 3300 | ![step_3300_validation_(512, 512)](https://github.com/user-attachments/assets/16bc7b4a-8b57-42a5-a29d-b20274558d1c) | ![step_3300_validation_(512, 512)](https://github.com/user-attachments/assets/88f09fcb-1120-4186-8852-c4f9fc3deee2) |

I'll leave the training running and post more images later.