### PR TITLE
wan i2v refactor: auto-create conditioning dataset when is_i2v is true on a dataset with no conditioning data defined

### DIFF
--- a/simpletuner/helpers/models/chroma/controlnet.py
+++ b/simpletuner/helpers/models/chroma/controlnet.py
@@ -7,9 +7,9 @@ from diffusers.configuration_utils import ConfigMixin
 from diffusers.loaders import PeftAdapterMixin
 from diffusers.models.attention_processor import AttentionProcessor
 from diffusers.models.controlnets.controlnet import ControlNetConditioningEmbedding, zero_module
-from diffusers.models.transformers.transformer_flux import FluxPosEmbed
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 from diffusers.models.modeling_utils import ModelMixin
+from diffusers.models.transformers.transformer_flux import FluxPosEmbed
 from diffusers.utils import USE_PEFT_BACKEND, BaseOutput, logging, scale_lora_layers, unscale_lora_layers
 
 from .transformer import (

--- a/simpletuner/helpers/models/qwen_image/transformer.py
+++ b/simpletuner/helpers/models/qwen_image/transformer.py
@@ -629,15 +629,11 @@ class QwenImageTransformer2DModel(
         patch_size = self.config.patch_size
         expected_tokens = grid_h * grid_w
         if num_tokens != expected_tokens:
-            raise ValueError(
-                f"Unexpected token count during untokenize: got {num_tokens}, expected {expected_tokens}"
-            )
+            raise ValueError(f"Unexpected token count during untokenize: got {num_tokens}, expected {expected_tokens}")
 
         expected_channels = patch_size * patch_size * self.out_channels
         if channels != expected_channels:
-            raise ValueError(
-                f"Unexpected channel count during untokenize: got {channels}, expected {expected_channels}"
-            )
+            raise ValueError(f"Unexpected channel count during untokenize: got {channels}, expected {expected_channels}")
 
         hidden_states = hidden_states.view(
             batch_size,

--- a/simpletuner/helpers/models/wan/model.py
+++ b/simpletuner/helpers/models/wan/model.py
@@ -323,6 +323,7 @@ class Wan(VideoModelFoundation):
         self._conditioning_image_embedder = None
         self._wan_logged_missing_img_encoder = False
         self._wan_vae_patch_lock = threading.Lock()
+        self._wan_warned_missing_i2v_conditioning = False
         if not hasattr(self.config, "wan_force_2_1_time_embedding"):
             self.config.wan_force_2_1_time_embedding = False
         self._wan_expand_timesteps = False
@@ -531,13 +532,25 @@ class Wan(VideoModelFoundation):
         return super().encode_with_vae(vae, patched_samples)
 
     def _apply_i2v_conditioning_to_kwargs(self, prepared_batch, transformer_kwargs):
-        if not self._is_i2v_like_flavour():
+        is_i2v_batch = bool(prepared_batch.get("is_i2v_data", False))
+        if not (self._is_i2v_like_flavour() or is_i2v_batch):
             return
         first_frame, last_frame = self._extract_conditioning_frames(prepared_batch)
-        if first_frame is None or transformer_kwargs.get("hidden_states") is None:
+        if first_frame is None:
+            if is_i2v_batch and not getattr(self, "_wan_warned_missing_i2v_conditioning", False) and should_log():
+                logger.warning(
+                    "Wan I2V conditioning data was requested but no conditioning frames were provided. "
+                    "Ensure your dataset supplies conditioning images when training I2V flavours."
+                )
+                self._wan_warned_missing_i2v_conditioning = True
+            return
+        elif getattr(self, "_wan_warned_missing_i2v_conditioning", False):
+            self._wan_warned_missing_i2v_conditioning = False
+
+        latent_tensor = transformer_kwargs.get("hidden_states")
+        if latent_tensor is None:
             return
 
-        latent_tensor = transformer_kwargs["hidden_states"]
         latent_device = latent_tensor.device
         latent_dtype = latent_tensor.dtype
 


### PR DESCRIPTION
seems to be missing?