### PR TITLE
when conditioning_data is a list, check inside it for the values to sort by

### DIFF
--- a/helpers/data_backend/factory.py
+++ b/helpers/data_backend/factory.py
@@ -638,7 +638,7 @@ def sort_dataset_configs_by_dependencies(data_backend_config):
         elif config.get("conditioning_type") == "reference_strict":
             # Look for the dataset that points to this one
             for other_config in enabled_configs:
-                if other_config.get("conditioning_data") == dataset_id:
+                if other_config.get("conditioning_data") == dataset_id or (isinstance(other_config.get("conditioning_data"), list) and dataset_id in other_config["conditioning_data"]):
                     source_id = other_config.get("id")
                     break
 


### PR DESCRIPTION
fixes a KeyError for `edited-images` dataset when following example with `conditioning_data = ["reference-images"]` instead of `conditioning_data = "reference_images"`