### PR TITLE
ui: remove annoying 2px layout shift

### DIFF
--- a/simpletuner/static/css/browser-compat.css
+++ b/simpletuner/static/css/browser-compat.css
@@ -62,14 +62,7 @@
     transition: all 0.3s ease;
 }
 
-/* Transform fallbacks */
-.dataset-card:hover {
-    -webkit-transform: translateY(-2px);
-    -moz-transform: translateY(-2px);
-    -ms-transform: translateY(-2px);
-    -o-transform: translateY(-2px);
-    transform: translateY(-2px);
-}
+/* Transform fallbacks - translateY removed to prevent layout shift on hover */
 
 /* Box shadow fallbacks */
 .card {

--- a/simpletuner/static/css/dataloader-builder.css
+++ b/simpletuner/static/css/dataloader-builder.css
@@ -168,7 +168,6 @@
 
 .dataset-item:hover,
 .dataset-card:hover {
-    transform: translateY(-2px);
     box-shadow: 0 15px 50px rgba(102, 126, 234, 0.15);
 }
 
@@ -1906,7 +1905,6 @@ textarea.resizable-path::-webkit-scrollbar {
 }
 
 #dataloaderSection .dataset-grid-card:hover {
-    transform: translateY(-2px);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
     border-color: rgba(255, 255, 255, 0.15);
 }

--- a/simpletuner/static/css/dataset-wizard.css
+++ b/simpletuner/static/css/dataset-wizard.css
@@ -100,7 +100,6 @@
 .dataset-wizard-modal .backend-card:hover {
     border-color: rgba(56, 189, 248, 0.5);
     background: rgba(32, 36, 50, 1);
-    transform: translateY(-2px);
 }
 
 .dataset-wizard-modal .backend-card.selected {
@@ -503,7 +502,6 @@
 .crop-style-option:hover {
     border-color: rgba(56, 189, 248, 0.5);
     background: rgba(32, 36, 50, 1);
-    transform: translateY(-2px);
 }
 
 .crop-style-option.selected {

--- a/simpletuner/static/css/deepspeed-builder.css
+++ b/simpletuner/static/css/deepspeed-builder.css
@@ -129,7 +129,6 @@
 .deepspeed-option-card:hover {
     background: rgba(30, 41, 59, 0.8);
     border-color: rgba(148, 163, 184, 0.4);
-    transform: translateY(-2px);
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 

--- a/simpletuner/static/css/streaming-validation-lightbox.css
+++ b/simpletuner/static/css/streaming-validation-lightbox.css
@@ -68,7 +68,6 @@
 /* Hover effect in PiP mode */
 .streaming-validation-lightbox:not(.expanded) .streaming-validation-content:hover {
     box-shadow: 0 12px 48px rgba(0, 0, 0, 0.4);
-    transform: translateY(-2px);
 }
 
 /* Expanded state - full viewport takeover (centered) */

--- a/simpletuner/static/css/trainer-core.css
+++ b/simpletuner/static/css/trainer-core.css
@@ -40,7 +40,6 @@
 .tab-fragment .checkpoint-card:hover,
 .tab-fragment .dataset-card:hover,
 .tab-fragment .config-card:hover {
-    transform: translateY(-2px);
     box-shadow: var(--shadow-panel-hover) !important;
 }
 

--- a/simpletuner/static/css/trainer.css
+++ b/simpletuner/static/css/trainer.css
@@ -211,7 +211,6 @@ body {
 }
 
 .config-card:hover {
-    transform: translateY(-2px);
     box-shadow: 0 15px 50px rgba(102, 126, 234, 0.15);
     background: var(--card-bg-hover);
 }
@@ -646,7 +645,6 @@ body {
 }
 
 .stat-card:hover {
-    transform: translateY(-2px);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
 }
 

--- a/simpletuner/static/css/training-wizard.css
+++ b/simpletuner/static/css/training-wizard.css
@@ -239,7 +239,6 @@
 .wizard-option-card:hover {
     background: rgba(30, 41, 59, 0.8);
     border-color: rgba(148, 163, 184, 0.4);
-    transform: translateY(-2px);
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 


### PR DESCRIPTION
This pull request removes the hover-based `translateY(-2px)` transform effect from various card and option elements across multiple CSS files. The primary goal is to prevent layout shifts when hovering, which can improve visual stability and user experience. The hover effect is now achieved solely through box-shadow and background changes, rather than moving elements vertically.

**Removal of hover translateY transforms:**

* Removed `transform: translateY(-2px);` from card hover states in `dataloader-builder.css`, affecting `.dataset-item`, `.dataset-card`, and `.dataset-grid-card` for a more stable hover effect. [[1]](diffhunk://#diff-ade0168e7aadcc561ae25a10c4d97146bbf2fd10e7a77642aca84d7f216cf0efL171) [[2]](diffhunk://#diff-ade0168e7aadcc561ae25a10c4d97146bbf2fd10e7a77642aca84d7f216cf0efL1909)
* Removed `transform: translateY(-2px);` from various card hovers in `trainer-core.css` and `trainer.css`, including `.checkpoint-card`, `.dataset-card`, `.config-card`, and `.stat-card`. [[1]](diffhunk://#diff-678495ee4dea6bd775563c376172b32f75b2b5b705fdf4aba1e7410d21e5ef52L43) [[2]](diffhunk://#diff-ef8f926b6417ca847a502b36519d8c05f951dc5ae669bdccc8d0d15ed968ebfeL214) [[3]](diffhunk://#diff-ef8f926b6417ca847a502b36519d8c05f951dc5ae669bdccc8d0d15ed968ebfeL649)
* Removed `transform: translateY(-2px);` from option and card hovers in `deepspeed-builder.css` and `training-wizard.css`, affecting `.deepspeed-option-card` and `.wizard-option-card`. [[1]](diffhunk://#diff-4c10e4652272ac2c6b17dfd6c1cd8f31ca1c0f1ffca88deb7f04e4fe489ecce8L132) [[2]](diffhunk://#diff-473ac1ab128f30d5e1843979aa9dc591fe308d8e2334ced6d7df4d46cafba609L242)
* Removed `transform: translateY(-2px);` from card and option hovers in `dataset-wizard.css`, including `.backend-card` and `.crop-style-option`. [[1]](diffhunk://#diff-88b2a510652a3b175b071f9d45ec06f3a86ab368c67f4c4e1f72e9cb51839c46L103) [[2]](diffhunk://#diff-88b2a510652a3b175b071f9d45ec06f3a86ab368c67f4c4e1f72e9cb51839c46L506)
* Removed `transform: translateY(-2px);` from `.streaming-validation-content` hover in `streaming-validation-lightbox.css` for more consistent PiP mode visuals.
* Updated `browser-compat.css` to remove the fallback transform for `.dataset-card:hover`, with a comment explaining the change is to prevent layout shift.