### PR TITLE
resolve bug where duplicating conf environment does not copy the whole subfolder

### DIFF
--- a/simpletuner/templates/environments_tab.html
+++ b/simpletuner/templates/environments_tab.html
@@ -388,13 +388,16 @@ function environmentsTabComponent() {
                     await trainerStore.updateConfigSelectors();
                 }
             }
-            window.dispatchEvent(new CustomEvent('configs-updated', {
-                detail: {
+            await this.announceConfigChange(
+                {
                     source: 'environment-create',
-                    name: payload && payload.name ? payload.name : null,
+                    name: payload && payload.name
+                        ? payload.name
+                        : (environment && environment.name ? environment.name : null),
                     environment: environment,
-                }
-            }));
+                },
+                { skipTrainerRefresh: true }
+            );
         },
 
         openCreateDataloaderModal(environmentName) {
@@ -474,6 +477,31 @@ function environmentsTabComponent() {
             if (store) {
                 await store.load();
             }
+        },
+
+        async announceConfigChange(detail = {}, { skipTrainerRefresh = false } = {}) {
+            const eventDetail = {
+                source: `${this.configType}-manager`,
+                configType: this.configType,
+                ...detail,
+            };
+
+            if (this.configType === 'model' && !skipTrainerRefresh) {
+                const trainerStore = Alpine.store('trainer');
+                if (trainerStore) {
+                    try {
+                        if (typeof trainerStore.loadEnvironmentConfigs === 'function') {
+                            await trainerStore.loadEnvironmentConfigs();
+                        } else if (typeof trainerStore.updateConfigSelectors === 'function') {
+                            await trainerStore.updateConfigSelectors();
+                        }
+                    } catch (error) {
+                        console.error('Failed to refresh trainer configs after update:', error);
+                    }
+                }
+            }
+
+            window.dispatchEvent(new CustomEvent('configs-updated', { detail: eventDetail }));
         },
 
         get allDataloaderConfigs() {
@@ -593,6 +621,10 @@ function environmentsTabComponent() {
                 if (response.ok) {
                      await this.loadConfigs();
                      window.showToast('Deleted configuration: ' + name, 'success');
+                     await this.announceConfigChange({
+                         source: 'environment-delete',
+                         name: sanitized,
+                     });
                  } else {
                      const error = await response.json();
                      // Show more specific error for active config
@@ -649,6 +681,10 @@ function environmentsTabComponent() {
                 if (response.ok) {
                     await this.loadConfigs();
                     window.showToast('Created duplicate: ' + targetName, 'success');
+                    await this.announceConfigChange({
+                        source: 'environment-duplicate',
+                        name: targetName,
+                    });
                 }
             } catch (error) {
                 console.error('Failed to duplicate config:', error);
@@ -677,6 +713,11 @@ function environmentsTabComponent() {
                 if (response.ok) {
                     await this.loadConfigs();
                     window.showToast('Renamed to ' + targetName, 'success');
+                    await this.announceConfigChange({
+                        source: 'environment-rename',
+                        name: targetName,
+                        previousName: sourceName,
+                    });
                 }
             } catch (error) {
                 console.error('Failed to rename config:', error);
@@ -729,6 +770,10 @@ function environmentsTabComponent() {
                 if (response.ok) {
                     await this.loadConfigs();
                     window.showToast('Created configuration from template: ' + normalizedName, 'success');
+                    await this.announceConfigChange({
+                        source: 'environment-from-template',
+                        name: normalizedName,
+                    });
                 }
             } catch (error) {
                 console.error('Failed to create from template:', error);
@@ -766,6 +811,10 @@ function environmentsTabComponent() {
                 if (response.ok) {
                     await this.loadConfigs();
                     window.showToast('Imported configuration: ' + name, 'success');
+                    await this.announceConfigChange({
+                        source: 'environment-import',
+                        name: name,
+                    });
                 }
              } catch (error) {
                  console.error('Failed to import config:', error);

--- a/tests/test_dependencies_common.py
+++ b/tests/test_dependencies_common.py
@@ -1,0 +1,74 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from simpletuner.simpletuner_sdk.server.dependencies import common
+from simpletuner.simpletuner_sdk.server.services.config_store import ConfigStore
+
+
+class ActiveConfigCacheTests(unittest.TestCase):
+    """Tests for loading the active configuration via dependency helper."""
+
+    def setUp(self) -> None:
+        self._instances_backup = ConfigStore._instances.copy()
+        ConfigStore._instances = {}
+        common._load_active_config_cached.clear_cache()
+
+    def tearDown(self) -> None:
+        ConfigStore._instances = self._instances_backup
+        common._load_active_config_cached.clear_cache()
+
+    def test_load_active_config_from_flat_file(self) -> None:
+        """Ensure flat `<name>.json` configs are supported when resolving the active entry."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir)
+            config_name = "flat-config"
+            config_payload = {"model_family": "wan", "learning_rate": 0.123}
+            (config_dir / f"{config_name}.json").write_text(json.dumps(config_payload))
+
+            defaults = SimpleNamespace(configs_dir=str(config_dir), active_config=None)
+
+            with (
+                patch.object(common, "WebUIStateStore") as mock_store_cls,
+                patch.object(ConfigStore, "get_active_config", return_value=config_name),
+            ):
+                mock_store = mock_store_cls.return_value
+                mock_store.load_defaults.return_value = defaults
+
+                resolved = common._load_active_config_cached()
+
+        self.assertIsInstance(resolved, dict)
+        self.assertEqual(resolved.get("learning_rate"), 0.123)
+        self.assertEqual(resolved.get("model_family"), "wan")
+
+    def test_load_active_config_from_directory_based_layout(self) -> None:
+        """Ensure standard `<name>/config.json` layouts still resolve."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir)
+            config_name = "folder-config"
+            payload = {"model_family": "wan", "learning_rate": 9.99}
+            env_dir = config_dir / config_name
+            env_dir.mkdir(parents=True, exist_ok=True)
+            (env_dir / "config.json").write_text(json.dumps(payload))
+
+            defaults = SimpleNamespace(configs_dir=str(config_dir), active_config=None)
+
+            with (
+                patch.object(common, "WebUIStateStore") as mock_store_cls,
+                patch.object(ConfigStore, "get_active_config", return_value=config_name),
+            ):
+                mock_store = mock_store_cls.return_value
+                mock_store.load_defaults.return_value = defaults
+
+                resolved = common._load_active_config_cached()
+
+        self.assertIsInstance(resolved, dict)
+        self.assertEqual(resolved.get("learning_rate"), 9.99)
+        self.assertEqual(resolved.get("model_family"), "wan")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
no longer creates `{id}.json` and `{id}.metadata.json` but instead just `{id}/.metadata.json` etc