### PR TITLE
Fix unit test failure after PR #1106

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -137,6 +137,8 @@ class TestTrainer(unittest.TestCase):
             mixed_precision="bf16",
             report_to="none",
             output_dir="output_dir",
+            flux_schedule_shift=3,
+            flux_schedule_auto_shift=False,
         ),
     )
     def test_misc_init(


### PR DESCRIPTION
My previous pull request #1106 caused the unit tests to fail. Setting both flux_schedule_shift and flux_schedule_auto_shift explicitly in the unit test seems to fix the issue.

```
======================================================================
ERROR: test_misc_init (test_trainer.TestTrainer.test_misc_init)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/unittest/mock.py", line 1378, in patched
    return func(*newargs, **newkeywargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/SimpleTuner/SimpleTuner/tests/test_trainer.py", line 154, in test_misc_init
    trainer = Trainer(disable_accelerator=True)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/SimpleTuner/SimpleTuner/helpers/training/trainer.py", line 164, in __init__
    self.parse_arguments(args=config, disable_accelerator=disable_accelerator)
  File "/home/runner/work/SimpleTuner/SimpleTuner/helpers/training/trainer.py", line 202, in parse_arguments
    safety_check(args=self.config, accelerator=self.accelerator)
  File "/home/runner/work/SimpleTuner/SimpleTuner/helpers/training/default_settings/safety_check.py", line 112, in safety_check
    args.flux_schedule_shift is not None and args.flux_schedule_shift > 0
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'MagicMock' and 'int'
```