### PR TITLE
Fix caption_with_blip3.py on CUDA

### DIFF
--- a/toolkit/captioning/caption_with_blip3.py
+++ b/toolkit/captioning/caption_with_blip3.py
@@ -75,7 +75,7 @@ def eval_blip3_model(query, raw_image, model, tokenizer, image_processor):
     )
     language_inputs = tokenizer([prompt], return_tensors="pt")
     inputs.update(language_inputs)
-    inputs = {name: tensor.to("mps") for name, tensor in inputs.items()}
+    inputs = {name: tensor.to("mps" if torch.backends.mps.is_available() else "cuda") for name, tensor in inputs.items()}
     generated_text = model.generate(
         **inputs,
         image_size=[raw_image.size],


### PR DESCRIPTION
caption_with_blip3.py only worked on mps devices, this commit makes it work on CUDA, too.