### PR TITLE
sana: fix parsing of complex human instructions (CHI)

### DIFF
--- a/tests/test_sana_complex_instruction.py
+++ b/tests/test_sana_complex_instruction.py
@@ -1,0 +1,20 @@
+import unittest
+
+from simpletuner.helpers.configuration.cmd_args import _normalize_sana_complex_instruction
+
+
+class TestSanaComplexInstruction(unittest.TestCase):
+    def test_multiline_string_is_normalized(self):
+        raw_value = "Line one\nLine two\n\nLine three  "
+        result = _normalize_sana_complex_instruction(raw_value)
+        self.assertEqual(result, ["Line one", "Line two", "Line three"])
+
+    def test_json_encoded_list_is_loaded(self):
+        raw_value = '["first", "second"]'
+        result = _normalize_sana_complex_instruction(raw_value)
+        self.assertEqual(result, ["first", "second"])
+
+    def test_none_like_values_return_none(self):
+        self.assertIsNone(_normalize_sana_complex_instruction(None))
+        self.assertIsNone(_normalize_sana_complex_instruction(""))
+        self.assertIsNone(_normalize_sana_complex_instruction("None"))


### PR DESCRIPTION
This pull request improves how the `sana_complex_human_instruction` argument is handled and normalized within the codebase, ensuring it is consistently parsed and validated regardless of input format. It introduces a new normalization function, updates the argument parsing logic to use this function, and adds unit tests for robustness.

**Enhancements to argument normalization and parsing:**

* Added `_normalize_sana_complex_instruction` to handle various input formats (string, list, file path, JSON, or multi-line string) and always return a list of strings or `None`. This function also handles file loading and error cases gracefully.
* Updated `parse_cmdline_args` to use the new normalization function for the `sana_complex_human_instruction` argument, simplifying and strengthening the parsing logic.

**Testing improvements:**

* Added `tests/test_sana_complex_instruction.py` with unit tests to verify normalization of multi-line strings, JSON-encoded lists, and handling of `None`-like values.