### PR TITLE
ui: preserving changed value and formDirty states between tab changes

### DIFF
--- a/simpletuner/templates/trainer_htmx.html
+++ b/simpletuner/templates/trainer_htmx.html
@@ -424,6 +424,7 @@ function trainerComponent() {
         _skipNextClean: false,
         originalFormData: {},
         formValueStore: {},
+        changedFieldNames: new Set(),
 
          // Config save dialog state
          showConfigSaveDialog: false,
@@ -484,6 +485,7 @@ function trainerComponent() {
                 this.originalFormData = {};
                 this.formDirty = false;
                 this._skipNextClean = false;
+                this.changedFieldNames.clear();
                 delete this._preservingFormState;
 
                 // Broadcast environment change event for other components
@@ -3917,10 +3919,17 @@ function trainerComponent() {
         markFormClean() {
             this.formDirty = false;
             this._skipNextClean = false;
+            // Clear changed field tracking and remove visual indicators
+            this.changedFieldNames.clear();
+            const formElement = document.getElementById('trainer-form');
+            if (formElement) {
+                formElement.querySelectorAll('.field-valid').forEach(el => {
+                    el.classList.remove('field-valid');
+                });
+            }
             // Capture current values for cross-tab persistence
             this.captureFormValues();
             // Store current form data as original
-            const formElement = document.getElementById('trainer-form');
             if (formElement) {
                 const formData = new FormData(formElement);
                 this.originalFormData = {};
@@ -4117,12 +4126,24 @@ function trainerComponent() {
                         }
                     });
                 }
+
+                // Re-apply field-valid highlight if this field was changed
+                if (this.changedFieldNames.has(name)) {
+                    nodes.forEach((node) => {
+                        if (node.classList.contains('form-control') || node.classList.contains('form-select')) {
+                            node.classList.add('field-valid');
+                        }
+                    });
+                }
             });
         },
 
         handleFieldInput(event) {
             if (event && event.target && event.target.name) {
                 this.updateStoredValue(event.target);
+                // Track this field as changed for visual highlighting
+                const canonicalName = this.canonicalizeKey(event.target.name) || event.target.name;
+                this.changedFieldNames.add(canonicalName);
             }
             this.checkFormDirty();
         },
@@ -5009,9 +5030,8 @@ function trainerComponent() {
                             if ($data._preservingFormState) {
                                 console.log('Applying stored form values after tab switch');
                                 $data.applyStoredValues();
-                                // Mark clean after tab switch - we just loaded fresh content from server
-                                // Don't call checkFormDirty() because originalFormData is from a different tab
-                                $data.markFormClean();
+                                // Do NOT call markFormClean() here - if the user had unsaved changes
+                                // before the tab switch, formDirty should remain true so they can save
                             } else if (!$data._skipNextClean) {
                                 $data.markFormClean();
                             }


### PR DESCRIPTION
This pull request improves the user experience for form state tracking and visual feedback in the `trainer_htmx.html` template. The main enhancements focus on accurately tracking which form fields have changed, providing clearer visual cues, and ensuring that the form's dirty state is preserved correctly when switching tabs.

Form field change tracking and visual feedback:

* Added a `changedFieldNames` set to track which fields have been modified, enabling more precise highlighting of changed fields (`trainer_htmx.html`). [[1]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14R427) [[2]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14R4129-R4146) [[3]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14R3922-L3923)
* Ensured that when a field is changed, it is visually highlighted, and highlights are cleared when the form is marked clean (`trainer_htmx.html`). [[1]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14R4129-R4146) [[2]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14R3922-L3923)

Form state management improvements:

* Updated logic so that when switching tabs, the form's dirty state is preserved if there were unsaved changes, preventing accidental loss of user input (`trainer_htmx.html`).
* Reset the `changedFieldNames` set whenever the form is reset or marked clean to keep the tracking consistent (`trainer_htmx.html`). [[1]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14R488) [[2]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14R3922-L3923)