### PR TITLE
ROCm: torch 2.9.1 dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ def get_rocm_dependencies():
         return [
             "torch>=2.9.1",
             "torchvision>=0.24.0",
+            "torchaudio>=2.4.1",
             "torchao>=0.14.1",
             ramtorch_dep,
         ]
@@ -137,6 +138,7 @@ def get_apple_dependencies():
     return [
         "torch>=2.9.1",
         "torchvision>=0.24.0",
+        "torchaudio>=2.4.1",
         "torchao>=0.14.1",
     ]
 
@@ -145,6 +147,7 @@ def get_cpu_dependencies():
     return [
         "torch>=2.9.1",
         "torchvision>=0.24.0",
+        "torchaudio>=2.4.1",
         "torchao>=0.14.1",
     ]
 


### PR DESCRIPTION
This pull request updates the ROCm dependency versions in the `setup.py` file to ensure compatibility with newer releases and removes a redundant `torchaudio` requirement from the general dependencies. The most important changes are:

**ROCm Dependency Updates:**

* Updated default ROCm versions for `torch`, `torchvision`, `torchaudio`, and `triton` in the `get_rocm_dependencies()` function to newer patch releases, and corrected the environment variable used for the `triton` version.
* Updated the download URL for the `pytorch_triton_rocm` wheel to version 3.5.1 to match the new default version.

**General Dependency Cleanup:**

* Removed the `torchaudio>=2.4.1` requirement from the main dependency list, as it is now handled specifically in the ROCm dependencies.