### PR TITLE
Fix crucial detail for multiple condition Kontext lora training

### DIFF
--- a/helpers/training/trainer.py
+++ b/helpers/training/trainer.py
@@ -344,6 +344,7 @@ class Trainer:
         self.state["global_step"] = 0
         self.state["global_resume_step"] = 0
         self.state["first_epoch"] = 1
+        self.state["args"]= self.config.__dict__
         self.timesteps_buffer = []
         self.guidance_values_list = []
         self.train_loss = 0.0


### PR DESCRIPTION
I am training the Kontext Lora for multiple condition, but I found the model by recent code can't get a correct result for multiple input. So I discovery that there is a crucial  BUG for multiple condition training in recent commits.  In `help/modle/flux/model.py`, The `sampling_mode`  awalys set  'random' and  each training only get one image from my two different condition datasets. So I think it needs to init `state `to solve the crucial bug.

In `help/modle/flux/model.py` , `prepare_batch_conditions` function, it uses 
`state.get("args", {}).get("conditioning_multidataset_sampling", "combined")` to get the dataset sample method. if we don't set variable 'state', it will be "random", it will induce the training model in an incorrect manner.