### PR TITLE
Trainer should complete the final model save event once it is done

### DIFF
--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -5641,6 +5641,15 @@ class Trainer:
                 self._finish_hub_uploads()
             else:
                 self._run_post_upload_script(local_path=self.config.output_dir, remote_path=None)
+            # Mark model_save as completed
+            event = lifecycle_stage_event(
+                key="model_save",
+                label="Saving Final Model",
+                status="completed",
+                message=f"Model saved to {self.config.output_dir}",
+                job_id=self.job_id,
+            )
+            self._emit_event(event)
         self.accelerator.end_training()
         # Emit training_complete event after all model saving and validation is complete
         event = lifecycle_stage_event(


### PR DESCRIPTION
This pull request adds an event emission to signal the completion of the model saving stage in the training workflow. This helps improve tracking and visibility of model save operations.

Training lifecycle improvements:

* Emit a `model_save` lifecycle event with status "completed" and a message indicating the save location after the final model is saved in `_upload_final_model()` in `trainer.py`.