### PR TITLE
refactor how masks are retrieved

### DIFF
--- a/helpers/multiaspect/dataset.py
+++ b/helpers/multiaspect/dataset.py
@@ -44,28 +44,30 @@ class MultiAspectDataset(Dataset):
                 image_metadata = sample.image_metadata
             else:
                 image_metadata = sample
-            if "target_size" in image_metadata:
-                calculated_aspect_ratio = MultiaspectImage.calculate_image_aspect_ratio(
-                    image_metadata["target_size"]
-                )
-                if first_aspect_ratio is None:
-                    first_aspect_ratio = calculated_aspect_ratio
-                elif first_aspect_ratio != calculated_aspect_ratio:
-                    raise ValueError(
-                        f"Aspect ratios must be the same for all images in a batch. Expected: {first_aspect_ratio}, got: {calculated_aspect_ratio}"
+                if "target_size" in image_metadata:
+                    calculated_aspect_ratio = (
+                        MultiaspectImage.calculate_image_aspect_ratio(
+                            image_metadata["target_size"]
+                        )
                     )
-            if "deepfloyd" not in StateTracker.get_args().model_type and (
-                image_metadata["original_size"] is None
-                or image_metadata["target_size"] is None
-            ):
-                raise Exception(
-                    f"Metadata was unavailable for image: {image_metadata['image_path']}. Ensure --skip_file_discovery=metadata is not set."
-                )
+                    if first_aspect_ratio is None:
+                        first_aspect_ratio = calculated_aspect_ratio
+                    elif first_aspect_ratio != calculated_aspect_ratio:
+                        raise ValueError(
+                            f"Aspect ratios must be the same for all images in a batch. Expected: {first_aspect_ratio}, got: {calculated_aspect_ratio}"
+                        )
+                if "deepfloyd" not in StateTracker.get_args().model_type and (
+                    image_metadata["original_size"] is None
+                    or image_metadata["target_size"] is None
+                ):
+                    raise Exception(
+                        f"Metadata was unavailable for image: {image_metadata['image_path']}. Ensure --skip_file_discovery=metadata is not set."
+                    )
 
-            if self.print_names:
-                logger.info(
-                    f"Dataset is now using image: {image_metadata['image_path']}"
-                )
+                if self.print_names:
+                    logger.info(
+                        f"Dataset is now using image: {image_metadata['image_path']}"
+                    )
 
             if type(sample) is TrainingSample:
                 output_data["conditioning_samples"].append(sample)

--- a/poetry.lock
+++ b/poetry.lock
@@ -5059,4 +5059,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "f0da2159964a47e2b1de1c17e96129090308cbc90f459e2f9818f06d52a836dc"
+content-hash = "3800eedc853dde74ffd0bd1b9056f56b27473500962122d4e3228a2f47e04764"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,8 @@ torchao = {version = "^0.5.0+cu124", source = "pytorch"}
 lm-eval = "^0.4.4"
 nvidia-cudnn-cu12 = "^9.4.0.58"
 nvidia-nccl-cu12 = "^2.23.4"
-pytorch-triton = {version = "^3.1.0+cf34004b8a", source = "pytorch-nightly"}
+pytorch-triton = {version = "3.1.0+cf34004b8a", source = "pytorch-nightly"}
+aiohappyeyeballs = "2.4.2"
 
 
 [build-system]


### PR DESCRIPTION
when square cropping, it worked alright, but when aspect bucketing with random crops or random/closest bucket, the mask would not prepare the same as the origin sample.

a prepare_like method is added to prepare one sample using the same transforms as another.

optimises startup speed of larger datasets by skipping the aspect bucketing and VAE caching steps which are not necessary.