### PR TITLE
Fixup crepa states extraction for K5

### DIFF
--- a/simpletuner/helpers/models/kandinsky5_video/model.py
+++ b/simpletuner/helpers/models/kandinsky5_video/model.py
@@ -460,7 +460,7 @@ class Kandinsky5Video(VideoModelFoundation):
             "text_rope_pos": text_rope_pos,
             "scale_factor": (1, 2, 2),
             "sparse_params": None,
-            "return_dict": True,
+            "return_dict": not capture_hidden,
             "force_keep_mask": force_keep_mask,
         }
         if capture_hidden:
@@ -474,8 +474,8 @@ class Kandinsky5Video(VideoModelFoundation):
             **transformer_kwargs,
         )
 
-        model_pred = model_output.sample
-        crepa_hidden = getattr(model_output, "crepa_hidden_states", None) if capture_hidden else None
+        model_pred = model_output[0] if capture_hidden else model_output.sample
+        crepa_hidden = model_output[1] if capture_hidden else None
         if capture_hidden and crepa_hidden is None and not getattr(self.crepa_regularizer, "use_backbone_features", False):
             raise ValueError(
                 f"CREPA requested hidden states from layer {self.crepa_regularizer.block_index} "


### PR DESCRIPTION
Transformer2DModelOutput's dataclass gets downcasted in diffusers inner code, losing captured_frame_hidden.

This PR makes it always return a tuple in Kandinsky5 and then it gets the hidden states values from its second part

The other models are already using tuples, so the fix is not neccessary for them