### PR TITLE
fix: type error when passing argument dict to Trainer initialization

### DIFF
--- a/simpletuner/helpers/configuration/loader.py
+++ b/simpletuner/helpers/configuration/loader.py
@@ -90,8 +90,7 @@ def load_config(args: dict = None, exit_on_error: bool = False):
     if "-h" in sys.argv or "--help" in sys.argv:
         return helpers["cmd"]()
 
-    mapped_config = args
-    if mapped_config is None or not mapped_config:
+    if args is None or not args:
         config_env = os.environ.get(
             "SIMPLETUNER_ENVIRONMENT",
             os.environ.get("SIMPLETUNER_ENV", os.environ.get("ENV", "default")),
@@ -116,6 +115,8 @@ def load_config(args: dict = None, exit_on_error: bool = False):
         mapped_config = helpers[config_backend]()
         if config_backend == "cmd":
             return mapped_config
+    else:
+        mapped_config = json_file.normalize_args(args)
 
     configuration = helpers["cmd"](input_args=mapped_config, exit_on_error=exit_on_error)
 


### PR DESCRIPTION
`parser.parse_args(...)` in simpletuner/helpers/configuration/cmd_args.py expects a list of strings instead of a dictionary object

Steps to reproduce error:
```python
from simpletuner.helpers.training.trainer import Trainer

trainer = Trainer(
    config={'model_family': 'sdxl', 'model_type': 'lora', 'optimizer': 'optimi-adamw'},
    exit_on_error=True,
)
```

```
[ERROR] Could not parse input: {'model_family': 'sdxl', 'model_type': 'lora', 'optimizer': 'optimi-adamw'}
[ERROR] Traceback (most recent call last):
  File "/Users/redevined/Projects/SimpleTuner/simpletuner/helpers/configuration/cmd_args.py", line 2401, in parse_cmdline_args
    args = parser.parse_args(input_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/redevined/.pyenv/versions/3.11.11/lib/python3.11/argparse.py", line 1874, in parse_args
    args, argv = self.parse_known_args(args, namespace)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/redevined/.pyenv/versions/3.11.11/lib/python3.11/argparse.py", line 1911, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/redevined/.pyenv/versions/3.11.11/lib/python3.11/argparse.py", line 2156, in _parse_known_args
    self.error(_('the following arguments are required: %s') %
  File "/Users/redevined/.pyenv/versions/3.11.11/lib/python3.11/argparse.py", line 2640, in error
    self.exit(2, _('%(prog)s: error: %(message)s\n') % args)
  File "/Users/redevined/.pyenv/versions/3.11.11/lib/python3.11/argparse.py", line 2627, in exit
    _sys.exit(status)
SystemExit: 2
```