### PR TITLE
chore: enhance the robustness of path processing

### DIFF
--- a/simpletuner/simpletuner_sdk/server/utils/paths.py
+++ b/simpletuner/simpletuner_sdk/server/utils/paths.py
@@ -73,11 +73,11 @@ def get_template_directory() -> Path:
     Returns:
         Path to the templates directory (always in package, not project root)
     """
-    import simpletuner
 
-    # Templates are always in the package directory, not project root
     simpletuner_package = get_simpletuner_root()
-    return simpletuner_package / "templates"
+    is_dev = (simpletuner_package / "pyproject.toml").exists()
+    subpath = "simpletuner/templates" if is_dev else "templates"
+    return simpletuner_package / subpath
 
 
 def get_static_directory() -> Path:
@@ -86,11 +86,12 @@ def get_static_directory() -> Path:
     Returns:
         Path to the static directory (always in package, not project root)
     """
-    import simpletuner
 
     # Static files are always in the package directory, not project root
     simpletuner_package = get_simpletuner_root()
-    return simpletuner_package / "static"
+    is_dev = (simpletuner_package / "pyproject.toml").exists()
+    subpath = "simpletuner/static" if is_dev else "static"
+    return simpletuner_package / subpath
 
 
 def resolve_config_path(


### PR DESCRIPTION
To fix issue #1842.

Note:
I have test on 2 linux machine
one of triggered issue #1842.
one normal.
all run UI well.


This pull request updates the path resolution logic in `simpletuner/simpletuner_sdk/server/utils/paths.py` to better handle both development and production environments. The main improvements ensure that the correct directories are located regardless of whether the package is being run from source or as an installed package.

**Path resolution improvements:**

* Updated `get_simpletuner_root()` to handle cases where `simpletuner.__file__` is `None`, ensuring the root path is correctly determined in all scenarios.

* Modified `get_template_directory()` to use `get_simpletuner_root()` and dynamically choose between `simpletuner/templates` (development) and `templates` (production) based on the existence of `pyproject.toml`.

* Modified `get_static_directory()` to use `get_simpletuner_root()` and dynamically choose between `simpletuner/static` (development) and `static` (production) based on the existence of `pyproject.toml`.