### PR TITLE
add on-demand checkpointing via API and UI

### DIFF
--- a/documentation/api/TUTORIAL.md
+++ b/documentation/api/TUTORIAL.md
@@ -148,6 +148,20 @@ curl -s -X POST http://localhost:8001/api/training/validation/run
 
 If no job is active the endpoint returns HTTP 400, so check `/api/training/status` first when scripting retries.
 
+### Trigger manual checkpoint
+
+To persist the current model state immediately (without waiting for the next scheduled checkpoint), hit:
+
+```bash
+curl -s -X POST http://localhost:8001/api/training/checkpoint/run
+```
+
+- The server responds with the active `job_id`.
+- The trainer saves a checkpoint after the next gradient synchronization using the same settings as scheduled checkpoints (upload rules, rolling retention, etc.).
+- Rolling cleanup and webhook notifications behave exactly like a scheduled checkpoint.
+
+As with validation, the endpoint returns HTTP 400 if no training job is running.
+
 ### Stream validation previews
 
 Models that expose Tiny AutoEncoder (or equivalent) hooks can emit **per-step validation previews** while an image/video is still being sampled. Enable the feature by adding the CLI flags to your payload:

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -262,6 +262,7 @@ class Trainer:
         self.should_abort = False
         self._external_abort_checker = None
         self._manual_validation_consumer: Optional[Callable[[], bool]] = None
+        self._manual_checkpoint_consumer: Optional[Callable[[], bool]] = None
         self.ema_model = None
         self.job_id = job_id
         StateTracker.set_job_id(job_id)
@@ -300,6 +301,15 @@ class Trainer:
         if self._manual_validation_consumer is None:
             return False
         return bool(self._manual_validation_consumer())
+
+    def register_manual_checkpoint_trigger(self, consumer: Callable[[], bool]) -> None:
+        """Register a callable that returns True once per manual checkpoint request."""
+        self._manual_checkpoint_consumer = consumer
+
+    def _consume_manual_checkpoint_request(self) -> bool:
+        if self._manual_checkpoint_consumer is None:
+            return False
+        return bool(self._manual_checkpoint_consumer())
 
     def _update_grad_metrics(
         self, target_logs: Dict[str, float], *, require_value_method: bool = False, clone_norm_value: bool = False
@@ -3930,9 +3940,18 @@ class Trainer:
                         and step % self.config.gradient_accumulation_steps == 0
                         and self.state["global_step"] > self.state["global_resume_step"]
                     )
