### PR TITLE
Add deduplication of captions

### DIFF
--- a/helpers/prompts.py
+++ b/helpers/prompts.py
@@ -462,6 +462,9 @@ class PromptHandler:
                 # allow caching of multiple captions, if returned by the backend.
                 captions.extend(caption)
 
+        # Deduplicate captions
+        captions = list(set(captions))
+
         return captions
 
     @staticmethod


### PR DESCRIPTION
This pull request adds deduplication of captions. I ran a little benchmark comparing two deduplication methods with 9997 captions from the pseudo-camera-10k dataset.

`captions = list(dict.fromkeys(captions))`
Deduplication complete in 875493 ns.
Deduplication complete in 865751 ns.
Deduplication complete in 880586 ns.

`captions = list(set(captions))`
Deduplication complete in 1007244 ns.
Deduplication complete in 943887 ns.
Deduplication complete in 936598 ns.

So building a dictionary is the fastest method. These are nanoseconds meaning that 9997 captions were deduplicated in less than 1 millisecond.