### PR TITLE
--num_validation_images should not be considered webUI-only option

### DIFF
--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/validation.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/validation.py
@@ -183,7 +183,6 @@ def register_validation_fields(registry: "FieldRegistry") -> None:
             help_text="Number of images to generate per validation",
             tooltip="More images give better sense of model performance but take longer to generate",
             importance=ImportanceLevel.ADVANCED,
-            webui_only=True,  # WebUI-specific field, not passed to trainer
             order=3,
             subsection="advanced",
         )


### PR DESCRIPTION
This pull request makes a minor update to the `register_validation_fields` function in `validation.py` by removing the `webui_only=True` attribute from a field definition. This change allows the field to be available outside of the WebUI context and potentially passed to the trainer.