### PR TITLE
Fix random validation errors for good (and restore torch.compile for the validation pipeline at the same time)

### DIFF
--- a/helpers/training/validation.py
+++ b/helpers/training/validation.py
@@ -968,6 +968,8 @@ class Validation:
                 "tokenizer": self.tokenizer_1,
                 "vae": self.vae,
                 "safety_checker": None,
+                "text_encoder_2": None,
+                "text_encoder_3": None,
             }
             if type(pipeline_cls) is StableDiffusionXLPipeline:
                 del extra_pipeline_kwargs["safety_checker"]
@@ -1071,7 +1073,7 @@ class Validation:
                     logger.error(e)
                     logger.error(traceback.format_exc())
                     continue
-                return None
+                break
             if self.args.validation_torch_compile:
                 if self.unet is not None and not is_compiled_module(self.unet):
                     logger.warning(

--- a/helpers/training/validation.py
+++ b/helpers/training/validation.py
@@ -968,9 +968,11 @@ class Validation:
                 "tokenizer": self.tokenizer_1,
                 "vae": self.vae,
                 "safety_checker": None,
-                "text_encoder_2": None,
-                "text_encoder_3": None,
             }
+            if self.args.model_family in ["sd3", "sdxl", "flux"]:
+                extra_pipeline_kwargs["text_encoder_2"] = None
+            if self.args.model_family in ["sd3"]:
+                extra_pipeline_kwargs["text_encoder_3"] = None
             if type(pipeline_cls) is StableDiffusionXLPipeline:
                 del extra_pipeline_kwargs["safety_checker"]
                 del extra_pipeline_kwargs["text_encoder"]


### PR DESCRIPTION
I saw the random validation errors were back after commit 48cfc09db92ff64281ab7eb6ca9e41f59bb9e23f removed some of my earlier fixes for the random validation issues. This time I decided to dig to the bottom of the issue of why the pipeline is randomly on the cpu.

The root cause turned out to be an early return in `setup_pipeline` which means that this line at the end of `setup_pipeline` is never executed:
```python
        self.pipeline = self.pipeline.to(self.inference_device)
```
And torch.compile before that is also never called.

I did notice that moving the entire pipeline to the accelerator device has some unwanted side-effects. It also moved text_encoder_2 and text_encoder_3 to the GPU when I was testing with SD3.5. Setting text_encoder_2 and text_encoder_3 to None in `extra_pipeline_kwargs` prevents them from being loaded in the first place. I'm hoping other pipelines won't complain about text_encoder_2 and text_encoder_3 in kwargs. I tried throwing in text_encoder_4 there and the SD3 pipeline didn't complain.

I tried testing validation_torch_compile but it seemed to be taking forever so I eventually just ended up killing it.