### PR TITLE
flux: use rank 0 for h100 detection since that is the most realistic setup

### DIFF
--- a/helpers/models/flux/transformer.py
+++ b/helpers/models/flux/transformer.py
@@ -210,11 +210,8 @@ class FluxSingleTransformerBlock(nn.Module):
 
         processor = FluxAttnProcessor2_0()
         if torch.cuda.is_available():
-            rank = (
-                torch.distributed.get_rank()
-                if torch.distributed.is_initialized()
-                else 0
-            )
+            # let's assume that the box only ever has H100s.
+            rank = 0
             primary_device = torch.cuda.get_device_properties(rank)
             if primary_device.major == 9 and primary_device.minor == 0:
                 if is_flash_attn_available:


### PR DESCRIPTION
fixes #1223 by just checking rank 0 for H100 access always.