### PR TITLE
fix issue where epoch-based validation tracking triggers on step 2

### DIFF
--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -1717,6 +1717,15 @@ class Validation:
         except (TypeError, ValueError):
             epoch_interval = None
 
+        epoch_step_ready = False
+        num_steps_per_epoch = getattr(self.config, "num_update_steps_per_epoch", None)
+        if num_steps_per_epoch is not None and self.current_epoch_step is not None:
+            try:
+                steps_per_epoch_int = int(num_steps_per_epoch)
+                epoch_step_ready = self.current_epoch_step >= max(steps_per_epoch_int - 1, 0)
+            except (TypeError, ValueError):
+                epoch_step_ready = False
+
         should_do_step_validation = False
         if (
             validation_prompts
@@ -1736,6 +1745,7 @@ class Validation:
             and self.global_step > self.global_resume_step
             and self.current_epoch is not None
             and self.current_epoch > 0
+            and epoch_step_ready
         ):
             if self._pending_epoch_validation is not None and self._pending_epoch_validation == self.current_epoch:
                 should_do_epoch_validation = True


### PR DESCRIPTION
This pull request updates the intermediary validation logic in the training helper to improve the accuracy of when epoch-level validation is triggered. The main change ensures that epoch validation only occurs once the current step has reached the end of the epoch, based on the configured number of steps per epoch.

Validation logic improvements:

* Added a check to determine if the current step has reached the end of the epoch by comparing `self.current_epoch_step` to `num_update_steps_per_epoch`, and only allowing epoch validation when this condition is met. [[1]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09R1720-R1728) [[2]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09R1748)