-                    if checkpoint_step_interval and self.state["global_step"] % checkpoint_step_interval == 0:
+                    manual_checkpoint_requested = self._consume_manual_checkpoint_request()
+                    scheduled_checkpoint_due = (
+                        checkpoint_step_interval and self.state["global_step"] % checkpoint_step_interval == 0
+                    )
+                    if manual_checkpoint_requested or scheduled_checkpoint_due:
+                        checkpoint_message = (
+                            f"Manual checkpoint requested. {webhook_pending_msg}"
+                            if manual_checkpoint_requested
+                            else webhook_pending_msg
+                        )
                         self._run_standard_checkpoint(
-                            webhook_message=webhook_pending_msg,
+                            webhook_message=checkpoint_message,
                             parent_loss=parent_loss,
                             epoch=epoch,
                             upload_to_hub=upload_to_hub,
@@ -4226,11 +4245,13 @@ def run_trainer_job(config):
     job_id = None
     should_abort_callable = None
     manual_validation_consumer = None
+    manual_checkpoint_consumer = None
 
     if hasattr(config, "__dict__"):
         attrs = vars(config).copy()
         should_abort_callable = attrs.pop("should_abort", None)
         manual_validation_consumer = attrs.pop("consume_manual_validation_request", None)
+        manual_checkpoint_consumer = attrs.pop("consume_manual_checkpoint_request", None)
         job_id = attrs.pop("__job_id__", None) or attrs.pop("job_id", None)
         config_payload = attrs
     elif isinstance(config, dict):
@@ -4238,6 +4259,7 @@ def run_trainer_job(config):
         job_id = config_payload.pop("__job_id__", None) or config_payload.pop("job_id", None)
         should_abort_callable = config_payload.pop("should_abort", None)
         manual_validation_consumer = config_payload.pop("consume_manual_validation_request", None)
+        manual_checkpoint_consumer = config_payload.pop("consume_manual_checkpoint_request", None)
     else:
         config_payload = config
 
@@ -4700,6 +4722,8 @@ def run_trainer_job(config):
             trainer.hf_access_token = hf_token
         if callable(manual_validation_consumer):
             trainer.register_manual_validation_trigger(manual_validation_consumer)
+        if callable(manual_checkpoint_consumer):
+            trainer.register_manual_checkpoint_trigger(manual_checkpoint_consumer)
 
     except Exception as e:
         webhook_handler = StateTracker.get_webhook_handler()

--- a/simpletuner/simpletuner_sdk/process_keeper.py
+++ b/simpletuner/simpletuner_sdk/process_keeper.py
@@ -205,12 +205,21 @@ func_file = r"{self.func_file}"
 should_abort = False
 command_check_thread = None
 manual_validation_event = threading.Event()
+manual_checkpoint_event = threading.Event()
 
 
 def consume_manual_validation_request():
     """Return True if a manual validation trigger was pending and clear it."""
     if manual_validation_event.is_set():
         manual_validation_event.clear()
+        return True
+    return False
+
+
+def consume_manual_checkpoint_request():
+    """Return True if a manual checkpoint trigger was pending and clear it."""
+    if manual_checkpoint_event.is_set():
+        manual_checkpoint_event.clear()
         return True
     return False
 
@@ -324,6 +333,9 @@ def check_commands():
                 elif command_name == "trigger_validation":
                     logger.info("Received manual validation trigger")
                     manual_validation_event.set()
+                elif command_name == "trigger_checkpoint":
+                    logger.info("Received manual checkpoint trigger")
+                    manual_checkpoint_event.set()
 
                 # Write back remaining commands
                 with open(command_file, 'w') as f:
@@ -357,6 +369,7 @@ class ConfigWrapper:
         self.__dict__.update(config)
         self.should_abort = lambda: should_abort
         self.consume_manual_validation_request = consume_manual_validation_request
+        self.consume_manual_checkpoint_request = consume_manual_checkpoint_request
 
 wrapped_config = ConfigWrapper(config)
 

--- a/simpletuner/simpletuner_sdk/server/routes/training.py
+++ b/simpletuner/simpletuner_sdk/server/routes/training.py
@@ -208,6 +208,24 @@ async def trigger_manual_validation():
     }
 
 
+@router.post("/checkpoint/run")
+async def trigger_manual_checkpoint():
+    """Request a checkpoint save after the next gradient sync."""
+    job_id = APIState.get_state("current_job_id")
+    if not job_id:
+        raise HTTPException(status_code=400, detail="No active training job")
+
+    try:
+        training_service.request_manual_checkpoint(job_id)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    return {
+        "message": "Checkpoint queued for the next gradient sync.",
+        "job_id": job_id,
+    }
+
+
 @router.post("/cancel", response_class=HTMLResponse)
 async def cancel_training(request: Request):
     """Cancel current training and return HTML response for HTMX."""

--- a/simpletuner/simpletuner_sdk/server/services/training_service.py
+++ b/simpletuner/simpletuner_sdk/server/services/training_service.py
@@ -1029,3 +1029,13 @@ def request_manual_validation(job_id: Optional[str] = None) -> str:
         raise RuntimeError("No active training job to validate.")
     process_keeper.send_process_command(active_job, "trigger_validation", None)
     return active_job
+
+
+def request_manual_checkpoint(job_id: Optional[str] = None) -> str:
+    """Signal the running trainer to persist a checkpoint after the next gradient sync."""
+
+    active_job = job_id or APIState.get_state("current_job_id")
+    if not active_job:
+        raise RuntimeError("No active training job to checkpoint.")
+    process_keeper.send_process_command(active_job, "trigger_checkpoint", None)
+    return active_job

