### PR TITLE
qwen-image-2512 as v2.0 flavour, and default for the model family

### DIFF
--- a/simpletuner/helpers/models/qwen_image/model.py
+++ b/simpletuner/helpers/models/qwen_image/model.py
@@ -77,9 +77,10 @@ class QwenImage(ImageModelFoundation):
     ZERO_COND_T_FLAVOURS = frozenset({"edit-v2+", "edit-v3"})
 
     # Default model flavor
-    DEFAULT_MODEL_FLAVOUR = "v1.0"
+    DEFAULT_MODEL_FLAVOUR = "v2.0"
     HUGGINGFACE_PATHS = {
         "v1.0": "Qwen/Qwen-Image",
+        "v2.0": "Qwen/Qwen-Image-2512",
         "edit-v1": "Qwen/Qwen-Image-Edit",
         "edit-v2": "Qwen/Qwen-Image-Edit-2509",
         "edit-v2+": "Qwen/Qwen-Image-Edit-2509",


### PR DESCRIPTION
This pull request updates the default model flavor for the `QwenImage` class to use a newer version and adds support for the corresponding HuggingFace model path.

Model version update and support:

* Changed the `DEFAULT_MODEL_FLAVOUR` in `QwenImage` from `"v1.0"` to `"v2.0"`, ensuring that the latest model version is used by default.
* Added a new HuggingFace path for the `"v2.0"` flavor: `"Qwen/Qwen-Image-2512"`, allowing the code to locate and use the updated model.