### PR TITLE
fix: raw webhook send error

### DIFF
--- a/simpletuner/helpers/webhooks/handler.py
+++ b/simpletuner/helpers/webhooks/handler.py
@@ -58,7 +58,7 @@ class WebhookHandler:
 
     def _send_request(
         self,
-        message: str,
+        message: str | dict,
         images: list = None,
         store_response: bool = False,
         raw_request: bool = False,
@@ -80,7 +80,8 @@ class WebhookHandler:
             # Prepare raw data payload for direct POST
             if raw_request:
                 # If already fully formed JSON or dict, just send raw
-                data = message
+                # Assure all values are JSON-serializable
+                data = json.loads(json.dumps(message, default=repr))
                 files = None
             else:
                 # Convert images to base64 for a generic "raw" JSON


### PR DESCRIPTION
Fix an error where sending structured data through the webhook fails due to unserializable objects.

This fix simply replaces dictionary values that are not JSON-serializable from `data`. A more explicit way might be to sanitize input to `_send_webhook_raw(...)` beforehand.

The error occurs in simpletuner/helpers/training/trainer.py, as the `Trainer.state` dictionary includes unserializable objects, such as a `ProjectConfiguration` instance.
```python
[...]

if (
    self.config.webhook_reporting_interval is not None
    and self.state["global_step"]
    % self.config.webhook_reporting_interval
    == 0
):
    structured_data = {
        "state": self.state,
        "loss": round(self.train_loss, 4),
        "parent_loss": parent_loss,
        "learning_rate": self.lr,
        "epoch": epoch,
        "final_epoch": self.config.num_train_epochs,
    }
    self._send_webhook_raw(
        structured_data=structured_data, message_type="train"
    )

[...]
```

Error log:
```
[ERROR] Could not send webhook request: Object of type ProjectConfiguration is not JSON serializable
```