### PR TITLE
split_buckets_between_processes: Fix issue with imbalanced steps between processes

### DIFF
--- a/helpers/data_backend/factory.py
+++ b/helpers/data_backend/factory.py
@@ -940,9 +940,18 @@ def configure_multi_databackend(
                 f"Cannot train using a dataset that has a single bucket with fewer than {args.train_batch_size} images."
                 f" You have to reduce your batch size, or increase your dataset size (id={init_backend['id']})."
             )
+
+        # In the case where max_train_steps is false and num_train_epochs is being used,
+        # padding should be applied so as to ensure each process is operating on the same
+        # number of images. If no padding is used the recalculated max_train_steps value
+        # may differ between processes resulting in training hanging near the end as each
+        # process ends up having their own idea of total steps.
+        apply_padding = True if not args.max_train_steps or args.max_train_steps == 0 else False
+
         # Now split the contents of these buckets between all processes
         init_backend["metadata_backend"].split_buckets_between_processes(
             gradient_accumulation_steps=args.gradient_accumulation_steps,
+            apply_padding=apply_padding
         )
 
         # Check if there is an existing 'config' in the metadata_backend.config

--- a/helpers/metadata/backends/base.py
+++ b/helpers/metadata/backends/base.py
@@ -340,7 +340,7 @@ class MetadataBackend:
         self.save_cache(enforce_constraints=True)
         logger.info("Completed aspect bucket update.")
 
-    def split_buckets_between_processes(self, gradient_accumulation_steps=1):
+    def split_buckets_between_processes(self, gradient_accumulation_steps=1, apply_padding=False):
         """
         Splits the contents of each bucket in aspect_ratio_bucket_indices between the available processes.
         """
@@ -368,7 +368,7 @@ class MetadataBackend:
                 )
 
             with self.accelerator.split_between_processes(
-                trimmed_images, apply_padding=False
+                trimmed_images, apply_padding=apply_padding
             ) as images_split:
                 # Now images_split contains only the part of the images list that this process should handle
                 new_aspect_ratio_bucket_indices[bucket] = images_split


### PR DESCRIPTION
configure_multi_databackend/split_buckets_between_processes:

* If max_train_steps is false, padding should be used with accelerator.split_between_processes otherwise a bucket with an odd number of images, an odd effective_batch_size, or the count of trimmed_images otherwise ending up as odd results in each process potentially having a different idea of max_train_steps after _recalculate_training_steps() is called (as it takes into account metadata bucket counts). In the case where the main process thinks its max_train_steps is greater than any other non-main processes when train() arrives at that step, it will hang until timeout on self.accelerate.gather() as a non-main process has left the training loop but the main process still has steps outstanding.

  An alternative way of solving this may involve ensuring that the length of trimmed_images is _never_ odd but that might entail dropping images from the dataset. Since apply_padding ensures all processes are equally balanced it seems like an acceptable side effect would instead be to just use it and sample slightly more steps than expected.

Related previous commits involving similar issues:

  1344a235
  af7dc404
  cd9740a0