### PR TITLE
Fix Flux schedule shift and add resolution-dependent schedule shift

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -253,6 +253,7 @@ usage: train.py [-h] [--snr_gamma SNR_GAMMA] [--use_soft_min_snr]
                 [--flow_matching_sigmoid_scale FLOW_MATCHING_SIGMOID_SCALE]
                 [--flux_fast_schedule]
                 [--flux_schedule_shift FLUX_SCHEDULE_SHIFT]
+                [--flux_schedule_auto_shift]
                 [--flux_guidance_mode {constant,random-range,mobius}]
                 [--flux_guidance_value FLUX_GUIDANCE_VALUE]
                 [--flux_guidance_min FLUX_GUIDANCE_MIN]
@@ -472,6 +473,16 @@ options:
                         that modification of this value can change how the
                         contrast is learnt by the model, and whether fine
                         details are ignored or accentuated.
+  --flux_schedule_auto_shift
+                        Shift the noise schedule depending on image
+                        resolution. The shift value calculation is taken from
+                        the official Flux inference code. Shift value is
+                        math.exp(1.15) = 3.1581 for a pixel count of 1024px *
+                        1024px. The shift value grows exponentially with
+                        higher pixel counts. It is a good idea to train on a
+                        mix of different resolutions when this option is
+                        enabled. You may need to lower your learning rate with
+                        this enabled.
   --flux_guidance_mode {constant,random-range,mobius}
                         Flux has a 'guidance' value used during training time
                         that reflects the CFG range of your training samples.

--- a/helpers/arguments.py
+++ b/helpers/arguments.py
@@ -144,6 +144,17 @@ def parse_args(input_args=None):
         ),
     )
     parser.add_argument(
+        "--flux_schedule_auto_shift",
+        action="store_true",
+        default=False,
+        help=(
+            "Shift the noise schedule depending on image resolution. The shift value calculation is taken from the official"
+            " Flux inference code. Shift value is math.exp(1.15) = 3.1581 for a pixel count of 1024px * 1024px. The shift"
+            " value grows exponentially with higher pixel counts. It is a good idea to train on a mix of different resolutions"
+            " when this option is enabled. You may need to lower your learning rate with this enabled."
+        ),
+    )
+    parser.add_argument(
         "--flux_guidance_mode",
         type=str,
         choices=["constant", "random-range", "mobius"],

--- a/helpers/models/flux/__init__.py
+++ b/helpers/models/flux/__init__.py
@@ -1,7 +1,38 @@
 import torch
 import random
+import math
 from helpers.models.flux.pipeline import FluxPipeline
 from helpers.training import steps_remaining_in_epoch
+from diffusers.pipelines.flux.pipeline_flux import (
+    calculate_shift as calculate_shift_flux,
+)
+
+
+def apply_flux_schedule_shift(args, noise_scheduler, sigmas, noise):
+    # Resolution-dependent shifting of timestep schedules as per section 5.3.2 of SD3 paper
+    shift = None
+    if (
+        args.flux_schedule_shift is not None
+        and args.flux_schedule_shift > 0
+    ):
+        # Static shift value for every resolution
+        shift = args.flux_schedule_shift
+    elif args.flux_schedule_auto_shift:
+        # Resolution-dependent shift value calculation used by official Flux inference implementation
+        image_seq_len = (noise.shape[-1] * noise.shape[-2]) // 4
+        mu = calculate_shift_flux(
+            (noise.shape[-1] * noise.shape[-2]) // 4,
+            noise_scheduler.config.base_image_seq_len,
+            noise_scheduler.config.max_image_seq_len,
+            noise_scheduler.config.base_shift,
+            noise_scheduler.config.max_shift,
+        )
+        shift = math.exp(mu)
+    if shift is not None:
+        sigmas = (sigmas * shift) / (
+            1 + (shift - 1) * sigmas
+        )
+    return sigmas
 
 
 def get_mobius_guidance(args, global_step, steps_per_epoch, batch_size, device):

--- a/helpers/training/trainer.py
+++ b/helpers/training/trainer.py
@@ -118,6 +118,9 @@ from helpers.models.flux import (
     unpack_latents,
     get_mobius_guidance,
 )
+from diffusers.pipelines.flux.pipeline_flux import (
+    calculate_shift as calculate_shift_flux,
+)
 
 is_optimi_available = False
 try:
@@ -1625,6 +1628,32 @@ class Trainer:
                                 self.config.flow_matching_sigmoid_scale
                                 * torch.randn((bsz,), device=self.accelerator.device)
                             )
