### PR TITLE
ensure edit-v2 either uses 1:1 or 0 image embeds

### DIFF
--- a/simpletuner/helpers/models/qwen_image/model.py
+++ b/simpletuner/helpers/models/qwen_image/model.py
@@ -659,10 +659,7 @@ class QwenImage(ImageModelFoundation):
         return super().text_embed_cache_key()
 
     def requires_text_embed_image_context(self) -> bool:
-        # Only edit-v1 requires image context in text embeddings.
-        # Edit-v2 supports multiple conditioning images, so we skip image context
-        # in embeddings and rely solely on the latent references.
-        return QwenImage._is_edit_v1_config(self)
+        return QwenImage._is_edit_config(self)
 
     def requires_conditioning_image_embeds(self) -> bool:
         return QwenImage._is_edit_v1_config(self)


### PR DESCRIPTION
qwen edit is the gift that keeps on giving. merry christmas :christmas_tree: :santa: 

the thing is, i'm too exhausted to go through and fully map every cond dataset to its text embed context.

one is fine. n-to-one is a pain in the ass. i'm not sure how other trainers have handled it, but the way we're doing it is to just use zero image embeds when there's more than one conditioning input.

**i'm sorry.** i don't like it either.

if you don't like it as much as i suspect some people might, you could workaround this by simply mashing all of your images together so that they exist as a single reference conditioning dataset. then, the code will correctly embed this image in the text embed.

other edit models don't have this problem unless they're relying on Qwen VL, because for these, the godforsaken image inputs impact the contents of the prompt embeds:

1) the text attends to the images, so the text embed is transformed by the presence of the image
2) you can't really "detach" the image context from the text embeds
3) thus, you cannot mix-and-match image embeds from different images with a single prompt embed

the effect this has on ~~my mental health~~ the trainer is that we had to bend over backward to link the image context to the prompt embed to begin with - they operate in separate stages. further, it balloons the size of the on-disk embed cache because they no longer deduplicate by prompt.

this may be revisited in the future if more models stick to this pattern but until then, Z-Image Omni is using SigLIP embeds like the old school stuff did, and this feels good enough to me.