### PR TITLE
dataset builder: relocate save button to action bar, fix dropdown config selector sync

### DIFF
--- a/simpletuner/templates/datasets_tab.html
+++ b/simpletuner/templates/datasets_tab.html
@@ -241,8 +241,79 @@
                 }
             }
 
+            // Function to sync the dropdown value from the trainer store's configValues
+            function syncDropdownFromStore() {
+                const trainerStore = Alpine.store('trainer');
+                if (!trainerStore) {
+                    console.log('[DATASETS DROPDOWN] Trainer store not ready');
+                    return;
+                }
+
+                const configValues = trainerStore.configValues || {};
+                const activeEnvConfig = trainerStore.activeEnvironmentConfig || {};
+
+                // Try multiple sources for the data_backend_config value
+                const configPath =
+                    configValues['data_backend_config'] ||
+                    configValues['--data_backend_config'] ||
+                    activeEnvConfig['data_backend_config'] ||
+                    activeEnvConfig['--data_backend_config'] ||
+                    '';
+
+                if (!configPath) {
+                    console.log('[DATASETS DROPDOWN] No data_backend_config found in store');
+                    return;
+                }
+
+                console.log('[DATASETS DROPDOWN] Syncing dropdown to:', configPath);
+
+                // Find the matching option in the dropdown
+                const options = dropdown.querySelectorAll('.dataset-option');
+                let matchFound = false;
+                let matchEnv = '';
+                let matchPath = '';
+
+                options.forEach(option => {
+                    const optionValue = option.dataset.value || '';
+                    const optionPath = option.dataset.path || '';
+                    if (optionValue === configPath || optionPath === configPath) {
+                        matchFound = true;
+                        matchEnv = option.dataset.environment || '';
+                        matchPath = optionPath;
+                    }
+                });
+
+                if (matchFound || configPath) {
+                    // Use the global function if available
+                    if (window.__setDatasetSelection) {
+                        const displayEnv = matchEnv || (configPath.includes('/') ? configPath.split('/')[0] : configPath);
+                        const displayPath = matchPath || configPath;
+                        window.__setDatasetSelection(dropdown, displayEnv, displayPath, configPath);
+                        console.log('[DATASETS DROPDOWN] Updated dropdown via __setDatasetSelection');
+                    } else {
+                        // Fallback: directly update the dropdown
+                        const hiddenInput = dropdown.querySelector('input[type="hidden"]');
+                        if (hiddenInput) {
+                            hiddenInput.value = configPath;
+                        }
+                        const toggleLabel = dropdown.querySelector('.dataset-toggle-label');
+                        if (toggleLabel && configPath) {
+                            const displayEnv = matchEnv || (configPath.includes('/') ? configPath.split('/')[0] : configPath);
+                            const displayPath = matchPath || configPath;
+                            toggleLabel.innerHTML = `
+                                <span class="dataset-env">${displayEnv}</span>
+                                <span class="dataset-path">${displayPath}</span>
+                            `;
+                        }
+                        console.log('[DATASETS DROPDOWN] Updated dropdown via fallback');
+                    }
+                }
+            }
+
             // Initial sync
             syncEnvironmentBadge();
+            // Delay the dropdown sync to ensure store is populated
+            setTimeout(syncDropdownFromStore, 100);
 
             // Watch for trainer store changes
             if (window.Alpine) {
@@ -250,6 +321,10 @@
                     const trainerStore = Alpine.store('trainer');
                     if (trainerStore) {
                         syncEnvironmentBadge();
+                        // Also sync dropdown when configValues or activeEnvironmentConfig changes
+                        const _ = trainerStore.configValues;
+                        const __ = trainerStore.activeEnvironmentConfig;
+                        syncDropdownFromStore();
                     }
                 });
             }
@@ -258,6 +333,13 @@
             if (window.__refreshDatasetDropdowns) {
                 window.__refreshDatasetDropdowns();
             }
+
+            // Listen for tab switches to re-sync when navigating to datasets tab
+            window.addEventListener('hashchange', () => {
+                if (window.location.hash === '#datasets') {
+                    setTimeout(syncDropdownFromStore, 50);
+                }
+            });
 
             // Add environment filter checkbox handler
             const filterCheckbox = document.getElementById('filterByEnvironment');

--- a/simpletuner/templates/trainer_htmx.html
+++ b/simpletuner/templates/trainer_htmx.html
@@ -5343,6 +5343,21 @@ function trainerComponent() {
 
             <div class="topbar-right">
                 <div class="header-actions">
+                    <!-- Save Dataset button - visible only on datasets tab -->
+                    <button type="button"
+                            class="trainer-action-btn btn"
+                            :class="$store.trainer.hasUnsavedChanges ? 'btn-warning' : 'btn-outline-secondary'"
+                            x-show="activeTab === 'datasets'"
+                            x-transition
+                            @click="$store.trainer.saveDatasets && $store.trainer.saveDatasets({ showToast: true, skipConfirmation: true })"
+                            title="Save dataset configuration">
+                        <i class="fas fa-database"></i>
+                        <span class="btn-text">Save Dataset</span>
+                        <span x-show="$store.trainer.hasUnsavedChanges" class="badge bg-danger ms-1" style="font-size: 0.65rem;">
+                            <i class="fas fa-exclamation-circle"></i>
+                        </span>
+                    </button>
+
                     <button type="button"
                             class="trainer-action-btn btn btn-outline-secondary"
                             :class="formDirty ? 'is-active' : ''"


### PR DESCRIPTION
This pull request enhances the dataset configuration experience in the SimpleTuner UI by improving synchronization between the dataset dropdown and the trainer store, ensuring the dropdown reflects the current configuration, and adding a visible "Save Dataset" button when there are unsaved changes. Additionally, it ensures the dropdown stays in sync when navigating between tabs.

**Dataset Dropdown Synchronization Improvements:**

* Added a new `syncDropdownFromStore` function in `datasets_tab.html` to update the dataset dropdown based on the current values in the trainer store, ensuring the UI always reflects the latest configuration. This function attempts to match the dropdown value from multiple possible sources in the store and updates the dropdown display accordingly, using a global setter if available or a fallback method.
* The dropdown now re-syncs when the datasets tab is activated (via hashchange), ensuring the correct dataset is shown when users switch tabs.
* The dropdown also re-syncs whenever relevant trainer store values (`configValues` or `activeEnvironmentConfig`) change, providing real-time UI updates.

**UI/UX Enhancements:**

* Added a "Save Dataset" button to the top bar in `trainer_htmx.html`, visible only on the datasets tab. This button highlights when there are unsaved changes and triggers a save action with a toast notification and no confirmation dialog.