### PR TITLE
align computation strip() and retrieval which does not strip()

### DIFF
--- a/simpletuner/helpers/prompts.py
+++ b/simpletuner/helpers/prompts.py
@@ -374,7 +374,19 @@ class PromptHandler:
                 sampler_backend_id=sampler_backend_id,
             )
         elif caption_strategy == "instanceprompt":
-            return instance_prompt
+            if instance_prompt is None:
+                raise ValueError("caption_strategy='instanceprompt' requires an instance_prompt value.")
+
+            if isinstance(instance_prompt, (list, tuple, set)):
+                cleaned_prompts = [str(prompt).strip() for prompt in instance_prompt if str(prompt).strip()]
+                if not cleaned_prompts:
+                    raise ValueError("caption_strategy='instanceprompt' requires at least one non-empty prompt.")
+                return cleaned_prompts
+
+            cleaned_prompt = str(instance_prompt).strip()
+            if cleaned_prompt == "":
+                raise ValueError("caption_strategy='instanceprompt' requires a non-empty prompt.")
+            return cleaned_prompt
         elif caption_strategy == "csv":
             return data_backend.get_caption(image_path)
         elif caption_strategy is not None:

--- a/tests/test_prompthandler.py
+++ b/tests/test_prompthandler.py
@@ -208,6 +208,48 @@ class TestPromptHandler(unittest.TestCase):
             data_backend=self.data_backend,
         )
 
+    def test_magic_prompt_instanceprompt_trims_whitespace(self):
+        """Ensure instanceprompt captions are normalized the same way as pre-compute."""
+        handler = PromptHandler(
+            self.args,
+            self.text_encoders,
+            self.tokenizers,
+            self.accelerator,
+            self.model_type,
+        )
+
+        result = handler.magic_prompt(
+            image_path="path/to/image.png",
+            use_captions=True,
+            caption_strategy="instanceprompt",
+            prepend_instance_prompt=False,
+            data_backend=self.data_backend,
+            instance_prompt="my-style, ",
+        )
+
+        self.assertEqual(result, "my-style,")
+
+    def test_magic_prompt_instanceprompt_cleans_list_prompts(self):
+        """Ensure instanceprompt lists are stripped and empties removed."""
+        handler = PromptHandler(
+            self.args,
+            self.text_encoders,
+            self.tokenizers,
+            self.accelerator,
+            self.model_type,
+        )
+
+        result = handler.magic_prompt(
+            image_path="path/to/image.png",
+            use_captions=True,
+            caption_strategy="instanceprompt",
+            prepend_instance_prompt=False,
+            data_backend=self.data_backend,
+            instance_prompt=["  keep-me  ", "  "],
+        )
+
+        self.assertEqual(result, ["keep-me"])
+
     def test_magic_prompt_raises_error_with_invalid_strategy(self):
         """Ensure magic_prompt raises ValueError with an unsupported caption strategy."""
         # Setup


### PR DESCRIPTION
This pull request enhances the handling and validation of the `instanceprompt` caption strategy in the `magic_prompt` function. It ensures that prompts are properly cleaned (trimmed of whitespace and empty prompts removed), and adds error handling for missing or empty prompts. Corresponding unit tests have been added to verify this behavior.

**Improvements to prompt handling and validation:**

* Improved `magic_prompt` in `prompts.py` to trim whitespace from `instance_prompt` values, remove empty prompts from lists, and raise clear errors if no valid prompt is provided.

**Testing enhancements:**

* Added unit tests in `test_prompthandler.py` to verify that single and list `instance_prompt` values are correctly cleaned and validated.