### PR TITLE
add a special case for square input images where we need to resize to the target as intermediary, which can be considered a safe operation

### DIFF
--- a/helpers/image_manipulation/training_sample.py
+++ b/helpers/image_manipulation/training_sample.py
@@ -341,6 +341,7 @@ class TrainingSample:
         if not self.crop_enabled:
             self.save_debug_image(f"images/{time.time()}-1b-nocrop-resize.png")
             self.resize()
+            self.save_debug_image(f"images/{time.time()}-2-final-output.png")
 
         image = self.image
         if return_tensor:
@@ -512,7 +513,9 @@ class TrainingSample:
                 self.aspect_ratio, self.resolution, self.original_size
             )
         )
-        if self.crop_aspect != "random" or not self.valid_metadata:
+        if (
+            self.crop_enabled and self.crop_aspect != "random"
+        ) or not self.valid_metadata:
             self.intermediary_size = calculated_intermediary_size
         self.aspect_ratio = MultiaspectImage.calculate_image_aspect_ratio(
             self.target_size

--- a/helpers/multiaspect/image.py
+++ b/helpers/multiaspect/image.py
@@ -124,6 +124,13 @@ class MultiaspectImage:
             logger.debug(
                 f"Returning the square edge {target_pixel_edge}x{target_pixel_edge} as the target size and original size as intermediary."
             )
+            if W_initial == H_initial:
+                # if we have squares, resizing straight to the target is alright.
+                return (
+                    (target_pixel_edge, target_pixel_edge),
+                    (target_pixel_edge, target_pixel_edge),
+                    aspect_ratio,
+                )
             return (
                 (target_pixel_edge, target_pixel_edge),
                 (W_initial, H_initial),


### PR DESCRIPTION
this impacts square image inputs, which slipped by initial tests since the debug image creation misses the very last step of creating a final output.

if you were using crop=false and had square images which differ from the `resolution`, this would cause problems like zoomed and cropped elements.