### PR TITLE
broadcast SSE when GPU goes OOM

### DIFF
--- a/simpletuner/simpletuner_sdk/server/services/callback_service.py
+++ b/simpletuner/simpletuner_sdk/server/services/callback_service.py
@@ -562,19 +562,8 @@ class CallbackService:
             f"Broadcasting lifecycle stage: {stage_state.get('progress_type')} (status={stage_state.get('status')}) for job {job_id}"
         )
 
-        async def _broadcast():
-            manager = get_sse_manager()
-            await manager.broadcast(payload, event_type="lifecycle.stage")
-
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
-
-        if loop and loop.is_running():
-            loop.create_task(_broadcast())
-        else:
-            asyncio.run(_broadcast())
+        manager = get_sse_manager()
+        manager.broadcast_threadsafe(payload, event_type="lifecycle.stage")
 
     def _broadcast_progress_reset(self, job_id: str | None, *, status: str) -> None:
         if job_id:
@@ -592,19 +581,8 @@ class CallbackService:
             "total_epochs": 0,
         }
 
-        async def _broadcast():
-            manager = get_sse_manager()
-            await manager.broadcast(payload, event_type="training_progress")
-
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
-
-        if loop and loop.is_running():
-            loop.create_task(_broadcast())
-        else:
-            asyncio.run(_broadcast())
+        manager = get_sse_manager()
+        manager.broadcast_threadsafe(payload, event_type="training_progress")
 
     def _broadcast_training_progress(self, job_id: str | None, progress_state: Mapping[str, Any]) -> None:
         """Broadcast real-time training progress updates via SSE."""
@@ -629,19 +607,8 @@ class CallbackService:
             f"({payload['percent']:.1f}%) for job {job_id}"
         )
 
-        async def _broadcast():
-            manager = get_sse_manager()
-            await manager.broadcast(payload, event_type="training.progress")
-
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
-
-        if loop and loop.is_running():
-            loop.create_task(_broadcast())
-        else:
-            asyncio.run(_broadcast())
+        manager = get_sse_manager()
+        manager.broadcast_threadsafe(payload, event_type="training.progress")
 
     def _should_suppress_event(self, event: CallbackEvent) -> bool:
         if not event:

--- a/tests/test_callback_service.py
+++ b/tests/test_callback_service.py
@@ -114,9 +114,9 @@ class CallbackServiceTestCase(unittest.TestCase):
     @patch("simpletuner.simpletuner_sdk.server.services.callback_service.get_sse_manager")
     def test_progress_event_broadcasts_via_sse(self, mock_get_sse_manager: Mock) -> None:
         """Test that progress events trigger SSE broadcasts with correct payload."""
-        # Setup mock SSE manager
+        # Setup mock SSE manager with thread-safe broadcast method
         mock_sse_manager = Mock()
-        mock_sse_manager.broadcast = AsyncMock()
+        mock_sse_manager.broadcast_threadsafe = Mock(return_value=True)
         mock_get_sse_manager.return_value = mock_sse_manager
 
         # Handle a progress event
@@ -142,12 +142,14 @@ class CallbackServiceTestCase(unittest.TestCase):
         # Verify SSE manager was called
         mock_get_sse_manager.assert_called()
 
-        # Verify broadcast was actually called (not just that it exists)
-        self.assertTrue(mock_sse_manager.broadcast.called, "SSE manager broadcast should have been called")
-        self.assertEqual(mock_sse_manager.broadcast.call_count, 1, "Broadcast should be called exactly once")
+        # Verify thread-safe broadcast was called
+        self.assertTrue(
+            mock_sse_manager.broadcast_threadsafe.called, "SSE manager broadcast_threadsafe should have been called"
+        )
+        self.assertEqual(mock_sse_manager.broadcast_threadsafe.call_count, 1, "Broadcast should be called exactly once")
 
         # Verify the broadcast payload contains expected fields
-        call_args = mock_sse_manager.broadcast.call_args
+        call_args = mock_sse_manager.broadcast_threadsafe.call_args
         self.assertIsNotNone(call_args, "Broadcast should have been called with arguments")
 
         args, kwargs = call_args
@@ -167,9 +169,9 @@ class CallbackServiceTestCase(unittest.TestCase):
     @patch("simpletuner.simpletuner_sdk.server.services.callback_service.get_sse_manager")
     def test_lifecycle_stage_broadcasts_via_sse(self, mock_get_sse_manager: Mock) -> None:
         """Test that lifecycle stage events trigger SSE broadcasts."""
-        # Setup mock SSE manager
+        # Setup mock SSE manager with thread-safe broadcast method
         mock_sse_manager = Mock()
-        mock_sse_manager.broadcast = AsyncMock()
+        mock_sse_manager.broadcast_threadsafe = Mock(return_value=True)
         mock_get_sse_manager.return_value = mock_sse_manager
 
         # Handle a lifecycle stage event
@@ -194,12 +196,14 @@ class CallbackServiceTestCase(unittest.TestCase):
         # Verify SSE manager was called
         mock_get_sse_manager.assert_called()
 
