### PR TITLE
When running sample transforms, the dataset_type should be considered so that we do not run video transforms on image

### DIFF
--- a/helpers/caching/vae.py
+++ b/helpers/caching/vae.py
@@ -116,7 +116,7 @@ class VAECache(WebhookMixin):
         self.vae_batch_size = vae_batch_size
         self.instance_data_dir = instance_data_dir
         self.model = model
-        self.transform_sample = model.get_transforms()
+        self.transform_sample = model.get_transforms(dataset_type=dataset_type)
         self.num_video_frames = None
         if self.dataset_type == "video":
             self.num_video_frames = num_video_frames
@@ -894,13 +894,19 @@ class VAECache(WebhookMixin):
                 count_to_process = min(qlen, self.vae_batch_size)
                 for idx in range(0, count_to_process):
                     if image_pixel_values:
-                        pixel_values, filepath, aspect_bucket, is_final_sample = (
-                            image_pixel_values.pop()
-                        )
+                        (
+                            pixel_values,
+                            filepath,
+                            aspect_bucket,
+                            is_final_sample,
+                        ) = image_pixel_values.pop()
                     else:
-                        pixel_values, filepath, aspect_bucket, is_final_sample = (
-                            self.vae_input_queue.get()
-                        )
+                        (
+                            pixel_values,
+                            filepath,
+                            aspect_bucket,
+                            is_final_sample,
+                        ) = self.vae_input_queue.get()
 
                     if batch_aspect_bucket is None:
                         batch_aspect_bucket = aspect_bucket

--- a/helpers/models/common.py
+++ b/helpers/models/common.py
@@ -257,7 +257,7 @@ class ModelFoundation(ABC):
 
         dataset_type is passed in for models that support transforming videos or images etc.
         """
-        if dataset_type != "image":
+        if dataset_type in ["video"]:
             raise ValueError(
                 f"{dataset_type} transforms are not supported by {self.NAME}."
             )


### PR DESCRIPTION
https://discord.com/channels/696818921625485342/1252663652583084123/1363334445460881570

```
An error occurred in a future: Input video must be a numpy array or a list of frames., file <frame at 0x55942965dbb0, file 'SimpleTuner/helpers/caching/vae.py', line 1053, code _process_futures>, 1049, future traceback Traceback (most recent call last):
  File "SimpleTuner/helpers/caching/vae.py", line 1049, in _process_futures
    future.result()
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 451, in result
    return self.__get_result()
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "SimpleTuner/helpers/caching/vae.py", line 869, in _process_images_in_batch
    raise e
  File "SimpleTuner/helpers/caching/vae.py", line 836, in _process_images_in_batch
    pixel_values = self.transform_sample(image).to(
  File ".venv/lib/python3.10/site-packages/torchvision/transforms/transforms.py", line 95, in __call__
    img = t(img)
  File "SimpleTuner/helpers/models/common.py", line 1276, in __call__
    raise TypeError("Input video must be a numpy array or a list of frames.")
TypeError: Input video must be a numpy array or a list of frames.
```