### PR TITLE
fix cloud provider api path usage

### DIFF
--- a/documentation/experimental/cloud/JOB_PROGRESS_AND_SYNC.md
+++ b/documentation/experimental/cloud/JOB_PROGRESS_AND_SYNC.md
@@ -427,7 +427,7 @@ When webhooks are configured:
 
 2. Verify provider connectivity:
    ```bash
-   curl http://localhost:8001/api/cloud/replicate/validate
+   curl http://localhost:8001/api/cloud/providers/replicate/validate
    ```
 
 3. Force a sync:

--- a/documentation/experimental/cloud/REPLICATE.md
+++ b/documentation/experimental/cloud/REPLICATE.md
@@ -284,10 +284,12 @@ env | grep -i proxy
 
 | Endpoint | Description |
 |----------|-------------|
-| `GET /api/cloud/replicate/versions` | List model versions |
-| `GET /api/cloud/replicate/validate` | Validate credentials |
-| `GET /api/cloud/replicate/billing` | Get credit balance |
-| `POST /api/cloud/replicate/submit` | Submit training job |
+| `GET /api/cloud/providers/replicate/versions` | List model versions |
+| `GET /api/cloud/providers/replicate/validate` | Validate credentials |
+| `GET /api/cloud/providers/replicate/billing` | Get credit balance |
+| `PUT /api/cloud/providers/replicate/token` | Save API token |
+| `DELETE /api/cloud/providers/replicate/token` | Delete API token |
+| `POST /api/cloud/jobs/submit` | Submit training job |
 | `POST /api/webhooks/replicate` | Webhook receiver |
 
 ## Links

--- a/simpletuner/cli/cloud/config.py
+++ b/simpletuner/cli/cloud/config.py
@@ -70,9 +70,9 @@ def cmd_cloud_config_set_token(args) -> int:
 
     if provider == "replicate":
         result = cloud_api_request(
-            "POST",
-            "/api/cloud/replicate/token",
-            data={"token": token},
+            "PUT",
+            "/api/cloud/providers/replicate/token",
+            data={"api_token": token},
         )
     else:
         print(f"Error: Token management not supported for provider '{provider}'.")
@@ -95,7 +95,7 @@ def cmd_cloud_config_delete_token(args) -> int:
     provider = getattr(args, "provider", "replicate")
 
     if provider == "replicate":
-        result = cloud_api_request("DELETE", "/api/cloud/replicate/token")
+        result = cloud_api_request("DELETE", "/api/cloud/providers/replicate/token")
     else:
         print(f"Error: Token management not supported for provider '{provider}'.")
         return 1

--- a/simpletuner/simpletuner_sdk/server/routes/cloud/providers.py
+++ b/simpletuner/simpletuner_sdk/server/routes/cloud/providers.py
@@ -485,7 +485,7 @@ async def test_webhook_external(provider: str) -> ExternalWebhookTestResponse:
         return ExternalWebhookTestResponse(success=False, message="Test failed", error=str(exc))
 
 
-@router.get("/replicate/validate", response_model=ValidateResponse)
+@router.get("/providers/replicate/validate", response_model=ValidateResponse)
 async def validate_replicate_key() -> ValidateResponse:
     """Check if REPLICATE_API_TOKEN is set and valid."""
     api_token = get_secrets_manager().get_replicate_token()
@@ -508,7 +508,7 @@ async def validate_replicate_key() -> ValidateResponse:
 class SaveTokenRequest(BaseModel):
     """Request to save an API token."""
 
-    token: str
+    api_token: str
 
 
 class SaveTokenResponse(BaseModel):
@@ -519,14 +519,14 @@ class SaveTokenResponse(BaseModel):
     error: Optional[str] = None
 
 
-@router.post("/replicate/token", response_model=SaveTokenResponse)
+@router.put("/providers/replicate/token", response_model=SaveTokenResponse)
 async def save_replicate_token(request: SaveTokenRequest) -> SaveTokenResponse:
     """Save the Replicate API token to the secrets file.
 
     The token is saved to ~/.simpletuner/secrets.json with restrictive permissions.
     Environment variable REPLICATE_API_TOKEN still takes precedence if set.
     """
