### PR TITLE
Add support for tiny PEFT-based Flux LoRA based on TheLastBen's post on Reddit

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -249,7 +249,7 @@ usage: train.py [-h] [--snr_gamma SNR_GAMMA] [--use_soft_min_snr]
                 [--model_family {pixart_sigma,kolors,sd3,flux,smoldit,sdxl,legacy}]
                 [--model_type {full,lora,deepfloyd-full,deepfloyd-lora,deepfloyd-stage2,deepfloyd-stage2-lora}]
                 [--legacy] [--kolors] [--flux]
-                [--flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit}]
+                [--flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit,tiny,tinier}]
                 [--flow_matching_sigmoid_scale FLOW_MATCHING_SIGMOID_SCALE]
                 [--flux_fast_schedule]
                 [--flux_schedule_shift FLUX_SCHEDULE_SHIFT]
@@ -441,7 +441,7 @@ options:
                         model.
   --flux                This option must be provided when training a Flux
                         model.
-  --flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit}
+  --flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit,tiny,tinier}
                         Flux has single and joint attention blocks. By
                         default, all attention layers are trained, but not the
                         feed-forward layers If 'mmdit' is provided, the text
@@ -453,7 +453,11 @@ options:
                         in earlier SD versions. If 'all' is provided, all
                         layers will be trained, minus feed-forward. If
                         'all+ffs' is provided, all layers will be trained
-                        including feed-forward.
+                        including feed-forward. If 'ai-toolkit' is provided,
+                        all layers will be trained including feed-forward and
+                        norms (based on ostris/ai-toolkit). If 'tiny' is
+                        provided, only two layers will be trained. If 'tinier'
+                        is provided, only one layers will be trained.
   --flow_matching_sigmoid_scale FLOW_MATCHING_SIGMOID_SCALE
                         Scale factor for sigmoid timestep sampling for flow-
                         matching models..

--- a/configure.py
+++ b/configure.py
@@ -479,7 +479,7 @@ def configure_env():
     # Flux-specific options
     if "FLUX" in env_contents and env_contents["--model_family"] == "flux":
         if env_contents["--model_type"].lower() == "lora" and not use_lycoris:
-            flux_targets = ["mmdit", "context", "all", "all+ffs", "ai-toolkit"]
+            flux_targets = ["mmdit", "context", "all", "all+ffs", "ai-toolkit", "tiny", "tinier"]
             flux_target_layers = None
             while flux_target_layers not in flux_targets:
                 if flux_target_layers:

--- a/helpers/configuration/cmd_args.py
+++ b/helpers/configuration/cmd_args.py
@@ -104,7 +104,7 @@ def parse_cmdline_args(input_args=None):
     parser.add_argument(
         "--flux_lora_target",
         type=str,
-        choices=["mmdit", "context", "context+ffs", "all", "all+ffs", "ai-toolkit"],
+        choices=["mmdit", "context", "context+ffs", "all", "all+ffs", "ai-toolkit", "tiny", "tinier"],
         default="all",
         help=(
             "Flux has single and joint attention blocks."
@@ -114,6 +114,9 @@ def parse_cmdline_args(input_args=None):
             " If 'context+ffs' is provided, then text attention and text feed-forward layers are trained. This is somewhat similar to text-encoder-only training in earlier SD versions."
             " If 'all' is provided, all layers will be trained, minus feed-forward."
             " If 'all+ffs' is provided, all layers will be trained including feed-forward."
+            " If 'ai-toolkit' is provided, all layers will be trained including feed-forward and norms (based on ostris/ai-toolkit)."
+            " If 'tiny' is provided, only two layers will be trained."
+            " If 'tinier' is provided, only one layers will be trained."
         ),
     )
     parser.add_argument(

--- a/helpers/training/adapter.py
+++ b/helpers/training/adapter.py
@@ -84,7 +84,7 @@ def determine_adapter_target_modules(args, unet, transformer):
                 "single_transformer_blocks.7.proj_out",
                 "single_transformer_blocks.20.proj_out",
             ]
-        elif args.flux_lora_target == "tinier":
+        elif args.flux_lora_target == "nano":
             # From TheLastBen
             # https://www.reddit.com/r/StableDiffusion/comments/1f523bd/good_flux_loras_can_be_less_than_45mb_128_dim/
             target_modules = [

--- a/helpers/training/adapter.py
+++ b/helpers/training/adapter.py
@@ -77,6 +77,19 @@ def determine_adapter_target_modules(args, unet, transformer):
                 "proj_mlp",
                 "proj_out",
             ]
+        elif args.flux_lora_target == "tiny":
+            # From TheLastBen
+            # https://www.reddit.com/r/StableDiffusion/comments/1f523bd/good_flux_loras_can_be_less_than_45mb_128_dim/
+            target_modules = [
+                "single_transformer_blocks.7.proj_out",
+                "single_transformer_blocks.20.proj_out",
+            ]
+        elif args.flux_lora_target == "tinier":
+            # From TheLastBen
+            # https://www.reddit.com/r/StableDiffusion/comments/1f523bd/good_flux_loras_can_be_less_than_45mb_128_dim/
+            target_modules = [
+                "single_transformer_blocks.7.proj_out",
+            ]
 
         return target_modules
 


### PR DESCRIPTION
As suggested on Reddit by TheLastBen:
https://www.reddit.com/r/StableDiffusion/comments/1f523bd/good_flux_loras_can_be_less_than_45mb_128_dim/

I'm currently testing --flux_lora_target=tinier with a rank 16 LoRA and it's having some effect:

| 100 steps | 1300 steps |
| --- | --- |
| ![step_100_validation_1024x1024](https://github.com/user-attachments/assets/4c4d951e-8a09-4faa-8b48-8e294b04419d) | ![step_1300_validation_1024x1024](https://github.com/user-attachments/assets/8b5a0dd3-a7c0-49f2-afa1-b429a7353f74) |

File size is only 576 kB for this ultra-tiny LoRA. My learning rate is at 1e-3 with adamw_bf16 optimizer.