### PR TITLE
ReflexFlow: fix sign of ADR calc, resolving extremely high loss and noise

### DIFF
--- a/tests/test_scheduled_sampling_rollout.py
+++ b/tests/test_scheduled_sampling_rollout.py
@@ -290,19 +290,19 @@ class ReflexFlowLossTests(unittest.TestCase):
     def test_reflexflow_weighting_and_adr(self):
         model = _FlowLossModel()
         latents = torch.zeros((1, 1, 1, 1), dtype=torch.float32)
-        noise = torch.zeros_like(latents)
+        noise = torch.ones_like(latents)
         prepared_batch = {
             "latents": latents,
             "noise": noise,
             "noisy_latents": torch.full_like(latents, 0.3),
             "timesteps": torch.tensor([1.0]),
-            "_reflexflow_clean_pred": torch.full_like(latents, 0.4),
-            "_reflexflow_biased_pred": torch.full_like(latents, 0.6),
+            "_reflexflow_clean_pred": torch.full_like(latents, 0.6),
+            "_reflexflow_biased_pred": torch.full_like(latents, 0.4),
         }
-        model_output = {"model_prediction": torch.full_like(latents, -0.3)}
+        model_output = {"model_prediction": torch.full_like(latents, 0.7)}
 
         loss = model.loss(prepared_batch, model_output, apply_conditioning_mask=False)
-        # Base loss (0.09) is doubled by FC weighting; ADR term is zero when pointing back to the clean sample.
+        # Base loss (0.09) is doubled by FC weighting; ADR term is zero when aligned with the noise-facing flow vector.
         self.assertAlmostEqual(loss.item(), 0.18, places=4)
 
 


### PR DESCRIPTION
This pull request corrects the directionality of vector computations in the ReflexFlow loss implementation and updates the corresponding unit test to match the new logic. The changes ensure that the loss and ADR (Alignment Direction Regularization) terms are computed in alignment with the intended flow-matching direction (from clean to noisy samples), which is critical for the correct behavior of the scheduled sampling and reflex flow loss.

**ReflexFlow loss directionality fixes:**

* The computation of the `exposure` variable in the loss function was reversed to correctly weight components that vanish in the rollout, now using `clean_pred - biased_pred` instead of the opposite.
* The calculation of the `target_vec` for the ADR term was corrected to align with the flow-matching vector field, now using `biased_latents - clean_latents` to represent the direction from clean to noisy samples.

**Unit test adjustments:**

* The `test_reflexflow_weighting_and_adr` unit test was updated to reflect the corrected directionality by adjusting the values of `noise`, `_reflexflow_clean_pred`, `_reflexflow_biased_pred`, and `model_prediction`. The test comment was also updated to clarify the expected behavior.