### PR TITLE
do not clear training-status if we have stages to render

### DIFF
--- a/simpletuner/templates/components/training_events_sse.html
+++ b/simpletuner/templates/components/training_events_sse.html
@@ -328,7 +328,6 @@
         }
 
         alert.className = 'alert alert-info startup-progress-alert';
-        alert.innerHTML = '';
         alert.dataset.startupGenerated = 'true';
 
         if (!startupStatusActive && startupStages.size === 0) {
@@ -336,9 +335,14 @@
             return;
         }
 
+        // Only clear and re-render if we have stages to display
+        // This preserves the "Training Starting" message from SSE events until stages arrive
         if (startupStages.size === 0) {
             return;
         }
+
+        // Clear content only when we're about to render stages
+        alert.innerHTML = '';
 
         const listEl = document.createElement('div');
         listEl.className = 'startup-progress-list';


### PR DESCRIPTION
This pull request makes a small adjustment to the logic for updating the training progress alert in the `training_events_sse.html` component. The change ensures that the alert's content is only cleared when there are actual stages to display, preserving the "Training Starting" message until further progress information is available. 

- Improved the alert update logic to only clear its content when startup stages are present, ensuring that initial messages like "Training Starting" are not prematurely removed.