### PR TITLE
Fix HiDream training for train_batch_size > 1

### DIFF
--- a/helpers/models/hidream/model.py
+++ b/helpers/models/hidream/model.py
@@ -252,6 +252,8 @@ class HiDream(ImageModelFoundation):
             img_ids = img_ids_pad.unsqueeze(0).to(
                 prepared_batch["noisy_latents"].device
             )
+            img_sizes = img_sizes.repeat(B, 1)
+            img_ids = img_ids.repeat(B, 1, 1)
         else:
             img_sizes = img_ids = None
 


### PR DESCRIPTION
`img_sizes` and `img_ids` need to be repeated based on batch size. In the original reference code, this was conditional behind `if self.do_classifier_free_guidance:` which I originally removed without too much thought:

https://github.com/HiDream-ai/HiDream-I1/blob/6629d04d71c5f344298128dd69af42505d0745a0/hi_diffusers/pipelines/hidream_image/pipeline_hidream_image.py#L629

Turns out, we do need this code but repeating `B` times instead of `2 * B` times is enough for training.

Just for reference, this is the error that was thrown before this fix with train_batch_size = 4:
```
Traceback (most recent call last):
  File "/nvme/home/mikaelh/Stable_Diffusion/bghira/SimpleTuner.blackwell/train.py", line 71, in <module>
    trainer.train()
  File "/nvme/home/mikaelh/Stable_Diffusion/bghira/SimpleTuner.blackwell/helpers/training/trainer.py", line 2066, in train
    model_pred = self.model_predict(
                 ^^^^^^^^^^^^^^^^^^^
  File "/nvme/home/mikaelh/Stable_Diffusion/bghira/SimpleTuner.blackwell/helpers/training/trainer.py", line 1761, in model_predict
    model_pred = self.model.model_predict(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nvme/home/mikaelh/Stable_Diffusion/bghira/SimpleTuner.blackwell/helpers/models/hidream/model.py", line 279, in model_predict
    "model_prediction": self.model(
                        ^^^^^^^^^^^
  File "/nvme/home/mikaelh/Stable_Diffusion/bghira/SimpleTuner.latest/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nvme/home/mikaelh/Stable_Diffusion/bghira/SimpleTuner.latest/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nvme/home/mikaelh/Stable_Diffusion/bghira/SimpleTuner.latest/.venv/lib/python3.11/site-packages/accelerate/utils/operations.py", line 814, in forward
    return model_forward(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nvme/home/mikaelh/Stable_Diffusion/bghira/SimpleTuner.latest/.venv/lib/python3.11/site-packages/accelerate/utils/operations.py", line 802, in __call__
    return convert_to_fp32(self.model_forward(*args, **kwargs))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nvme/home/mikaelh/Stable_Diffusion/bghira/SimpleTuner.latest/.venv/lib/python3.11/site-packages/torch/amp/autocast_mode.py", line 44, in decorate_autocast
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/nvme/home/mikaelh/Stable_Diffusion/bghira/SimpleTuner.blackwell/helpers/models/hidream/transformer.py", line 1382, in forward
    ids = torch.cat((img_ids, txt_ids), dim=1)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Sizes of tensors must match except in dimension 1. Expected size 1 but got size 4 for tensor number 1 in the list.
```