### PR TITLE
Fix the lora loading bug when resuming the Kontext LoRA training

### DIFF
--- a/helpers/models/flux/pipeline.py
+++ b/helpers/models/flux/pipeline.py
@@ -53,6 +53,7 @@ from diffusers.utils import (
     convert_state_dict_to_peft,
     logging,
 )
+from diffusers.loaders.lora_base import _fetch_state_dict
 from diffusers.models.lora import (
     text_encoder_attn_modules,
     text_encoder_mlp_modules,
@@ -344,7 +345,8 @@ class FluxLoraLoaderMixin(LoraBaseMixin):
             "framework": "pytorch",
         }
 
-        state_dict, metadata = cls._fetch_state_dict(
+        
+        state_dict, metadata = _fetch_state_dict(
             pretrained_model_name_or_path_or_dict=pretrained_model_name_or_path_or_dict,
             weight_name=weight_name,
             use_safetensors=use_safetensors,
@@ -358,6 +360,7 @@ class FluxLoraLoaderMixin(LoraBaseMixin):
             user_agent=user_agent,
             allow_pickle=allow_pickle,
         )
+        
         is_dora_scale_present = any("dora_scale" in k for k in state_dict)
         if is_dora_scale_present:
             warn_msg = "It seems like you are using a DoRA checkpoint that is not compatible in Diffusers at the moment. So, we are going to filter out the keys associated to 'dora_scale` from the state dict. If you think this is a mistake please open an issue https://github.com/huggingface/diffusers/issues/new."


### PR DESCRIPTION
It will load lora by diffuser code of
`from diffusers.loaders.lora_base import _fetch_state_dict`