### PR TITLE
multi-node training fixes for state tracker

### DIFF
--- a/documentation/DISTRIBUTED.md
+++ b/documentation/DISTRIBUTED.md
@@ -62,7 +62,7 @@ sudo systemctl status nfs-kernel-server
 
 ---
 
-#### **On the Slave Machine:**
+#### On the slave nodes that send optimiser and other states
 
 **1. Install NFS Client Packages**
 

--- a/helpers/training/save_hooks.py
+++ b/helpers/training/save_hooks.py
@@ -494,7 +494,7 @@ class SaveHookManager:
             StateTracker.load_training_state(self.training_state_path)
         else:
             logger.warning(
-                f"Could not find training_state.json in checkpoint dir {input_dir}"
+                f"Could not find {self.training_state_path} in checkpoint dir {input_dir}"
             )
         if "lora" in self.args.model_type and self.args.lora_type == "standard":
             self._load_lora(models=models, input_dir=input_dir)

--- a/helpers/training/save_hooks.py
+++ b/helpers/training/save_hooks.py
@@ -330,11 +330,11 @@ class SaveHookManager:
 
     def save_model_hook(self, models, weights, output_dir):
         # Write "training_state.json" to the output directory containing the training state
-        if not self.accelerator.is_main_process:
-            return
         StateTracker.save_training_state(
             os.path.join(output_dir, self.training_state_path)
         )
+        if not self.accelerator.is_main_process:
+            return
         if "lora" in self.args.model_type and self.args.lora_type == "standard":
             self._save_lora(models=models, weights=weights, output_dir=output_dir)
             return

--- a/helpers/training/save_hooks.py
+++ b/helpers/training/save_hooks.py
@@ -1,5 +1,6 @@
 from diffusers.training_utils import EMAModel, _set_state_dict_into_text_encoder
 from helpers.training.wrappers import unwrap_model
+from helpers.training.multi_process import _get_rank as get_rank
 from diffusers.utils import (
     convert_state_dict_to_diffusers,
     convert_unet_state_dict_to_peft,
@@ -184,7 +185,7 @@ class SaveHookManager:
                 self.ema_model_cls = PixArtTransformer2DModel
         self.training_state_path = "training_state.json"
         if self.accelerator is not None:
-            rank = getattr(self.accelerator, "rank", 0)
+            rank = get_rank()
             if rank > 0:
                 self.training_state_path = f"training_state-rank{rank}.json"
 

--- a/helpers/training/trainer.py
+++ b/helpers/training/trainer.py
@@ -19,6 +19,7 @@ os.environ["ACCELERATE_LOG_LEVEL"] = "WARNING"
 from helpers import log_format  # noqa
 from helpers.configuration.loader import load_config
 from helpers.caching.memory import reclaim_memory
+from helpers.training.multi_process import _get_rank as get_rank
 from helpers.training.validation import Validation, prepare_validation_prompt_list
 from helpers.training.state_tracker import StateTracker
 from helpers.training.schedulers import load_scheduler_from_args
@@ -1464,7 +1465,9 @@ class Trainer:
             if "sampler" in backend:
                 backend["sampler"].load_states(
                     state_path=os.path.join(
-                        self.config.output_dir, path, "training_state.json"
+                        self.config.output_dir,
+                        path,
+                        f"training_state-{get_rank()}.json",
                     ),
                 )
         self.state["global_resume_step"] = self.state["global_step"] = (

--- a/helpers/training/trainer.py
+++ b/helpers/training/trainer.py
@@ -2645,7 +2645,8 @@ class Trainer:
                                     logger.debug(f"Backend: {backend}")
                                     backend["sampler"].save_state(
                                         state_path=os.path.join(
-                                            save_path, "training_state.json"
+                                            save_path,
+                                            self.model_hooks.training_state_path,
                                         ),
                                     )
 


### PR DESCRIPTION
- disable validations / benchmarking for deepspeed zero 3, fixing #965 
- save training state for every rank and apply them correctly at resume time