-        # Verify broadcast was actually called
-        self.assertTrue(mock_sse_manager.broadcast.called, "SSE manager broadcast should have been called")
-        self.assertEqual(mock_sse_manager.broadcast.call_count, 1, "Broadcast should be called exactly once")
+        # Verify thread-safe broadcast was called
+        self.assertTrue(
+            mock_sse_manager.broadcast_threadsafe.called, "SSE manager broadcast_threadsafe should have been called"
+        )
+        self.assertEqual(mock_sse_manager.broadcast_threadsafe.call_count, 1, "Broadcast should be called exactly once")
 
         # Verify the broadcast payload
-        call_args = mock_sse_manager.broadcast.call_args
+        call_args = mock_sse_manager.broadcast_threadsafe.call_args
         self.assertIsNotNone(call_args, "Broadcast should have been called with arguments")
 
         args, kwargs = call_args
@@ -215,9 +219,9 @@ class CallbackServiceTestCase(unittest.TestCase):
     @patch("simpletuner.simpletuner_sdk.server.services.callback_service.get_sse_manager")
     def test_error_status_broadcasts_progress_reset(self, mock_get_sse_manager: Mock) -> None:
         """Test that error status events trigger progress reset broadcasts."""
-        # Setup mock SSE manager
+        # Setup mock SSE manager with thread-safe broadcast method
         mock_sse_manager = Mock()
-        mock_sse_manager.broadcast = AsyncMock()
+        mock_sse_manager.broadcast_threadsafe = Mock(return_value=True)
         mock_get_sse_manager.return_value = mock_sse_manager
 
         # Handle an error status event
@@ -234,12 +238,14 @@ class CallbackServiceTestCase(unittest.TestCase):
         # Verify SSE manager was called for progress reset
         mock_get_sse_manager.assert_called()
 
-        # Verify broadcast was actually called
-        self.assertTrue(mock_sse_manager.broadcast.called, "SSE manager broadcast should have been called")
-        self.assertEqual(mock_sse_manager.broadcast.call_count, 1, "Broadcast should be called exactly once")
+        # Verify thread-safe broadcast was called
+        self.assertTrue(
+            mock_sse_manager.broadcast_threadsafe.called, "SSE manager broadcast_threadsafe should have been called"
+        )
+        self.assertEqual(mock_sse_manager.broadcast_threadsafe.call_count, 1, "Broadcast should be called exactly once")
 
         # Verify the broadcast payload for progress reset
-        call_args = mock_sse_manager.broadcast.call_args
+        call_args = mock_sse_manager.broadcast_threadsafe.call_args
         self.assertIsNotNone(call_args, "Broadcast should have been called with arguments")
 
         args, kwargs = call_args


### PR DESCRIPTION
This pull request refactors how server-sent event (SSE) broadcasts are triggered within the `callback_service` to ensure thread safety and reliability, especially when events are emitted from background threads. The main change is the introduction and use of a new `broadcast_threadsafe` method in the SSE manager, replacing direct async calls and complex event loop handling. Corresponding tests have been updated to mock and verify this new thread-safe broadcasting approach.

**Core improvements for thread-safe SSE broadcasting:**

* Added a new `broadcast_threadsafe` method to the `SSEManager` class, enabling safe broadcasting of SSE messages from any thread by scheduling the broadcast on the main event loop. (`simpletuner/simpletuner_sdk/server/services/sse_manager.py`)
* Modified the SSE manager to track the main event loop and thread, ensuring that broadcasts are correctly dispatched regardless of the calling thread. (`simpletuner/simpletuner_sdk/server/services/sse_manager.py`)
* Updated the callback service to use `broadcast_threadsafe` instead of direct async broadcasting, simplifying the logic and removing manual event loop detection and handling. (`simpletuner/simpletuner_sdk/server/services/callback_service.py`) [[1]](diffhunk://#diff-e61d3194fcf4b0c77d66f5276ddadf4b082f5323ba5d7ea24eab2f621e835652L565-R566) [[2]](diffhunk://#diff-e61d3194fcf4b0c77d66f5276ddadf4b082f5323ba5d7ea24eab2f621e835652L595-R585) [[3]](diffhunk://#diff-e61d3194fcf4b0c77d66f5276ddadf4b082f5323ba5d7ea24eab2f621e835652L632-R611)

**Testing updates:**

* Refactored tests to mock and assert calls to `broadcast_threadsafe` instead of the original `broadcast` method, ensuring that the new thread-safe mechanism is exercised and validated. (`tests/test_callback_service.py`) [[1]](diffhunk://#diff-415bee541ec3398ac4cb2fc9b4e122c97375d96c1b14558cb2df312ea6942a7aL117-R119) [[2]](diffhunk://#diff-415bee541ec3398ac4cb2fc9b4e122c97375d96c1b14558cb2df312ea6942a7aL145-R152) [[3]](diffhunk://#diff-415bee541ec3398ac4cb2fc9b4e122c97375d96c1b14558cb2df312ea6942a7aL170-R174) [[4]](diffhunk://#diff-415bee541ec3398ac4cb2fc9b4e122c97375d96c1b14558cb2df312ea6942a7aL197-R206) [[5]](diffhunk://#diff-415bee541ec3398ac4cb2fc9b4e122c97375d96c1b14558cb2df312ea6942a7aL218-R224) [[6]](diffhunk://#diff-415bee541ec3398ac4cb2fc9b4e122c97375d96c1b14558cb2df312ea6942a7aL237-R248)

**Dependency update:**

* Added import of the `threading` module in the SSE manager to support thread identification for thread-safe operations. (`simpletuner/simpletuner_sdk/server/services/sse_manager.py`)