### PR TITLE
when encoding text embeds,  force the move to accelerator on round one

### DIFF
--- a/helpers/data_backend/factory.py
+++ b/helpers/data_backend/factory.py
@@ -453,9 +453,9 @@ def configure_parquet_database(backend: dict, args, data_backend: BaseDataBacken
     )
 
 
-def move_text_encoders(args, text_encoders: list, target_device: str):
+def move_text_encoders(args, text_encoders: list, target_device: str, force_move: bool = False):
     """Move text encoders to the target device."""
-    if text_encoders is None or not args.offload_during_startup:
+    if text_encoders is None or (not args.offload_during_startup and not force_move):
         return
     # we'll move text encoder only if their precision arg is no_change
     # otherwise, we assume the user has already moved them to the correct device due to quantisation.
@@ -634,7 +634,7 @@ def configure_multi_databackend(
 
         # Generate a TextEmbeddingCache object
         logger.debug(f"rank {get_rank()} is creating TextEmbeddingCache")
-        move_text_encoders(args, text_encoders, accelerator.device)
+        move_text_encoders(args, text_encoders, accelerator.device, force_move=True)
         init_backend["text_embed_cache"] = TextEmbeddingCache(
             id=init_backend["id"],
             data_backend=init_backend["data_backend"],


### PR DESCRIPTION
```
Expected all tensors to be on the same device, but found at least two devices, cpu and cuda:0! (when checking argument for argument index in method wrapper_CUDA__index_select)
Traceback (most recent call last):
  File "/mnt/Linux/Code/SimpleTuner/train.py", line 50, in <module>
    trainer.init_data_backend()
  File "/mnt/Linux/Code/SimpleTuner/helpers/training/trainer.py", line 500, in init_data_backend
    raise e
  File "/mnt/Linux/Code/SimpleTuner/helpers/training/trainer.py", line 473, in init_data_backend
    configure_multi_databackend(
  File "/mnt/Linux/Code/SimpleTuner/helpers/data_backend/factory.py", line 1224, in configure_multi_databackend
    init_backend["text_embed_cache"].compute_embeddings_for_prompts(
  File "/mnt/Linux/Code/SimpleTuner/helpers/caching/text_embeds.py", line 294, in compute_embeddings_for_prompts
    output = self.compute_prompt_embeddings_with_model(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Linux/Code/SimpleTuner/helpers/caching/text_embeds.py", line 409, in compute_prompt_embeddings_with_model
    text_encoder_output = self.model.encode_text_batch(
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Linux/Code/SimpleTuner/helpers/models/common.py", line 1123, in encode_text_batch
    encoded_text = self._encode_prompts(text_batch, is_negative_prompt)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Linux/Code/SimpleTuner/helpers/models/hidream/model.py", line 255, in _encode_prompts
    ]._encode_prompt(
      ^^^^^^^^^^^^^^^
  File "/mnt/Linux/Code/SimpleTuner/helpers/models/hidream/pipeline.py", line 752, in _encode_prompt
    t5_prompt_embeds = self._get_t5_prompt_embeds(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Linux/Code/SimpleTuner/helpers/models/hidream/pipeline.py", line 244, in _get_t5_prompt_embeds
    prompt_embeds = self.text_encoder_3(
                    ^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Linux/Code/SimpleTuner/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Linux/Code/SimpleTuner/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1750, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Linux/Code/SimpleTuner/venv/lib/python3.12/site-packages/transformers/models/t5/modeling_t5.py", line 2100, in forward
    encoder_outputs = self.encoder(
                      ^^^^^^^^^^^^^
  File "/mnt/Linux/Code/SimpleTuner/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Linux/Code/SimpleTuner/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1750, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Linux/Code/SimpleTuner/venv/lib/python3.12/site-packages/transformers/models/t5/modeling_t5.py", line 1009, in forward
    inputs_embeds = self.embed_tokens(input_ids)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Linux/Code/SimpleTuner/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Linux/Code/SimpleTuner/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1750, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Linux/Code/SimpleTuner/venv/lib/python3.12/site-packages/torch/nn/modules/sparse.py", line 190, in forward
    return F.embedding(
           ^^^^^^^^^^^^
  File "/mnt/Linux/Code/SimpleTuner/venv/lib/python3.12/site-packages/torch/nn/functional.py", line 2551, in embedding
    return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cpu and cuda:0! (when checking argument for argument index in method wrapper_CUDA__index_select)

(venv) rmbp@linux:/mnt/Linux/Code/SimpleTuner$ 
```

resolves issue reported on Discord.