### PR TITLE
add /workspace to search path for db

### DIFF
--- a/simpletuner/simpletuner_sdk/server/services/cloud/async_job_store.py
+++ b/simpletuner/simpletuner_sdk/server/services/cloud/async_job_store.py
@@ -114,6 +114,22 @@ class AsyncJobStore:
                 return Path(defaults.configs_dir)
             return store.base_dir.parent / "config"
         except Exception:
+            # Fallback with same priority as WebUIStateStore
+            candidate_roots = []
+            if Path("/workspace").exists():
+                candidate_roots.append(Path("/workspace/simpletuner"))
+            if Path("/notebooks").exists():
+                candidate_roots.append(Path("/notebooks/simpletuner"))
+            candidate_roots.append(Path.home() / ".simpletuner")
+
+            for root in candidate_roots:
+                config_dir = root / "config"
+                if config_dir.exists():
+                    return config_dir
+
+            if candidate_roots:
+                return candidate_roots[0] / "config"
+
             return Path.home() / ".simpletuner" / "config"
 
     async def _ensure_initialized(self) -> None:


### PR DESCRIPTION
This pull request updates how the configuration directory is resolved for SimpleTuner, especially improving support for common machine learning (ML) environments on Linux. The changes prioritize ML workspace paths and ensure better fallback logic, making the configuration directory selection more robust and consistent across environments.

**Improvements to configuration directory resolution:**

* Updated the fallback logic in `_resolve_config_dir` (in `async_job_store.py`) to check for `/workspace/simpletuner` and `/notebooks/simpletuner` before defaulting to the user's home directory, improving compatibility with ML environments.
* Changed the documentation and logic in `get_default_config_dir` (in `base.py`) to clarify and implement the new priority order for Linux: `/workspace/simpletuner`, `/notebooks/simpletuner`, then `~/.simpletuner`. [[1]](diffhunk://#diff-57a2d224e2313c074108ce07bc4512ca72194730bdaa9c73b1a20cc043277cdaL34-R34) [[2]](diffhunk://#diff-57a2d224e2313c074108ce07bc4512ca72194730bdaa9c73b1a20cc043277cdaL47-R66)