### PR TITLE
emit user creation audit event

### DIFF
--- a/documentation/experimental/server/AUDIT.md
+++ b/documentation/experimental/server/AUDIT.md
@@ -71,6 +71,7 @@ All endpoints require the `admin.audit` permission.
 | `user.created` | New user created |
 | `user.updated` | User details updated |
 | `user.deleted` | User deleted |
+| `user.password.changed` | User changed their password |
 | `user.level.changed` | User level/role changed |
 | `user.permission.changed` | User permission changed |
 

--- a/simpletuner/simpletuner_sdk/server/routes/auth.py
+++ b/simpletuner/simpletuner_sdk/server/routes/auth.py
@@ -207,6 +207,18 @@ async def create_first_admin(
             # Reload user with permissions
             user = await store.get_user(user.id)
 
+            # Audit log
+            await audit_log(
+                AuditEventType.USER_CREATED,
+                f"First admin user '{user.username}' created during initial setup",
+                actor_id=user.id,
+                actor_username=user.username,
+                actor_ip=client_ip,
+                target_type="user",
+                target_id=str(user.id),
+                details={"is_admin": True, "setup": "first_admin"},
+            )
+
             logger.info("First admin user created: %s", user.username)
 
             return LoginResponse(
@@ -534,6 +546,18 @@ async def register(
 
         # Reload user with permissions
         user = await store.get_user(user.id)
+
+        # Audit log
+        await audit_log(
+            AuditEventType.USER_CREATED,
+            f"User '{user.username}' registered via public registration",
+            actor_id=user.id,
+            actor_username=user.username,
+            actor_ip=client_ip,
+            target_type="user",
+            target_id=str(user.id),
+            details={"registration": "public"},
+        )
 
         logger.info("New user registered: %s", user.username)
 

--- a/simpletuner/simpletuner_sdk/server/routes/users.py
+++ b/simpletuner/simpletuner_sdk/server/routes/users.py
@@ -196,6 +196,19 @@ async def create_user(
                 invalidate_single_user_mode()
                 logger.info("Removed placeholder local@localhost user")
 
+        # Audit log
+        from ..services.cloud.audit import AuditEventType, audit_log
+
+        await audit_log(
+            AuditEventType.USER_CREATED,
+            f"User '{user.username}' created by admin '{admin.username}'",
+            actor_id=admin.id,
+            actor_username=admin.username,
+            target_type="user",
+            target_id=str(user.id),
+            details={"created_username": user.username, "is_admin": user.is_admin},
+        )
+
         logger.info("User created by admin %s: %s", admin.username, user.username)
 
         return UserResponse.from_user(user)

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -944,6 +944,7 @@ class TestPlaceholderCleanupOnUserCreate(unittest.IsolatedAsyncioTestCase):
 
         # Create a mock admin user for the dependency
         mock_admin = MagicMock()
+        mock_admin.id = 1
         mock_admin.username = "local"
 
         # Create a real user via admin panel
@@ -979,6 +980,7 @@ class TestPlaceholderCleanupOnUserCreate(unittest.IsolatedAsyncioTestCase):
         )
 
         mock_admin = MagicMock()
+        mock_admin.id = 1
         mock_admin.username = "local"
 
         # Create a real user
@@ -1019,6 +1021,7 @@ class TestPlaceholderCleanupOnUserCreate(unittest.IsolatedAsyncioTestCase):
         middleware._local_admin = MagicMock()
 
         mock_admin = MagicMock()
+        mock_admin.id = 1
         mock_admin.username = "local"
 
         # Create real user (should trigger cache invalidation)


### PR DESCRIPTION
This pull request adds audit logging for user creation events across different user creation flows and updates documentation to reflect a new audit event. It also makes minor improvements to test setup for admin user mocks.

**Audit logging improvements:**

* Added audit logging to `create_first_admin` in `auth.py` to record when the first admin user is created during initial setup.
* Added audit logging to `register` in `auth.py` to record when a user registers via public registration.
* Added audit logging to `create_user` in `users.py` to record when an admin creates a user, including relevant details about the action.

**Documentation updates:**

* Updated `AUDIT.md` to include the `user.password.changed` audit event in the list of user-related audit events.

**Test improvements:**

* Set `id` attribute for `mock_admin` in several tests in `test_auth_routes.py` to ensure accurate test behavior. [[1]](diffhunk://#diff-a08386d3bff90c2e7c53f267d2c76d4d8d35e816723edc724d638cc74ed7c906R947) [[2]](diffhunk://#diff-a08386d3bff90c2e7c53f267d2c76d4d8d35e816723edc724d638cc74ed7c906R983) [[3]](diffhunk://#diff-a08386d3bff90c2e7c53f267d2c76d4d8d35e816723edc724d638cc74ed7c906R1024)