### PR TITLE
when enabling user auth, remove local user and clear session cache

### DIFF
--- a/simpletuner/simpletuner_sdk/server/routes/auth.py
+++ b/simpletuner/simpletuner_sdk/server/routes/auth.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, EmailStr, Field
 
 from ..services.cloud.audit import AuditEventType, audit_log
 from ..services.cloud.auth import UserStore, get_current_user, get_optional_user, require_permission
-from ..services.cloud.auth.middleware import SESSION_COOKIE_NAME, get_client_ip
+from ..services.cloud.auth.middleware import SESSION_COOKIE_NAME, get_client_ip, invalidate_single_user_mode
 from ..services.cloud.auth.models import AuthProvider, User
 from .users import UserResponse
 
@@ -172,6 +172,7 @@ async def create_first_admin(
             local_user = await store.get_user_by_username("local")
             if local_user and local_user.email == "local@localhost":
                 await store.delete_user(local_user.id)
+                invalidate_single_user_mode()
 
             # Create the admin user
             user = await store.create_user(

--- a/simpletuner/simpletuner_sdk/server/services/cloud/auth/middleware.py
+++ b/simpletuner/simpletuner_sdk/server/services/cloud/auth/middleware.py
@@ -179,6 +179,12 @@ class AuthMiddleware:
             self._store = UserStore()
         return self._store
 
+    def clear_single_user_cache(self) -> None:
+        """Clear the single-user mode cache, forcing re-evaluation on next request."""
+        self._single_user_checked = False
+        self._single_user_mode = False
+        self._local_admin = None
+
     async def _ensure_single_user_mode(self) -> Optional[User]:
         """Check for single-user mode and ensure a local admin exists.
 
@@ -327,6 +333,15 @@ def get_auth_middleware() -> AuthMiddleware:
     if _auth_middleware is None:
         _auth_middleware = AuthMiddleware()
     return _auth_middleware
+
+
+def invalidate_single_user_mode() -> None:
+    """Invalidate single-user mode cache, forcing re-check on next request.
+
+    Call this when a real user is created or the placeholder user is deleted.
+    """
+    if _auth_middleware is not None:
+        _auth_middleware.clear_single_user_cache()
 
 
 async def get_auth_context(request: Request) -> AuthContext:

--- a/simpletuner/simpletuner_sdk/server/services/cloud/auth/user_store.py
+++ b/simpletuner/simpletuner_sdk/server/services/cloud/auth/user_store.py
@@ -355,7 +355,8 @@ class UserStore:
         return await self._users.update(user_id, {"last_login_at": now})
 
     async def delete_user(self, user_id: int) -> bool:
-        """Delete a user."""
+        """Delete a user and invalidate all their sessions."""
+        await self._sessions.delete_user_sessions(user_id)
         return await self._users.delete(user_id)
 
     async def get_user_count(self) -> int:


### PR DESCRIPTION
This pull request introduces robust handling and cache invalidation for "single-user mode" in the authentication system, ensures that deleting a user also invalidates all their sessions, and adds comprehensive tests for these behaviors. The changes improve the reliability and security of user management, especially in environments that start in single-user mode and later transition to multi-user.

**Key changes include:**

### Single-user mode cache invalidation

* Added `clear_single_user_cache` method to `AuthMiddleware` and a global `invalidate_single_user_mode` function to force re-evaluation of single-user mode when real users are created or the placeholder user is deleted. This prevents stale cache issues when switching from single-user to multi-user environments. [[1]](diffhunk://#diff-fd729bf0b3157c3be4dbfc262d04b3adefb64b49262ed1d55394d5fea908d78dR182-R187) [[2]](diffhunk://#diff-fd729bf0b3157c3be4dbfc262d04b3adefb64b49262ed1d55394d5fea908d78dR338-R346)
* Updated user creation endpoints (`create_first_admin` and `create_user`) to delete the placeholder `local@localhost` user and invalidate the single-user mode cache when a real user is created, ensuring correct mode detection. [[1]](diffhunk://#diff-0a07275fcd3c0b4b66f1ea2c2b2fdb8e47faefd15ba1d07c7e942204a0f032c9R175) [[2]](diffhunk://#diff-4cc431d67a93963a0c406214dcf5b7ebed2bef7e63f50d60d55dde50c5fef3eaR191-R198)

### Session invalidation on user deletion

* Modified `delete_user` in `UserStore` to delete all of a user's sessions when their account is deleted, improving security by ensuring no lingering sessions remain for removed users.

### Testing and validation

* Added extensive asynchronous unit tests for:
  - Single-user mode cache invalidation and re-evaluation.
  - Session invalidation on user deletion.
  - Proper cleanup of the placeholder user when a real user is created.
  - Ensuring these changes do not affect unrelated users or sessions.

### Import updates

* Updated imports in `routes/auth.py` and `routes/users.py` to include the new cache invalidation function. [[1]](diffhunk://#diff-0a07275fcd3c0b4b66f1ea2c2b2fdb8e47faefd15ba1d07c7e942204a0f032c9L18-R18) [[2]](diffhunk://#diff-4cc431d67a93963a0c406214dcf5b7ebed2bef7e63f50d60d55dde50c5fef3eaR18)