### PR TITLE
Support --lr-scale-sqrt and tidy up associated output

### DIFF
--- a/helpers/configuration/cmd_args.py
+++ b/helpers/configuration/cmd_args.py
@@ -1205,6 +1205,12 @@ def get_argument_parser():
         help="Scale the learning rate by the number of GPUs, gradient accumulation steps, and batch size.",
     )
     parser.add_argument(
+        "--lr_scale_sqrt",
+        action="store_true",
+        default=False,
+        help="If using --lr-scale, use the square root of (number of GPUs * gradient accumulation steps * batch size).",
+    )
+    parser.add_argument(
         "--lr_scheduler",
         type=str,
         default="sine",


### PR DESCRIPTION
* By default, `--lr-scale` is the product of learning rate, batch size, gradient accumulation, and number of GPUs. This adds an additional option `--lr-scale-sqrt` to instead multiply by the square root of (batch size, gradient accumulation, and number of GPUs). This is being provided as an option as there are multiple schools of thought on what is "correct" - so let the user decide.

* Related log output cleaned up a bit to display scientific notation and emit useful info at the end.

Example output:

`--lr-scale`:
```
Scaling learning rate from 1.0e-04 to 8.0e-04 due to --lr-scale (bsz: 8, ga: 1, nprocs: 1)
```
`--lr-scale` and `--lr-scale-sqrt`:
```
Scaling learning rate from 1.0e-04 to 2.8e-04 due to --lr-scale and --lr-scale-sqrt (bsz: 8, ga: 1, nprocs: 1)
```