### PR TITLE
Fix missing barriers contributing to multi-process cache races

### DIFF
--- a/helpers/data_backend/factory.py
+++ b/helpers/data_backend/factory.py
@@ -842,7 +842,7 @@ def configure_multi_databackend(
         )
 
         preserve_data_backend_cache = backend.get("preserve_data_backend_cache", False)
-        if not preserve_data_backend_cache:
+        if not preserve_data_backend_cache and accelerator.is_local_main_process:
             StateTracker.delete_cache_files(
                 data_backend_id=init_backend["id"],
                 preserve_data_backend_cache=preserve_data_backend_cache,

--- a/helpers/training/trainer.py
+++ b/helpers/training/trainer.py
@@ -399,6 +399,8 @@ class Trainer:
             os.makedirs(self.config.output_dir, exist_ok=True)
         if self.config.preserve_data_backend_cache:
             return
+        if not self.accelerator.is_local_main_process:
+            return
         StateTracker.delete_cache_files(
             preserve_data_backend_cache=self.config.preserve_data_backend_cache
         )


### PR DESCRIPTION
* configure_multi_databackend: add missing is_local_main guard

* init_clear_backend_cache: add missing is_local_main guard

Both of these were contributing to multiple processes racing each other to delete the same cache files resulting in different processes having different ideas of reality depending on who won.