### PR TITLE
Avoid multi-threaded competition

### DIFF
--- a/simpletuner/helpers/training/state_tracker.py
+++ b/simpletuner/helpers/training/state_tracker.py
@@ -100,7 +100,11 @@ class StateTracker:
                     logger.warning(f"(rank={os.environ.get('RANK')}) Deleted cache file: {cache_path}")
                 except:
                     pass
-                fcntl.flock(f, fcntl.LOCK_UN)
+                try:
+                    fcntl.flock(f, fcntl.LOCK_UN)
+                except:
+                    # delete by other process, then just continue
+                    pass
 
     @classmethod
     def _load_from_disk(cls, cache_name, retry_limit: int = 0):


### PR DESCRIPTION
This pull request makes a minor update to the `delete_cache_files` method in `state_tracker.py` to improve error handling when releasing file locks. The change ensures that if the file has already been deleted by another process, the code continues gracefully without raising an exception.

* Improved error handling when releasing file locks in `delete_cache_files` to prevent exceptions if the file is already deleted by another process.