### PR TITLE
by default show quantize_via if lora mode enabled, and use a helper to set field visibility instead

### DIFF
--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/model.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/model.py
@@ -507,7 +507,6 @@ def register_model_fields(registry: "FieldRegistry") -> None:
             ],
             dependencies=[
                 FieldDependency(field="model_type", operator="equals", value="lora", action="enable"),
-                FieldDependency(field="base_model_precision", operator="not_equals", value="no_change", action="enable"),
             ],
             help_text="Where to perform model quantization",
             tooltip="CPU is safer for 24GB cards with large models. GPU is faster but may OOM.",

--- a/simpletuner/static/js/training-wizard.js
+++ b/simpletuner/static/js/training-wizard.js
@@ -2555,6 +2555,19 @@ function trainingWizardComponent() {
             return overrides.length > 0 ? overrides.join(', ') : 'Defaults';
         },
 
+        hasAnyPrecisionChanged() {
+            if (this.answers.base_model_precision && this.answers.base_model_precision !== 'no_change') {
+                return true;
+            }
+            for (let i = 1; i <= 4; i++) {
+                const value = this.answers[`text_encoder_${i}_precision`];
+                if (value && value !== 'no_change') {
+                    return true;
+                }
+            }
+            return false;
+        },
+
         // Dataset wizard integration
         async openDatasetWizard(createStandalone = false) {
             console.log('[TRAINING WIZARD] openDatasetWizard called, createStandalone:', createStandalone);

--- a/simpletuner/templates/partials/training_wizard_modal.html
+++ b/simpletuner/templates/partials/training_wizard_modal.html
@@ -178,7 +178,7 @@
                             </div>
                         </template>
 
-                        <div class="mb-0" x-show="quantizationFields.quantizeVia">
+                        <div class="mb-0" x-show="quantizationFields.quantizeVia && hasAnyPrecisionChanged()">
                             <label class="form-label" x-text="quantizationFields.quantizeVia ? quantizationFields.quantizeVia.label : 'Quantization Device'"></label>
                             <select class="form-select"
                                     x-model="answers.quantize_via">


### PR DESCRIPTION
This pull request refines how quantization options are shown in the training wizard by tightening the logic around when the "Quantization Device" field appears. It introduces a new method to check if any precision has changed, and updates the UI and backend logic to reflect this dependency.

Conditional display improvements for quantization options:

* Added a new `hasAnyPrecisionChanged()` method to the `trainingWizardComponent` in `training-wizard.js` to check if any precision selections differ from their default values.
* Updated the quantization device field in `training_wizard_modal.html` to only display if quantization is enabled and any precision has changed, improving the wizard's clarity.

Backend dependency logic adjustment:

* Removed the dependency on `base_model_precision` from the quantization field in `model.py`, ensuring quantization options are not incorrectly gated by this field alone.