### PR TITLE
aspect ratio incorrect on square crops

### DIFF
--- a/tests/test_training_sample.py
+++ b/tests/test_training_sample.py
@@ -435,7 +435,248 @@ class TestTrainingSample(unittest.TestCase):
             sample.aspect_ratio, 1.0, "Should not force a square shape in this case."
         )
 
+    def test_image_square_crop_preserves_square_input(self):
+        """Test that square cropping works correctly."""
+        square_img = Image.new("RGB", (1024, 1024), "white")
+        sample = TrainingSample(
+            square_img, self.data_backend_id, {"original_size": (1024, 1024)}
+        )
 
+        sample.prepare()
+        # The image should be cropped to a square shape
+        self.assertEqual(sample.image.size[0], sample.image.size[1])
+        self.assertEqual(sample.image.size[0], 512)
+        self.assertEqual(sample.aspect_ratio, 1.0)
+
+    def test_image_square_crop_from_random_aspect_ratio(self):
+        """Test that square cropping works correctly."""
+        random_img = Image.new("RGB", (800, 600), "white")
+        # enable square cropping
+        StateTracker.get_data_backend_config = MagicMock(
+            return_value={
+                "crop": True,
+                "crop_style": "center",
+                "crop_aspect": "square",
+                "resolution": 512,
+                "resolution_type": "pixel",
+            }
+        )
+        sample = TrainingSample(
+            random_img, self.data_backend_id, {"original_size": (800, 600)}
+        )
+
+        sample.prepare()
+        # The image should be cropped to a square shape
+        self.assertEqual(sample.aspect_ratio, 1.0, f"Bad sample: {sample.__dict__}")
+        self.assertEqual(sample.image.size[0], sample.image.size[1])
+        self.assertEqual(sample.image.size[0], 512)
+
+    def test_area_resolution_square_crop_exact_aspect_ratio(self):
+        """
+        Test that when using area-based resolution (1.048576) with square crop,
+        we get exactly 1024x1024 images with aspect ratio 1.0, not 1056x1056.
+        """
+        # Mock StateTracker methods to prevent file operations
+        StateTracker.get_args = MagicMock(return_value=MagicMock(
+            aspect_bucket_alignment=64,
+            aspect_bucket_rounding=2,
+            output_dir="/tmp"
+        ))
+        StateTracker.set_resolution_by_aspect = MagicMock()
+        StateTracker.get_resolution_by_aspect = MagicMock(return_value=None)
+        StateTracker._save_to_disk = MagicMock()
+        
+        # Configure for area-based resolution with square crop
+        StateTracker.get_data_backend_config = MagicMock(
+            return_value={
+                "crop": True,
+                "crop_style": "random",
+                "crop_aspect": "square",
+                "resolution": 1.048576,  # This should map to 1024x1024
+                "resolution_type": "area",
+                "target_downsample_size": 1.048576,
+                "maximum_image_size": 1.048576,
+            }
+        )
+        
+        # Test with various input sizes
+        test_cases = [
+            (1920, 1080),  # 16:9
+            (3883, 5825),  # Portrait
+            (5787, 3858),  # Landscape
+            (1024, 1024),  # Already square
+            (800, 600),    # 4:3
+        ]
+        
+        for width, height in test_cases:
+            with self.subTest(input_size=(width, height)):
+                test_img = Image.new("RGB", (width, height), "white")
+                sample = TrainingSample(
+                    test_img,
+                    self.data_backend_id,
+                    {"original_size": (width, height)},
+                    model=MagicMock(
+                        MAXIMUM_CANVAS_SIZE=None,
+                        get_transforms=MagicMock(return_value=lambda x: x)
+                    ),
+                )
+                
+                prepared = sample.prepare()
+                
+                # Check that the target size is exactly 1024x1024
+                self.assertEqual(
+                    sample.target_size,
+                    (1024, 1024),
+                    f"Target size should be 1024x1024, not {sample.target_size}"
+                )
+                
+                # Check that the final image is exactly 1024x1024
+                self.assertEqual(
+                    sample.image.size,
+                    (1024, 1024),
+                    f"Image size should be 1024x1024, not {sample.image.size}"
+                )
+                
+                # Check that aspect ratio is exactly 1.0
+                self.assertEqual(
+                    prepared.aspect_ratio,
+                    1.0,
+                    f"Aspect ratio should be exactly 1.0, not {prepared.aspect_ratio}"
+                )
+                
+                # Double-check by calculating aspect ratio from dimensions
+                calculated_aspect = round(sample.image.size[0] / sample.image.size[1], 2)
+                self.assertEqual(
+                    calculated_aspect,
+                    1.0,
+                    f"Calculated aspect ratio should be 1.0, not {calculated_aspect}"
+                )
+
+    def test_pixel_resolution_calculations(self):
+        """
+        Test that pixel_resolution is calculated correctly for area-based resolutions.
+        """
+        # Mock StateTracker to prevent file operations
+        StateTracker.get_args = MagicMock(return_value=MagicMock(
+            aspect_bucket_alignment=64,
+            aspect_bucket_rounding=2,
+            output_dir="/tmp"
+        ))
+        StateTracker.set_resolution_by_aspect = MagicMock()
+        StateTracker.get_resolution_by_aspect = MagicMock(return_value=None)
+        StateTracker._save_to_disk = MagicMock()
+        
+        test_cases = [
+            (0.25, 512),   # 0.25 megapixels -> 512x512
+            (0.5, 768),    # 0.5 megapixels -> 768x768
+            (1.0, 1024),   # 1.0 megapixels -> 1024x1024
+            (1.048576, 1024),  # ~1.0 megapixels -> 1024x1024
+            (2.0, 1536),   # 2.0 megapixels -> 1536x1536
+            (4.0, 2048),   # 4.0 megapixels -> 2048x2048
+        ]
+        
+        for resolution, expected_pixel_res in test_cases:
+            with self.subTest(resolution=resolution):
+                StateTracker.get_data_backend_config = MagicMock(
+                    return_value={
+                        "crop": True,
+                        "crop_style": "center",
+                        "crop_aspect": "square",
+                        "resolution": resolution,
+                        "resolution_type": "area",
+                    }
+                )
+                
+                sample = TrainingSample(
+                    self.test_image,
+                    self.data_backend_id,
+                    self.test_metadata,
+                )
+                
+                self.assertEqual(
+                    sample.pixel_resolution,
+                    expected_pixel_res,
+                    f"Resolution {resolution} should map to {expected_pixel_res}px, not {sample.pixel_resolution}px"
+                )
+
+    def test_square_crop_batch_consistency(self):
+        """
+        Test that multiple images in a batch all have exactly the same aspect ratio
+        when using square crop, preventing the VAE cache error.
+        """
+        # Mock StateTracker to prevent file operations
+        StateTracker.get_args = MagicMock(return_value=MagicMock(
+            aspect_bucket_alignment=64,
+            aspect_bucket_rounding=2,
+            output_dir="/tmp"
+        ))
+        StateTracker.set_resolution_by_aspect = MagicMock()
+        StateTracker.get_resolution_by_aspect = MagicMock(return_value=None)
+        StateTracker._save_to_disk = MagicMock()
+        
+        StateTracker.get_data_backend_config = MagicMock(
+            return_value={
+                "crop": True,
+                "crop_style": "random",
+                "crop_aspect": "square",
+                "resolution": 1.048576,
+                "resolution_type": "area",
+                "target_downsample_size": 1.048576,
+                "maximum_image_size": 1.048576,
+            }
+        )
+        
+        # Create a batch of images with different sizes
+        batch_images = [
+            Image.new("RGB", (1920, 1080), "white"),
+            Image.new("RGB", (3883, 5825), "white"),
+            Image.new("RGB", (5787, 3858), "white"),
+            Image.new("RGB", (800, 600), "white"),
+            Image.new("RGB", (4475, 6709), "white"),
+        ]
+        
+        aspect_ratios = []
+        sizes = []
+        
+        for i, img in enumerate(batch_images):
+            sample = TrainingSample(
+                img,
+                self.data_backend_id,
+                {"original_size": img.size},
+                model=MagicMock(
+                    MAXIMUM_CANVAS_SIZE=None,
+                    get_transforms=MagicMock(return_value=lambda x: x)
+                ),
+            )
+            
+            prepared = sample.prepare()
+            aspect_ratios.append(prepared.aspect_ratio)
+            sizes.append(sample.image.size)
+        
+        # All aspect ratios should be exactly 1.0
+        for i, ar in enumerate(aspect_ratios):
+            self.assertEqual(
+                ar,
+                1.0,
+                f"Image {i} has aspect ratio {ar}, expected 1.0"
+            )
+        
+        # All sizes should be exactly (1024, 1024)
+        for i, size in enumerate(sizes):
+            self.assertEqual(
+                size,
+                (1024, 1024),
+                f"Image {i} has size {size}, expected (1024, 1024)"
+            )
+        
+        # Verify that VAE cache check would pass
+        first_aspect = aspect_ratios[0]
+        for i, ar in enumerate(aspect_ratios[1:], 1):
+            self.assertEqual(
+                ar,
+                first_aspect,
+                f"Image {i} aspect ratio {ar} doesn't match first image {first_aspect}"
+            )
 # Helper mock classes and functions
 class MockCropper:
     def __init__(self, image, image_metadata):


### PR DESCRIPTION
manifests by pre-caching failing with aspect ratio differing among samples when square crops are enabled. not sure which commit introduced it.

calculations were landing 1.0 square crops on 1056x1056 instead of 1024px, so that's been fixed as well.