### PR TITLE
[UI] prevent quant from being used for full training; prevent LoRA combined with DeepSpeed

### DIFF
--- a/tests/test_ui_validation_constraints.py
+++ b/tests/test_ui_validation_constraints.py
@@ -1,0 +1,100 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from simpletuner.simpletuner_sdk.server.services.config_store import ConfigStore
+from simpletuner.simpletuner_sdk.server.services.validation_service import ValidationService, ValidationSeverity
+
+
+class UIValidationConstraintTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._instances_backup = ConfigStore._instances.copy()
+        ConfigStore._instances = {}
+        self.addCleanup(self._restore_instances)
+
+    def _restore_instances(self) -> None:
+        ConfigStore._instances = self._instances_backup
+
+    def test_full_model_type_rejects_quantized_base_precision(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = ConfigStore(config_dir=Path(tmpdir), config_type="model")
+            validation = store.validate_config(
+                {
+                    "--model_type": "full",
+                    "--base_model_precision": "int8-quanto",
+                }
+            )
+
+        self.assertFalse(validation.is_valid)
+        self.assertTrue(
+            any("base model" in error.lower() and "quant" in error.lower() for error in validation.errors),
+            validation.errors,
+        )
+
+    def test_full_model_type_allows_no_change_base_precision(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = ConfigStore(config_dir=Path(tmpdir), config_type="model")
+            validation = store.validate_config(
+                {
+                    "--model_type": "full",
+                    "--base_model_precision": "no_change",
+                }
+            )
+
+        self.assertTrue(validation.is_valid)
+        self.assertFalse(
+            any("base model" in error.lower() and "quant" in error.lower() for error in validation.errors),
+            validation.errors,
+        )
+
+    def test_lora_model_type_rejects_deepspeed_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = ConfigStore(config_dir=Path(tmpdir), config_type="model")
+            validation = store.validate_config(
+                {
+                    "--model_type": "lora",
+                    "--deepspeed_config": '{"zero_optimization": {"stage": 2}}',
+                }
+            )
+
+        self.assertFalse(validation.is_valid)
+        self.assertTrue(
+            any("lora" in error.lower() and "deepspeed" in error.lower() for error in validation.errors),
+            validation.errors,
+        )
+
+
+class ValidationServiceConstraintTests(unittest.TestCase):
+    def test_validation_service_flags_full_quantization(self) -> None:
+        service = ValidationService()
+        result = service.validate_configuration(
+            {
+                "model_type": "full",
+                "base_model_precision": "int8-quanto",
+            },
+            validate_paths=False,
+            estimate_vram=False,
+        )
+
+        self.assertFalse(result.is_valid)
+        self.assertTrue(
+            any(msg.field == "base_model_precision" and msg.severity == ValidationSeverity.ERROR for msg in result.messages),
+            [msg.to_dict() for msg in result.messages],
+        )
+
+    def test_validation_service_flags_lora_deepspeed(self) -> None:
+        service = ValidationService()
+        result = service.validate_configuration(
+            {
+                "model_type": "lora",
+                "deepspeed_config": {"zero_optimization": {"stage": 2}},
+            },
+            validate_paths=False,
+            estimate_vram=False,
+        )
+
+        self.assertFalse(result.is_valid)
+        self.assertTrue(
+            any(msg.field == "deepspeed_config" and msg.severity == ValidationSeverity.ERROR for msg in result.messages),
+            [msg.to_dict() for msg in result.messages],
+        )


### PR DESCRIPTION
This pull request introduces new validation rules for model configuration to prevent incompatible settings, and adds comprehensive unit tests to ensure these constraints are enforced. The main focus is to disallow full model training with quantized base model precision, and to prevent combining LoRA training with DeepSpeed. The changes affect both the core validation logic and the test suite.

**Validation logic improvements:**

* Added validation in `ConfigStore` and `ValidationService` to reject configurations where `model_type` is `'full'` and `base_model_precision` is set to a quantized value (anything other than `'no_change'` or empty), with a clear error message. [[1]](diffhunk://#diff-baf015f29f03b6467d8c6f05827979239243d69a35b92614ecfdb454efeda411R1342-R1368) [[2]](diffhunk://#diff-e3e32c24beba8e0dc91887b07f26192cb68f865b6bec87cd5b6a4cb8a236e8b1R356-R376)
* Added validation to prevent using `deepspeed_config` with `model_type` set to `'lora'`, returning an explicit error if both are set. [[1]](diffhunk://#diff-baf015f29f03b6467d8c6f05827979239243d69a35b92614ecfdb454efeda411R1342-R1368) [[2]](diffhunk://#diff-e3e32c24beba8e0dc91887b07f26192cb68f865b6bec87cd5b6a4cb8a236e8b1R356-R376)

**Testing improvements:**

* Introduced a new test file `tests/test_ui_validation_constraints.py` with unit tests for the new validation rules, covering both the `ConfigStore` and `ValidationService` layers. The tests check that invalid combinations are correctly rejected and valid ones are accepted.