### PR TITLE
Fix parent-student training broken by v2 refactor

### DIFF
--- a/helpers/models/common.py
+++ b/helpers/models/common.py
@@ -865,7 +865,10 @@ class ModelFoundation(ABC):
         Depending on the noise schedule prediction type or flow-matching settings,
         the target is computed differently.
         """
-        if self.PREDICTION_TYPE is PredictionTypes.FLOW_MATCHING:
+        if prepared_batch.get("target") is not None:
+            # Parent-student training
+            target = prepared_batch["target"]
+        elif self.PREDICTION_TYPE is PredictionTypes.FLOW_MATCHING:
             target = prepared_batch["noise"] - prepared_batch["latents"]
         elif self.PREDICTION_TYPE is PredictionTypes.EPSILON:
             target = prepared_batch["noise"]

--- a/helpers/training/trainer.py
+++ b/helpers/training/trainer.py
@@ -2053,7 +2053,7 @@ class Trainer:
                                 )
                             prepared_batch["target"] = self.model_predict(
                                 prepared_batch=prepared_batch,
-                            )
+                            )["model_prediction"]
                             if self.config.lora_type.lower() == "lycoris":
                                 training_logger.debug(
                                     "Attaching LyCORIS adapter for student prediction."


### PR DESCRIPTION
I tried parent-student training with HiDream but I never saw step_loss dropping to almost zero which indicated that parent-student training was broken.

Commit 6ac8ca727cac36aa9bba728c9ca44ab90135934a didn't quite fix parent-student training because prepared_batch["target"] is not used everywhere.

I added a check for prepared_batch["target"] to `get_prediction_target` in helpers/models/common.py. I also changed the contents of prepared_batch["target"] so that it's a `torch.Tensor` instead of a `dict`.

After the fix, I can see the loss sometimes dropping to almost zero as expected:
```
Epoch 1/1, Steps:   2%|▎                | 100/6000 [14:40<13:03:08,  7.96s/it, grad_absmax=0.0645, lr=0.0001, step_loss=3.24]

Epoch 1/1, Steps:   2%|▏            | 101/6000 [16:37<66:36:32, 40.65s/it, grad_absmax=0.0135, lr=0.000101, step_loss=0.0156]
```