### PR TITLE
fix: only run save full model on main process

### DIFF
--- a/helpers/training/save_hooks.py
+++ b/helpers/training/save_hooks.py
@@ -316,6 +316,8 @@ class SaveHookManager:
 
     def save_model_hook(self, models, weights, output_dir):
         # Write "training_state.json" to the output directory containing the training state
+        if not self.accelerator.is_main_process:
+            return
         StateTracker.save_training_state(
             os.path.join(output_dir, "training_state.json")
         )


### PR DESCRIPTION
was running into a bug where `_save_full_model` would break during multi-gpu full finetuning.
The function was being run by all processes, and 
```
        for item in os.listdir(temporary_dir):
            s = os.path.join(temporary_dir, item)
            d = os.path.join(output_dir, item)
            if os.path.isdir(s):
                shutil.copytree(s, d, dirs_exist_ok=True)  # Python 3.8+
            else:
                shutil.copy2(s, d)

        # Remove the temporary directory
        shutil.rmtree(temporary_dir)
```
would error out because the temporary_dir would get deleted while other processes were trying to copy files that no longer existed. 

Fixed by returning early if not main process. 