### PR TITLE
Rename FeedForwardSwiGLU back to FeedForward for convenience

### DIFF
--- a/helpers/models/hidream/transformer.py
+++ b/helpers/models/hidream/transformer.py
@@ -397,7 +397,7 @@ class HiDreamAttnProcessor_flashattn:
             return hidden_states
 
 
-class FeedForwardSwiGLU(nn.Module):
+class FeedForward(nn.Module):
     def __init__(
         self,
         dim: int,
@@ -553,7 +553,7 @@ class MoEGate(nn.Module):
 
 
 # Modified from https://github.com/deepseek-ai/DeepSeek-V3/blob/main/inference/model.py
-class MOEFeedForwardSwiGLU(nn.Module):
+class MOEFeedForward(nn.Module):
     def __init__(
         self,
         dim: int,
@@ -563,9 +563,9 @@ class MOEFeedForwardSwiGLU(nn.Module):
         aux_loss_alpha: float = 0.01,
     ):
         super().__init__()
-        self.shared_experts = FeedForwardSwiGLU(dim, hidden_dim // 2)
+        self.shared_experts = FeedForward(dim, hidden_dim // 2)
         self.experts = nn.ModuleList(
-            [FeedForwardSwiGLU(dim, hidden_dim) for i in range(num_routed_experts)]
+            [FeedForward(dim, hidden_dim) for i in range(num_routed_experts)]
         )
         self.gate = MoEGate(
             embed_dim=dim,
@@ -675,7 +675,7 @@ class HiDreamImageSingleTransformerBlock(nn.Module):
         # 3. Feed-forward
         self.norm3_i = nn.LayerNorm(dim, eps=1e-06, elementwise_affine=False)
         if num_routed_experts > 0:
-            self.ff_i = MOEFeedForwardSwiGLU(
+            self.ff_i = MOEFeedForward(
                 dim=dim,
                 hidden_dim=4 * dim,
                 num_routed_experts=num_routed_experts,
@@ -683,7 +683,7 @@ class HiDreamImageSingleTransformerBlock(nn.Module):
                 aux_loss_alpha=aux_loss_alpha,
             )
         else:
-            self.ff_i = FeedForwardSwiGLU(dim=dim, hidden_dim=4 * dim)
+            self.ff_i = FeedForward(dim=dim, hidden_dim=4 * dim)
 
     def forward(
         self,
@@ -749,16 +749,16 @@ class HiDreamImageTransformerBlock(nn.Module):
         # 3. Feed-forward
         self.norm3_i = nn.LayerNorm(dim, eps=1e-06, elementwise_affine=False)
         if num_routed_experts > 0:
-            self.ff_i = MOEFeedForwardSwiGLU(
+            self.ff_i = MOEFeedForward(
                 dim=dim,
                 hidden_dim=4 * dim,
                 num_routed_experts=num_routed_experts,
                 num_activated_experts=num_activated_experts,
             )
         else:
-            self.ff_i = FeedForwardSwiGLU(dim=dim, hidden_dim=4 * dim)
+            self.ff_i = FeedForward(dim=dim, hidden_dim=4 * dim)
         self.norm3_t = nn.LayerNorm(dim, eps=1e-06, elementwise_affine=False)
-        self.ff_t = FeedForwardSwiGLU(dim=dim, hidden_dim=4 * dim)
+        self.ff_t = FeedForward(dim=dim, hidden_dim=4 * dim)
 
     def forward(
         self,
@@ -958,8 +958,8 @@ class HiDreamImageTransformer2DModel(
             (
                 HiDreamImageBlock,
                 Attention,
-                FeedForwardSwiGLU,
-                MOEFeedForwardSwiGLU,
+                FeedForward,
+                MOEFeedForward,
             ),
         ):
             if hasattr(module, "gradient_checkpointing"):


### PR DESCRIPTION
Just repeating commit 614eef438023132b90e53c98e93388110bcad488 and renaming FeedForwardSwiGLU to FeedForward. FeedForward training was fixed in commit e96bdd8bfcf070c55f39b87e55d94c1935379aae after that.

I tested resuming from a checkpoint after adjusting my lycoris config to match and the training is running just fine.