### PR TITLE
ReflexFlow: enable by default when flow-matching scheduled sampling is enabled

### DIFF
--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -691,7 +691,7 @@ See the [DATALOADER.md](DATALOADER.md#automatic-dataset-oversubscription) guide 
 
 - **What**: Enable ReflexFlow-style enhancements (anti-drift + frequency-compensated weighting) during scheduled sampling for flow-matching models.
 - **Why**: Reduces exposure bias when rolling out flow-matching models by adding directional regularization and bias-aware loss weighting.
-- **Default**: False. Requires `--scheduled_sampling_max_step_offset` > 0.
+- **Default**: Auto-enable for flow-matching models when `--scheduled_sampling_max_step_offset` > 0; override with `--scheduled_sampling_reflexflow=false`.
 
 ### `--scheduled_sampling_reflexflow_alpha`
 

--- a/documentation/experimental/SCHEDULED_SAMPLING.md
+++ b/documentation/experimental/SCHEDULED_SAMPLING.md
@@ -65,7 +65,7 @@ The solver used for the rollout generation steps.
 
 For flow-matching models (`--prediction_type flow_matching`), scheduled sampling now supports ReflexFlow-style exposure bias mitigation:
 
-*   `scheduled_sampling_reflexflow`: Enable ReflexFlow enhancements during rollout.
+*   `scheduled_sampling_reflexflow`: Enable ReflexFlow enhancements during rollout (auto-enabled for flow-matching models when scheduled sampling is active; pass `--scheduled_sampling_reflexflow=false` to opt out).
 *   `scheduled_sampling_reflexflow_alpha`: Scale the exposure-bias-based loss weight (frequency compensation).
 *   `scheduled_sampling_reflexflow_beta1`: Scale the directional anti-drift regularizer (default 10.0 to mirror the paper).
 *   `scheduled_sampling_reflexflow_beta2`: Scale the frequency-compensated loss (default 1.0).

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/advanced.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/advanced.py
@@ -319,7 +319,7 @@ def register_advanced_fields(registry: "FieldRegistry") -> None:
             tab="training",
             section="loss_functions",
             subsection="advanced",
-            default_value=False,
+            default_value=None,
             help_text="Apply ReflexFlow anti-drift and frequency-compensation weighting during scheduled sampling for flow-matching models.",
             tooltip="Adds ADR directional regularization and exposure-bias weighting to rollout samples.",
             importance=ImportanceLevel.EXPERIMENTAL,


### PR DESCRIPTION
This pull request introduces automatic enabling of ReflexFlow enhancements for flow-matching models during scheduled sampling, unless the user explicitly opts out. The changes update documentation, configuration defaults, model logic, and add new tests to ensure correct behavior.

### ReflexFlow auto-enabling logic

* Added `_maybe_enable_reflexflow_default` method to `ModelFoundation` in `simpletuner/helpers/models/common.py`, which sets `scheduled_sampling_reflexflow=True` automatically for flow-matching models when scheduled sampling is active and the user has not set the flag.
* Invoked `_maybe_enable_reflexflow_default` during model initialization and batch preparation to ensure the flag is set early and consistently. [[1]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR261) [[2]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR2575)

### Configuration and documentation updates

* Changed the default value for the `scheduled_sampling_reflexflow` field in the advanced configuration registry to `None`, indicating it will be auto-enabled unless explicitly set.
* Updated documentation in `OPTIONS.md` and `SCHEDULED_SAMPLING.md` to clarify that ReflexFlow is now auto-enabled for flow-matching models when scheduled sampling is active, and users can opt out with `--scheduled_sampling_reflexflow=false`. [[1]](diffhunk://#diff-45e063db3ebcffb55dde68f083e92399a74f4cefbb464e8cd36911971c50933fL694-R694) [[2]](diffhunk://#diff-2e307bcee8b5f5f23dbf9bf558d2ab992944f1e769d16fd9f63710a6ce82d6a3L68-R68)

### Testing

* Added `ReflexFlowDefaultToggleTests` to `tests/test_scheduled_sampling_rollout.py` to verify that ReflexFlow is auto-enabled for flow-matching models, respects explicit user opt-out, and does not enable for non-flow-matching models.