### PR TITLE
fix bug when loading predefined conditioning_image_embeds sets

### DIFF
--- a/simpletuner/helpers/data_backend/config/base.py
+++ b/simpletuner/helpers/data_backend/config/base.py
@@ -53,6 +53,7 @@ class BaseBackendConfig(ABC):
             DatasetType.VIDEO,
             DatasetType.TEXT_EMBEDS,
             DatasetType.IMAGE_EMBEDS,
+            DatasetType.CONDITIONING_IMAGE_EMBEDS,
             DatasetType.CAPTION,
         ]
         if self.dataset_type not in valid_dataset_types:

--- a/simpletuner/helpers/data_backend/config/image_embed.py
+++ b/simpletuner/helpers/data_backend/config/image_embed.py
@@ -45,7 +45,11 @@ class ImageEmbedBackendConfig(BaseBackendConfig):
     def validate(self, args: Dict[str, Any]) -> None:
         validators.validate_backend_id(self.id)
 
-        validators.validate_dataset_type(self.dataset_type, [DatasetType.IMAGE_EMBEDS], self.id)
+        validators.validate_dataset_type(
+            self.dataset_type,
+            [DatasetType.IMAGE_EMBEDS, DatasetType.CONDITIONING_IMAGE_EMBEDS],
+            self.id,
+        )
 
         validators.check_for_caption_filter_list_misuse(self.dataset_type, False, self.id)
 


### PR DESCRIPTION
For error state:

<img width="1319" height="636" alt="image" src="https://github.com/user-attachments/assets/a1fd3e70-d380-4e18-80f7-1c6ff1433424" />

From config:

<img width="1019" height="770" alt="image" src="https://github.com/user-attachments/assets/26831cc4-17f7-4b0c-9ed5-b0baad036401" />
