### PR TITLE
Add an option to completely disable validation

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -1472,7 +1472,7 @@ options:
   --num_validation_images NUM_VALIDATION_IMAGES
                         Number of images that should be generated during
                         validation with `validation_prompt`.
-  --disable_validation
+  --validation_disable
                         Enable to completely disable all validation.
   --validation_steps VALIDATION_STEPS
                         Run validation every X steps. Validation consists of

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -1472,6 +1472,8 @@ options:
   --num_validation_images NUM_VALIDATION_IMAGES
                         Number of images that should be generated during
                         validation with `validation_prompt`.
+  --disable_validation
+                        Enable to completely disable all validation.
   --validation_steps VALIDATION_STEPS
                         Run validation every X steps. Validation consists of
                         running the prompt `args.validation_prompt` multiple

--- a/helpers/configuration/cmd_args.py
+++ b/helpers/configuration/cmd_args.py
@@ -1676,7 +1676,7 @@ def get_argument_parser():
         help="Number of images that should be generated during validation with `validation_prompt`.",
     )
     parser.add_argument(
-        "--disable_validation",
+        "--validation_disable",
         action="store_true",
         help="Enable to completely disable the generation of validation images."
     )

--- a/helpers/configuration/cmd_args.py
+++ b/helpers/configuration/cmd_args.py
@@ -1676,6 +1676,11 @@ def get_argument_parser():
         help="Number of images that should be generated during validation with `validation_prompt`.",
     )
     parser.add_argument(
+        "--disable_validation",
+        action="store_true",
+        help="Enable to completely disable the generation of validation images."
+    )
+    parser.add_argument(
         "--validation_steps",
         type=int,
         default=100,

--- a/helpers/training/trainer.py
+++ b/helpers/training/trainer.py
@@ -725,7 +725,7 @@ class Trainer:
         ):
             logger.error("Cannot run validations with DeepSpeed ZeRO stage 3.")
             return
-        if self.accelerator.is_main_process:
+        if self.accelerator.is_main_process and not self.config.disable_validation:
             if self.config.model_family == "flux":
                 (
                     self.validation_prompts,
@@ -1468,6 +1468,8 @@ class Trainer:
             logger.error("Cannot run validations with DeepSpeed ZeRO stage 3.")
             return
         self.evaluation = None
+        if self.config.disable_validation:
+            return
         if (
             self.config.eval_steps_interval is not None
             and self.config.eval_steps_interval > 0

--- a/helpers/training/trainer.py
+++ b/helpers/training/trainer.py
@@ -725,7 +725,7 @@ class Trainer:
         ):
             logger.error("Cannot run validations with DeepSpeed ZeRO stage 3.")
             return
-        if self.accelerator.is_main_process and not self.config.disable_validation:
+        if self.accelerator.is_main_process and not self.config.validation_disable:
             if self.config.model_family == "flux":
                 (
                     self.validation_prompts,
@@ -1468,7 +1468,7 @@ class Trainer:
             logger.error("Cannot run validations with DeepSpeed ZeRO stage 3.")
             return
         self.evaluation = None
-        if self.config.disable_validation:
+        if self.config.validation_disable:
             return
         if (
             self.config.eval_steps_interval is not None


### PR DESCRIPTION
In some cases, we want to train without doing any validation whatsoever, and without losing any time on validation (for example, in a production setting where we're going to train a bunch of loras with the same settings but with different data) or textembed caching.

At the moment, this isn't possible:
  - The training loop crashes if the validation prompt library is empty AND the unconditional prompt is disabled.
  - This means we always lose some time on precomputing the text embeddings for whatever placeholder validation prompt is present.
  - The post training validation cannot actually be disabled at all.

This PR adds a simple option that disables the attempt to precache the validation prompts, and also blocks any intermittent or post-training validation.