+                            # Resolution-dependent shifting of timestep schedules as per section 5.3.2 of SD3 paper
+                            flux_shift_value = None
+                            if (
+                                self.config.flux_schedule_shift is not None
+                                and self.config.flux_schedule_shift > 0
+                            ):
+                                # Static shift value for every resolution
+                                flux_shift_value = self.config.flux_schedule_shift
+                            elif self.config.flux_schedule_auto_shift:
+                                # Resolution-dependent shift value calculation used by official Flux inference implementation
+                                image_seq_len = (noise.shape[-1] * noise.shape[-2]) // 4
+                                mu = calculate_shift_flux(
+                                    (noise.shape[-1] * noise.shape[-2]) // 4,
+                                    self.noise_scheduler.config.base_image_seq_len,
+                                    self.noise_scheduler.config.max_image_seq_len,
+                                    self.noise_scheduler.config.base_shift,
+                                    self.noise_scheduler.config.max_shift,
+                                )
+                                training_logger.debug(
+                                    f"image_seq_len = {image_seq_len}, mu = {mu}, noise.shape = {noise.shape}"
+                                )
+                                flux_shift_value = math.exp(mu)
+                            if flux_shift_value is not None:
+                                sigmas = (sigmas * flux_shift_value) / (
+                                    1 + (flux_shift_value - 1) * sigmas
+                                )
                         else:
                             # fast schedule can only use these sigmas, and they can be sampled up to batch size times
                             available_sigmas = [
@@ -1644,13 +1673,6 @@ class Trainer:
                                 device=self.accelerator.device,
                             )
                         timesteps = sigmas * 1000.0
-                        if (
-                            self.config.flux_schedule_shift is not None
-                            and self.config.flux_schedule_shift > 0
-                        ):
-                            timesteps = (
-                                timesteps * self.config.flux_schedule_shift
-                            ) / (1 + (self.config.flux_schedule_shift - 1) * timesteps)
                         sigmas = sigmas.view(-1, 1, 1, 1)
                     else:
                         # Sample a random timestep for each image, potentially biased by the timestep weights.


### PR DESCRIPTION
This is based on discussion after PR #892. This fixes --flux_schedule_shift by applying the shift to the sigmas. This makes it equivalent with Kohya's code.

This pull request also adds new option --flux_schedule_auto_shift for resolution-dependent shifting based on official Flux inference code:
https://github.com/black-forest-labs/flux/blob/b4f689aaccd40de93429865793e84a734f4a6254/src/flux/sampling.py#L66

People on Discord have been trying this yesterday already and results have been positive. Previous version of the code is here (before rebasing it due refactored train.py):
https://github.com/mhirki/SimpleTuner/commit/7cafb8677543923d11dd00197f0f122d69920cf4

I tested the code using my previous configuration from this run:
https://huggingface.co/mikaelh/flux-sanna-marin-v0.4-fp8-adan2

One of the observations from my own testing was that learning rate needed to be reduced. Initially I tried running with --flux_schedule_shift=3.1582 and lowering learning rate by 2x but that ended up overfitting so I ended up using a checkpoint from 2000 steps. Then I tried --flux_schedule_auto_shift with 5x lower learning rate and it turned out well.

| --flux_schedule_shift=3.1582 with 2x lower LR @ 2000 steps | --flux_schedule_auto_shift with 5x lower LR @ 3000 steps |
| --- | --- |
| ![flux_1725001441_0001](https://github.com/user-attachments/assets/1c5e503a-b3fc-4f9b-8b4d-c99109e188d5) | ![flux_1725092497_0001](https://github.com/user-attachments/assets/766b24c4-7000-4f21-88f2-00d77004507f) |
| ![flux_1725001553_0001](https://github.com/user-attachments/assets/785073f1-36f4-484c-8b86-eece0fe74d29) | ![flux_1725092526_0001](https://github.com/user-attachments/assets/9725a865-2017-4b21-b79a-d1d4af1af153) |
| ![flux_1725001583_0001](https://github.com/user-attachments/assets/d696fc69-99f4-4ab5-8d79-551991b85409) | ![flux_1725092556_0001](https://github.com/user-attachments/assets/6d66ded9-2e94-4a7c-a3bb-29d3952b9d61) |
| ![flux_1725001613_0001](https://github.com/user-attachments/assets/e5267f92-41f8-47f7-bb70-826d256b3633) | ![flux_1725092586_0001](https://github.com/user-attachments/assets/63c27c6b-2296-4830-af95-59998105abb0) |
| ![flux_1725001643_0001](https://github.com/user-attachments/assets/73ec0866-30d6-408e-a56b-27b8e019f293) | ![flux_1725092624_0001](https://github.com/user-attachments/assets/84ebb3c9-c915-4cbb-9f3f-a89aaeab57f6) |
| ![flux_1725001674_0001](https://github.com/user-attachments/assets/8bc8a7ec-e323-48c5-a05e-063da7554e65) | ![flux_1725092663_0001](https://github.com/user-attachments/assets/3013bb8e-1878-4463-935f-4a802cb8976d) |
| ![flux_1725001704_0001](https://github.com/user-attachments/assets/77203b00-69b7-4349-b310-fe4c23bcce81) | ![flux_1725092693_0001](https://github.com/user-attachments/assets/16cb700a-bc50-4a65-bed8-ed9777ed6f1d) |
| ![flux_1725001735_0001](https://github.com/user-attachments/assets/9b10caf9-1b77-480a-aa26-a19262e3d984) | ![flux_1725092723_0001](https://github.com/user-attachments/assets/2e5a40d0-ddac-4bfc-bd06-3bc3d1317e6f) |
