### PR TITLE
increase rate limits for unauthenticated users

### DIFF
--- a/simpletuner/simpletuner_sdk/server/middleware/security_middleware.py
+++ b/simpletuner/simpletuner_sdk/server/middleware/security_middleware.py
@@ -65,8 +65,8 @@ DEFAULT_RATE_LIMIT_RULES: List[Tuple[str, int, int, Optional[List[str]]]] = [
 ]
 
 # Default rate limit for unauthenticated/anonymous requests
-# This is intentionally low to prevent abuse
-DEFAULT_ANONYMOUS_RATE_LIMIT = 60  # calls per period
+# Set high enough to allow page loads (which trigger 10+ API calls each)
+DEFAULT_ANONYMOUS_RATE_LIMIT = 180  # calls per period
 
 # Multiplier for authenticated users (they get this many times more requests)
 # e.g., if anonymous limit is 60/min, authenticated users get 600/min
@@ -182,6 +182,8 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             # Auth status checks (needed during login/onboarding flow)
             "/api/auth/setup/status",
             "/api/auth/check",
+            "/api/auth/me",
+            "/api/users/meta/auth-status",
         ]
         self.enable_audit = enable_audit
         self._lock = threading.Lock()


### PR DESCRIPTION
This pull request makes two main changes to the `security_middleware.py` file, focusing on improving user experience for anonymous users and ensuring proper authentication checks. The most important changes are:

**Rate limiting adjustments:**

* Increased the default anonymous rate limit from 60 to 180 calls per period to better accommodate typical page loads that trigger multiple API calls, reducing the chance of users being rate-limited unnecessarily.

**Authentication and onboarding flow:**

* Added `/api/auth/me` and `/api/users/meta/auth-status` to the list of endpoints allowed during the authentication status check, ensuring smoother login and onboarding experiences.