### PR TITLE
fix overlapping text in admin setup form

### DIFF
--- a/simpletuner/templates/partials/cloud_first_run_setup.html
+++ b/simpletuner/templates/partials/cloud_first_run_setup.html
@@ -53,7 +53,7 @@
                                                id="setup-email"
                                                class="form-control"
                                                x-model="setupState.form.email"
-                                               placeholder="admin@example.com"
+                                               placeholder=" "
                                                required
                                                :disabled="setupState.submitting">
                                         <label for="setup-email">Email Address</label>
@@ -67,7 +67,7 @@
                                                id="setup-username"
                                                class="form-control"
                                                x-model="setupState.form.username"
-                                               placeholder="admin"
+                                               placeholder=" "
                                                pattern="^[a-zA-Z0-9_\-]+$"
                                                minlength="3"
                                                maxlength="50"
@@ -84,7 +84,7 @@
                                                id="setup-display-name"
                                                class="form-control"
                                                x-model="setupState.form.displayName"
-                                               placeholder="Admin User"
+                                               placeholder=" "
                                                :disabled="setupState.submitting">
                                         <label for="setup-display-name">Display Name (optional)</label>
                                     </div>
@@ -97,7 +97,7 @@
                                                id="setup-password"
                                                class="form-control"
                                                x-model="setupState.form.password"
-                                               placeholder="Password"
+                                               placeholder=" "
                                                minlength="8"
                                                required
                                                :disabled="setupState.submitting">
@@ -112,7 +112,7 @@
                                                id="setup-confirm-password"
                                                class="form-control"
                                                x-model="setupState.form.confirmPassword"
-                                               placeholder="Confirm"
+                                               placeholder=" "
                                                minlength="8"
                                                required
                                                :disabled="setupState.submitting"


### PR DESCRIPTION
This pull request makes a small UI update to the admin account creation form in the `cloud_first_run_setup.html` template. The placeholders for all input fields have been changed from example text to a single space, resulting in empty placeholder fields.

- All input fields (`email`, `username`, `displayName`, `password`, and `confirmPassword`) now have empty placeholders instead of example or descriptive text. [[1]](diffhunk://#diff-e54b75c66c5e37369e4724129c3f77619c4b21e35e7573cefa1d4c3d2d343b08L56-R56) [[2]](diffhunk://#diff-e54b75c66c5e37369e4724129c3f77619c4b21e35e7573cefa1d4c3d2d343b08L70-R70) [[3]](diffhunk://#diff-e54b75c66c5e37369e4724129c3f77619c4b21e35e7573cefa1d4c3d2d343b08L87-R87) [[4]](diffhunk://#diff-e54b75c66c5e37369e4724129c3f77619c4b21e35e7573cefa1d4c3d2d343b08L100-R100) [[5]](diffhunk://#diff-e54b75c66c5e37369e4724129c3f77619c4b21e35e7573cefa1d4c3d2d343b08L115-R115)