### PR TITLE
Throw an error if both --flux_schedule_auto_shift and --flux_schedule_shift are enabled.

### DIFF
--- a/helpers/training/default_settings/safety_check.py
+++ b/helpers/training/default_settings/safety_check.py
@@ -107,3 +107,12 @@ def safety_check(args, accelerator):
             f"{args.model_type} tuning is not compatible with quantisation. Please set --base_model_precision to 'no_change' or train LyCORIS/LoRA."
         )
         sys.exit(1)
+
+    if (
+        args.flux_schedule_shift is not None and args.flux_schedule_shift > 0
+        and args.flux_schedule_auto_shift
+    ):
+        logger.error(
+            f"--flux_schedule_auto_shift cannot be combined with --flux_schedule_shift. Please set --flux_schedule_shift to 0 if you want to train with --flux_schedule_auto_shift."
+        )
+        sys.exit(1)


### PR DESCRIPTION
As an alternative to PR #1105, just throw an error if both --flux_schedule_auto_shift and --flux_schedule_shift are enabled, forcing the user to explicitly choose one of them.

Since the default value of --flux_schedule_shift is now 3 after commit 4a7d42320e4457be7e52540cac1df191a1b88596, people need to set it 0 if they want to continue training with auto-shift.