### PR TITLE
Added check for UniPCMultistepScheduler

### DIFF
--- a/helpers/models/hidream/pipeline.py
+++ b/helpers/models/hidream/pipeline.py
@@ -15,7 +15,7 @@ from transformers import (
 from diffusers.image_processor import VaeImageProcessor
 from diffusers.loaders import FromSingleFileMixin
 from diffusers.models.autoencoders import AutoencoderKL
-from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
+from diffusers.schedulers import FlowMatchEulerDiscreteScheduler, UniPCMultistepScheduler
 from diffusers.utils import (
     USE_PEFT_BACKEND,
     is_torch_xla_available,
@@ -998,6 +998,9 @@ class HiDreamImagePipeline(DiffusionPipeline, FromSingleFileMixin):
             self.scheduler.set_timesteps(
                 num_inference_steps, device=device, shift=math.exp(mu)
             )
+            timesteps = self.scheduler.timesteps
+        elif isinstance(self.scheduler, UniPCMultistepScheduler):
+            self.scheduler.set_timesteps(num_inference_steps, device=device)  # , shift=math.exp(mu))
             timesteps = self.scheduler.timesteps
         else:
             timesteps, num_inference_steps = retrieve_timesteps(


### PR DESCRIPTION
Hi, we are HiDream.ai official team. Recently, we updated the scheduler configuration in our Hugging Face model repositories to make it easier to run inference directly with Diffusers. However, we understand that this change may have caused inconvenience for some users.

To ensure compatibility, we recommend updating the pipeline code as follows:

```python
elif isinstance(self.scheduler, UniPCMultistepScheduler):
    self.scheduler.set_timesteps(num_inference_steps, device=device)  # , shift=math.exp(mu))
    timesteps = self.scheduler.timesteps

```

This way, inference will work properly regardless of whether the user is using `FlowUniPCMultistepScheduler` from our GitHub repository or `UniPCMultistepScheduler` from Diffusers.

> [!NOTE]
> this scheduler update does not change the actual behavior or type of the scheduler used by the model. Instead, we simply replaced the previously saved `FlowMatchEulerDiscreteScheduler` in the Hugging Face repository with `UniPCMultistepScheduler` (for **HiDream-I1-Full**) and `FlowMatchLCMScheduler` (for **HiDream-I1-Dev** and **HiDream-I1-Fast**), which provide the same functionality as our `FlowUniPCMultistepScheduler` and `FlashFlowMatchEulerDiscreteSchedulerOutput` from the GitHub repository. This change aims to improve generation quality and streamline compatibility.