### PR TITLE
UI (datasets): remove ControlNet conditioning option from selections when CN is disabled; select reference_strict by default otherwise

### DIFF
--- a/simpletuner/static/js/dataloader-builder.js
+++ b/simpletuner/static/js/dataloader-builder.js
@@ -414,7 +414,9 @@
                 id: `conditioning-${Date.now()}`,
                 type: 'local',
                 dataset_type: 'conditioning',
-                conditioning_type: 'controlnet',
+                // Default to reference_strict for non-ControlNet models (most common use case)
+                // ControlNet training will set this appropriately via modelContext
+                conditioning_type: 'reference_strict',
                 instance_data_dir: '/path/to/conditioning',
                 cache_dir_vae: '{output_dir}/cache/vae/{model_family}/{id}',
                 disabled: false,

--- a/simpletuner/templates/components/dataloader/sections/conditioning_body.html
+++ b/simpletuner/templates/components/dataloader/sections/conditioning_body.html
@@ -7,7 +7,7 @@
         <select class="form-select form-select-sm"
                 x-model="editingDataset.conditioning_type"
                 @change="markAsUnsaved()">
-            <option value="controlnet">ControlNet</option>
+            <option value="controlnet" x-show="modelContext.controlnetEnabled">ControlNet</option>
             <option value="mask">Inpainting Mask</option>
             <option value="reference_strict">Reference (Strict Alignment)</option>
             <option value="reference_loose">Reference (Loose Alignment)</option>

--- a/simpletuner/templates/trainer_htmx.html
+++ b/simpletuner/templates/trainer_htmx.html
@@ -1408,7 +1408,9 @@ function trainerComponent() {
             }
 
             if (dataset.dataset_type === 'conditioning') {
-                dataset.conditioning_type = dataset.conditioning_type || 'controlnet';
+                // Default to 'controlnet' if ControlNet training is enabled, otherwise 'reference_strict'
+                const defaultConditioningType = this.modelContext?.controlnetEnabled ? 'controlnet' : 'reference_strict';
+                dataset.conditioning_type = dataset.conditioning_type || defaultConditioningType;
                 dataset.default = this.normalizeBoolean(dataset.default);
                 dataset.source_dataset_id = this._coerceString(dataset.source_dataset_id);
             }


### PR DESCRIPTION
This pull request updates the default behavior and UI options related to the "conditioning type" for datasets, improving support for non-ControlNet models and making the interface more context-aware. The main changes ensure that the default conditioning type is set according to whether ControlNet training is enabled, and that the UI only shows the ControlNet option when appropriate.

**Conditioning type defaults and UI improvements:**

* The default `conditioning_type` for new conditioning datasets is now set to `'reference_strict'` instead of `'controlnet'`, unless ControlNet training is enabled, in which case it defaults to `'controlnet'`. This makes the tool more user-friendly for non-ControlNet use cases. [[1]](diffhunk://#diff-1e22566c16658eff950730c4142fc0aaa58e66f8a5361d43911c2051604497b1L417-R419) [[2]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14L1411-R1413)
* In the conditioning type dropdown, the "ControlNet" option is now only shown if ControlNet training is enabled, reducing confusion for users working with other model types.