### PR TITLE
Small fixes for running on AMD GPUs

### DIFF
--- a/helpers/training/default_settings/safety_check.py
+++ b/helpers/training/default_settings/safety_check.py
@@ -3,6 +3,7 @@ from os import environ
 from diffusers.utils import is_wandb_available
 from helpers.training.multi_process import _get_rank as get_rank
 from helpers.training.state_tracker import StateTracker
+from torch.version import cuda as cuda_version
 
 logger = logging.getLogger(__name__)
 if get_rank() == 0:
@@ -73,6 +74,7 @@ def safety_check(args, accelerator):
         accelerator is not None
         and accelerator.device.type == "cuda"
         and accelerator.is_main_process
+        and cuda_version is not None
     ):
         import subprocess
 

--- a/helpers/training/optimizer_param.py
+++ b/helpers/training/optimizer_param.py
@@ -55,6 +55,12 @@ except:
             "Could not load bitsandbytes library. BnB-specific optimisers and other functionality will be unavailable."
         )
 
+# Some optimizers are not available in multibackend bitsandbytes as of January 2025.
+is_ademamix_available = False
+if is_bitsandbytes_available:
+    if 'AdEMAMix' in dir(bitsandbytes.optim):
+        is_ademamix_available = True
+
 optimizer_choices = {
     "adamw_bf16": {
         "precision": "bf16",
@@ -353,6 +359,47 @@ if is_bitsandbytes_available:
                 },
                 "class": bitsandbytes.optim.PagedAdamW8bit,
             },
+            "bnb-lion": {
+                "precision": "any",
+                "default_settings": {
+                    "betas": (0.9, 0.99),
+                    "weight_decay": 0.0,
+                    "min_8bit_size": 4096,
+                },
+                "class": bitsandbytes.optim.Lion,
+            },
+            "bnb-lion8bit": {
+                "precision": "any",
+                "default_settings": {
+                    "betas": (0.9, 0.99),
+                    "weight_decay": 0.0,
+                    "min_8bit_size": 4096,
+                },
+                "class": bitsandbytes.optim.Lion8bit,
+            },
+            "bnb-lion-paged": {
+                "precision": "any",
+                "default_settings": {
+                    "betas": (0.9, 0.99),
+                    "weight_decay": 0.0,
+                    "min_8bit_size": 4096,
+                },
+                "class": bitsandbytes.optim.PagedLion,
+            },
+            "bnb-lion8bit-paged": {
+                "precision": "any",
+                "default_settings": {
+                    "betas": (0.9, 0.99),
+                    "weight_decay": 0.0,
+                    "min_8bit_size": 4096,
+                },
+                "class": bitsandbytes.optim.PagedLion8bit,
+            },
+        })
+
+if is_ademamix_available:
+    optimizer_choices.update(
+        {
             "bnb-ademamix": {
                 "precision": "any",
                 "default_settings": {
@@ -404,43 +451,7 @@ if is_bitsandbytes_available:
                     "min_8bit_size": 4096,
                 },
                 "class": bitsandbytes.optim.PagedAdEMAMix8bit,
-            },
-            "bnb-lion": {
-                "precision": "any",
-                "default_settings": {
-                    "betas": (0.9, 0.99),
-                    "weight_decay": 0.0,
-                    "min_8bit_size": 4096,
-                },
-                "class": bitsandbytes.optim.Lion,
-            },
-            "bnb-lion8bit": {
-                "precision": "any",
-                "default_settings": {
-                    "betas": (0.9, 0.99),
-                    "weight_decay": 0.0,
-                    "min_8bit_size": 4096,
-                },
-                "class": bitsandbytes.optim.Lion8bit,
-            },
-            "bnb-lion-paged": {
-                "precision": "any",
-                "default_settings": {
-                    "betas": (0.9, 0.99),
-                    "weight_decay": 0.0,
-                    "min_8bit_size": 4096,
-                },
-                "class": bitsandbytes.optim.PagedLion,
-            },
-            "bnb-lion8bit-paged": {
-                "precision": "any",
-                "default_settings": {
-                    "betas": (0.9, 0.99),
-                    "weight_decay": 0.0,
-                    "min_8bit_size": 4096,
-                },
-                "class": bitsandbytes.optim.PagedLion8bit,
-            },
+            }
         }
     )
 


### PR DESCRIPTION
Small modification to enable running on AMD GPUs:

1. bypass GPU mem size check if torch.cuda.version is none
2. reordered the optimizer list and added an if clause to check if bitsandbytes ademamix optimizers are available. These optimizers are not yet in the multibackend bitsandbytes for rocm.

The modified code was tested on AMD MI300X and Nvidia H100.