### PR TITLE
(#2266) start_step and start_epoch should be flexible options and allow overriding

### DIFF
--- a/simpletuner/helpers/data_backend/factory.py
+++ b/simpletuner/helpers/data_backend/factory.py
@@ -2638,6 +2638,8 @@ class FactoryRegistry:
             "video",
             "conditioning_data",
             "conditioning",
+            "start_step",
+            "start_epoch",
             "hash_filenames",  # always enabled, not user-configurable
         ]
         _latest_config_version = latest_config_version()


### PR DESCRIPTION
This pull request makes a small update to the configuration versioning logic in the `simpletuner/helpers/data_backend/factory.py` file. Two new configuration keys, `start_step` and `start_epoch`, have been added to the list of recognized keys for versioning.

- Added `start_step` and `start_epoch` to the list of configuration keys handled in the versioning process in `_handle_config_versioning` (`simpletuner/helpers/data_backend/factory.py`).