### PR TITLE
Add `"none"` to --report_to argument

### DIFF
--- a/helpers/configuration/cmd_args.py
+++ b/helpers/configuration/cmd_args.py
@@ -1280,7 +1280,8 @@ def parse_cmdline_args(input_args=None):
         default="wandb",
         help=(
             'The integration to report the results and logs to. Supported platforms are `"tensorboard"`'
-            ' (default), `"wandb"` and `"comet_ml"`. Use `"all"` to report to all integrations.'
+            ' (default), `"wandb"` and `"comet_ml"`. Use `"all"` to report to all integrations,'
+            ' or `"none"` to disable logging.'
         ),
     )
     parser.add_argument(

--- a/helpers/training/trainer.py
+++ b/helpers/training/trainer.py
@@ -163,6 +163,7 @@ class Trainer:
 
     def parse_arguments(self, args=None):
         self.config = load_config(args)
+        report_to = None if self.config.report_to.lower() == "none" else self.config.report_to
         self.accelerator = Accelerator(
             gradient_accumulation_steps=self.config.gradient_accumulation_steps,
             mixed_precision=(
@@ -170,7 +171,7 @@ class Trainer:
                 if not torch.backends.mps.is_available()
                 else None
             ),
-            log_with=self.config.report_to,
+            log_with=report_to,
             project_config=self.config.accelerator_project_config,
             kwargs_handlers=[self.config.process_group_kwargs],
         )


### PR DESCRIPTION
This PR introduces the option to disable all logging by specifying --report_to none. Previously, logs were automatically reported to supported integrations like Tensorboard, Wandb, or Comet. With this change, users can now choose to disable logging entirely if desired, enhancing flexibility in scenarios where logging is not needed.