### PR TITLE
Add support for --checkpointing_rolling_steps and --checkpointing_use_tempdir

### DIFF
--- a/helpers/configuration/cmd_args.py
+++ b/helpers/configuration/cmd_args.py
@@ -1102,10 +1102,40 @@ def get_argument_parser():
         ),
     )
     parser.add_argument(
+        "--checkpointing_rolling_steps",
+        type=int,
+        default=0,
+        help=(
+            "Functions similarly to --checkpointing_steps, but only a single rolling checkpoint is ever saved and this checkpoint does not count"
+            " towards the value of --checkpoints_total_limit. Useful for when the underlying runtime environment may be prone to spontaneous"
+            " interruption (e.g. spot instances, unreliable hardware, etc) and saving state more frequently is beneficial. This allows one to"
+            " save normal checkpoints at a reasonable cadence but save a rolling checkpoint more frequently so as to avoid losing progress."
+        ),
+    )
+    parser.add_argument(
+        "--checkpointing_use_tempdir",
+        action="store_true",
+        default=False,
+        help=(
+            "Write saved checkpoint directories to a temporary name and atomically rename after successfully writing all state. This ensures that a"
+            " given checkpoint will never be considered for resuming if it wasn't fully written out - as the state cannot be guaranteed. Useful for"
+            " when the underlying runtime environment may be prone to spontaneous interruption (e.g. spot instances, unreliable hardware, etc)."
+        ),
+    )
+    parser.add_argument(
         "--checkpoints_total_limit",
         type=int,
         default=None,
         help="Max number of checkpoints to store.",
+    )
+    parser.add_argument(
+        "--checkpoints_rolling_total_limit",
+        type=int,
+        default=1,
+        help=(
+            "Max number of rolling checkpoints to store. One almost always wants this to be 1, but there could be a usecase where one desires to"
+            " run a shorter window of more frequent checkpoints alongside a normal checkpointing interval done at less frequent steps."
+        ),
     )
     parser.add_argument(
         "--resume_from_checkpoint",

--- a/helpers/training/trainer.py
+++ b/helpers/training/trainer.py
@@ -1207,10 +1207,7 @@ class Trainer:
             path = os.path.basename(self.config.resume_from_checkpoint)
         else:
             # Get the most recent checkpoint
-            dirs = os.listdir(self.config.output_dir)
-            dirs = [d for d in dirs if d.startswith("checkpoint")]
-            dirs = sorted(dirs, key=lambda x: int(x.split("-")[1]))
-            path = dirs[-1] if len(dirs) > 0 else None
+            path = self.checkpoint_state_latest(self.config.output_dir)
 
         if path is None:
             logger.info(
@@ -1876,6 +1873,107 @@ class Trainer:
         loss = loss.mean()  # Scalar value
         return loss
 
+    def checkpoint_state_remove(self, output_dir, checkpoint):
+        removing_checkpoint = os.path.join(
+            output_dir, checkpoint
+        )
+        try:
+            logger.debug(f"Removing {removing_checkpoint}")
+            shutil.rmtree(
+                removing_checkpoint, ignore_errors=True
+            )
+        except Exception as e:
+            logger.error(
+                f"Failed to remove directory: {removing_checkpoint}"
+            )
+            print(e)
+
+    def checkpoint_state_filter(self, output_dir, suffix=None):
+        checkpoints_keep = []
+        checkpoints = os.listdir(output_dir)
+        for checkpoint in checkpoints:
+            cs = checkpoint.split("-")
+            base = cs[0]; sfx = None
+            if len(cs) < 2:
+                continue
+            elif len(cs) > 2:
+                sfx = cs[2]
+
+            if base != 'checkpoint':
+                continue
+            if suffix and sfx and suffix != sfx:
+                continue
+            if (suffix and not sfx) or (sfx and not suffix):
+                continue
+
+            checkpoints_keep.append(checkpoint)
+
+        return checkpoints_keep
+
+    def checkpoint_state_cleanup(self, output_dir, limit, suffix=None):
+        # remove any left over temp checkpoints (partially written, etc)
+        checkpoints = self.checkpoint_state_filter(output_dir, 'tmp')
+        for removing_checkpoint in checkpoints:
+            self.checkpoint_state_remove(output_dir, removing_checkpoint)
+
+        # now remove normal checkpoints past the limit
+        checkpoints = self.checkpoint_state_filter(output_dir, suffix)
+        checkpoints = sorted(
+            checkpoints, key=lambda x: int(x.split("-")[1])
+        )
+
+        # before we save the new checkpoint, we need to have at _most_ `limit - 1` checkpoints
+        if len(checkpoints) < limit:
+            return
+
+        num_to_remove = len(checkpoints) - limit + 1
+        removing_checkpoints = checkpoints[0:num_to_remove]
+        logger.debug(
+            f"{len(checkpoints)} checkpoints already exist, removing {len(removing_checkpoints)} checkpoints"
+        )
+        logger.debug(
+            f"removing checkpoints: {', '.join(removing_checkpoints)}"
+        )
+
+        for removing_checkpoint in removing_checkpoints:
+            self.checkpoint_state_remove(output_dir, removing_checkpoint)
+
+    def checkpoint_state_save(self, output_dir, suffix=None):
+        print("\n")
+
+        save_path = os.path.join(
+            output_dir,
+            f"checkpoint-{self.state['global_step']}",
+        )
+        if suffix:
+            save_path = f"{save_path}-{suffix}"
+
+        # A temporary directory should be used so that saving state is an atomic operation.
+        save_path_tmp = f"{save_path}-tmp" if self.config.checkpointing_use_tempdir else save_path
+
+        # schedulefree optim needs the optimizer to be in eval mode to save the state (and then back to train after)
+        self.mark_optimizer_eval()
+        self.accelerator.save_state(save_path_tmp)
+        self.mark_optimizer_train()
+        for _, backend in StateTracker.get_data_backends().items():
+            if "sampler" in backend:
+                logger.debug(f"Backend: {backend}")
+                backend["sampler"].save_state(
+                    state_path=os.path.join(
+                        save_path_tmp,
+                        self.model_hooks.training_state_path,
+                    ),
+                )
+        if save_path != save_path_tmp:
+            os.rename(save_path_tmp, save_path)
+
+    def checkpoint_state_latest(self, output_dir):
+        # both checkpoint-[0-9]+ and checkpoint-[0-9]-rolling are candidates
+        dirs = os.listdir(output_dir)
+        dirs = [d for d in dirs if d.startswith("checkpoint") and not d.endswith("tmp")]
+        dirs = sorted(dirs, key=lambda x: int(x.split("-")[1]))
+        return dirs[-1] if len(dirs) > 0 else None
+
     def train(self):
         self.init_trackers()
         self._train_initial_msg()
@@ -2247,76 +2345,41 @@ class Trainer:
                         self._send_webhook_raw(
                             structured_data=structured_data, message_type="train"
                         )
-                    if self.state["global_step"] % self.config.checkpointing_steps == 0:
+
+                    if self.config.checkpointing_steps and self.state["global_step"] % self.config.checkpointing_steps == 0:
                         self._send_webhook_msg(
                             message=f"Checkpoint: `{webhook_pending_msg}`",
                             message_level="info",
                         )
-                        if self.accelerator.is_main_process:
+                        if (
+                            self.accelerator.is_main_process
+                            and self.config.checkpoints_total_limit is not None
+                        ):
                             # _before_ saving state, check if this save would set us over the `checkpoints_total_limit`
-                            if self.config.checkpoints_total_limit is not None:
-                                checkpoints = os.listdir(self.config.output_dir)
-                                checkpoints = [
-                                    d for d in checkpoints if d.startswith("checkpoint")
-                                ]
-                                checkpoints = sorted(
-                                    checkpoints, key=lambda x: int(x.split("-")[1])
-                                )
-
-                                # before we save the new checkpoint, we need to have at _most_ `checkpoints_total_limit - 1` checkpoints
-                                if (
-                                    len(checkpoints)
-                                    >= self.config.checkpoints_total_limit
-                                ):
-                                    num_to_remove = (
-                                        len(checkpoints)
-                                        - self.config.checkpoints_total_limit
-                                        + 1
-                                    )
-                                    removing_checkpoints = checkpoints[0:num_to_remove]
-                                    logger.debug(
-                                        f"{len(checkpoints)} checkpoints already exist, removing {len(removing_checkpoints)} checkpoints"
-                                    )
-                                    logger.debug(
-                                        f"removing checkpoints: {', '.join(removing_checkpoints)}"
-                                    )
-
-                                    for removing_checkpoint in removing_checkpoints:
-                                        removing_checkpoint = os.path.join(
-                                            self.config.output_dir, removing_checkpoint
-                                        )
-                                        try:
-                                            shutil.rmtree(
-                                                removing_checkpoint, ignore_errors=True
-                                            )
-                                        except Exception as e:
-                                            logger.error(
-                                                f"Failed to remove directory: {removing_checkpoint}"
-                                            )
-                                            print(e)
+                            self.checkpoint_state_cleanup(self.config.output_dir, self.config.checkpoints_total_limit)
 
                         if (
                             self.accelerator.is_main_process
                             or self.config.use_deepspeed_optimizer
                         ):
-                            save_path = os.path.join(
-                                self.config.output_dir,
-                                f"checkpoint-{self.state['global_step']}",
-                            )
-                            print("\n")
-                            # schedulefree optim needs the optimizer to be in eval mode to save the state (and then back to train after)
-                            self.mark_optimizer_eval()
-                            self.accelerator.save_state(save_path)
-                            self.mark_optimizer_train()
-                            for _, backend in StateTracker.get_data_backends().items():
-                                if "sampler" in backend:
-                                    logger.debug(f"Backend: {backend}")
-                                    backend["sampler"].save_state(
-                                        state_path=os.path.join(
-                                            save_path,
-                                            self.model_hooks.training_state_path,
-                                        ),
-                                    )
+                            self.checkpoint_state_save(self.config.output_dir)
+                    elif self.config.checkpointing_rolling_steps and self.state["global_step"] % self.config.checkpointing_rolling_steps == 0:
+                        self._send_webhook_msg(
+                            message=f"Checkpoint: `{webhook_pending_msg}`",
+                            message_level="info",
+                        )
+                        if (
+                            self.accelerator.is_main_process
+                            and self.config.checkpoints_rolling_total_limit is not None
+                        ):
+                            # _before_ saving state, check if this save would set us over the `checkpoints_rolling_total_limit`
+                            self.checkpoint_state_cleanup(self.config.output_dir, self.config.checkpoints_rolling_total_limit, 'rolling')
+
+                        if (
+                            self.accelerator.is_main_process
+                            or self.config.use_deepspeed_optimizer
+                        ):
+                            self.checkpoint_state_save(self.config.output_dir, 'rolling')
 
                     if (
                         self.config.accelerator_cache_clear_interval is not None


### PR DESCRIPTION
* --checkpointing_rolling_steps: Support creating "rolling" checkpoint saves that are independently tracked from normal checkpoint saves and which use a total limit of 1. This allows saving checkpoints more frequently in environments where spontaneous interruption is common (e.g. spot instances) but without requiring the config to specify an overly aggressive value for --checkpointing_steps.

* --checkpointing_use_tempdir: Write out all checkpoint saves to checkpoint-STEP-tmp and then atomically rename to checkpoint-STEP after success. This ensures that partially written state is never used for resuming as it's almost impossible to recover from and requires manual deletion which is a problem for automated resumes.

* init_resume_checkpoint: Move "latest" checkpoint code into checkpoint_state_latest() method which is rolling checkpoint aware.

* checkpoint_state_remove: New method to handle deleting checkpoint dirs as it's called from multiple places.

* checkpoint_state_filter: New method to determine which checkpoints should be considered candidates for keep/delete which is "suffix" aware so things like normal checkpoints vs rolling checkpoints can be handled differently. Also used with "tmp" suffixes.

* checkpoint_state_cleanup: New method to handle pruning of checkpoint dirs beyond total limit. Also used for rolling checkpoints (limit=1).

* checkpoint_state_save: New method to handle saving of checkpoints and optionally using a temporary name + rename after success when --checkpointing_use_tempdir = true.

Note: most of the new methods are reusing code that already existed.