### PR TITLE
send multigpu validation trigger through shared file

### DIFF
--- a/simpletuner/train.py
+++ b/simpletuner/train.py
@@ -1,4 +1,5 @@
 import atexit
+import json
 import logging
 
 # Quiet down, you.
@@ -15,6 +16,7 @@ logging.config.dictConfig(
     }
 )
 from os import environ
+from pathlib import Path
 
 environ["ACCELERATE_LOG_LEVEL"] = "WARNING"
 
@@ -30,6 +32,65 @@ if hasattr(log_format, "configure_third_party_loggers"):
     log_format.configure_third_party_loggers()
 
 logger = get_logger("SimpleTuner")
+
+
+def _build_signal_consumer(signal_path_text: str | None, key: str):
+    if not signal_path_text:
+        return None
+
+    signal_path = Path(signal_path_text)
+    seen = 0
+    pending = 0
+    last_mtime = None
+    read_error_logged = False
+
+    def _consume():
+        nonlocal seen, pending, last_mtime, read_error_logged
+
+        try:
+            stat = signal_path.stat()
+        except FileNotFoundError:
+            if not read_error_logged:
+                logger.warning("Accelerate trigger file missing at %s", signal_path)
+                read_error_logged = True
+            return False
+        except Exception as exc:
+            if not read_error_logged:
+                logger.warning("Failed to stat accelerate trigger file %s: %s", signal_path, exc)
+                read_error_logged = True
+            return False
+
+        if last_mtime is None or stat.st_mtime > last_mtime:
+            last_mtime = stat.st_mtime
+            try:
+                with signal_path.open("r", encoding="utf-8") as handle:
+                    payload = json.load(handle)
+                read_error_logged = False
+            except Exception as exc:
+                if not read_error_logged:
+                    logger.warning("Failed to read accelerate trigger file %s: %s", signal_path, exc)
+                    read_error_logged = True
+                return False
+            if not isinstance(payload, dict):
+                if not read_error_logged:
+                    logger.warning("Unexpected accelerate trigger payload in %s", signal_path)
+                    read_error_logged = True
+                return False
+            try:
+                count_value = int(payload.get(key, 0))
+            except (TypeError, ValueError):
+                count_value = 0
+            if count_value > seen:
+                pending += count_value - seen
+                seen = count_value
+
+        if pending > 0:
+            pending -= 1
+            return True
+        return False
+
+    return _consume
+
 
 if __name__ == "__main__":
     trainer = None
@@ -55,6 +116,13 @@ if __name__ == "__main__":
         trainer = Trainer(
             exit_on_error=True,
         )
+        signal_file = environ.get("SIMPLETUNER_ACCELERATE_SIGNAL_FILE")
+        validation_consumer = _build_signal_consumer(signal_file, "manual_validation")
+        checkpoint_consumer = _build_signal_consumer(signal_file, "manual_checkpoint")
+        if callable(validation_consumer):
+            trainer.register_manual_validation_trigger(validation_consumer)
+        if callable(checkpoint_consumer):
+            trainer.register_manual_checkpoint_trigger(checkpoint_consumer)
         trainer.configure_webhook()
         trainer.init_noise_schedule()
         trainer.init_seed()


### PR DESCRIPTION
This pull request adds a robust mechanism for relaying manual trigger signals (such as validation and checkpoint requests) between processes when using the `accelerate` launcher in `simpletuner`. It introduces a file-based signaling system, updates both the trainer and entrypoint to support this, and adds comprehensive tests for the new functionality.

**Manual trigger relay system:**

* Added a file-based signaling mechanism in `trainer.py` to relay manual validation and checkpoint triggers between processes via a JSON file, including setup, periodic update, and cleanup logic. (`simpletuner/helpers/training/trainer.py`) [[1]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R5269-R5271) [[2]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R5306-R5389) [[3]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R5492-R5495) [[4]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R5586-R5592) [[5]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R5657)

* Introduced `_build_signal_consumer` in `train.py` to monitor and consume trigger signals from the JSON file, and registered these consumers with the `Trainer` if the signaling environment variable is present. (`simpletuner/train.py`) [[1]](diffhunk://#diff-612c91ac3c60bd876f96ae085dc6ac960812213123606fc423a3d29226d90327R2) [[2]](diffhunk://#diff-612c91ac3c60bd876f96ae085dc6ac960812213123606fc423a3d29226d90327R19) [[3]](diffhunk://#diff-612c91ac3c60bd876f96ae085dc6ac960812213123606fc423a3d29226d90327R36-R94) [[4]](diffhunk://#diff-612c91ac3c60bd876f96ae085dc6ac960812213123606fc423a3d29226d90327R119-R125)

**Testing:**

* Added a new test to ensure that manual trigger relays are correctly written to the signal file and cleaned up after use, including mocks for process and file operations. (`tests/test_trainer.py`) [[1]](diffhunk://#diff-9f4241cfae54a446e69be20582f2536fa636341a35714881b1ad7dcf7000e371R5-R6) [[2]](diffhunk://#diff-9f4241cfae54a446e69be20582f2536fa636341a35714881b1ad7dcf7000e371R785-R851)