### PR TITLE
z-image turbo & omni: implement musubi block swap

### DIFF
--- a/simpletuner/helpers/models/z_image/transformer.py
+++ b/simpletuner/helpers/models/z_image/transformer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import math
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -28,11 +29,14 @@ from diffusers.models.normalization import RMSNorm
 from diffusers.utils.torch_utils import maybe_allow_in_graph
 from torch.nn.utils.rnn import pad_sequence
 
+from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.qk_clip_logging import publish_attention_max_logits
 from simpletuner.helpers.training.tread import TREADRouter
 
 ADALN_EMBED_DIM = 256
 SEQ_MULTI_OF = 32
+
+logger = logging.getLogger(__name__)
 
 
 def _store_hidden_state(buffer, key: str, hidden_states: torch.Tensor, image_tokens_start: int | None = None):
@@ -402,6 +406,8 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
         axes_dims=[32, 48, 48],
         axes_lens=[1024, 512, 512],
         enable_time_sign_embed: bool = False,
+        musubi_blocks_to_swap: int = 0,
+        musubi_block_swap_device: str = "cpu",
     ) -> None:
         super().__init__()
         self.in_channels = in_channels
@@ -478,6 +484,13 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
         self.axes_lens = axes_lens
 
         self.rope_embedder = RopeEmbedder(theta=rope_theta, axes_dims=axes_dims, axes_lens=axes_lens)
+
+        self._musubi_block_swap = MusubiBlockSwapManager.build(
+            depth=n_layers,
+            blocks_to_swap=musubi_blocks_to_swap,
+            swap_device=musubi_block_swap_device,
+            logger=logger,
+        )
 
     def set_router(self, router: TREADRouter, routes: List[Dict[str, Any]]):
         self._tread_router = router
@@ -745,7 +758,17 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
         skip_set = set(skip_layers) if skip_layers is not None else set()
         capture_idx = 0
 
+        # Musubi block swap activation
+        combined_blocks = list(self.layers)
+        musubi_manager = self._musubi_block_swap
+        musubi_offload_active = False
+        grad_enabled = torch.is_grad_enabled()
+        if musubi_manager is not None:
+            musubi_offload_active = musubi_manager.activate(combined_blocks, unified.device, grad_enabled)
+
         for idx, layer in enumerate(self.layers):
+            if musubi_offload_active and musubi_manager.is_managed_block(idx):
+                musubi_manager.stream_in(layer, unified.device)
             if use_routing and route_ptr < len(routes) and idx == routes[route_ptr]["start_layer_idx"]:
                 mask_ratio = routes[route_ptr]["selection_ratio"]
                 force_keep = torch.zeros_like(unified_attn_mask)
@@ -777,6 +800,9 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
                 unified_attn_mask = saved_attn
                 routing_now = False
                 route_ptr += 1
+
+            if musubi_offload_active and musubi_manager.is_managed_block(idx):
+                musubi_manager.stream_out(layer)
 
         unified = self.all_final_layer[f"{patch_size}-{f_patch_size}"](unified, adaln_input)
         unified = list(unified.unbind(dim=0))


### PR DESCRIPTION
This pull request adds support for dynamic offloading and swapping of transformer blocks using the Musubi block swap mechanism in both the `z_image` and `z_image_omni` transformer models. This enhancement allows selective blocks to be swapped in and out of device memory during forward passes, which can help manage memory usage for large models. The changes introduce new initialization parameters, integrate the Musubi block swap manager, and update the forward pass logic to activate and manage block swapping.

**Musubi block swap integration:**

* Added optional parameters `musubi_blocks_to_swap` and `musubi_block_swap_device` to the constructors of both `ZImageTransformer` and `ZImageOmniTransformer` to configure the number of blocks to swap and the device for offloading. [[1]](diffhunk://#diff-8a4adb9e6956a827ded3b9935466f2f2d4459ac3be5c6e7c5db05fc21644d0bdR409-R410) [[2]](diffhunk://#diff-7b0a7d6b88720abcb3867b4035111b3ad3d54c2c322ab18a30f97bb5fc6c594dR469-R470)
* Integrated `MusubiBlockSwapManager` into both transformer models, initializing it during construction and storing it as a member variable. [[1]](diffhunk://#diff-8a4adb9e6956a827ded3b9935466f2f2d4459ac3be5c6e7c5db05fc21644d0bdR488-R494) [[2]](diffhunk://#diff-7b0a7d6b88720abcb3867b4035111b3ad3d54c2c322ab18a30f97bb5fc6c594dR564-R570)
* Updated the forward pass (`apply_layer`) in both models to activate Musubi block swapping, stream in managed blocks before processing, and stream them out after processing, allowing for dynamic memory management during inference or training. [[1]](diffhunk://#diff-8a4adb9e6956a827ded3b9935466f2f2d4459ac3be5c6e7c5db05fc21644d0bdR761-R771) [[2]](diffhunk://#diff-8a4adb9e6956a827ded3b9935466f2f2d4459ac3be5c6e7c5db05fc21644d0bdR804-R806) [[3]](diffhunk://#diff-7b0a7d6b88720abcb3867b4035111b3ad3d54c2c322ab18a30f97bb5fc6c594dR1124-R1134) [[4]](diffhunk://#diff-7b0a7d6b88720abcb3867b4035111b3ad3d54c2c322ab18a30f97bb5fc6c594dR1186-R1188)

**Logging improvements:**

* Added logging initialization to both transformer files to support debug and info messages from the Musubi block swap manager. [[1]](diffhunk://#diff-8a4adb9e6956a827ded3b9935466f2f2d4459ac3be5c6e7c5db05fc21644d0bdR15) [[2]](diffhunk://#diff-8a4adb9e6956a827ded3b9935466f2f2d4459ac3be5c6e7c5db05fc21644d0bdR32-R40) [[3]](diffhunk://#diff-7b0a7d6b88720abcb3867b4035111b3ad3d54c2c322ab18a30f97bb5fc6c594dR15) [[4]](diffhunk://#diff-7b0a7d6b88720abcb3867b4035111b3ad3d54c2c322ab18a30f97bb5fc6c594dR34-R42)