### PR TITLE
Add non-Python files to SimpleTuner wheel.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include simpletuner *.html *.css *.js *.ico *.json *.md


### PR DESCRIPTION
See https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html#controlling-files-in-the-distribution

By default, only `*.py` files are included in the distribution when using setuptools. This means that other files, such as HTML files, are missing.

To fix this issue, we include them in `MANIFEST.in`.
