### PR TITLE
move first admin creation setup to the Manage Users page

### DIFF
--- a/simpletuner/static/js/modules/admin/index.js
+++ b/simpletuner/static/js/modules/admin/index.js
@@ -12,6 +12,23 @@ window.adminPanelComponent = function() {
         // Current user info
         currentUser: null,
 
+        // First-run setup state
+        setupState: {
+            loading: true,
+            needsSetup: false,
+            hasAdmin: false,
+            submitting: false,
+            error: null,
+            showPassword: false,
+            form: {
+                email: '',
+                username: '',
+                displayName: '',
+                password: '',
+                confirmPassword: '',
+            },
+        },
+
         // Active tab
         activeTab: 'users',
 
@@ -400,12 +417,24 @@ window.adminPanelComponent = function() {
     // Core methods that orchestrate initialization
     const coreMethods = {
         async init() {
+            // Check first-run setup status before anything else
+            await this.checkSetupStatus();
+
+            // If setup is needed, don't proceed with normal initialization
+            if (this.setupState.needsSetup) {
+                return;
+            }
+
             // Wait for auth before making any API calls
             const canProceed = await window.waitForAuthReady();
             if (!canProceed) {
                 return;
             }
 
+            this._runCoreInitialization();
+        },
+
+        _runCoreInitialization() {
             this.loadCurrentUser();
             this.loadHints();
             this.loadEnterpriseOnboardingState();
@@ -421,6 +450,82 @@ window.adminPanelComponent = function() {
             this.loadAuthProviders();
             this.loadPermissions();
             this.loadOrganizations();
+        },
+
+        async checkSetupStatus() {
+            this.setupState.loading = true;
+            try {
+                const response = await fetch('/api/auth/setup/status');
+                if (response.ok) {
+                    const data = await response.json();
+                    this.setupState.needsSetup = data.needs_setup;
+                    this.setupState.hasAdmin = data.has_admin;
+                } else if (response.status === 404) {
+                    // Endpoint doesn't exist - auth module not loaded, no setup needed
+                    this.setupState.needsSetup = false;
+                }
+            } catch (error) {
+                console.warn('Could not determine setup status:', error);
+                this.setupState.needsSetup = false;
+            } finally {
+                this.setupState.loading = false;
+            }
+        },
+
+        get setupFormValid() {
+            const form = this.setupState?.form;
+            if (!form) return false;
+            return (
+                form.email &&
+                form.email.includes('@') &&
+                form.username &&
+                form.username.length >= 3 &&
+                form.password &&
+                form.password.length >= 8 &&
+                form.password === form.confirmPassword
+            );
+        },
+
+        async submitFirstRunSetup() {
+            if (!this.setupFormValid) return;
+
+            this.setupState.submitting = true;
+            this.setupState.error = null;
+
+            try {
+                const response = await fetch('/api/auth/setup/first-admin', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        email: this.setupState.form.email,
+                        username: this.setupState.form.username,
+                        password: this.setupState.form.password,
+                        display_name: this.setupState.form.displayName || null,
+                    }),
+                });
+
+                if (response.ok) {
+                    const data = await response.json();
+                    if (data.success) {
+                        // Setup complete, mark as no longer needing setup
+                        this.setupState.needsSetup = false;
+                        if (window.showToast) {
+                            window.showToast('Admin account created successfully!', 'success');
+                        }
+                        // Run full initialization now that we have an admin
+                        this._runCoreInitialization();
+                    } else {
+                        this.setupState.error = data.message || 'Failed to create admin account';
+                    }
+                } else {
+                    const data = await response.json();
+                    this.setupState.error = data.detail || 'Failed to create admin account';
+                }
+            } catch (error) {
+                this.setupState.error = 'Network error: ' + error.message;
+            } finally {
+                this.setupState.submitting = false;
+            }
         },
 
         setActiveTab(tabName) {

--- a/simpletuner/static/js/modules/cloud/index.js
+++ b/simpletuner/static/js/modules/cloud/index.js
@@ -96,20 +96,21 @@ if (!window.cloudDashboardComponent) {
             },
 
             async init() {
-                // Check first-run setup status before loading everything else
-                await this.checkSetupStatus();
-
-                // Only proceed with normal initialization if setup is complete AND user is logged in
-                if (!this.setupState.needsSetup && !this.setupState.needsLogin) {
-                    this._runCoreInitialization();
-                    this.initSSEConnectionMonitor();
-
-                    this.$watch('activeProvider', () => {
-                        this.jobsInitialized = false;
-                        this.loadJobs();
-                        this.loadProviderConfig();
-                    });
+                // Wait for auth before making any API calls
+                // First-run admin setup is handled in the Manage Users tab (admin_tab.html)
+                const canProceed = await window.waitForAuthReady();
+                if (!canProceed) {
+                    return;
                 }
+
+                this._runCoreInitialization();
+                this.initSSEConnectionMonitor();
+
+                this.$watch('activeProvider', () => {
+                    this.jobsInitialized = false;
+                    this.loadJobs();
+                    this.loadProviderConfig();
+                });
             },
 
             initSSEConnectionMonitor() {

--- a/simpletuner/templates/admin_tab.html
+++ b/simpletuner/templates/admin_tab.html
@@ -2,12 +2,25 @@
 <!-- CSS auto cache-busted by autoCacheBustCSS() on HTMX load -->
 <link rel="stylesheet" href="/static/css/form-sections.css" id="css-form-sections-admin">
 <link rel="stylesheet" href="/static/css/admin.css" id="css-admin">
+<link rel="stylesheet" href="/static/css/cloud-onboarding.css" id="css-cloud-onboarding-admin">
 
 <div class="tab-fragment"
      id="admin-tab-content"
      data-tab-name="admin"
      x-data="adminPanelComponent()"
      x-init="init()">
+
+    <!-- Loading state while checking setup status -->
+    <div class="text-center py-5" x-show="setupState?.loading" x-cloak>
+        <i class="fas fa-spinner fa-spin fa-2x text-muted"></i>
+        <p class="text-muted mt-2">Loading...</p>
+    </div>
+
+    <!-- First-Run Setup Wizard (shown when no admin exists) -->
+    {% include 'partials/cloud_first_run_setup.html' %}
+
+    <!-- Normal UI (hidden during first-run setup) -->
+    <div x-show="setupState && !setupState.needsSetup && !setupState.loading" x-cloak>
 
     <!-- Page Header -->
     <div class="admin-header">
@@ -177,5 +190,7 @@
 
         </div><!-- /.admin-main-content -->
     </template><!-- End of main content wrapper (shown after enterprise onboarding) -->
+
+    </div><!-- End of normal UI wrapper (hidden during first-run setup) -->
 
 </div><!-- /.tab-fragment -->

--- a/simpletuner/templates/cloud_tab.html
+++ b/simpletuner/templates/cloud_tab.html
@@ -13,17 +13,6 @@
      x-init="init()"
      @beforeunload.window="destroy()">
 
-    <!-- Loading state while checking setup status -->
-    <div class="text-center py-5" x-show="setupState?.loading" x-cloak>
-        <i class="fas fa-spinner fa-spin fa-2x text-muted"></i>
-        <p class="text-muted mt-2">Loading...</p>
-    </div>
-
-    <!-- First-Run Setup Wizard (shown when no admin exists) -->
-    {% include 'partials/cloud_first_run_setup.html' %}
-
-    <!-- Normal UI (hidden during first-run setup) -->
-    <div x-show="setupState && !setupState.needsSetup && !setupState.loading" x-cloak>
 
     <!-- Provider Tabs -->
     {% include 'partials/cloud_provider_tabs.html' %}
@@ -234,8 +223,6 @@
          x-show="selectedJob"
          x-cloak
          @click="selectedJob = null"></div>
-
-    </div><!-- End of normal UI wrapper (hidden during first-run setup) -->
 
     <!-- Upload Progress (floating, shown when active) -->
     {% include 'partials/cloud_upload_progress.html' %}


### PR DESCRIPTION
This pull request refactors the first-run admin setup flow so that the setup wizard is now only shown in the Admin tab, instead of both the Admin and Cloud tabs. The core logic for handling first-run setup is moved into the admin panel component, and the cloud dashboard no longer blocks initialization for setup status. This results in a clearer separation of concerns and a more streamlined onboarding experience.

**Admin panel first-run setup enhancements:**

* Introduced a new `setupState` object and related logic in `adminPanelComponent` to handle first-run setup, including status checks, form validation, and submitting the first admin account. (`simpletuner/static/js/modules/admin/index.js`) [[1]](diffhunk://#diff-e2d3f2c28204ec059b3a60baa753c0f12eb856288dc05354999f56f6212989a5R15-R31) [[2]](diffhunk://#diff-e2d3f2c28204ec059b3a60baa753c0f12eb856288dc05354999f56f6212989a5R420-R437) [[3]](diffhunk://#diff-e2d3f2c28204ec059b3a60baa753c0f12eb856288dc05354999f56f6212989a5R455-R530)
* Updated `admin_tab.html` to display a loading spinner and the first-run setup wizard only when needed, hiding the normal admin UI until setup is complete. (`simpletuner/templates/admin_tab.html`) [[1]](diffhunk://#diff-5e2f99847cb44cfb0b46738dbe70980e168157af14b40911ee35a2e707ef115fR5-R24) [[2]](diffhunk://#diff-5e2f99847cb44cfb0b46738dbe70980e168157af14b40911ee35a2e707ef115fR194-R195)

**Cloud dashboard simplification:**

* Removed first-run setup checks and wizard from the cloud dashboard component and UI, so that setup is only managed through the Admin tab. (`simpletuner/static/js/modules/cloud/index.js`, `simpletuner/templates/cloud_tab.html`) [[1]](diffhunk://#diff-d1cf51a89c17fe8a2e7fbad3deec1889282f7cd4d9b46e1679c80480dcb8d2aaL99-L103) [[2]](diffhunk://#diff-d1cf51a89c17fe8a2e7fbad3deec1889282f7cd4d9b46e1679c80480dcb8d2aaL112) [[3]](diffhunk://#diff-572e770cacde5670b626d5ec3ff558d2d332346d01ce283e83df77eac78dd3eeL16-L26) [[4]](diffhunk://#diff-572e770cacde5670b626d5ec3ff558d2d332346d01ce283e83df77eac78dd3eeL238-L239)