### PR TITLE
gradient checkpointing speed-up

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -544,11 +544,11 @@ def configure_env():
     )
     env_contents["--gradient_checkpointing"] = "true"
     gradient_checkpointing_interval = prompt_user(
-        "Would you like to configure a gradient checkpointing interval? A value larger than 1 will increase VRAM usage but speed up training by skipping checkpoint creation every Nth layer",
+        "Would you like to configure a gradient checkpointing interval? A value larger than 1 will increase VRAM usage but speed up training by skipping checkpoint creation every Nth layer, and a zero will disable this feature.",
         0,
     )
     try:
-        if int(gradient_checkpointing_interval) > 0:
+        if int(gradient_checkpointing_interval) > 1:
             env_contents["--gradient_checkpointing_interval"] = int(
                 gradient_checkpointing_interval
             )

--- a/configure.py
+++ b/configure.py
@@ -543,6 +543,18 @@ def configure_env():
         )
     )
     env_contents["--gradient_checkpointing"] = "true"
+    gradient_checkpointing_interval = prompt_user(
+        "Would you like to configure a gradient checkpointing interval? A value larger than 1 will increase VRAM usage but speed up training by skipping checkpoint creation every Nth layer",
+        0,
+    )
+    try:
+        if int(gradient_checkpointing_interval) > 0:
+            env_contents["--gradient_checkpointing_interval"] = int(
+                gradient_checkpointing_interval
+            )
+    except:
+        print("Could not parse gradient checkpointing interval. Not enabling.")
+        pass
 
     env_contents["--caption_dropout_probability"] = float(
         prompt_user(

--- a/configure.py
+++ b/configure.py
@@ -433,13 +433,29 @@ def configure_env():
     env_contents["--attention_mechanism"] = "diffusers"
     use_sageattention = (
         prompt_user(
-            "Would you like to use SageAttention? This is an experimental option that can greatly speed up training. (y/[n])",
+            "Would you like to use SageAttention for image validation generation? (y/[n])",
             "n",
         ).lower()
         == "y"
     )
     if use_sageattention:
         env_contents["--attention_mechanism"] = "sageattention"
+        env_contents["--sageattention_usage"] = "inference"
+        use_sageattention_training = (
+            prompt_user(
+                (
+                    "Would you like to use SageAttention to cover the forward and backward pass during training?"
+                    " This has the undesirable consequence of leaving the attention layers untrained,"
+                    " as SageAttention lacks the capability to fully track gradients through quantisation."
+                    " If you are not training the attention layers for some reason, this may not matter and"
+                    " you can safely enable this. For all other use-cases, reconsideration and caution are warranted."
+                ),
+                "n",
+            ).lower()
+            == "y"
+        )
+        if use_sageattention_training:
+            env_contents["--sageattention_usage"] = "both"
 
     # properly disable wandb/tensorboard/comet_ml etc by default
     report_to_str = "none"

--- a/helpers/configuration/cmd_args.py
+++ b/helpers/configuration/cmd_args.py
@@ -1055,6 +1055,15 @@ def get_argument_parser():
         help="Whether or not to use gradient checkpointing to save memory at the expense of slower backward pass.",
     )
     parser.add_argument(
+        "--gradient_checkpointing_interval",
+        default=None,
+        type=int,
+        help=(
+            "Some models (Flux, SDXL, SD1.x/2.x) can have their gradient checkpointing limited to every nth block."
+            " This can speed up training but will use more memory with larger intervals."
+        ),
+    )
+    parser.add_argument(
         "--learning_rate",
         type=float,
         default=4e-7,

--- a/helpers/configuration/cmd_args.py
+++ b/helpers/configuration/cmd_args.py
@@ -1744,7 +1744,7 @@ def get_argument_parser():
     parser.add_argument(
         "--enable_xformers_memory_efficient_attention",
         action="store_true",
-        help="Whether or not to use xformers. Deprecated and slated for future removal.",
+        help="Whether or not to use xformers. Deprecated and slated for future removal. Use --attention_mechanism.",
     )
     parser.add_argument(
         "--set_grads_to_none",

--- a/helpers/models/flux/transformer.py
+++ b/helpers/models/flux/transformer.py
@@ -588,10 +588,6 @@ class FluxTransformer2DModelWithMasking(
                 )
             ):
 
-                print(
-                    f"checkpointing index {index_block} at interval: {self.gradient_checkpointing_interval}"
-                )
-
                 def create_custom_forward(module, return_dict=None):
                     def custom_forward(*inputs):
                         if return_dict is not None:

--- a/helpers/training/default_settings/safety_check.py
+++ b/helpers/training/default_settings/safety_check.py
@@ -133,3 +133,21 @@ def safety_check(args, accelerator):
                 f"{args.base_model_precision} is not supported with SageAttention. Please select from int8 or fp8, or, disable quantisation to use SageAttention."
             )
             sys.exit(1)
+
+    gradient_checkpointing_interval_supported_models = [
+        "flux",
+        "sdxl",
+    ]
+    if args.gradient_checkpointing_interval is not None:
+        if (
+            args.model_family.lower()
+            not in gradient_checkpointing_interval_supported_models
+        ):
+            logger.error(
+                f"Gradient checkpointing is not supported with {args.model_family} models. Please disable --gradient_checkpointing_interval by setting it to None, or remove it from your configuration. Currently supported models: {gradient_checkpointing_interval_supported_models}"
+            )
+            sys.exit(1)
+        if args.gradient_checkpointing_interval == 0:
+            raise ValueError(
+                "Gradient checkpointing interval must be greater than 0. Please set it to a positive integer."
+            )

--- a/helpers/training/gradient_checkpointing_interval.py
+++ b/helpers/training/gradient_checkpointing_interval.py
@@ -1,0 +1,42 @@
+import torch
+from torch.utils.checkpoint import checkpoint as original_checkpoint
+
+
+# Global variables to keep track of the checkpointing state
+_checkpoint_call_count = 0
+_checkpoint_interval = 4  # You can set this to any interval you prefer
+
+
+def reset_checkpoint_counter():
+    """Resets the checkpoint call counter. Call this at the beginning of the forward pass."""
+    global _checkpoint_call_count
+    _checkpoint_call_count = 0
+
+
+def set_checkpoint_interval(n):
+    """Sets the interval at which checkpointing is skipped."""
+    global _checkpoint_interval
+    _checkpoint_interval = n
+
+
+def checkpoint_wrapper(function, *args, use_reentrant=True, **kwargs):
+    """Wrapper function for torch.utils.checkpoint.checkpoint."""
+    global _checkpoint_call_count, _checkpoint_interval
+    _checkpoint_call_count += 1
+
+    if (
+        _checkpoint_interval > 0
+        and (_checkpoint_call_count % _checkpoint_interval) == 0
+    ):
+        # Use the original checkpoint function
+        return original_checkpoint(
+            function, *args, use_reentrant=use_reentrant, **kwargs
+        )
+    else:
+        # Skip checkpointing: execute the function directly
+        # Do not pass 'use_reentrant' to the function
+        return function(*args, **kwargs)
+
+
+# Monkeypatch torch.utils.checkpoint.checkpoint
+torch.utils.checkpoint.checkpoint = checkpoint_wrapper

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -140,6 +140,7 @@ class TestTrainer(unittest.TestCase):
             flux_schedule_shift=3,
             flux_schedule_auto_shift=False,
             validation_guidance_skip_layers=None,
+            gradient_checkpointing_interval=None,
         ),
     )
     def test_misc_init(


### PR DESCRIPTION
thanks to snek on discord for the heads-up to [Erwann Millon's post](https://x.com/ErwannMillon/status/1828890824337436993) on a quick win for gradient checkpointing.

while investigating i found that inference was running w/ checkpointing even though we're not calculating grads so that's been disabled before validations run too.

## flux

generation time from 29s to 14s for a 28 step img on flux dev on a 4090 with a 5800X3D and fp8-quanto 

when training with a rank 1 lora we can use `--gradient_checkpointing_interval=2` on a 24G 4090 w/ fp8-quanto and speed up from 4.25 second per training step to 3.00 second per training step at 1024px

otherwise you'd be able to train much larger LoRA on 24G.

haven't tested this on larger GPUs yet, where the benefits are greater and allows higher intervals.

## sdxl

implemented via a hackjob from hell, thanks to the o1-preview LLM and the tendril-like complexity of the forward block checkpointing in the diffusers Unet code. it's a big sledgehammer that overwrites the torch checkpointing function so that it only _actually_ runs every n calls.

speeds up training from 1.00 it/sec to 1.50 it/sec using the same dataset from flux training test on a LoRA rank of 16.

it's easy to OOM here with an interval that's too high, and in the case of SDXL it'll possibly happen randomly after your first validations run. so, be mindful of that.