### PR TITLE
add a new accelerate strategy for num_processes on Hardware tab to be enabled and take precedence

### DIFF
--- a/simpletuner/simpletuner_sdk/server/services/webui_state.py
+++ b/simpletuner/simpletuner_sdk/server/services/webui_state.py
@@ -89,7 +89,7 @@ def _normalise_accelerate_overrides(raw: Any) -> Dict[str, Any]:
             if normalized_key == "mode":
                 if isinstance(value, str):
                     normalized_value = value.strip().lower()
-                    if normalized_value in {"auto", "manual", "disabled"}:
+                    if normalized_value in {"auto", "manual", "disabled", "hardware"}:
                         cleaned[normalized_key] = normalized_value
                 continue
 
@@ -125,6 +125,9 @@ def _normalise_accelerate_overrides(raw: Any) -> Dict[str, Any]:
                         ordered.append(device_id)
                     cleaned[normalized_key] = ordered
                 continue
+
+    if cleaned.get("mode") == "hardware":
+        cleaned.pop("--num_processes", None)
 
     return cleaned
 

--- a/simpletuner/templates/trainer_htmx.html
+++ b/simpletuner/templates/trainer_htmx.html
@@ -3111,8 +3111,9 @@ function trainerComponent() {
             const numProcesses = typeof clone['--num_processes'] === 'number'
                 ? clone['--num_processes']
                 : parseInt(clone['--num_processes'], 10);
+            const validModes = ['auto', 'manual', 'disabled', 'hardware'];
             let mode = typeof clone.mode === 'string' ? clone.mode.trim().toLowerCase() : undefined;
-            if (!['auto', 'manual', 'disabled'].includes(mode || '')) {
+            if (!validModes.includes(mode || '')) {
                 if (deviceIds.length > 1) {
                     mode = 'manual';
                 } else if (Number.isFinite(numProcesses) && numProcesses > 1) {
@@ -3123,11 +3124,20 @@ function trainerComponent() {
                     mode = 'auto';
                 }
             }
+            const normalizedMode = validModes.includes(mode || '') ? mode : 'auto';
             return {
-                mode: mode || 'auto',
-                manual_count: Number.isFinite(manualCount) && manualCount > 0 ? manualCount : null,
+                mode: normalizedMode || 'auto',
+                manual_count:
+                    normalizedMode === 'manual' && Number.isFinite(manualCount) && manualCount > 0
+                        ? manualCount
+                        : null,
                 device_ids: deviceIds,
-                '--num_processes': Number.isFinite(numProcesses) && numProcesses > 0 ? numProcesses : null,
+                '--num_processes':
+                    normalizedMode === 'hardware'
+                        ? null
+                        : Number.isFinite(numProcesses) && numProcesses > 0
+                            ? numProcesses
+                            : null,
             };
         },
         async prepareAccelerateOnboarding(rawValue) {
@@ -3148,6 +3158,8 @@ function trainerComponent() {
         },
         serializeAccelerateOnboardingValue() {
             const mode = (this.onboardingAccelerate.mode || 'auto').toLowerCase();
+            const validModes = ['auto', 'manual', 'disabled', 'hardware'];
+            const normalizedMode = validModes.includes(mode) ? mode : 'auto';
             const uniqueDeviceIds = Array.isArray(this.onboardingAccelerate.deviceIds)
                 ? Array.from(new Set(this.onboardingAccelerate.deviceIds
                     .map((value) => {
@@ -3158,12 +3170,15 @@ function trainerComponent() {
                 : [];
             const manualCount = parseInt(this.onboardingAccelerate.manualCount, 10);
             const hasManualCount = Number.isFinite(manualCount) && manualCount > 0;
+            if (normalizedMode === 'hardware') {
+                return { mode: 'hardware' };
+            }
             let numProcesses;
-            if (mode === 'disabled') {
+            if (normalizedMode === 'disabled') {
                 numProcesses = 1;
-            } else if (mode === 'auto') {
+            } else if (normalizedMode === 'auto') {
                 numProcesses = this.gpuInventory.optimalProcesses || this.gpuInventory.count || 1;
-            } else if (mode === 'manual') {
+            } else if (normalizedMode === 'manual') {
                 if (uniqueDeviceIds.length > 0) {
                     numProcesses = uniqueDeviceIds.length;
                 } else if (hasManualCount) {
@@ -3178,13 +3193,13 @@ function trainerComponent() {
 
             const normalizedProcesses = Math.max(1, parseInt(numProcesses, 10) || 1);
             const payload = {
-                mode: mode === 'manual' ? 'manual' : mode === 'disabled' ? 'disabled' : 'auto',
+                mode: normalizedMode === 'manual' ? 'manual' : normalizedMode === 'disabled' ? 'disabled' : 'auto',
                 '--num_processes': normalizedProcesses,
             };
 
-            if (mode === 'manual' && uniqueDeviceIds.length > 0) {
+            if (normalizedMode === 'manual' && uniqueDeviceIds.length > 0) {
                 payload.device_ids = uniqueDeviceIds;
-            } else if (mode === 'manual' && hasManualCount) {
+            } else if (normalizedMode === 'manual' && hasManualCount) {
                 payload.manual_count = Math.max(1, manualCount);
             }
 
@@ -4634,6 +4649,17 @@ function trainerComponent() {
                                 Choose GPUs manually
                             </label>
                         </div>
+                        <div class="form-check">
+                            <input class="form-check-input"
+                                   type="radio"
+                                   id="accelerate-mode-hardware"
+                                   value="hardware"
+                                   x-model="onboardingAccelerate.mode"
+                                   name="accelerate_mode">
+                            <label class="form-check-label" for="accelerate-mode-hardware">
+                                Use num_processes from Hardware tab
+                            </label>
+                        </div>
 
                         <template x-if="gpuInventory.loading">
                             <div class="alert alert-info mt-3 py-2">
@@ -4684,6 +4710,9 @@ function trainerComponent() {
                             </template>
                             <template x-if="onboardingAccelerate.mode === 'disabled'">
                                 <span>SimpleTuner will restrict Accelerate to a single GPU.</span>
+                            </template>
+                            <template x-if="onboardingAccelerate.mode === 'hardware'">
+                                <span>Hardware tab controls the Accelerate process count.</span>
                             </template>
                         </div>
                         <div x-effect="if (onboardingAccelerate.mode === 'manual' && gpuInventory.devices.length) { const selected = (onboardingAccelerate.deviceIds || []).length; if (selected > 0 && onboardingAccelerate.manualCount !== selected) { onboardingAccelerate.manualCount = selected; } }"></div>

--- a/simpletuner/templates/ui_settings_tab.html
+++ b/simpletuner/templates/ui_settings_tab.html
@@ -82,8 +82,9 @@ if (!window.uiSettingsTabComponent) {
                 const numProcesses = typeof clone['--num_processes'] === 'number'
                     ? clone['--num_processes']
                     : parseInt(clone['--num_processes'], 10);
+                const validModes = ['auto', 'manual', 'disabled', 'hardware'];
                 let mode = typeof clone.mode === 'string' ? clone.mode.trim().toLowerCase() : undefined;
-                if (!['auto', 'manual', 'disabled'].includes(mode || '')) {
+                if (!validModes.includes(mode || '')) {
                     if (deviceIds.length > 1) {
                         mode = 'manual';
                     } else if (Number.isFinite(numProcesses) && numProcesses > 1) {
@@ -94,11 +95,20 @@ if (!window.uiSettingsTabComponent) {
                         mode = 'auto';
                     }
                 }
+                const normalizedMode = validModes.includes(mode || '') ? mode : 'auto';
                 return {
-                    mode: mode || 'auto',
-                    manual_count: Number.isFinite(manualCount) && manualCount > 0 ? manualCount : null,
+                    mode: normalizedMode || 'auto',
+                    manual_count:
+                        normalizedMode === 'manual' && Number.isFinite(manualCount) && manualCount > 0
+                            ? manualCount
+                            : null,
                     device_ids: deviceIds,
-                    '--num_processes': Number.isFinite(numProcesses) && numProcesses > 0 ? numProcesses : null,
+                    '--num_processes':
+                        normalizedMode === 'hardware'
+                            ? null
+                            : Number.isFinite(numProcesses) && numProcesses > 0
+                                ? numProcesses
+                                : null,
                 };
             },
             prepareAccelerateState(rawValue) {
@@ -330,6 +340,8 @@ if (!window.uiSettingsTabComponent) {
                 if (mode === 'disabled') {
                     this.settings.accelerate.deviceIds = [];
                     this.settings.accelerate.manualCount = 1;
+                } else if (mode === 'hardware') {
+                    this.settings.accelerate.deviceIds = [];
                 } else {
                     this.ensureGpuInventory();
                 }
@@ -358,6 +370,9 @@ if (!window.uiSettingsTabComponent) {
                 if (mode === 'manual') {
                     return `Will launch ${accelerateState.manualCount} process${accelerateState.manualCount === 1 ? '' : 'es'} by default.`;
                 }
+                if (mode === 'hardware') {
+                    return 'Hardware tab controls the Accelerate process count.';
+                }
                 if (mode === 'disabled') {
                     return 'SimpleTuner will restrict Accelerate to a single GPU.';
                 }
@@ -367,6 +382,8 @@ if (!window.uiSettingsTabComponent) {
             serializeAccelerateSettings() {
                 const state = this.settings.accelerate || {};
                 const mode = (state.mode || 'auto').toLowerCase();
+                const validModes = ['auto', 'manual', 'disabled', 'hardware'];
+                const normalizedMode = validModes.includes(mode) ? mode : 'auto';
                 const uniqueDeviceIds = Array.isArray(state.deviceIds)
                     ? Array.from(new Set(
                         state.deviceIds
@@ -381,12 +398,16 @@ if (!window.uiSettingsTabComponent) {
                 const hasManualCount = Number.isFinite(manualCountParsed) && manualCountParsed > 0;
                 const manualCount = hasManualCount ? manualCountParsed : null;
 
+                if (normalizedMode === 'hardware') {
+                    return { mode: 'hardware' };
+                }
+
                 let numProcesses;
-                if (mode === 'disabled') {
+                if (normalizedMode === 'disabled') {
                     numProcesses = 1;
-                } else if (mode === 'auto') {
+                } else if (normalizedMode === 'auto') {
                     numProcesses = this.gpuInventory.optimalProcesses || this.gpuInventory.count || manualCount || 1;
-                } else if (mode === 'manual') {
+                } else if (normalizedMode === 'manual') {
                     if (uniqueDeviceIds.length > 0) {
                         numProcesses = uniqueDeviceIds.length;
                     } else if (manualCount) {
@@ -401,12 +422,12 @@ if (!window.uiSettingsTabComponent) {
 
                 const normalizedProcesses = Math.max(1, parseInt(numProcesses, 10) || 1);
                 const payload = {
-                    mode: mode === 'manual' ? 'manual' : mode === 'disabled' ? 'disabled' : 'auto',
+                    mode: normalizedMode === 'manual' ? 'manual' : normalizedMode === 'disabled' ? 'disabled' : 'auto',
                     '--num_processes': normalizedProcesses,
                 };
-                if (mode === 'manual' && uniqueDeviceIds.length > 0) {
+                if (normalizedMode === 'manual' && uniqueDeviceIds.length > 0) {
                     payload.device_ids = uniqueDeviceIds;
-                } else if (mode === 'manual' && manualCount) {
+                } else if (normalizedMode === 'manual' && manualCount) {
                     payload.manual_count = Math.max(1, manualCount);
                 }
                 return payload;
@@ -685,6 +706,19 @@ if (!window.uiSettingsTabComponent) {
                                        @change="setAccelerateMode('manual')">
                                 <label class="form-check-label" for="ui-accelerate-mode-manual">
                                     Choose GPUs manually
+                                </label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input"
+                                       type="radio"
+                                       id="ui-accelerate-mode-hardware"
+                                       value="hardware"
+                                       name="ui-accelerate-mode"
+                                       :checked="settings.accelerate.mode === 'hardware'"
+                                       @change="setAccelerateMode('hardware')">
+                                <label class="form-check-label" for="ui-accelerate-mode-hardware">
+                                    Use num_processes from Hardware tab
+                                    <span class="text-muted d-block small">Trainer Hardware > Accelerate settings control the launch count.</span>
                                 </label>
                             </div>
                         </div>

--- a/tests/pages/trainer_page.py
+++ b/tests/pages/trainer_page.py
@@ -765,8 +765,7 @@ class TrainerPage(BasePage):
                 "return document.body.dataset.trainingActive || 'false';"
             )
             run_disabled = driver.execute_script(
-                "const runBtn=document.getElementById('runBtn');"
-                "return !!(runBtn && runBtn.disabled);"
+                "const runBtn=document.getElementById('runBtn');" "return !!(runBtn && runBtn.disabled);"
             )
             cancel_enabled = driver.execute_script(
                 "const cancelBtn=document.getElementById('cancelBtn');" "return !!(cancelBtn && !cancelBtn.disabled);"

--- a/tests/test_webui_backend.py
+++ b/tests/test_webui_backend.py
@@ -170,6 +170,22 @@ class WebUIStateStoreTests(unittest.TestCase):
         self.assertEqual(loaded.accelerate_overrides.get("manual_count"), 3)
         self.assertEqual(loaded.accelerate_overrides.get("device_ids"), [0, 1, 3])
 
+    def test_accelerate_hardware_mode_discards_num_processes(self) -> None:
+        defaults = WebUIDefaults()
+        defaults.accelerate_overrides = {
+            "mode": "hardware",
+            "--num_processes": "6",
+            "manual_count": "4",
+        }
+
+        self.store.save_defaults(defaults)
+        loaded = self.store.load_defaults()
+
+        self.assertEqual(loaded.accelerate_overrides.get("mode"), "hardware")
+        self.assertNotIn("--num_processes", loaded.accelerate_overrides)
+        # Manual metadata remains so users can switch back without losing previous input
+        self.assertEqual(loaded.accelerate_overrides.get("manual_count"), 4)
+
 
 class WebUIDefaultsUpdateTests(WebUIStateStoreTests):
     def test_update_configs_dir_only_preserves_other_fields(self) -> None:


### PR DESCRIPTION
This pull request adds support for a new "hardware" mode to the Accelerate configuration in both backend and frontend code. The "hardware" mode allows the process count for Accelerate to be controlled by the Hardware tab rather than being set directly in the Accelerate settings. The changes ensure that when "hardware" mode is selected, the `--num_processes` field is omitted from Accelerate overrides and is instead delegated to hardware defaults. Updates span Python backend logic, frontend templates, and test coverage.

**Accelerate mode logic and configuration:**

* Added "hardware" as a valid Accelerate mode in backend normalization functions and ensured that when selected, `--num_processes` is omitted from Accelerate overrides and process count is delegated to hardware defaults. (`simpletuner/simpletuner_sdk/server/services/training_service.py`, `simpletuner/simpletuner_sdk/server/services/webui_state.py`) [[1]](diffhunk://#diff-9fd1c40702569a890a889ae607e7e9d7000868c8d9364f57eb6e4e394e15c4c4L509-R512) [[2]](diffhunk://#diff-9fd1c40702569a890a889ae607e7e9d7000868c8d9364f57eb6e4e394e15c4c4R530-R532) [[3]](diffhunk://#diff-9fd1c40702569a890a889ae607e7e9d7000868c8d9364f57eb6e4e394e15c4c4R543-R546) [[4]](diffhunk://#diff-0212aa5234fd39c68f2274c7f9107f167807aafb524f77ed06de97cb58bc9913L92-R92) [[5]](diffhunk://#diff-0212aa5234fd39c68f2274c7f9107f167807aafb524f77ed06de97cb58bc9913R129-R131)

* Updated frontend onboarding and settings logic to support "hardware" mode, ensuring that the mode is recognized, displayed, and that `--num_processes` is omitted when "hardware" is selected. (`simpletuner/templates/trainer_htmx.html`, `simpletuner/templates/ui_settings_tab.html`) [[1]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14R3114-R3116) [[2]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14R3127-R3140) [[3]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14R3161-R3162) [[4]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14R3173-R3181) [[5]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14L3181-R3202) [[6]](diffhunk://#diff-5de8609cba0809ce90ad16914ab96cdbb837ed230b60433c91932cd8c7cd57adR85-R87) [[7]](diffhunk://#diff-5de8609cba0809ce90ad16914ab96cdbb837ed230b60433c91932cd8c7cd57adR98-R111) [[8]](diffhunk://#diff-5de8609cba0809ce90ad16914ab96cdbb837ed230b60433c91932cd8c7cd57adR343-R344) [[9]](diffhunk://#diff-5de8609cba0809ce90ad16914ab96cdbb837ed230b60433c91932cd8c7cd57adR385-R386) [[10]](diffhunk://#diff-5de8609cba0809ce90ad16914ab96cdbb837ed230b60433c91932cd8c7cd57adR401-R410) [[11]](diffhunk://#diff-5de8609cba0809ce90ad16914ab96cdbb837ed230b60433c91932cd8c7cd57adL404-R430)

**User interface updates:**

* Added new radio button options and explanatory text for "hardware" mode in both onboarding and settings UI, clarifying that process count is controlled by the Hardware tab. (`simpletuner/templates/trainer_htmx.html`, `simpletuner/templates/ui_settings_tab.html`) [[1]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14R4652-R4662) [[2]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14R4714-R4716) [[3]](diffhunk://#diff-5de8609cba0809ce90ad16914ab96cdbb837ed230b60433c91932cd8c7cd57adR711-R723) [[4]](diffhunk://#diff-5de8609cba0809ce90ad16914ab96cdbb837ed230b60433c91932cd8c7cd57adR373-R375)

**Test coverage:**

* Added a new test to verify that "hardware" mode delegates process count to field defaults and does not save `num_processes` in the Accelerate config. (`tests/test_training_service.py`)

**Refactoring and minor fixes:**

* Minor code style and logic improvements in test and page files for consistency. (`tests/pages/trainer_page.py`, `tests/test_training_service.py`) [[1]](diffhunk://#diff-a4b18e15c30f04322095952a2993cfdf3179db49cc5c3d5335d760eecec0c249L768-R768) [[2]](diffhunk://#diff-d6b3092d8c48569efe8498e906e78d0a5388d2de5f11f71b73ecb87f5ba08ceaR70) [[3]](diffhunk://#diff-d6b3092d8c48569efe8498e906e78d0a5388d2de5f11f71b73ecb87f5ba08ceaL80-R81)

These changes collectively ensure that users can select "hardware" mode for Accelerate, which delegates process count management to the hardware configuration, improving flexibility and clarity in configuration workflows.