### PR TITLE
Revert "fix layout of validation images"

### DIFF
--- a/helpers/training/validation.py
+++ b/helpers/training/validation.py
@@ -1653,8 +1653,8 @@ class Validation:
                                 display_validation_results[idx] = (
                                     self.stitch_three_images(
                                         left_image=validation_input_image,
-                                        middle_image=benchmark_image,
-                                        right_image=original_img,
+                                        middle_image=original_img,
+                                        right_image=benchmark_image,
                                         labels=labels_to_use,
                                     )
                                 )


### PR DESCRIPTION
Reverts bghira/SimpleTuner#1512

Apparently the output order was correct.