### PR TITLE
Fix AttributeError: 'Namespace' object has no attribute 'cache_file_suffix'

### DIFF
--- a/simpletuner/helpers/data_backend/factory.py
+++ b/simpletuner/helpers/data_backend/factory.py
@@ -1665,7 +1665,7 @@ class FactoryRegistry:
                 accelerator=self.accelerator,
                 instance_data_dir=init_backend.get("instance_data_dir", ""),
                 cache_dir=init_backend["cache_dir"],
-                cache_file_suffix=self.args.cache_file_suffix,
+                cache_file_suffix=getattr(self.args, "cache_file_suffix", None),
                 write_batch_size=backend.get("write_batch_size", self.args.write_batch_size),
                 read_batch_size=backend.get("read_batch_size", self.args.read_batch_size),
             )


### PR DESCRIPTION


**Problem**: Direct access to `self.args.cache_file_suffix` at line 1668 in `simpletuner/simpletuner/helpers/data_backend/factory.py` caused AttributeError when users didn't specify the optional `--cache_file_suffix` parameter.

**Solution**: Changed `cache_file_suffix=self.args.cache_file_suffix` to `cache_file_suffix=getattr(self.args, "cache_file_suffix", None)` to provide safe default handling. This follows the established pattern in the codebase for optional arguments and maintains backward compatibility.

**Files Changed**: `simpletuner/simpletuner/helpers/data_backend/factory.py` (1 line)