### PR TITLE
fix: set optimizer details to empty dict w/ deepspeed

### DIFF
--- a/helpers/training/optimizer_param.py
+++ b/helpers/training/optimizer_param.py
@@ -297,6 +297,7 @@ def determine_optimizer_class_with_config(
         extra_optimizer_args["eps"] = args.adam_epsilon
         extra_optimizer_args["weight_decay"] = args.adam_weight_decay
         default_settings = extra_optimizer_args
+        optimizer_details = {}
     elif is_quantized and not enable_adamw_bf16:
         logger.error(
             f"When --base_model_default_dtype=fp32, AdamWBF16 may not be used. Switching to AdamW."


### PR DESCRIPTION
set optimizer details to empty dict to prevent variable undefined error when using deepspeed