### PR TITLE
Give --flux_schedule_auto_shift parameter priority over --flux_schedule_shift

### DIFF
--- a/helpers/models/flux/__init__.py
+++ b/helpers/models/flux/__init__.py
@@ -14,7 +14,7 @@ def apply_flux_schedule_shift(args, noise_scheduler, sigmas, noise):
     if args.flux_schedule_shift is not None and args.flux_schedule_shift > 0:
         # Static shift value for every resolution
         shift = args.flux_schedule_shift
-    elif args.flux_schedule_auto_shift:
+    if args.flux_schedule_auto_shift:
         # Resolution-dependent shift value calculation used by official Flux inference implementation
         image_seq_len = (noise.shape[-1] * noise.shape[-2]) // 4
         mu = calculate_shift_flux(


### PR DESCRIPTION
I think `--flux_schedule_auto_shift` should have priority over `--flux_schedule_shift` now that the latter has a new default value after commit 4a7d42320e4457be7e52540cac1df191a1b88596. This prevents old configs from breaking assuming that people have only specified `--flux_schedule_auto_shift` in their config.