### PR TITLE
fix first-admin setup submission

### DIFF
--- a/simpletuner/static/js/modules/admin/index.js
+++ b/simpletuner/static/js/modules/admin/index.js
@@ -472,19 +472,7 @@ window.adminPanelComponent = function() {
             }
         },
 
-        get setupFormValid() {
-            const form = this.setupState?.form;
-            if (!form) return false;
-            return (
-                form.email &&
-                form.email.includes('@') &&
-                form.username &&
-                form.username.length >= 3 &&
-                form.password &&
-                form.password.length >= 8 &&
-                form.password === form.confirmPassword
-            );
-        },
+        // Note: setupFormValid getter moved to return object to avoid spread evaluation issue
 
         async submitFirstRunSetup() {
             if (!this.setupFormValid) return;
@@ -570,6 +558,19 @@ window.adminPanelComponent = function() {
         // Getters must be defined here, not in spread modules, to avoid evaluation issues
         get anyHintsDismissed() {
             return this.hints && Object.values(this.hints).some(v => !v);
+        },
+        get setupFormValid() {
+            const form = this.setupState?.form;
+            if (!form) return false;
+            return (
+                form.email &&
+                form.email.includes('@') &&
+                form.username &&
+                form.username.length >= 3 &&
+                form.password &&
+                form.password.length >= 8 &&
+                form.password === form.confirmPassword
+            );
         },
     };
 };


### PR DESCRIPTION
This pull request refactors the location of the `setupFormValid` getter within the `adminPanelComponent` in `simpletuner/static/js/modules/admin/index.js`. The main purpose is to address an issue with spread evaluation by moving the getter from the function body to the returned object.

Refactoring for getter placement:

* Moved the `setupFormValid` getter from the function body to the returned object in `adminPanelComponent` to avoid issues with spread evaluation. [[1]](diffhunk://#diff-e2d3f2c28204ec059b3a60baa753c0f12eb856288dc05354999f56f6212989a5L475-R475) [[2]](diffhunk://#diff-e2d3f2c28204ec059b3a60baa753c0f12eb856288dc05354999f56f6212989a5R562-R574)