### PR TITLE
fix validation for compiled model with validation adapter LoRA

### DIFF
--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -1985,6 +1985,7 @@ class Validation:
                 "The current pipeline does not support loading LoRA adapters. "
                 "Remove --validation_adapter_path/--validation_adapter_config to continue."
             )
+
         def _snapshot_requires_grad(module):
             snapshot = {}
             for _, comp in getattr(module, "components", {}).items() if hasattr(module, "components") else []:
@@ -2022,6 +2023,107 @@ class Validation:
                 ramtorch_utils.ensure_available()
         except Exception:
             pass
+        # Handle torch.compile OptimizedModules by temporarily unwrapping to _orig_mod for adapter loading.
+        compiled_modules: dict[str, Any] = {}
+
+        def _needs_orig_mod_patch():
+            try:
+                for _, module in pipeline.named_modules():
+                    if isinstance(_, str) and _.startswith("_orig_mod"):
+                        return True
+                    if isinstance(_, str) and "._orig_mod." in _:
+                        return True
+            except Exception:
+                pass
+            return False
+
+        def _patch_peft_for_compiled():
+            if not _needs_orig_mod_patch():
+                return
+            try:
+                import copy
+                import peft.mapping as peft_mapping
+                from peft.tuners.tuners_utils import BaseTuner
+            except Exception:
+                return
+
+            def _dup_state(state_dict):
+                if not isinstance(state_dict, dict):
+                    return state_dict
+                patched = copy.copy(state_dict)
+                for k, v in state_dict.items():
+                    if isinstance(k, str) and not k.startswith("_orig_mod."):
+                        pref = f"_orig_mod.{k}"
+                        if pref not in patched:
+                            patched[pref] = v
+                return patched
+
+            if not getattr(peft_mapping.inject_adapter_in_model, "_orig_mod_patch", False):
+                orig_inject = peft_mapping.inject_adapter_in_model
+
+                def _wrapped_inject(peft_config, model, adapter_name: str | None = None, *a, **kw):
+                    sd = kw.get("state_dict")
+                    if sd is None and a:
+                        sd = a[0]
+                        a = a[1:]
+                    sd = _dup_state(sd)
+                    if sd is not None:
+                        kw["state_dict"] = sd
+                    return orig_inject(peft_config, model, adapter_name=adapter_name, *a, **kw)
+
+                _wrapped_inject._orig_mod_patch = True
+                peft_mapping.inject_adapter_in_model = _wrapped_inject  # type: ignore
+
+            if not getattr(BaseTuner.inject_adapter, "_orig_mod_patch", False):
+                orig_base = BaseTuner.inject_adapter
+
+                def _wrapped_base(self, peft_config, model, adapter_name="default", *a, **kw):
+                    targets = getattr(peft_config, "target_modules", None)
+                    if targets:
+                        tl = [targets] if isinstance(targets, str) else list(targets)
+                        pref = [f"_orig_mod.{t}" for t in tl if isinstance(t, str) and not t.startswith("_orig_mod.")]
+                        if pref:
+                            peft_config.target_modules = list(dict.fromkeys(tl + pref))
+                    sd = kw.get("state_dict")
+                    if sd is None and a:
+                        sd = a[0]
+                        a = a[1:]
+                    sd = _dup_state(sd)
+                    if sd is not None:
+                        kw["state_dict"] = sd
+                    return orig_base(self, peft_config, model, adapter_name, *a, **kw)
+
+                _wrapped_base._orig_mod_patch = True
+                BaseTuner.inject_adapter = _wrapped_base  # type: ignore[assignment]
+
+        def _unwrap_compiled_components():
+            if not hasattr(pipeline, "components") or not isinstance(pipeline.components, dict):
+                return
+            for name, module in list(pipeline.components.items()):
+                if not hasattr(module, "_orig_mod"):
+                    continue
+                compiled_modules[name] = module
+                try:
+                    orig = module._orig_mod
+                    pipeline.components[name] = orig
+                    if hasattr(pipeline, name):
+                        setattr(pipeline, name, orig)
+                except Exception:
+                    continue
+
+        def _restore_compiled_components():
+            if not compiled_modules:
+                return
+            for name, module in compiled_modules.items():
+                try:
+                    pipeline.components[name] = module
+                    if hasattr(pipeline, name):
+                        setattr(pipeline, name, module)
+                except Exception:
+                    continue
+
+        _patch_peft_for_compiled()
+        _unwrap_compiled_components()
         requires_grad_snapshot = _snapshot_requires_grad(pipeline)
         adapter_names: list[str] = []
         adapter_scales: list[float] = []
@@ -2046,6 +2148,7 @@ class Validation:
         finally:
             self._remove_validation_adapters(pipeline, adapter_names)
             _restore_requires_grad(pipeline, requires_grad_snapshot)
+            _restore_compiled_components()
 
     def _set_validation_adapter_weights(self, pipeline, adapter_names: list[str], adapter_scales: list[float]):
         if not adapter_names:


### PR DESCRIPTION
This pull request improves compatibility with `torch.compile` (OptimizedModule) models when loading LoRA adapters, addressing issues where module names are prefixed with `_orig_mod.`. The changes ensure that adapter loading and related utilities work seamlessly with both compiled and non-compiled models by patching PEFT (Parameter-Efficient Fine-Tuning) internals and duplicating state dictionary keys and target module names as needed.

The most important changes are:

**Compatibility with torch.compile/OptimizedModule:**
* Added logic in `simpletuner/helpers/training/validation.py` to temporarily unwrap compiled modules and patch PEFT adapter injection utilities, ensuring adapter loading works with `_orig_mod.`-prefixed modules. This includes duplicating state dict keys and target module names with the `_orig_mod.` prefix and restoring the original modules after loading. [[1]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09R2026-R2126) [[2]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09R2151)
* Patched PEFT's `inject_adapter_in_model` and `BaseTuner.inject_adapter` to automatically handle `_orig_mod.` prefixes in both module names and state dicts, allowing adapters to be injected into compiled models transparently.

**LoRA and PEFT utility enhancements:**
* Updated LoRA config and model patching logic to duplicate state dict keys and target module names with `_orig_mod.` prefixes where necessary, improving robustness when working with compiled models. [[1]](diffhunk://#diff-35085c1320aeab677e8f229708eb17ff88af3495d0da5f1c1162af961acefd08R277-R294) [[2]](diffhunk://#diff-35085c1320aeab677e8f229708eb17ff88af3495d0da5f1c1162af961acefd08R306-R315)
* Patched `BaseTuner._check_target_module_exists` to recognize both normal and `_orig_mod.`-prefixed module names, improving target module resolution for adapter injection.

**General infrastructure and patch management:**
* Ensured all PEFT and LoRA patches are applied by calling the new `_maybe_patch_peft_inject()` utility in `ramtorch_utils.ensure_available()`, and added a global flag to prevent duplicate patching. [[1]](diffhunk://#diff-35085c1320aeab677e8f229708eb17ff88af3495d0da5f1c1162af961acefd08R13) [[2]](diffhunk://#diff-35085c1320aeab677e8f229708eb17ff88af3495d0da5f1c1162af961acefd08R53)

These changes collectively make LoRA adapter loading robust to torch.compile optimizations and module name mangling, improving the reliability of training and validation workflows.