-    token = request.token.strip()
+    token = request.api_token.strip()
 
     if not token:
         return SaveTokenResponse(success=False, error="Token cannot be empty")
@@ -562,7 +562,7 @@ async def save_replicate_token(request: SaveTokenRequest) -> SaveTokenResponse:
         return SaveTokenResponse(success=True, file_path=file_path, error=f"Token saved but validation failed: {exc}")
 
 
-@router.delete("/replicate/token", response_model=SaveTokenResponse)
+@router.delete("/providers/replicate/token", response_model=SaveTokenResponse)
 async def delete_replicate_token() -> SaveTokenResponse:
     """Delete the Replicate API token from the secrets file."""
     secrets_mgr = get_secrets_manager()
@@ -573,7 +573,7 @@ async def delete_replicate_token() -> SaveTokenResponse:
     return SaveTokenResponse(success=False, error="Failed to delete token")
 
 
-@router.get("/replicate/versions", response_model=ModelVersionsResponse)
+@router.get("/providers/replicate/versions", response_model=ModelVersionsResponse)
 async def list_replicate_versions(
     model_id: Optional[str] = Query(None, description="Model ID (owner/model). Defaults to configured model.")
 ) -> ModelVersionsResponse:
@@ -603,7 +603,7 @@ async def list_replicate_versions(
         return ModelVersionsResponse(error=str(exc))
 
 
-@router.get("/replicate/billing")
+@router.get("/providers/replicate/billing")
 async def get_replicate_billing() -> Dict[str, Any]:
     """Get Replicate billing/credit information."""
     api_token = get_secrets_manager().get_replicate_token()


### PR DESCRIPTION
This pull request updates the API endpoints and related documentation for the Replicate cloud provider to use a more consistent and namespaced path structure. It also updates the CLI and backend code to match the new API, and standardizes token field naming. These changes improve maintainability and clarity when working with multiple cloud providers.

**API endpoint restructuring and documentation updates:**

* Changed all Replicate API endpoints to use the `/api/cloud/providers/replicate/` namespace for validation, token management, version listing, and billing. This affects both backend route definitions and documentation references. [[1]](diffhunk://#diff-bf3f8a4824ce7f85b97293f416c2e5421794c4c2b38606bfe513b1757cff670bL488-R488) [[2]](diffhunk://#diff-bf3f8a4824ce7f85b97293f416c2e5421794c4c2b38606bfe513b1757cff670bL522-R529) [[3]](diffhunk://#diff-bf3f8a4824ce7f85b97293f416c2e5421794c4c2b38606bfe513b1757cff670bL565-R565) [[4]](diffhunk://#diff-bf3f8a4824ce7f85b97293f416c2e5421794c4c2b38606bfe513b1757cff670bL576-R576) [[5]](diffhunk://#diff-bf3f8a4824ce7f85b97293f416c2e5421794c4c2b38606bfe513b1757cff670bL606-R606) [[6]](diffhunk://#diff-f1c9c726979482f6208b52cd769e2afca4774edeba3a4631ba9ae9bd7ceb4d59L430-R430) [[7]](diffhunk://#diff-8ab7952c9ba333ad5e8a24ff1ffe7ef2cf1475d6c8b61eb820560d0af1b1ef9bL287-R292)

**CLI and backend code alignment:**

* Updated CLI commands in `simpletuner/cli/cloud/config.py` to use the new API endpoints and to send the token as `api_token` instead of `token`. [[1]](diffhunk://#diff-e23a0aa2e204acb78dd4c3c832eb6df2bba61c348f24667243300997ce516d08L73-R75) [[2]](diffhunk://#diff-e23a0aa2e204acb78dd4c3c832eb6df2bba61c348f24667243300997ce516d08L98-R98)
* Standardized the request model for saving tokens to use `api_token` as the field name, and updated all related backend logic accordingly. [[1]](diffhunk://#diff-bf3f8a4824ce7f85b97293f416c2e5421794c4c2b38606bfe513b1757cff670bL511-R511) [[2]](diffhunk://#diff-bf3f8a4824ce7f85b97293f416c2e5421794c4c2b38606bfe513b1757cff670bL522-R529)

These changes ensure that the Replicate provider's API is namespaced and consistent, making it easier to extend support for other providers in the future.