### PR TITLE
(#2124) use prefixed temporary dataset name instead of duplicating

### DIFF
--- a/simpletuner/static/js/dataloader-section-component.js
+++ b/simpletuner/static/js/dataloader-section-component.js
@@ -384,8 +384,9 @@ function dataloaderSectionComponent() {
             return;
         }
         if (!dataset._uiKey) {
-            const fallback = dataset.instance_data_dir || dataset.dataset_type || dataset.type || 'dataset';
-            dataset._uiKey = dataset.id || `${fallback}-${Date.now()}-${_datasetKeyCounter++}`;
+            // Always generate a stable unique key independent of dataset.id
+            // This prevents key changes when the user edits the dataset ID field
+            dataset._uiKey = `ds-${Date.now()}-${_datasetKeyCounter++}`;
         }
         if (dataset._connectionStatus === undefined) {
             dataset._connectionStatus = null;

--- a/simpletuner/templates/components/dataloader/sections/conditioning_body.html
+++ b/simpletuner/templates/components/dataloader/sections/conditioning_body.html
@@ -31,7 +31,7 @@
                 x-model="editingDataset.source_dataset_id"
                 @change="markAsUnsaved()">
             <option value="">Select source dataset...</option>
-            <template x-for="option in sourceDatasetOptions(editingDataset)" :key="option.id">
+            <template x-for="(option, idx) in sourceDatasetOptions(editingDataset)" :key="`src-${idx}-${option.id}`">
                 <option :value="option.id" x-text="option.label"></option>
             </template>
         </select>


### PR DESCRIPTION
Closes #2124 

This pull request focuses on improving the stability and uniqueness of UI keys for datasets and source dataset options in the dataloader section. The changes ensure that UI keys do not change unexpectedly when editing dataset IDs, which helps maintain consistent component rendering and avoids potential UI bugs.

**UI Key Generation Improvements:**

* The `dataset._uiKey` is now always generated as a stable and unique key independent of `dataset.id`, preventing key changes when the dataset ID field is edited. (`simpletuner/static/js/dataloader-section-component.js`)

**Source Dataset Option Rendering:**

* The key for each option in the source dataset dropdown is now generated using both its index and ID, improving key stability and uniqueness in the UI. (`simpletuner/templates/components/dataloader/sections/conditioning_body.html`)