### PR TITLE
Rename 'tinier' to 'nano' everywhere

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -249,7 +249,7 @@ usage: train.py [-h] [--snr_gamma SNR_GAMMA] [--use_soft_min_snr]
                 [--model_family {pixart_sigma,kolors,sd3,flux,smoldit,sdxl,legacy}]
                 [--model_type {full,lora,deepfloyd-full,deepfloyd-lora,deepfloyd-stage2,deepfloyd-stage2-lora}]
                 [--legacy] [--kolors] [--flux]
-                [--flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit,tiny,tinier}]
+                [--flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit,tiny,nano}]
                 [--flow_matching_sigmoid_scale FLOW_MATCHING_SIGMOID_SCALE]
                 [--flux_fast_schedule]
                 [--flux_schedule_shift FLUX_SCHEDULE_SHIFT]
@@ -441,7 +441,7 @@ options:
                         model.
   --flux                This option must be provided when training a Flux
                         model.
-  --flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit,tiny,tinier}
+  --flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit,tiny,nano}
                         Flux has single and joint attention blocks. By
                         default, all attention layers are trained, but not the
                         feed-forward layers If 'mmdit' is provided, the text
@@ -456,7 +456,7 @@ options:
                         including feed-forward. If 'ai-toolkit' is provided,
                         all layers will be trained including feed-forward and
                         norms (based on ostris/ai-toolkit). If 'tiny' is
-                        provided, only two layers will be trained. If 'tinier'
+                        provided, only two layers will be trained. If 'nano'
                         is provided, only one layers will be trained.
   --flow_matching_sigmoid_scale FLOW_MATCHING_SIGMOID_SCALE
                         Scale factor for sigmoid timestep sampling for flow-

--- a/configure.py
+++ b/configure.py
@@ -479,7 +479,7 @@ def configure_env():
     # Flux-specific options
     if "FLUX" in env_contents and env_contents["--model_family"] == "flux":
         if env_contents["--model_type"].lower() == "lora" and not use_lycoris:
-            flux_targets = ["mmdit", "context", "all", "all+ffs", "ai-toolkit", "tiny", "tinier"]
+            flux_targets = ["mmdit", "context", "all", "all+ffs", "ai-toolkit", "tiny", "nano"]
             flux_target_layers = None
             while flux_target_layers not in flux_targets:
                 if flux_target_layers:

--- a/helpers/configuration/cmd_args.py
+++ b/helpers/configuration/cmd_args.py
@@ -104,7 +104,7 @@ def parse_cmdline_args(input_args=None):
     parser.add_argument(
         "--flux_lora_target",
         type=str,
-        choices=["mmdit", "context", "context+ffs", "all", "all+ffs", "ai-toolkit", "tiny", "tinier"],
+        choices=["mmdit", "context", "context+ffs", "all", "all+ffs", "ai-toolkit", "tiny", "nano"],
         default="all",
         help=(
             "Flux has single and joint attention blocks."
@@ -116,7 +116,7 @@ def parse_cmdline_args(input_args=None):
             " If 'all+ffs' is provided, all layers will be trained including feed-forward."
             " If 'ai-toolkit' is provided, all layers will be trained including feed-forward and norms (based on ostris/ai-toolkit)."
             " If 'tiny' is provided, only two layers will be trained."
-            " If 'tinier' is provided, only one layers will be trained."
+            " If 'nano' is provided, only one layers will be trained."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
Followup to #912 to finish renaming 'tinier' to 'nano'.