### PR TITLE
train.sh: Respect HF_HOME

### DIFF
--- a/train.sh
+++ b/train.sh
@@ -91,7 +91,12 @@ if [ -z "${DISABLE_UPDATES}" ]; then
 fi
 # Run the training script.
 if [[ -z "${ACCELERATE_CONFIG_PATH}" ]]; then
-    ACCELERATE_CONFIG_PATH="${HOME}/.cache/huggingface/accelerate/default_config.yaml"
+    # Look for accelerate config in HF_HOME first, otherwise fallback to $HOME
+    if [[ -f "${HF_HOME}/accelerate/default_config.yaml" ]]; then
+        ACCELERATE_CONFIG_PATH="${HF_HOME}/accelerate/default_config.yaml"
+    else
+        ACCELERATE_CONFIG_PATH="${HOME}/.cache/huggingface/accelerate/default_config.yaml"
+    fi
 fi
 if [ -f "${ACCELERATE_CONFIG_PATH}" ]; then
     echo "Using Accelerate config file: ${ACCELERATE_CONFIG_PATH}"


### PR DESCRIPTION
* HF_HOME was specified in the Dockerfile as /workspace/huggingface via commit 1584ddd27. When running `accelerate config`, this is the base path that will actually be used to write the config.

  Note: HF_HOME pointing to this location by default also makes sense as it provides a suitable default path from which to map volumes which may involve pre-populated models whereas mapping volumes to /root/.cache/huggingface makes a lot less sense.