### PR TITLE
add websocket auth middleware

### DIFF
--- a/simpletuner/simpletuner_sdk/server/routes/training.py
+++ b/simpletuner/simpletuner_sdk/server/routes/training.py
@@ -21,7 +21,7 @@ from simpletuner.helpers.utils.checkpoint_manager import CheckpointManager
 from simpletuner.simpletuner_sdk import process_keeper
 from simpletuner.simpletuner_sdk.api_state import APIState
 from simpletuner.simpletuner_sdk.server.services import training_service
-from simpletuner.simpletuner_sdk.server.services.cloud.auth.middleware import get_current_user
+from simpletuner.simpletuner_sdk.server.services.cloud.auth.middleware import get_current_user, get_current_user_ws
 from simpletuner.simpletuner_sdk.server.services.cloud.auth.models import User
 
 logger = logging.getLogger(__name__)
@@ -414,7 +414,7 @@ async def get_training_events(since_index: int = 0, _user: User = Depends(get_cu
 
 
 @router.websocket("/events/stream")
-async def stream_training_events(websocket: WebSocket, _user: User = Depends(get_current_user)):
+async def stream_training_events(websocket: WebSocket, _user: User = Depends(get_current_user_ws)):
     """Stream training events via WebSocket."""
     await websocket.accept()
 

--- a/simpletuner/simpletuner_sdk/server/services/cloud/auth/__init__.py
+++ b/simpletuner/simpletuner_sdk/server/services/cloud/auth/__init__.py
@@ -4,7 +4,14 @@ Provides user management, API key authentication, session handling,
 RBAC, and quota management.
 """
 
-from .middleware import AuthMiddleware, get_current_user, get_optional_user, require_any_permission, require_permission
+from .middleware import (
+    AuthMiddleware,
+    get_current_user,
+    get_current_user_ws,
+    get_optional_user,
+    require_any_permission,
+    require_permission,
+)
 from .models import APIKey, Permission, ResourceRule, ResourceType, RuleAction, User, UserLevel
 from .password import PasswordHasher
 from .quotas import Quota, QuotaAction, QuotaChecker, QuotaStatus, QuotaType
@@ -30,6 +37,7 @@ __all__ = [
     # Middleware
     "AuthMiddleware",
     "get_current_user",
+    "get_current_user_ws",
     "get_optional_user",
     "require_permission",
     "require_any_permission",

--- a/simpletuner/simpletuner_sdk/server/services/cloud/auth/middleware.py
+++ b/simpletuner/simpletuner_sdk/server/services/cloud/auth/middleware.py
@@ -12,7 +12,7 @@ import logging
 from functools import wraps
 from typing import Callable, List, Optional, Union
 
-from fastapi import Depends, HTTPException, Request, status
+from fastapi import Depends, HTTPException, Request, WebSocket, WebSocketException, status
 from fastapi.security import APIKeyHeader
 
 from .models import APIKey, User
@@ -391,6 +391,83 @@ async def get_optional_user(request: Request) -> Optional[User]:
             return {"user": "anonymous"}
     """
     auth = await get_auth_context(request)
+    return auth.user
+
+
+async def get_auth_context_ws(websocket: WebSocket) -> AuthContext:
+    """Get auth context from a WebSocket connection.
+
+    Checks session cookie and API key from WebSocket headers.
+    """
+    middleware = get_auth_middleware()
+
+    # Get client IP
+    client_ip = websocket.client.host if websocket.client else "unknown"
+
+    # Check for internal network bypass
+    enterprise = _get_enterprise_config()
+    if enterprise and enterprise.should_bypass_auth(client_ip, websocket.url.path):
+        logger.debug("Auth bypassed for internal network (WebSocket): %s", client_ip)
+        return AuthContext(
+            is_authenticated=True,
+            is_internal_bypass=True,
+            client_ip=client_ip,
+        )
+
+    # Try API key authentication from headers
+    api_key = websocket.headers.get("X-API-Key")
+    if api_key:
+        result = await middleware.store.authenticate_api_key(api_key)
+        if result:
+            user, key = result
+            logger.debug("WebSocket authenticated via API key: %s", key.key_prefix)
+            return AuthContext(
+                user=user,
+                api_key=key,
+                is_authenticated=True,
+                client_ip=client_ip,
+            )
+
+    # Try session cookie
+    session_id = websocket.cookies.get(SESSION_COOKIE_NAME)
+    if session_id:
+        user = await middleware.store.get_session_user(session_id)
+        if user:
+            logger.debug("WebSocket authenticated via session: %s", user.username)
+            return AuthContext(
+                user=user,
+                session_id=session_id,
+                is_authenticated=True,
+                client_ip=client_ip,
+            )
+
+    # Check for single-user mode
+    local_admin = await middleware._ensure_single_user_mode()
+    if local_admin:
+        logger.debug("WebSocket authenticated via single-user mode")
+        return AuthContext(
+            user=local_admin,
+            is_authenticated=True,
+            client_ip=client_ip,
+        )
+
+    return AuthContext(client_ip=client_ip)
+
+
+async def get_current_user_ws(websocket: WebSocket) -> User:
+    """FastAPI dependency that requires an authenticated user for WebSocket.
+
+    Raises WebSocketException with 1008 (Policy Violation) if not authenticated.
+
+    Usage:
+        @router.websocket("/ws")
+        async def websocket_route(websocket: WebSocket, user: User = Depends(get_current_user_ws)):
+            await websocket.accept()
+            ...
+    """
+    auth = await get_auth_context_ws(websocket)
+    if not auth.is_authenticated or not auth.user:
+        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
     return auth.user
 
 


### PR DESCRIPTION
This pull request introduces support for authenticating WebSocket connections in addition to standard HTTP requests. The main changes add new authentication utilities for WebSockets, update relevant imports and exports, and switch existing WebSocket routes to use the new authentication dependency.

**WebSocket Authentication Enhancements:**

* Added `get_auth_context_ws` and `get_current_user_ws` functions to `middleware.py` to handle authentication for WebSocket connections, supporting API key, session cookie, internal network bypass, and single-user mode. (`simpletuner/simpletuner_sdk/server/services/cloud/auth/middleware.py`)
* Updated the WebSocket training events route in `training.py` to use the new `get_current_user_ws` dependency for proper authentication. (`simpletuner/simpletuner_sdk/server/routes/training.py`) [[1]](diffhunk://#diff-7257ef4deb1f0729db9d1f1a765a06660288cc7a345267c0529493aca5f06683L417-R417) [[2]](diffhunk://#diff-7257ef4deb1f0729db9d1f1a765a06660288cc7a345267c0529493aca5f06683L24-R24)

**Imports and Exports Updates:**

* Added `get_current_user_ws` to the imports and public API in `__init__.py` to make the new WebSocket authentication dependency available throughout the codebase. (`simpletuner/simpletuner_sdk/server/services/cloud/auth/__init__.py`) [[1]](diffhunk://#diff-714f2df4d60c58a599ff116d5a6ea331e74aee5628864ce4c31963ee5a4469f0L7-R14) [[2]](diffhunk://#diff-714f2df4d60c58a599ff116d5a6ea331e74aee5628864ce4c31963ee5a4469f0R40)
* Updated imports in `training.py` to include `get_current_user_ws`. (`simpletuner/simpletuner_sdk/server/routes/training.py`)
* Added necessary FastAPI imports for WebSocket authentication in `middleware.py`. (`simpletuner/simpletuner_sdk/server/services/cloud/auth/middleware.py`)