### PR TITLE
Fixing broken python-tests action

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -32,4 +32,4 @@ jobs:
       run: poetry -C install/apple install
 
     - name: Run Tests
-      run: poetry -C install/apple run python -m unittest discover tests/
+      run: poetry -C ./ -P install/apple run python -m unittest discover tests/


### PR DESCRIPTION
Makes poetry run the tests from the right folder.