### PR TITLE
fix user db and storage path

### DIFF
--- a/simpletuner/simpletuner_sdk/server/services/cloud/async_job_store.py
+++ b/simpletuner/simpletuner_sdk/server/services/cloud/async_job_store.py
@@ -104,7 +104,12 @@ class AsyncJobStore:
             return cls._instance
 
     def _resolve_config_dir(self) -> Path:
-        """Resolve config directory from WebUIStateStore or default."""
+        """Resolve config directory from WebUIStateStore or default.
+
+        Returns the SimpleTuner root directory (e.g. /notebooks/simpletuner
+        or ~/.simpletuner). The database path is then constructed as
+        config_dir / "cloud" / "jobs.db".
+        """
         try:
             from .webui_state import WebUIStateStore
 
@@ -112,25 +117,11 @@ class AsyncJobStore:
             defaults = store.load_defaults()
             if defaults.configs_dir:
                 return Path(defaults.configs_dir)
-            return store.base_dir.parent / "config"
+            return store.base_dir.parent
         except Exception:
-            # Fallback with same priority as WebUIStateStore
-            candidate_roots = []
-            if Path("/workspace").exists():
-                candidate_roots.append(Path("/workspace/simpletuner"))
-            if Path("/notebooks").exists():
-                candidate_roots.append(Path("/notebooks/simpletuner"))
-            candidate_roots.append(Path.home() / ".simpletuner")
+            from .storage.base import get_default_config_dir
 
-            for root in candidate_roots:
-                config_dir = root / "config"
-                if config_dir.exists():
-                    return config_dir
-
-            if candidate_roots:
-                return candidate_roots[0] / "config"
-
-            return Path.home() / ".simpletuner" / "config"
+            return get_default_config_dir()
 
     async def _ensure_initialized(self) -> None:
         """Ensure all component stores are initialized."""

--- a/simpletuner/simpletuner_sdk/server/services/cloud/auth/stores/base.py
+++ b/simpletuner/simpletuner_sdk/server/services/cloud/auth/stores/base.py
@@ -20,11 +20,15 @@ def get_default_db_path() -> Path:
     """Get the default database path for auth stores.
 
     Checks SIMPLETUNER_AUTH_DB_PATH environment variable first for test isolation.
+    Uses the same config directory resolution as the storage layer to ensure
+    consistency across ML environments (/workspace, /notebooks, ~/.simpletuner).
     """
     env_path = os.environ.get("SIMPLETUNER_AUTH_DB_PATH")
     if env_path:
         return Path(env_path)
-    return Path.home() / ".simpletuner" / "config" / "cloud" / "jobs.db"
+    from ...storage.base import get_default_config_dir
+
+    return get_default_config_dir() / "cloud" / "jobs.db"
 
 
 class BaseAuthStore:


### PR DESCRIPTION
This pull request improves the way configuration directories are resolved for both the job store and authentication store, ensuring consistency across different environments. The main changes refactor directory resolution logic to use a shared helper, reducing code duplication and potential mismatches.

**Configuration Directory Resolution Improvements:**

* Updated `_resolve_config_dir` in `async_job_store.py` to use the `get_default_config_dir` helper from `storage.base`, replacing custom fallback logic and ensuring a single source of truth for config directory resolution.
* Modified `get_default_db_path` in `auth/stores/base.py` to also use `get_default_config_dir`, aligning its behavior with the rest of the storage layer and improving consistency across ML environments.