### PR TITLE
Dataloader Docs - Correct caption strategy for instance prompt

### DIFF
--- a/documentation/DATALOADER.md
+++ b/documentation/DATALOADER.md
@@ -79,7 +79,7 @@ Here is the most basic example of a dataloader configuration file, as `multidata
 ### `caption_strategy`
 
 - **textfile** requires your image.png be next to an image.txt that contains one or more captions, separated by newlines. These image+text pairs **must be in the same directory**.
-- **instance_prompt** requires a value for `instance_prompt` also be provided, and will use **only** this value for the caption of every image in the set.
+- **instanceprompt** requires a value for `instance_prompt` also be provided, and will use **only** this value for the caption of every image in the set.
 - **filename** will use a converted and cleaned-up version of the filename as its caption, eg. after swapping underscores for spaces.
 - **parquet** will pull captions from the parquet table that contains the rest of the image metadata. use the `parquet` field to configure this. See [Parquet caption strategy](#parquet-caption-strategy--json-lines-datasets).
 


### PR DESCRIPTION
The docs show `instance_prompt` when the value should be `instanceprompt`.

```
2024-08-29 15:28:24,677 [ERROR] (__main__) Unsupported caption strategy: instance_prompt. Supported: 'filename', 'textfile', 'parquet', 'instanceprompt', traceback: Traceback (most recent call last):
```