### PR TITLE
when example uses lr warmup, use constant_with_warmup

### DIFF
--- a/simpletuner/examples/auraflow.peft-lora/config.json
+++ b/simpletuner/examples/auraflow.peft-lora/config.json
@@ -14,7 +14,7 @@
     "lora_alpha": 8,
     "lora_rank": 8,
     "lora_type": "standard",
-    "lr_scheduler": "constant",
+    "lr_scheduler": "constant_with_warmup",
     "lr_warmup_steps": 100,
     "max_grad_norm": 0.01,
     "max_train_steps": 100,

--- a/simpletuner/examples/bria.lycoris-lokr/config.json
+++ b/simpletuner/examples/bria.lycoris-lokr/config.json
@@ -16,7 +16,7 @@
     "lora_rank": 8,
     "lora_type": "lycoris",
     "lycoris_config": "config/examples/bria.lycoris-lokr/lycoris_config.json",
-    "lr_scheduler": "constant",
+    "lr_scheduler": "constant_with_warmup",
     "lr_warmup_steps": 100,
     "max_grad_norm": 0.01,
     "max_train_steps": 100,

--- a/simpletuner/examples/kontext.peft-lora/config.json
+++ b/simpletuner/examples/kontext.peft-lora/config.json
@@ -16,7 +16,6 @@
     "lora_rank": 16,
     "lora_type": "standard",
     "lr_scheduler": "constant",
-    "lr_warmup_steps": 0,
     "max_train_steps": 100,
     "minimum_image_size": 0,
     "mixed_precision": "bf16",

--- a/simpletuner/examples/sdxl.peft-controlnet-lora/config.json
+++ b/simpletuner/examples/sdxl.peft-controlnet-lora/config.json
@@ -11,7 +11,7 @@
     "learning_rate": 1e-4,
     "lora_rank": 128,
     "lora_alpha": 128,
-    "lr_scheduler": "constant",
+    "lr_scheduler": "constant_with_warmup",
     "lr_warmup_steps": 0,
     "max_train_steps": 100,
     "minimum_image_size": 0,


### PR DESCRIPTION
Fixes an error that you receive on first launch of an example that has conflicting options set.