### PR TITLE
Expand aspect_bucket_alignment options; allow override with --i_know_what_i_am_doing

### DIFF
--- a/helpers/configuration/cmd_args.py
+++ b/helpers/configuration/cmd_args.py
@@ -1101,7 +1101,7 @@ def get_argument_parser():
     parser.add_argument(
         "--aspect_bucket_alignment",
         type=int,
-        choices=[8, 64],
+        choices=[8, 16, 24, 32, 64],
         default=64,
         help=(
             "When training diffusion models, the image sizes generally must align to a 64 pixel interval."

--- a/helpers/models/qwen_image/model.py
+++ b/helpers/models/qwen_image/model.py
@@ -324,11 +324,23 @@ class QwenImage(ImageModelFoundation):
 
         # Qwen Image specific checks
         if self.config.aspect_bucket_alignment != 32:
-            logger.warning(
-                f"{self.NAME} requires an alignment value of 32px. "
-                "Overriding the value of --aspect_bucket_alignment."
-            )
-            self.config.aspect_bucket_alignment = 32
+            if not getattr(self.config, "i_know_what_i_am_doing", False):
+                logger.warning(
+                    f"{self.NAME} requires an alignment value of 32px. "
+                    "Overriding the value of --aspect_bucket_alignment. "
+                    "If you really want to proceed without this enforcement, "
+                    "supply `--i_know_what_i_am_doing`. -!-"
+                )
+                self.config.aspect_bucket_alignment = 32
+            else:
+                logger.warning(
+                    f"-!- {self.NAME} requires an alignment value of 32px, but you have "
+                    "supplied `--i_know_what_i_am_doing`, so this limit will not be enforced. -!-"
+                )
+                logger.warning(
+                    "Proceeding with a non-32px alignment may cause bucketting errors, "
+                    "image artifacts, or unstable training behaviour."
+                )
 
         # Ensure we're using flow matching
         if self.config.prediction_type != "flow_matching":


### PR DESCRIPTION
This PR makes two improvements to aspect bucket alignment handling:

- Expands allowed alignment choices from `[8, 64]` to `[8, 16, 24, 32, 64]`.
- For QwenImage, alignment is still forced to 32px by default, but users can bypass this by supplying `--i_know_what_i_am_doing`.

This gives flexibility for advanced use cases while keeping safer defaults for most training scenarios.
