### PR TITLE
(#2173) remove early check for CREPA since we are using LayerSync features with certain configs

### DIFF
--- a/simpletuner/helpers/models/kandinsky5_video/model.py
+++ b/simpletuner/helpers/models/kandinsky5_video/model.py
@@ -476,7 +476,7 @@ class Kandinsky5Video(VideoModelFoundation):
 
         model_pred = model_output.sample
         crepa_hidden = getattr(model_output, "crepa_hidden_states", None) if capture_hidden else None
-        if capture_hidden and crepa_hidden is None:
+        if capture_hidden and crepa_hidden is None and not getattr(self.crepa_regularizer, "use_backbone_features", False):
             raise ValueError(
                 f"CREPA requested hidden states from layer {self.crepa_regularizer.block_index} "
                 "but none were returned. Check that crepa_block_index is within the model's block count."

--- a/simpletuner/helpers/models/ltxvideo/model.py
+++ b/simpletuner/helpers/models/ltxvideo/model.py
@@ -250,7 +250,7 @@ class LTXVideo(VideoModelFoundation):
             else:
                 model_pred = model_output[0] if isinstance(model_output, tuple) else model_output
                 crepa_hidden = None
-            if crepa_hidden is None:
+            if crepa_hidden is None and not getattr(self.crepa_regularizer, "use_backbone_features", False):
                 raise ValueError(
                     f"CREPA requested hidden states from layer {self.crepa_regularizer.block_index} "
                     "but none were returned. Check that crepa_block_index is within the model's block count."

--- a/simpletuner/helpers/models/sanavideo/model.py
+++ b/simpletuner/helpers/models/sanavideo/model.py
@@ -201,7 +201,7 @@ class SanaVideo(VideoModelFoundation):
             else:
                 model_pred = model_output[0] if isinstance(model_output, tuple) else model_output
                 crepa_hidden = None
-            if crepa_hidden is None:
+            if crepa_hidden is None and not getattr(self.crepa_regularizer, "use_backbone_features", False):
                 raise ValueError(
                     f"CREPA requested hidden states from layer {self.crepa_regularizer.block_index} "
                     "but none were returned. Check that crepa_block_index is within the model's block count."

--- a/simpletuner/helpers/models/wan/model.py
+++ b/simpletuner/helpers/models/wan/model.py
@@ -1124,7 +1124,7 @@ class Wan(VideoModelFoundation):
             else:
                 model_pred = model_output[0] if isinstance(model_output, tuple) else model_output
                 crepa_hidden = None
-            if crepa_hidden is None:
+            if crepa_hidden is None and not getattr(self.crepa_regularizer, "use_backbone_features", False):
                 raise ValueError(
                     f"CREPA requested hidden states from layer {self.crepa_regularizer.block_index} "
                     "but none were returned. Check that crepa_block_index is within the model's block count."


### PR DESCRIPTION
This pull request updates the error handling logic related to CREPA hidden states in several model helper files. The main change is that a ValueError is now only raised if hidden states are missing and the `use_backbone_features` flag is not set on the `crepa_regularizer`. This prevents unnecessary errors when backbone features are being used.

**Error handling improvements for CREPA hidden states:**

* Updated the conditional check before raising a ValueError in `model_predict` for the following model helper files so that the error is only raised if `crepa_hidden` is `None` and `use_backbone_features` is not enabled on the `crepa_regularizer`:
  - `simpletuner/helpers/models/kandinsky5_video/model.py`
  - `simpletuner/helpers/models/ltxvideo/model.py`
  - `simpletuner/helpers/models/sanavideo/model.py`
  - `simpletuner/helpers/models/wan/model.py`