### PR TITLE
hv 1.5: add eval and requires_grad=False

### DIFF
--- a/simpletuner/helpers/models/hunyuanvideo/model.py
+++ b/simpletuner/helpers/models/hunyuanvideo/model.py
@@ -382,6 +382,8 @@ class HunyuanVideo(VideoModelFoundation):
             if hasattr(self.config, "vae_dtype") and self.config.vae_dtype == "fp32":
                 _vae_dtype = torch.float32
             self.vae.to(self.accelerator.device, dtype=_vae_dtype)
+        self.vae.requires_grad_(False)
+        self.vae.eval()
         self.AUTOENCODER_SCALING_FACTOR = getattr(self.vae.config, "scaling_factor", 1.0)
 
     def get_pipeline(self, pipeline_type: str = PipelineTypes.TEXT2IMG, load_base_model: bool = True):


### PR DESCRIPTION
Closes #2261 

This pull request makes a small but important change to the VAE (Variational Autoencoder) loading process to ensure better model performance and stability during inference.

- Model evaluation mode and gradient disabling:
  * In `simpletuner/helpers/models/hunyuanvideo/model.py`, after moving the VAE to the appropriate device and setting its data type, the VAE's parameters are set to not require gradients and the model is switched to evaluation mode. This prevents accidental training and ensures consistent inference behavior.