### PR TITLE
add --offload_during_save to workaround OOMs during dequant

### DIFF
--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -54,6 +54,12 @@ Where `foo` is your config environment - or just use `config/config.json` if you
 - **Why**: This is useful for large models like HiDream and Wan 2.1, which can OOM when loading the VAE cache. This option does not impact quality of training, but for very large text encoders or slow CPUs, it can extend startup time substantially with many datasets. This is disabled by default due to this reason.
 - **Tip**: Complements the group offloading feature below for especially memory-constrained systems.
 
+### `--offload_during_save`
+
+- **What**: Temporarily move the entire pipeline to CPU while `save_hooks.py` prepares checkpoints so that all FP8/quantized weights are written off-device.
+- **Why**: Saving fp8-quanto weights can spike VRAM usage (for example, during `state_dict()` serialization). This option keeps the model on the accelerator for training but offloads it briefly when a save is triggered to avoid CUDA OOMs.
+- **Tip**: Enable this only when saving fails with OOM errors; the loader moves the model back afterward so training resumes seamlessly.
+
 ### `--enable_group_offload`
 
 - **What**: Enables diffusers' grouped module offloading so model blocks can be staged on CPU (or disk) between forward passes.

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/training.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/training.py
@@ -316,6 +316,22 @@ def register_training_fields(registry: "FieldRegistry") -> None:
         )
     )
 
+    registry._add_field(
+        ConfigField(
+            name="offload_during_save",
+            arg_name="--offload_during_save",
+            ui_label="Offload During Save",
+            field_type=FieldType.CHECKBOX,
+            tab="training",
+            section="memory_optimization",
+            default_value=False,
+            help_text="Temporarily move models to CPU when checkpoints are written to avoid VRAM pressure.",
+            tooltip="Helps avoid CUDA OOMs during fp8 checkpoint saves; the model is restored immediately afterwards.",
+            importance=ImportanceLevel.ADVANCED,
+            order=10,
+        )
+    )
+
     # Feed-forward chunking (Wan)
     registry._add_field(
         ConfigField(


### PR DESCRIPTION
Closes #1645

This pull request introduces a new memory optimization feature that helps prevent CUDA out-of-memory (OOM) errors during model checkpoint saves by temporarily offloading models to the CPU. The main changes include the implementation of this offloading mechanism, the addition of a corresponding configuration option, and updates to the documentation and configuration UI.

**Memory Optimization:**
* Added a context manager `_offload_models_during_save` in `save_hooks.py` that moves models to CPU before saving checkpoints and restores them to the accelerator after saving, reducing VRAM usage during save operations.
* Integrated the offload context manager into the `save_model_hook` method to ensure model offloading is applied during checkpoint saves.

**Configuration and Documentation:**
* Added a new command-line/configuration option `--offload_during_save` to enable or disable the offloading behavior, with appropriate help text and tooltips in the configuration UI.
* Updated `OPTIONS.md` documentation to describe the new `--offload_during_save` option, including its purpose, usage tips, and scenarios where it is helpful.