--- a/simpletuner/templates/trainer_htmx.html
+++ b/simpletuner/templates/trainer_htmx.html
@@ -5550,6 +5550,12 @@ function trainerComponent() {
                 <div class="event-dock-actions">
                     <button type="button" class="btn btn-sm btn-outline-light"
                             x-show="showTrainingProgress"
+                            title="Trigger checkpoint save after next gradient sync"
+                            @click="window.triggerManualCheckpoint()">
+                        <i class="fas fa-save"></i> Trigger Checkpoint
+                    </button>
+                    <button type="button" class="btn btn-sm btn-outline-light"
+                            x-show="showTrainingProgress"
                             title="Trigger validation run after next gradient sync"
                             @click="window.triggerManualValidation()">
                         <i class="fas fa-check-circle"></i> Trigger Validation
@@ -5791,6 +5797,24 @@ window.triggerManualValidation = async function() {
         }
     } catch (error) {
         window.showToast('Error triggering validation: ' + error.message, 'error');
+    }
+};
+
+// Function to trigger manual checkpointing
+window.triggerManualCheckpoint = async function() {
+    try {
+        const response = await fetch('/api/training/checkpoint/run', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' }
+        });
+        const data = await response.json();
+        if (response.ok) {
+            window.showToast(data.message || 'Checkpoint queued successfully', 'success');
+        } else {
+            window.showToast(data.detail || 'Failed to queue checkpoint', 'error');
+        }
+    } catch (error) {
+        window.showToast('Error triggering checkpoint: ' + error.message, 'error');
     }
 };
 </script>

--- a/tests/test_training_service.py
+++ b/tests/test_training_service.py
@@ -346,6 +346,19 @@ class TrainingServiceTests(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             training_service.request_manual_validation()
 
+    def test_request_manual_checkpoint_sends_command(self) -> None:
+        training_service.APIState.set_state("current_job_id", "job-abc")
+        with patch.object(training_service.process_keeper, "send_process_command") as mock_send:
+            job_id = training_service.request_manual_checkpoint()
+
+        self.assertEqual(job_id, "job-abc")
+        mock_send.assert_called_once_with("job-abc", "trigger_checkpoint", None)
+
+    def test_request_manual_checkpoint_without_job_raises(self) -> None:
+        training_service.APIState.set_state("current_job_id", None)
+        with self.assertRaises(RuntimeError):
+            training_service.request_manual_checkpoint()
+
     def test_build_config_bundle_filters_webui_only_fields(self) -> None:
         """Test that webui_only fields are filtered from config_dict and don't appear in trainer configs."""
 


### PR DESCRIPTION
This pull request introduces a new feature that allows users to manually trigger a model checkpoint during training, in addition to scheduled checkpoints. This functionality is exposed through a new API endpoint and is integrated throughout the backend, SDK, and frontend UI. The implementation ensures that manual checkpoints follow the same retention, upload, and notification rules as scheduled ones. Tests and documentation are also updated to reflect this new capability.

**Manual Checkpoint Trigger Feature:**

* Added a new POST endpoint `/api/training/checkpoint/run` to trigger a manual checkpoint, returning the active `job_id` and appropriate error codes if no job is running. [[1]](diffhunk://#diff-7257ef4deb1f0729db9d1f1a765a06660288cc7a345267c0529493aca5f06683R211-R228) [[2]](diffhunk://#diff-14a76156bbc3175bf0a48706a02952ed44f8fc788a6b8ee3c32bf27b1e7abf6cR151-R164)
* Implemented `request_manual_checkpoint` in the training service to send a `trigger_checkpoint` command to the process keeper, mirroring the validation trigger pattern.
* Updated the trainer logic to check for manual checkpoint requests and perform checkpointing after the next gradient synchronization, with appropriate webhook messaging and error handling. [[1]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R305-R313) [[2]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27L3933-R3954) [[3]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R265) [[4]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R4248-R4262) [[5]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R4725-R4726)

**SDK and Process Keeper Integration:**

* Added a new event and consumer for manual checkpoint requests in the process keeper, including command handling and config wiring to the trainer. [[1]](diffhunk://#diff-9189b7669099b8835588eb18e71254fe6877e815a04b148799bbe7edebea0ee7R208) [[2]](diffhunk://#diff-9189b7669099b8835588eb18e71254fe6877e815a04b148799bbe7edebea0ee7R219-R226) [[3]](diffhunk://#diff-9189b7669099b8835588eb18e71254fe6877e815a04b148799bbe7edebea0ee7R336-R338) [[4]](diffhunk://#diff-9189b7669099b8835588eb18e71254fe6877e815a04b148799bbe7edebea0ee7R372)

**Frontend and Documentation:**

* Added a "Trigger Checkpoint" button to the training UI, calling the new API endpoint and displaying toast notifications for success or failure. [[1]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14R5551-R5556) [[2]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14R5802-R5819)
* Updated the API tutorial documentation to describe the new manual checkpoint endpoint and its behavior.

**Testing:**

* Added tests to ensure manual checkpoint requests are correctly handled and errors are raised if no job is active.