### PR TITLE
重要なファイルの日本語翻訳を追加（オーパスによる自動翻訳）

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,208 @@
+# SimpleTuner 💹
+
+> ℹ️ オプトイン設定の `report_to`、`push_to_hub`、または手動で設定されたwebhook以外、いかなる第三者にもデータは送信されません。
+
+**SimpleTuner**は、シンプルさに重点を置いており、コードを理解しやすくすることに焦点を当てています。このコードベースは共有の学術的な取り組みとして機能し、貢献を歓迎します。
+
+コミュニティに参加したい場合は、Terminus Research Groupを通じて[Discord](https://discord.gg/JGkSwEbjRb)で見つけることができます。
+ご質問がある場合は、お気軽にそちらでお問い合わせください。
+
+<img width="1944" height="1657" alt="image" src="https://github.com/user-attachments/assets/af3a24ec-7347-4ddf-8edf-99818a246de1" />
+
+
+## 目次
+
+- [設計思想](#設計思想)
+- [チュートリアル](#チュートリアル)
+- [機能](#機能)
+  - [コアトレーニング機能](#コアトレーニング機能)
+  - [モデルアーキテクチャサポート](#モデルアーキテクチャサポート)
+  - [高度なトレーニング技術](#高度なトレーニング技術)
+  - [モデル固有の機能](#モデル固有の機能)
+  - [クイックスタートガイド](#クイックスタートガイド)
+- [ハードウェア要件](#ハードウェア要件)
+- [ツールキット](#ツールキット)
+- [セットアップ](#セットアップ)
+- [トラブルシューティング](#トラブルシューティング)
+
+## 設計思想
+
+- **シンプルさ**: ほとんどのユースケースに適した優れたデフォルト設定を目指し、調整の手間を減らします。
+- **汎用性**: 小規模なデータセットから大規模なコレクションまで、幅広い画像数量を処理できるように設計されています。
+- **最先端の機能**: 実証済みの効果がある機能のみを組み込み、未検証のオプションの追加を避けます。
+
+## チュートリアル
+
+[新しいWeb UIチュートリアル](/documentation/webui/TUTORIAL.md)または[クラシックなコマンドラインチュートリアル](/documentation/TUTORIAL.md)を始める前に、このREADMEを完全に確認してください。このドキュメントには、最初に知っておく必要がある重要な情報が含まれています。
+
+完全なドキュメントを読んだりWebインターフェースを使用したりせずに手動で設定するクイックスタートについては、[クイックスタート](/documentation/QUICKSTART.md)ガイドを使用できます。
+
+メモリに制約のあるシステムの場合は、[DeepSpeedドキュメント](/documentation/DEEPSPEED.md)を参照してください。これは、Microsoftの🤗AccelerateとDeepSpeedを使用してオプティマイザー状態のオフロードを設定する方法を説明しています。DTensorベースのシャーディングとコンテキスト並列化については、SimpleTuner内の新しいFullyShardedDataParallel v2ワークフローをカバーする[FSDP2ガイド](/documentation/FSDP2.md)をお読みください。
+
+マルチノード分散トレーニングの場合、[このガイド](/documentation/DISTRIBUTED.md)は、INSTALLおよびクイックスタートガイドの設定をマルチノードトレーニングに適したものに調整し、数十億のサンプルを含む画像データセットに最適化するのに役立ちます。
+
+---
+
+## 機能
+
+SimpleTunerは、一貫した機能可用性を持つ複数の拡散モデルアーキテクチャにわたる包括的なトレーニングサポートを提供します:
+
+### コアトレーニング機能
+
+- **ユーザーフレンドリーなWeb UI** - 洗練されたダッシュボードを通じてトレーニングライフサイクル全体を管理
+- **マルチモーダルトレーニング** - **画像、動画、音声**生成モデルのための統合パイプライン
+- **マルチGPUトレーニング** - 自動最適化による複数GPU間の分散トレーニング
+- **高度なキャッシング** - より高速なトレーニングのために、画像、動画、音声、キャプション埋め込みをディスクにキャッシュ
+- **アスペクト比バケッティング** - さまざまな画像/動画サイズとアスペクト比のサポート
+- **コンセプトスライダー** - LoRA/LyCORIS/full（LyCORIS `full`経由）のスライダー対応ターゲティング、ポジティブ/ネガティブ/ニュートラルサンプリング、プロンプトごとの強度；[Slider LoRAガイド](/documentation/SLIDER_LORA.md)を参照
+- **メモリ最適化** - ほとんどのモデルが24G GPUでトレーニング可能、多くは最適化により16Gで可能
+- **DeepSpeed & FSDP2統合** - optim/grad/parameterシャーディング、コンテキスト並列アテンション、勾配チェックポイント、オプティマイザー状態オフロードにより、より小さなGPUで大規模モデルをトレーニング
+- **S3トレーニング** - クラウドストレージ（Cloudflare R2、Wasabi S3）から直接トレーニング
+- **EMAサポート** - 安定性と品質向上のための指数移動平均重み
+- **カスタム実験トラッカー** - `accelerate.GeneralTracker`を`simpletuner/custom-trackers`にドロップし、`--report_to=custom-tracker --custom_tracker=<name>`を使用
+
+### マルチユーザー&エンタープライズ機能
+
+SimpleTunerには、エンタープライズグレードの機能を備えた完全なマルチユーザートレーニングプラットフォームが含まれています—**永久に無料でオープンソース**。
+
+- **ワーカーオーケストレーション** - 中央パネルに自動接続し、SSE経由でジョブディスパッチを受信する分散GPUワーカーを登録；エフェメラル（クラウド起動）および永続的（常時稼働）ワーカーをサポート；[ワーカーオーケストレーションガイド](/documentation/experimental/server/WORKERS.md)を参照
+- **SSO統合** - LDAP/Active DirectoryまたはOIDCプロバイダー（Okta、Azure AD、Keycloak、Google）で認証；[外部認証ガイド](/documentation/experimental/server/EXTERNAL_AUTH.md)を参照
+- **ロールベースアクセス制御** - 4つのデフォルトロール（Viewer、Researcher、Lead、Admin）と17以上の詳細な権限；globパターンでリソースルールを定義し、チームごとに設定、ハードウェア、またはプロバイダーを制限
+- **組織&チーム** - 上限ベースのクォータを持つ階層的マルチテナント構造；組織の制限は絶対最大値を強制し、チームの制限は組織の境界内で動作
+- **クォータ&支出制限** - 組織、チーム、またはユーザースコープでコスト上限（日次/月次）、ジョブ同時実行数制限、送信レート制限を強制；アクションにはブロック、警告、または承認要求が含まれる
+- **優先度付きジョブキュー** - チーム間の公平な共有スケジューリング、長時間待機ジョブの飢餓防止、管理者の優先度オーバーライドを備えた5つの優先度レベル（Low → Critical）
+- **承認ワークフロー** - コストしきい値を超えるジョブ、初回ユーザー、または特定のハードウェアリクエストに対して承認をトリガーする設定可能なルール；UI、API、またはメール返信経由で承認
+- **メール通知** - ジョブステータス、承認リクエスト、クォータ警告、完了アラートのためのSMTP/IMAP統合
+- **APIキー&スコープ権限** - CI/CDパイプライン用に有効期限と制限されたスコープを持つAPIキーを生成
+- **監査ログ** - コンプライアンスのためのチェーン検証ですべてのユーザーアクションを追跡；[監査ガイド](/documentation/experimental/server/AUDIT.md)を参照
+
+デプロイメントの詳細については、[エンタープライズガイド](/documentation/experimental/server/ENTERPRISE.md)を参照してください。
+
+### モデルアーキテクチャサポート
+
+| モデル | パラメータ数 | PEFT LoRA | Lycoris | Full-Rank | ControlNet | 量子化 | Flow Matching | テキストエンコーダー |
+|-------|------------|-----------|---------|-----------|------------|--------------|---------------|---------------|
+| **Stable Diffusion XL** | 3.5B | ✓ | ✓ | ✓ | ✓ | int8/nf4 | ✗ | CLIP-L/G |
+| **Stable Diffusion 3** | 2B-8B | ✓ | ✓ | ✓* | ✓ | int8/fp8/nf4 | ✓ | CLIP-L/G + T5-XXL |
+| **Flux.1** | 12B | ✓ | ✓ | ✓* | ✓ | int8/fp8/nf4 | ✓ | CLIP-L + T5-XXL |
+| **Flux.2** | 32B | ✓ | ✓ | ✓* | ✗ | int8/fp8/nf4 | ✓ | Mistral-3 Small |
+| **ACE-Step** | 3.5B | ✓ | ✓ | ✓* | ✗ | int8 | ✓ | UMT5 |
+| **Chroma 1** | 8.9B | ✓ | ✓ | ✓* | ✗ | int8/fp8/nf4 | ✓ | T5-XXL |
+| **Auraflow** | 6.8B | ✓ | ✓ | ✓* | ✓ | int8/fp8/nf4 | ✓ | UMT5-XXL |
+| **PixArt Sigma** | 0.6B-0.9B | ✗ | ✓ | ✓ | ✓ | int8 | ✗ | T5-XXL |
+| **Sana** | 0.6B-4.8B | ✗ | ✓ | ✓ | ✗ | int8 | ✓ | Gemma2-2B |
+| **Lumina2** | 2B | ✓ | ✓ | ✓ | ✗ | int8 | ✓ | Gemma2 |
+| **Kwai Kolors** | 5B | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ChatGLM-6B |
+| **LTX Video** | 5B | ✓ | ✓ | ✓ | ✗ | int8/fp8 | ✓ | T5-XXL |
+| **Wan Video** | 1.3B-14B | ✓ | ✓ | ✓* | ✗ | int8 | ✓ | UMT5 |
+| **HiDream** | 17B (8.5B MoE) | ✓ | ✓ | ✓* | ✓ | int8/fp8/nf4 | ✓ | CLIP-L + T5-XXL + Llama |
+| **Cosmos2** | 2B-14B | ✗ | ✓ | ✓ | ✗ | int8 | ✓ | T5-XXL |
+| **OmniGen** | 3.8B | ✓ | ✓ | ✓ | ✗ | int8/fp8 | ✓ | T5-XXL |
+| **Qwen Image** | 20B | ✓ | ✓ | ✓* | ✗ | int8/nf4 (req.) | ✓ | T5-XXL |
+| **SD 1.x/2.x (Legacy)** | 0.9B | ✓ | ✓ | ✓ | ✓ | int8/nf4 | ✗ | CLIP-L |
+
+*✓ = サポート, ✗ = 非サポート, * = Full-rankトレーニングにDeepSpeedが必要*
+
+### 高度なトレーニング技術
+
+- **TREAD** - Kontextトレーニングを含む、transformerモデル用のトークンワイズドロップアウト
+- **マスクロストレーニング** - セグメンテーション/深度ガイダンスによる優れた収束
+- **事前正則化** - キャラクター一貫性のためのトレーニング安定性の向上
+- **勾配チェックポイント** - メモリ/速度最適化のための設定可能な間隔
+- **損失関数** - スケジューリングサポート付きのL2、Huber、Smooth L1
+- **SNR重み付け** - トレーニングダイナミクスを改善するためのMin-SNRガンマ重み付け
+- **グループオフロード** - Diffusers v0.33+モジュールグループCPU/ディスクステージング（オプションのCUDAストリーム付き）
+- **検証アダプタースイープ** - 検証中に一時的にLoRAアダプター（単一またはJSONプリセット）を接続して、トレーニングループに触れることなくアダプターのみまたは比較レンダリングを測定
+- **外部検証フック** - 組み込みの検証パイプラインまたはアップロード後のステップを独自のスクリプトに交換して、別のGPUでチェックを実行したり、任意のクラウドプロバイダーにアーティファクトを転送したりできます（[詳細](/documentation/OPTIONS.md#validation_method)）
+- **CREPA正則化** - ビデオDiTのためのフレーム間表現アライメント（[ガイド](/documentation/experimental/VIDEO_CREPA.md)）
+- **LoRA I/Oフォーマット** - 標準のDiffusersレイアウトまたはComfyUIスタイルの`diffusion_model.*`キーでPEFT LoRAをロード/保存（Flux/Flux2/Lumina2/Z-ImageはComfyUI入力を自動検出）
+
+### モデル固有の機能
+
+- **Flux Kontext** - Fluxモデルの編集条件付けとimage-to-imageトレーニング
+- **PixArt two-stage** - PixArt Sigma用のeDiffトレーニングパイプラインサポート
+- **Flow matchingモデル** - beta/uniform分布を使用した高度なスケジューリング
+- **HiDream MoE** - Mixture of Expertsゲートロス増強
+- **T5マスクトレーニング** - FluxおよびコンパチブルモデルのディテールアップEnhanced
+- **QKVフュージョン** - メモリと速度の最適化（Flux、Lumina2）
+- **TREAD統合** - ほとんどのモデルの選択的トークンルーティング
+- **Wan 2.x I2V** - 高/低ステージプリセットと2.1時間埋め込みフォールバック（Wanクイックスタートを参照）
+- **Classifier-free guidance** - 蒸留モデルのオプションのCFG再導入
+
+### クイックスタートガイド
+
+サポートされているすべてのモデルの詳細なクイックスタートガイドが利用可能です:
+
+- **[TwinFlow Few-Step (RCGM)ガイド](/documentation/distillation/TWINFLOW.md)** - Few-step/one-step生成のためのRCGM補助損失を有効化（フローモデルまたはdiff2flow経由の拡散）
+- **[Flux.1ガイド](/documentation/quickstart/FLUX.md)** - Kontext編集サポートとQKVフュージョンを含む
+- **[Flux.2ガイド](/documentation/quickstart/FLUX2.md)** - **NEW!** Mistral-3テキストエンコーダーを搭載した最新の巨大なFluxモデル
+- **[Z-Imageガイド](/documentation/quickstart/ZIMAGE.md)** - アシスタントアダプター + TREAD高速化を備えたBase/Turbo LoRA
+- **[ACE-Stepガイド](/documentation/quickstart/ACE_STEP.md)** - **NEW!** 音声生成モデルトレーニング（text-to-music）
+- **[Chromaガイド](/documentation/quickstart/CHROMA.md)** - ChromaSpecificスケジュールを持つLodestoneのflow-matching transformer
+- **[Stable Diffusion 3ガイド](/documentation/quickstart/SD3.md)** - ControlNet付きのFullおよびLoRAトレーニング
+- **[Stable Diffusion XLガイド](/documentation/quickstart/SDXL.md)** - 完全なSDXLトレーニングパイプライン
+- **[Auraflowガイド](/documentation/quickstart/AURAFLOW.md)** - Flow-matchingモデルトレーニング
+- **[PixArt Sigmaガイド](/documentation/quickstart/SIGMA.md)** - two-stageサポート付きのDiTモデル
+- **[Sanaガイド](/documentation/quickstart/SANA.md)** - 軽量flow-matchingモデル
+- **[Lumina2ガイド](/documentation/quickstart/LUMINA2.md)** - 2Bパラメータflow-matchingモデル
+- **[Kwai Kolorsガイド](/documentation/quickstart/KOLORS.md)** - ChatGLMエンコーダー付きSDXLベース
+- **[LongCat-Videoガイド](/documentation/quickstart/LONGCAT_VIDEO.md)** - Qwen-2.5-VLを使用したflow-matching text-to-videoおよびimage-to-video
+- **[LongCat-Video Editガイド](/documentation/quickstart/LONGCAT_VIDEO_EDIT.md)** - Conditioning-firstフレーバー（image-to-video）
+- **[LongCat-Imageガイド](/documentation/quickstart/LONGCAT_IMAGE.md)** - Qwen-2.5-VLエンコーダーを備えた6Bバイリンガルflow-matchingモデル
+- **[LongCat-Image Editガイド](/documentation/quickstart/LONGCAT_EDIT.md)** - 参照潜在変数を必要とする画像編集フレーバー
+- **[LTX Videoガイド](/documentation/quickstart/LTXVIDEO.md)** - ビデオ拡散トレーニング
+- **[Hunyuan Video 1.5ガイド](/documentation/quickstart/HUNYUANVIDEO.md)** - SRステージを備えた8.3B flow-matching T2V/I2V
+- **[Wan Videoガイド](/documentation/quickstart/WAN.md)** - TREADサポート付きビデオflow-matching
+- **[HiDreamガイド](/documentation/quickstart/HIDREAM.md)** - 高度な機能を備えたMoEモデル
+- **[Cosmos2ガイド](/documentation/quickstart/COSMOS2IMAGE.md)** - マルチモーダル画像生成
+- **[OmniGenガイド](/documentation/quickstart/OMNIGEN.md)** - 統合画像生成モデル
+- **[Qwen Imageガイド](/documentation/quickstart/QWEN_IMAGE.md)** - 20Bパラメータ大規模トレーニング
+- **[Stable Cascade Stage Cガイド](/quickstart/STABLE_CASCADE_C.md)** - 結合されたprior+decoder検証を備えたPrior LoRA
+- **[Kandinsky 5.0 Imageガイド](/documentation/quickstart/KANDINSKY5_IMAGE.md)** - Qwen2.5-VL + Flux VAEを使用した画像生成
+- **[Kandinsky 5.0 Videoガイド](/documentation/quickstart/KANDINSKY5_VIDEO.md)** - HunyuanVideo VAEを使用したビデオ生成
+
+---
+
+## ハードウェア要件
+
+### 一般要件
+
+- **NVIDIA**: RTX 3080+推奨（H200まで検証済み）
+- **AMD**: 7900 XTX 24GBおよびMI300X検証済み（NVIDIAに比べて高いメモリ使用量）
+- **Apple**: LoRAトレーニング用にM3 Max+、24GB+のユニファイドメモリ
+
+### モデルサイズ別のメモリガイドライン
+
+- **大規模モデル（12B+）**: Full-rankにはA100-80G、LoRA/LycorisにはFFFF24G+
+- **中規模モデル（2B-8B）**: LoRAには16G+、Full-rankトレーニングには40G+
+- **小規模モデル（<2B）**: ほとんどのトレーニングタイプに12G+で十分
+
+**注**: 量子化（int8/fp8/nf4）により、メモリ要件が大幅に削減されます。モデル固有の要件については、個別の[クイックスタートガイド](#クイックスタートガイド)を参照してください。
+
+## セットアップ
+
+SimpleTunerは、ほとんどのユーザーがpip経由でインストールできます:
+
+```bash
+# 基本インストール（CPU専用PyTorch）
+pip install simpletuner
+
+# CUDAユーザー（NVIDIA GPU）
+pip install simpletuner[cuda]
+
+# ROCmユーザー（AMD GPU）
+pip install simpletuner[rocm]
+
+# Apple Siliconユーザー（M1/M2/M3/M4 Mac）
+pip install simpletuner[apple]
+```
+
+手動インストールまたは開発セットアップについては、[インストールドキュメント](/documentation/INSTALL.md)を参照してください。
+
+## トラブルシューティング
+
+環境（`config/config.env`）ファイルに`export SIMPLETUNER_LOG_LEVEL=DEBUG`を追加することで、より詳細なインサイトを得るためにデバッグログを有効にします。
+
+トレーニングループのパフォーマンス分析には、`SIMPLETUNER_TRAINING_LOOP_LOG_LEVEL=DEBUG`を設定すると、設定の問題を強調表示するタイムスタンプが付きます。
+
+利用可能なオプションの包括的なリストについては、[このドキュメント](/documentation/OPTIONS.md)を参照してください。

--- a/documentation/INSTALL.ja.md
+++ b/documentation/INSTALL.ja.md
@@ -1,0 +1,273 @@
+# セットアップ
+
+Docker または他のコンテナオーケストレーションプラットフォームを使用したいユーザーは、まず[このドキュメント](DOCKER.md)を参照してください。
+
+## インストール
+
+Windows 10 以降で操作しているユーザー向けに、Docker と WSL をベースにしたインストールガイドが[このドキュメント](DOCKER.md)で利用可能です。
+
+### Pip インストール方法
+
+SimpleTuner は pip を使用して簡単にインストールできます。これはほとんどのユーザーに推奨されます:
+
+```bash
+# CUDA 用
+pip install 'simpletuner[cuda]'
+# ROCm 用
+pip install 'simpletuner[rocm]'
+# Apple Silicon 用
+pip install 'simpletuner[apple]'
+# CPU のみ(非推奨)
+pip install 'simpletuner[cpu]'
+# JPEG XL サポート用(オプション)
+pip install 'simpletuner[jxl]'
+
+# 開発要件(オプション、PR の提出やテストの実行にのみ必要)
+pip install 'simpletuner[dev]'
+```
+
+### Git リポジトリ方式
+
+ローカル開発やテスト用に、SimpleTuner リポジトリをクローンして Python venv をセットアップできます:
+
+```bash
+git clone --branch=release https://github.com/bghira/SimpleTuner.git
+
+cd SimpleTuner
+
+# python --version が 3.11 を示す場合は 3.12 にアップグレードする必要があります。
+python3.12 -m venv .venv
+
+source .venv/bin/activate
+```
+
+> ℹ️ `config/config.env` ファイルで `export VENV_PATH=/path/to/.venv` を設定することで、独自のカスタム venv パスを使用できます。
+
+**注意:** ここでは現在 `release` ブランチをインストールしています。`main` ブランチには、より良い結果や低メモリ使用量を持つ可能性のある実験的機能が含まれている場合があります。
+
+自動プラットフォーム検出で SimpleTuner をインストール:
+
+```bash
+# 基本インストール(CUDA/ROCm/Apple を自動検出)
+pip install -e .
+
+# JPEG XL サポート付き
+pip install -e .[jxl]
+```
+
+**注意:** setup.py は自動的にプラットフォーム(CUDA/ROCm/Apple)を検出し、適切な依存関係をインストールします。
+
+#### NVIDIA Hopper / Blackwell フォローアップ手順
+
+オプションとして、Hopper(または新しい)機器は、`torch.compile` を使用する際の推論およびトレーニングパフォーマンス向上のために FlashAttention3 を利用できます。
+
+venv をアクティブにした状態で、SimpleTuner ディレクトリから次のコマンドシーケンスを実行する必要があります:
+
+```bash
+git clone https://github.com/Dao-AILab/flash-attention
+pushd flash-attention
+  pushd hopper
+    python setup.py install
+  popd
+popd
+```
+
+> ⚠️ SimpleTuner での flash_attn ビルドの管理は、現在十分にサポートされていません。これはアップデート時に壊れる可能性があり、このビルド手順を時々手動で再実行する必要があります。
+
+#### AMD ROCm フォローアップ手順
+
+AMD MI300X を使用可能にするには、以下を実行する必要があります:
+
+```bash
+apt install amd-smi-lib
+pushd /opt/rocm/share/amd_smi
+  python3 -m pip install --upgrade pip
+  python3 -m pip install .
+popd
+```
+
+> ℹ️ **ROCm アクセラレーションのデフォルト**: SimpleTuner が HIP 対応の PyTorch ビルドを検出すると、自動的に `PYTORCH_TUNABLEOP_ENABLED=1` をエクスポート(既に設定していない場合)し、TunableOp カーネルが利用可能になります。MI300/gfx94x デバイスでは、デフォルトで `HIPBLASLT_ALLOW_TF32=1` も設定され、手動での環境設定なしに hipBLASLt の TF32 パスが有効になります。
+
+### 全プラットフォーム共通
+
+- 2a. **オプション1(推奨)**: `simpletuner configure` を実行
+- 2b. **オプション2**: `config/config.json.example` を `config/config.json` にコピーして詳細を入力
+
+> ⚠️ Hugging Face Hub に容易にアクセスできない国にいるユーザーは、使用している `$SHELL` に応じて、`~/.bashrc` または `~/.zshrc` に `HF_ENDPOINT=https://hf-mirror.com` を追加する必要があります。
+
+#### マルチ GPU トレーニング {#multiple-gpu-training}
+
+SimpleTuner には、WebUI を通じた**自動 GPU 検出と設定**が含まれるようになりました。初回ロード時に、GPU を検出して Accelerate を自動的に設定するオンボーディング手順がガイドされます。
+
+##### WebUI 自動検出(推奨)
+
+WebUI を初めて起動するか、`simpletuner configure` を使用すると、「Accelerate GPU Defaults」オンボーディング手順が表示されます:
+
+1. **自動検出**: システム上の利用可能な全 GPU を検出
+2. **GPU 詳細の表示**: 名前、メモリ、デバイス ID を含む
+3. **最適設定の推奨**: マルチ GPU トレーニング用の最適設定を推奨
+4. **3つの設定モードを提供:**
+
+   - **オートモード**(推奨): 検出された全 GPU を最適なプロセス数で使用
+   - **マニュアルモード**: 特定の GPU を選択するか、カスタムプロセス数を設定
+   - **無効モード**: シングル GPU トレーニングのみ
+
+**仕組み:**
+- システムは CUDA/ROCm 経由で GPU ハードウェアを検出
+- 利用可能なデバイスに基づいて最適な `--num_processes` を計算
+- 特定の GPU が選択されている場合、自動的に `CUDA_VISIBLE_DEVICES` を設定
+- 将来のトレーニング実行のために設定を保存
+
+##### 手動設定
+
+WebUI を使用しない場合、`config.json` で GPU の可視性を直接制御できます:
+
+```json
+{
+  "accelerate_visible_devices": [0, 1, 2],
+  "num_processes": 3
+}
+```
+
+これにより、トレーニングは GPU 0、1、2 に制限され、3 つのプロセスが起動されます。
+
+3. `--report_to='wandb'`(デフォルト)を使用している場合、以下は統計情報のレポートに役立ちます:
+
+```bash
+wandb login
+```
+
+API キーを見つけて設定するために、表示される指示に従ってください。
+
+完了すると、すべてのトレーニングセッションと検証データが Weights & Biases で利用可能になります。
+
+> ℹ️ Weights & Biases または Tensorboard のレポートを完全に無効にしたい場合は、`--report-to=none` を使用してください
+
+
+4. simpletuner でトレーニングを開始します。ログは `debug.log` に書き込まれます
+
+```bash
+simpletuner train
+```
+
+> ⚠️ この時点で、`simpletuner configure` を使用した場合は完了です! そうでない場合 - これらのコマンドは動作しますが、さらなる設定が必要です。詳細については[チュートリアル](TUTORIAL.md)を参照してください。
+
+### ユニットテストの実行
+
+インストールが正常に完了したことを確認するためにユニットテストを実行するには:
+
+```bash
+python -m unittest discover tests/
+```
+
+## 高度: 複数の設定環境
+
+複数のモデルをトレーニングするユーザーや、異なるデータセットや設定を素早く切り替える必要があるユーザー向けに、起動時に 2 つの環境変数が検査されます。
+
+使用方法:
+
+```bash
+simpletuner train env=default config_backend=env
+```
+
+- `env` はデフォルトで `default` になり、このガイドで設定した通常の `SimpleTuner/config/` ディレクトリを指します
+  - `simpletuner train env=pixart` を使用すると、`SimpleTuner/config/pixart` ディレクトリを使用して `config.env` を見つけます
+- `config_backend` はデフォルトで `env` になり、このガイドで設定した通常の `config.env` ファイルを使用します
+  - サポートされるオプション: `env`、`json`、`toml`、または `train.py` を手動で実行する場合は `cmd`
+  - `simpletuner train config_backend=json` を使用すると、`config.env` の代わりに `SimpleTuner/config/config.json` を検索します
+  - 同様に、`config_backend=toml` は `config.env` を使用します
+
+これらの値の一方または両方を含む `config/config.env` を作成できます:
+
+```bash
+ENV=default
+CONFIG_BACKEND=json
+```
+
+これらは次回以降の実行時に記憶されます。これらは[上記](#multiple-gpu-training)で説明したマルチ GPU オプションに加えて追加できることに注意してください。
+
+## トレーニングデータ
+
+約 10,000 枚の画像とファイル名としてのキャプションを含む、SimpleTuner ですぐに使用できる公開データセットが[Hugging Face Hub で利用可能](https://huggingface.co/datasets/bghira/pseudo-camera-10k)です。
+
+画像は単一のフォルダにまとめることも、サブディレクトリに整理することもできます。
+
+### 画像選択ガイドライン
+
+**品質要件:**
+- JPEG アーティファクトやぼやけた画像は避ける - 最新のモデルはこれらを検出します
+- 粒状の CMOS センサーノイズを避ける(生成される全画像に現れます)
+- 透かし、バッジ、署名なし(これらは学習されます)
+- 映画のフレームは一般的に圧縮のため機能しません(代わりにプロダクションスチルを使用)
+
+**技術仕様:**
+- 64 で割り切れる画像が最適(リサイズなしで再利用可能)
+- バランスの取れた機能のために、正方形と非正方形の画像を混在
+- 最良の結果のために、多様で高品質なデータセットを使用
+
+### キャプショニング
+
+SimpleTuner はファイルの一括名前変更のための[キャプショニングスクリプト](/scripts/toolkit/README.md)を提供します。サポートされるキャプション形式:
+- ファイル名をキャプションとして使用(デフォルト)
+- `--caption_strategy=textfile` でテキストファイル
+- JSONL、CSV、または高度なメタデータファイル
+
+**推奨キャプショニングツール:**
+- **InternVL2**: 最高品質だが低速(小規模データセット向け)
+- **BLIP3**: 優れた指示追従性を持つ最良の軽量オプション
+- **Florence2**: 最速だが出力を好まない人もいる
+
+### トレーニングバッチサイズ
+
+最大バッチサイズは VRAM と解像度に依存します:
+```
+vram 使用量 = バッチサイズ * 解像度 + 基本要件
+```
+
+**主要原則:**
+- VRAM の問題なしで可能な限り最大のバッチサイズを使用
+- 高解像度 = より多くの VRAM = より低いバッチサイズ
+- 128x128 でバッチサイズ 1 が機能しない場合、ハードウェアが不十分
+
+#### マルチ GPU データセット要件
+
+複数の GPU でトレーニングする場合、データセットは**有効バッチサイズ**に対して十分な大きさである必要があります:
+```
+有効バッチサイズ = train_batch_size × GPU 数 × gradient_accumulation_steps
+```
+
+**例:** 4 GPU で `train_batch_size=4` の場合、アスペクトバケットごとに少なくとも 16 サンプルが必要です。
+
+**小規模データセット用のソリューション:**
+- `--allow_dataset_oversubscription` を使用して繰り返しを自動調整
+- データローダー設定で手動で `repeats` を設定
+- バッチサイズまたは GPU 数を削減
+
+完全な詳細については [DATALOADER.md](DATALOADER.md#multi-gpu-training-and-dataset-sizing) を参照してください。
+
+## Hugging Face Hub への公開
+
+完了時にモデルを Hub に自動的にプッシュするには、`config/config.json` に追加します:
+
+```json
+{
+  "push_to_hub": true,
+  "hub_model_name": "your-model-name"
+}
+```
+
+トレーニング前にログイン:
+```bash
+huggingface-cli login
+```
+
+## デバッグ
+
+`config/config.env` に追加して詳細なログを有効にします:
+
+```bash
+export SIMPLETUNER_LOG_LEVEL=DEBUG
+export SIMPLETUNER_TRAINING_LOOP_LOG_LEVEL=DEBUG
+```
+
+プロジェクトルートに全てのログエントリを含む `debug.log` ファイルが作成されます。

--- a/documentation/QUICKSTART.ja.md
+++ b/documentation/QUICKSTART.ja.md
@@ -1,0 +1,56 @@
+# クイックスタートガイド
+
+**注意**: より高度な設定については、[チュートリアル](TUTORIAL.md)および[オプションリファレンス](OPTIONS.md)を参照してください。
+
+## 機能互換性
+
+完全かつ最も正確な機能マトリックスについては、[メインREADME](https://github.com/bghira/SimpleTuner#model-architecture-support)を参照してください。
+
+## モデルクイックスタートガイド
+
+| モデル | パラメータ数 | PEFT LoRA | Lycoris | Full-Rank | 量子化 | 混合精度 | Grad Checkpoint | Flow Shift | TwinFlow | LayerSync | ControlNet | Sliders† | ガイド |
+| --- | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | --- |
+| PixArt Sigma | 0.6B–0.9B | ✗ | ✓ | ✓ | int8 オプション | bf16 | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | [SIGMA.md](quickstart/SIGMA.md) |
+| NVLabs Sana | 1.6B–4.8B | ✗ | ✓ | ✓ | int8 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✗ | ✓ | [SANA.md](quickstart/SANA.md) |
+| Kwai Kolors | 2.7B | ✓ | ✓ | ✓ | 非推奨 | bf16 | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | [KOLORS.md](quickstart/KOLORS.md) |
+| Stable Diffusion 3 | 2B–8B | ✓ | ✓ | ✓ | int8/fp8/nf4 オプション | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✓ | [SD3.md](quickstart/SD3.md) |
+| Flux.1 | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ | [FLUX.md](quickstart/FLUX.md) |
+| Flux.2 | 32B | ✓ | ✓ | ✓* | int8/fp8/nf4 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✗ | ✓ | [FLUX2.md](quickstart/FLUX2.md) |
+| Flux Kontext | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ | [FLUX_KONTEXT.md](quickstart/FLUX_KONTEXT.md) |
+| Z-Image Turbo | 6B | ✓ | ✗ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | [ZIMAGE.md](quickstart/ZIMAGE.md) |
+| ACE-Step | 3.5B | ✓ | ✓ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | [ACE_STEP.md](quickstart/ACE_STEP.md) |
+| Chroma 1 | 8.9B | ✓ | ✓ | ✓* | int8/fp8/nf4 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✗ | ✓ | [CHROMA.md](quickstart/CHROMA.md) |
+| Auraflow | 6B | ✓ | ✓ | ✓* | int8/fp8/nf4 オプション | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✓ | [AURAFLOW.md](quickstart/AURAFLOW.md) |
+| HiDream I1 | 17B (8.5B MoE) | ✓ | ✓ | ✓* | int8/fp8/nf4 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | [HIDREAM.md](quickstart/HIDREAM.md) |
+| OmniGen | 3.8B | ✓ | ✓ | ✓ | int8/fp8 オプション | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | [OMNIGEN.md](quickstart/OMNIGEN.md) |
+| Stable Diffusion XL | 2.6B | ✓ | ✓ | ✓ | 非推奨 | bf16 | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | [SDXL.md](quickstart/SDXL.md) |
+| Lumina2 | 2B | ✓ | ✓ | ✓ | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [LUMINA2.md](quickstart/LUMINA2.md) |
+| Cosmos2 | 2B | ✓ | ✓ | ✓ | 非推奨 | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | [COSMOS2IMAGE.md](quickstart/COSMOS2IMAGE.md) |
+| LTX Video | ~2.5B | ✓ | ✓ | ✓ | int8/fp8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | [LTXVIDEO.md](quickstart/LTXVIDEO.md) |
+| Hunyuan Video 1.5 | 8.3B | ✓ | ✓ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | [HUNYUANVIDEO.md](quickstart/HUNYUANVIDEO.md) |
+| Wan 2.x | 1.3B–14B | ✓ | ✓ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | [WAN.md](quickstart/WAN.md) |
+| Qwen Image | 20B | ✓ | ✓ | ✓* | **必須** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | [QWEN_IMAGE.md](quickstart/QWEN_IMAGE.md) |
+| Qwen Image Edit | 20B | ✓ | ✓ | ✓* | **必須** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | [QWEN_EDIT.md](quickstart/QWEN_EDIT.md) |
+| Stable Cascade (C) | 1B, 3.6B prior | ✓ | ✓ | ✓* | 非対応 | fp32 (必須) | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | [STABLE_CASCADE_C.md](quickstart/STABLE_CASCADE_C.md) |
+| Kandinsky 5.0 Image | 6B (lite) | ✓ | ✓ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [KANDINSKY5_IMAGE.md](quickstart/KANDINSKY5_IMAGE.md) |
+| Kandinsky 5.0 Video | 2B (lite), 19B (pro) | ✓ | ✓ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | [KANDINSKY5_VIDEO.md](quickstart/KANDINSKY5_VIDEO.md) |
+| LongCat-Video | 13.6B | ✓ | ✓ | ✓* | int8/fp8 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✗ | ✓ | [LONGCAT_VIDEO.md](quickstart/LONGCAT_VIDEO.md) |
+| LongCat-Video Edit | 13.6B | ✓ | ✓ | ✓* | int8/fp8 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✗ | ✓ | [LONGCAT_VIDEO_EDIT.md](quickstart/LONGCAT_VIDEO_EDIT.md) |
+| LongCat-Image | 6B | ✓ | ✓ | ✓* | int8/fp8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | [LONGCAT_IMAGE.md](quickstart/LONGCAT_IMAGE.md) |
+| LongCat-Image Edit | 6B | ✓ | ✓ | ✓* | int8/fp8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | [LONGCAT_EDIT.md](quickstart/LONGCAT_EDIT.md) |
+
+*✓ = サポート、✓* = Full-RankにはDeepSpeed/FSDP2が必要、✗ = 非サポート、`✓+`はVRAMプレッシャーによりチェックポイントが推奨されることを示します。TwinFlow ✓は`twinflow_enabled=true`のときのネイティブサポートを意味します（拡散モデルには`diff2flow_enabled+twinflow_allow_diff2flow`が必要）。LayerSync ✓はバックボーンがセルフアライメント用のトランスフォーマー隠れ状態を公開していることを意味し、✗はそのバッファを持たないUNetスタイルのバックボーンを示します。†SlidersはLoRAおよびLyCORIS（Full-Rank LyCORIS "full"を含む）に適用されます。*
+
+> ℹ️ Wanクイックスタートには2.1 + 2.2ステージプリセットと時間埋め込みトグルが含まれます。Flux Kontextは、Flux.1をベースに構築された編集ワークフローをカバーします。
+
+> ⚠️ これらのクイックスタートは生きたドキュメントです。新しいモデルの登場やトレーニングレシピの改善に伴い、時折更新されることがあります。
+
+### 高速パス: Z-Image TurboとFlux Schnell
+
+- **Z-Image Turbo**: TREADを使用した完全サポートのLoRA。量子化なし（int8も動作）でもNVIDIAとmacOSで高速に動作します。多くの場合、ボトルネックはトレーナーのセットアップだけです。
+- **Flux Schnell**: クイックスタート設定が高速ノイズスケジュールとアシスタントLoRAスタックを自動的に処理します。Schnell LoRAをトレーニングするための追加フラグは不要です。
+
+### 高度な実験的機能
+
+- **Diff2Flow**: 標準的なepsilon/v-predictionモデル（SD1.5、SDXL、DeepFloydなど）をFlow Matching損失目的関数を使用してトレーニングできます。これにより、古いアーキテクチャと最新のフローベースのトレーニング間のギャップを埋めます。
+- **Scheduled Sampling**: トレーニング中にモデル自身に中間ノイズ潜在変数を生成させる（「ロールアウト」）ことで露出バイアスを軽減します。これにより、モデルが自身の生成エラーから回復する方法を学習できます。

--- a/documentation/TUTORIAL.ja.md
+++ b/documentation/TUTORIAL.ja.md
@@ -1,0 +1,21 @@
+# チュートリアル
+
+このチュートリアルは [インストールガイド](INSTALL.md) に統合されました。
+
+## クイックスタート
+
+1. **SimpleTunerのインストール**: `pip install simpletuner[cuda]` (他のプラットフォームについてはREADMEを参照)
+2. **設定**: `simpletuner configure` (対話型セットアップ)
+3. **トレーニング**: `simpletuner train`
+
+## 詳細ガイド
+
+- **[インストールガイド](INSTALL.md)** - トレーニングデータの準備を含む完全なセットアップ
+- **[クイックスタートガイド](QUICKSTART.md)** - モデル固有のトレーニングガイド
+- **[ハードウェア要件](https://github.com/bghira/SimpleTuner#hardware-requirements)** - VRAMとシステム要件
+
+詳細については以下を参照してください:
+
+- **[インストールガイド](INSTALL.md)** - トレーニングデータの準備を含む完全なセットアップ
+- **[オプションリファレンス](OPTIONS.md)** - 完全なパラメータリスト
+- **[データローダー設定](DATALOADER.md)** - データセットのセットアップ

--- a/documentation/api/TUTORIAL.ja.md
+++ b/documentation/api/TUTORIAL.ja.md
@@ -1,0 +1,913 @@
+# APIトレーニングチュートリアル
+
+## はじめに
+
+このガイドでは、セットアップとデータセット管理はコマンドラインで行いながら、**HTTP API経由で完全に**SimpleTunerのトレーニングジョブを実行する方法を説明します。他のチュートリアルの構造に沿っていますが、WebUIのオンボーディングはスキップします。以下の内容を学びます:
+
+- 統合サーバーのインストールと起動
+- OpenAPIスキーマの検出とダウンロード
+- RESTコールを使用した環境の作成と更新
+- `/api/training`を介したトレーニングジョブの検証、起動、監視
+- 2つの実証済み設定への分岐: PixArt Sigma 900Mフルファインチューンと、Flux Kontext LyCORIS LoRA実行
+
+## 前提条件
+
+- Python 3.10–3.12、Git、および`pip`
+- 仮想環境にインストールされたSimpleTuner（`pip install 'simpletuner[cuda]'`またはプラットフォームに合わせたバリアント）
+- 必要なHugging Faceリポジトリへのアクセス（ゲート付きモデルをプルする前に`huggingface-cli login`）
+- キャプション付きでローカルにステージングされたデータセット（PixArt用のキャプションテキストファイル、Kontext用のペアになった編集/参照フォルダ）
+- `curl`と`jq`を使用できるシェル
+
+## サーバーの起動 {#start-the-server}
+
+SimpleTunerのチェックアウト先（またはパッケージがインストールされている環境）から:
+
+```bash
+simpletuner server --port 8001
+```
+
+APIは`http://localhost:8001`で利用できます。以下のコマンドを別のターミナルで実行している間、サーバーは実行したままにしてください。
+
+> **ヒント:** トレーニングの準備ができている既存の設定環境がある場合、`--env`を付けてサーバーを起動すると、サーバーが完全にロードされた後に自動的にトレーニングが開始されます:
+>
+> ```bash
+> simpletuner server --port 8001 --env my-training-config
+> ```
+>
+> これにより起動時に設定が検証され、サーバーの準備が完了した直後にトレーニングが開始されます—無人または自動デプロイメントに便利です。`--env`オプションは`simpletuner train --env`と同じように機能します。
+
+### 設定とデプロイメント
+
+本番環境では、バインドアドレスとポートを設定できます:
+
+| オプション | 環境変数 | デフォルト | 説明 |
+|--------|---------------------|---------|-------------|
+| `--host` | `SIMPLETUNER_HOST` | `0.0.0.0` | サーバーをバインドするアドレス（リバースプロキシの背後では`127.0.0.1`を使用） |
+| `--port` | `SIMPLETUNER_PORT` | `8001` | サーバーをバインドするポート |
+
+<details>
+<summary><b>本番デプロイメントオプション（TLS、リバースプロキシ、Systemd、Docker）</b></summary>
+
+本番デプロイメントでは、TLS終端のためにリバースプロキシを使用することを推奨します。
+
+#### Nginx設定
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name training.example.com;
+
+    # TLS configuration (example using Let's Encrypt paths)
+    ssl_certificate /etc/letsencrypt/live/training.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/training.example.com/privkey.pem;
+
+    # WebSocket support for SSE streaming (Critical for real-time logs)
+    location /api/training/stream {
+        proxy_pass http://127.0.0.1:8001;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_set_header Host $host;
+        # SSE-specific settings
+        proxy_buffering off;
+        proxy_read_timeout 86400s;
+    }
+
+    # Main application
+    location / {
+        proxy_pass http://127.0.0.1:8001;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        # Large file uploads for datasets
+        client_max_body_size 10G;
+        proxy_request_buffering off;
+    }
+}
+```
+
+#### Caddy設定
+
+```caddyfile
+training.example.com {
+    reverse_proxy 127.0.0.1:8001 {
+        # SSE streaming support
+        flush_interval -1
+    }
+    # Large file uploads
+    request_body {
+        max_size 10GB
+    }
+}
+```
+
+#### systemdサービス
+
+```ini
+[Unit]
+Description=SimpleTuner Training Server
+After=network.target
+
+[Service]
+Type=simple
+User=trainer
+WorkingDirectory=/home/trainer/simpletuner-workspace
+Environment="SIMPLETUNER_HOST=127.0.0.1"
+Environment="SIMPLETUNER_PORT=8001"
+ExecStart=/home/trainer/simpletuner-workspace/.venv/bin/simpletuner server
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+#### TraefikとDocker Compose
+
+```yaml
+version: '3.8'
+services:
+  simpletuner:
+    image: ghcr.io/bghira/simpletuner:latest
+    command: simpletuner server --host 0.0.0.0 --port 8001
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.simpletuner.rule=Host(`training.example.com`)"
+      - "traefik.http.services.simpletuner.loadbalancer.server.port=8001"
+```
+</details>
+
+## 認証
+
+SimpleTunerはマルチユーザー認証をサポートしています。初回起動時には、管理者アカウントを作成する必要があります。
+
+### 初回セットアップ
+
+セットアップが必要かどうかを確認します:
+
+```bash
+curl -s http://localhost:8001/api/cloud/auth/setup/status | jq
+```
+
+`needs_setup`が`true`の場合、最初の管理者を作成します:
+
+```bash
+curl -s -X POST http://localhost:8001/api/cloud/auth/setup/first-admin \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "email": "admin@example.com",
+    "username": "admin",
+    "password": "your-secure-password"
+  }'
+```
+
+### APIキー
+
+スクリプトによるアクセスのために、ログイン後にAPIキーを生成します:
+
+```bash
+# まずログイン（セッションクッキーを保存）
+curl -s -X POST http://localhost:8001/api/cloud/auth/login \
+  -H 'Content-Type: application/json' \
+  -c cookies.txt \
+  -d '{"username": "admin", "password": "your-secure-password"}'
+
+# APIキーを作成
+curl -s -X POST http://localhost:8001/api/cloud/auth/api-keys \
+  -H 'Content-Type: application/json' \
+  -b cookies.txt \
+  -d '{"name": "automation-key"}' | jq
+```
+
+返されたキー（`st_`接頭辞付き）を後続のリクエストで使用します:
+
+```bash
+curl -s http://localhost:8001/api/training/status \
+  -H 'X-API-Key: st_your_key_here'
+```
+
+### ユーザー管理
+
+管理者はAPIまたはWebUIの**ユーザー管理**ページから追加のユーザーを作成できます:
+
+```bash
+# 新しいユーザーを作成（管理者セッションが必要）
+curl -s -X POST http://localhost:8001/api/users \
+  -H 'Content-Type: application/json' \
+  -b cookies.txt \
+  -d '{
+    "email": "researcher@example.com",
+    "username": "researcher",
+    "password": "their-password",
+    "level_names": ["researcher"]
+  }'
+```
+
+> **注意:** パブリック登録はデフォルトで無効になっています。管理者は**ユーザー管理 → 登録**タブで有効にできますが、プライベートデプロイメントでは無効のままにすることを推奨します。
+
+## APIの探索
+
+FastAPIはインタラクティブなドキュメントとOpenAPIスキーマを提供します:
+
+```bash
+# FastAPI Swagger UI
+python -m webbrowser http://localhost:8001/docs
+
+# ReDocビュー
+python -m webbrowser http://localhost:8001/redoc
+
+# ローカル検査用にスキーマをダウンロード
+curl -o openapi.json http://localhost:8001/openapi.json
+jq '.info' openapi.json
+```
+
+このチュートリアルで使用されるすべてのエンドポイントは、`configurations`および`training`タグの下に記載されています。
+
+## 高速パス: 環境なしで実行
+
+**設定/環境管理を完全にスキップ**したい場合、トレーニングエンドポイントに完全なCLIスタイルのペイロードを直接投稿することで、1回限りのトレーニング実行を発行できます:
+
+1. データセットを記述するデータローダーJSONを作成または再利用します。トレーナーは`--data_backend_config`で参照されるパスのみを必要とします。
+
+   ```bash
+   cat <<'JSON' > config/multidatabackend-once.json
+   [
+     {
+       "id": "demo-images",
+       "type": "local",
+       "dataset_type": "image",
+       "instance_data_dir": "/data/datasets/demo",
+       "caption_strategy": "textfile",
+       "resolution": 1024,
+       "resolution_type": "pixel_area"
+     },
+     {
+       "id": "demo-text-embeds",
+       "type": "local",
+       "dataset_type": "text_embeds",
+       "default": true,
+       "cache_dir": "/data/cache/text/demo"
+     }
+   ]
+   JSON
+   ```
+
+2. インライン設定を検証します。すべての必須CLI引数（`--model_family`、`--model_type`、`--pretrained_model_name_or_path`、`--output_dir`、`--data_backend_config`、および`--num_train_epochs`または`--max_train_steps`のいずれか）を提供します:
+
+   ```bash
+   curl -s -X POST http://localhost:8001/api/training/validate \
+     -F __active_tab__=model \
+     -F --model_family=pixart_sigma \
+     -F --model_type=full \
+     -F --model_flavour=900M-1024-v0.6 \
+     -F --pretrained_model_name_or_path=terminusresearch/pixart-900m-1024-ft-v0.6 \
+     -F --output_dir=/workspace/output/inline-demo \
+     -F --data_backend_config=config/multidatabackend-once.json \
+     -F --train_batch_size=1 \
+     -F --learning_rate=0.0001 \
+     -F --max_train_steps=200 \
+     -F --num_train_epochs=0
+   ```
+
+   緑色の「Configuration Valid」スニペットは、トレーナーがペイロードを受け入れることを確認します。
+
+3. **同じ**フォームフィールドでトレーニングを起動します（`--seed`や`--validation_prompt`などのオーバーライドを追加できます）:
+
+   ```bash
+   curl -s -X POST http://localhost:8001/api/training/start \
+     -F __active_tab__=model \
+     -F --model_family=pixart_sigma \
+     -F --model_type=full \
+     -F --model_flavour=900M-1024-v0.6 \
+     -F --pretrained_model_name_or_path=terminusresearch/pixart-900m-1024-ft-v0.6 \
+     -F --output_dir=/workspace/output/inline-demo \
+     -F --data_backend_config=config/multidatabackend-once.json \
+     -F --train_batch_size=1 \
+     -F --learning_rate=0.0001 \
+     -F --max_train_steps=200 \
+     -F --num_train_epochs=0 \
+     -F --validation_prompt='test shot of <token>'
+   ```
+
+サーバーは提出された設定をデフォルトと自動的にマージし、解決された設定をアクティブファイルに書き込み、トレーニングを開始します。再利用可能な環境が必要な場合、残りのセクションではより完全なワークフローをカバーします—任意のモデルファミリーに同じアプローチを再利用できます。
+
+### アドホック実行の監視
+
+このガイドの後半で使用される同じステータスエンドポイントを通じて進行状況を追跡できます:
+
+- `GET /api/training/status`をポーリングして、高レベルの状態、アクティブなジョブID、起動段階情報を取得します。
+- `GET /api/training/events?since_index=N`で増分ログを取得するか、`/api/training/events/stream`のWebSocketを介してストリーミングします。
+
+プッシュスタイルの更新には、フォームフィールドと一緒にWebhook設定を提供します:
+
+```bash
+curl -s -X POST http://localhost:8001/api/training/start \
+  -F __active_tab__=model \
+  -F --model_family=pixart_sigma \
+  ... \
+  -F --webhook_config='[{"webhook_type":"raw","callback_url":"https://example.com/simpletuner","log_level":"info","ssl_no_verify":false}]' \
+  -F --webhook_reporting_interval=10
+```
+
+ペイロードは文字列としてJSONシリアライズされている必要があります。サーバーはジョブライフサイクルの更新を`callback_url`にポストします。サポートされているフィールドについては、`documentation/OPTIONS.md`の`--webhook_config`の説明、またはサンプル`config/webhooks.json`テンプレートを参照してください。
+
+<details>
+<summary><b>リバースプロキシのWebhook設定</b></summary>
+
+HTTPSを使用したリバースプロキシを使用する場合、Webhook URLはパブリックエンドポイントである必要があります:
+
+1.  **パブリックサーバー:** `https://training.example.com/webhook/callback`を使用
+2.  **トンネリング:** ローカル開発にはngrokまたはcloudflaredを使用
+
+**リアルタイムログ（SSE）のトラブルシューティング:**
+`GET /api/training/events`は機能するがストリームがハングする場合:
+*   **Nginx:** `proxy_buffering off;`を確認し、`proxy_read_timeout`を高く設定（例: 86400s）。
+*   **CloudFlare:** 長時間接続を終了します。CloudFlare Tunnelを使用するか、ストリームエンドポイントのプロキシをバイパスします。
+</details>
+
+### 手動検証のトリガー
+
+スケジュールされた検証間隔の**間**に評価パスを強制したい場合は、新しいエンドポイントを呼び出します:
+
+```bash
+curl -s -X POST http://localhost:8001/api/training/validation/run
+```
+
+- サーバーはアクティブな`job_id`でレスポンスします。
+- トレーナーは次の勾配同期の直後に発動する検証実行をキューに入れます（現在のマイクロバッチを中断しません）。
+- 実行は設定された検証プロンプト/設定を再利用するため、結果の画像は通常のイベント/ログストリームに表示されます。
+- 組み込みパイプラインではなく外部実行可能ファイルに検証をオフロードするには、設定（またはペイロード）で`--validation_method=external-script`を設定し、`--validation_external_script`をスクリプトに指定します。プレースホルダーを使用してトレーニングコンテキストをスクリプトに渡すことができます: `{local_checkpoint_path}`、`{global_step}`、`{tracker_run_name}`、`{tracker_project_name}`、`{model_family}`、`{huggingface_path}`、`{remote_checkpoint_path}`（検証の場合は空）、および任意の`validation_*`設定値（例: `validation_num_inference_steps`、`validation_guidance`、`validation_noise_scheduler`）。スクリプトをファイア・アンド・フォーゲットでトレーニングをブロックせずに実行したい場合は、`--validation_external_background`を有効にします。
+- チェックポイントがローカルに書き込まれた直後（アップロードがバックグラウンドで実行中でも）に自動化をトリガーしたいですか？ `--post_checkpoint_script='/opt/hooks/run_eval.sh {local_checkpoint_path} {global_step}'`を設定します。検証フックと同じプレースホルダーを使用します。このフックでは`{remote_checkpoint_path}`は空に解決されます。
+- SimpleTunerの組み込みアップロードを維持し、結果のリモートURLを独自のツールに渡すことを好みますか？ 代わりに`--post_upload_script`を設定します。これは公開プロバイダー/Hugging Face Hubアップロードごとに1回、`{remote_checkpoint_path}`（バックエンドによって提供される場合）と同じコンテキストプレースホルダーで発動します。SimpleTunerはスクリプトからの結果を取り込まないため、アーティファクト/メトリクスを自分でトラッカーにログします。
+  - 例: `--post_upload_script='/opt/hooks/notify.sh {remote_checkpoint_path} {tracker_project_name} {tracker_run_name}'`（`notify.sh`はトラッカーAPIを呼び出します）。
+  - 動作サンプル:
+    - `simpletuner/examples/external-validation/replicate_post_upload.py`は`{remote_checkpoint_path}`、`{model_family}`、`{model_type}`、`{lora_type}`、`{huggingface_path}`を使用してReplicate推論をトリガーします。
+    - `simpletuner/examples/external-validation/wavespeed_post_upload.py`は同じプレースホルダーを使用してWaveSpeed推論をトリガーし、完了をポーリングします。
+    - `simpletuner/examples/external-validation/fal_post_upload.py`はfal.ai Flux LoRA推論をトリガーします（`FAL_KEY`と`flux`を含む`model_family`が必要）。
+    - `simpletuner/examples/external-validation/use_second_gpu.py`はアップロードを必要とせずに別のGPUでFlux LoRA推論を実行します。
+
+アクティブなジョブがない場合、エンドポイントはHTTP 400を返すため、リトライをスクリプト化する際は最初に`/api/training/status`を確認してください。
+
+### 手動チェックポイントのトリガー
+
+次のスケジュールされたチェックポイントを待たずに、現在のモデル状態を即座に永続化するには、以下を実行します:
+
+```bash
+curl -s -X POST http://localhost:8001/api/training/checkpoint/run
+```
+
+- サーバーはアクティブな`job_id`でレスポンスします。
+- トレーナーは次の勾配同期後に、スケジュールされたチェックポイントと同じ設定（アップロードルール、ローリング保持など）を使用してチェックポイントを保存します。
+- ローリングクリーンアップとWebhook通知は、スケジュールされたチェックポイントとまったく同じように動作します。
+
+検証と同様に、トレーニングジョブが実行中でない場合、エンドポイントはHTTP 400を返します。
+
+### 検証プレビューのストリーム
+
+Tiny AutoEncoder（または同等の）フックを公開するモデルは、画像/ビデオがまだサンプリング中に**ステップごとの検証プレビュー**を発行できます。ペイロードにCLIフラグを追加して機能を有効にします:
+
+```bash
+curl -s -X POST http://localhost:8001/api/training/start \
+  -F __active_tab__=validation \
+  -F --validation_preview=true \
+  -F --validation_preview_steps=4 \
+  -F --validation_num_inference_steps=20 \
+  …その他のフィールド…
+```
+
+- `--validation_preview`（デフォルトは`false`）はプレビューデコーダーのロックを解除します。
+- `--validation_preview_steps`は中間フレームを発行する頻度を決定します。上記の例では、ステップ1、5、9、13、17、20でイベントを受信します（最初のステップは常に発行され、その後4ステップごと）。
+
+各プレビューは`validation.image`イベントとして公開されます（`simpletuner/helpers/training/validation.py:899-929`を参照）。rawウェブフック、`GET /api/training/events`、または`/api/training/events/stream`のSSEストリームを介してこれらを消費できます。典型的なペイロードは次のようになります:
+
+```json
+{
+  "type": "validation.image",
+  "title": "Validation (step 5/20): night bench",
+  "body": "night bench shot of <token>",
+  "data": {
+    "step": 5,
+    "timestep": 563.0,
+    "resolution": [1024, 1024],
+    "validation_type": "intermediary",
+    "prompt": "night bench shot of <token>",
+    "step_label": "5/20"
+  },
+  "images": [
+    {"src": "data:image/png;base64,...", "mime_type": "image/png"}
+  ]
+}
+```
+
+ビデオ対応モデルは代わりに`videos`配列を添付します（`mime_type: image/gif`のGIFデータURI）。これらのイベントはほぼリアルタイムでストリーミングされるため、ダッシュボードに直接表示したり、rawウェブフックバックエンドを介してSlack/Discordに送信したりできます。
+
+## 一般的なAPIワークフロー
+
+1. **環境を作成** – `POST /api/configs/environments`
+2. **データローダーファイルを入力** – 生成された`config/<env>/multidatabackend.json`を編集
+3. **トレーニングハイパーパラメータを更新** – `PUT /api/configs/<env>`
+4. **環境を有効化** – `POST /api/configs/<env>/activate`
+5. **トレーニングパラメータを検証** – `POST /api/training/validate`
+6. **トレーニングを起動** – `POST /api/training/start`
+7. **ジョブを監視または停止** – `/api/training/status`、`/api/training/events`、`/api/training/stop`、`/api/training/cancel`
+
+以下の各例はこのフローに従います。
+
+## オプション: API経由でデータセットをアップロード（ローカルバックエンド） {#optional-upload-datasets-over-the-api-local-backends}
+
+データセットがSimpleTunerを実行しているマシンにまだない場合、データローダーを配線する前にHTTP経由でプッシュできます。アップロードエンドポイントは設定された`datasets_dir`（WebUIオンボーディング中に設定）を尊重し、ローカルファイルシステム向けです:
+
+1. データセットルート下に**ターゲットフォルダーを作成**:
+
+   ```bash
+   DATASETS_DIR=${DATASETS_DIR:-/workspace/simpletuner/datasets}
+   curl -s -X POST http://localhost:8001/api/datasets/folders \
+     -F parent_path="$DATASETS_DIR" \
+     -F folder_name="pixart-upload"
+   ```
+
+2. **ファイルまたはZIPをアップロード**（画像とオプションの`.txt/.jsonl/.csv`メタデータが受け入れられます）:
+
+   ```bash
+   # zipをアップロード（サーバー上で自動的に展開）
+   curl -s -X POST http://localhost:8001/api/datasets/upload/zip \
+     -F target_path="$DATASETS_DIR/pixart-upload" \
+     -F file=@/path/to/dataset.zip
+
+   # または個別のファイルをアップロード
+   curl -s -X POST http://localhost:8001/api/datasets/upload \
+     -F target_path="$DATASETS_DIR/pixart-upload" \
+     -F files[]=@image001.png \
+     -F files[]=@image001.txt
+   ```
+
+> **アップロードのトラブルシューティング:** リバースプロキシを使用している場合に大きなアップロードが「Entity Too Large」エラーで失敗する場合は、本文サイズ制限を増やしていることを確認してください（例: Nginxの`client_max_body_size 10G;`またはCaddyの`request_body { max_size 10GB }`）。
+
+アップロード完了後、`multidatabackend.json`エントリを新しいフォルダー（例: `"/data/datasets/pixart-upload"`）に指定します。
+
+## 例: PixArt Sigma 900Mフルファインチューン
+
+### 1. REST経由で環境を作成
+
+```bash
+curl -s -X POST http://localhost:8001/api/configs/environments \
+  -H 'Content-Type: application/json' \
+  -d
+```json
+{
+        "name": "pixart-api-demo",
+        "model_family": "pixart_sigma",
+        "model_flavour": "900M-1024-v0.6",
+        "model_type": "full",
+        "description": "PixArt 900M API-driven training"
+      }
+```
+
+これにより`config/pixart-api-demo/`とスターター`multidatabackend.json`が作成されます。
+
+### 2. データセットを配線
+
+データローダーファイルを編集します（パスを実際のデータセット/キャッシュの場所に置き換えます）:
+
+```bash
+cat <<'JSON' > config/pixart-api-demo/multidatabackend.json
+[
+  {
+    "id": "pixart-camera",
+    "type": "local",
+    "dataset_type": "image",
+    "instance_data_dir": "/data/datasets/pseudo-camera-10k",
+    "caption_strategy": "filename",
+    "resolution": 1.0,
+    "resolution_type": "area",
+    "minimum_image_size": 0.25,
+    "maximum_image_size": 1.0,
+    "target_downsample_size": 1.0,
+    "cache_dir_vae": "/data/cache/vae/pixart/pseudo-camera-10k",
+    "crop": true,
+    "crop_style": "random",
+    "crop_aspect": "square",
+    "metadata_backend": "discovery"
+  },
+  {
+    "id": "pixart-text-embeds",
+    "type": "local",
+    "dataset_type": "text_embeds",
+    "default": true,
+    "cache_dir": "/data/cache/text/pixart/pseudo-camera-10k",
+    "write_batch_size": 128
+  }
+]
+JSON
+```
+
+### 3. API経由でハイパーパラメータを更新
+
+現在の設定を取得し、オーバーライドをマージして、結果を戻します:
+
+```bash
+curl -s http://localhost:8001/api/configs/pixart-api-demo \
+  | jq '.config + {
+      "--output_dir": "/workspace/output/pixart900m",
+      "--train_batch_size": 2,
+      "--gradient_accumulation_steps": 2,
+      "--learning_rate": 0.0001,
+      "--optimizer": "adamw_bf16",
+      "--lr_scheduler": "cosine",
+      "--lr_warmup_steps": 500,
+      "--max_train_steps": 1800,
+      "--num_train_epochs": 0,
+      "--validation_prompt": "a studio portrait of <token> wearing a leather jacket",
+      "--validation_guidance": 3.8,
+      "--validation_resolution": "1024x1024",
+      "--validation_num_inference_steps": 28,
+      "--cache_dir_vae": "/data/cache/vae/pixart",
+      "--seed": 1337,
+      "--resume_from_checkpoint": "latest",
+      "--base_model_precision": "bf16",
+      "--dataloader_prefetch": true,
+      "--report_to": "none",
+      "--checkpoints_total_limit": 4,
+      "--validation_seed": 12345,
+      "--data_backend_config": "pixart-api-demo/multidatabackend.json"
+    }' > /tmp/pixart-config.json
+
+jq '{
+      "name": "pixart-api-demo",
+      "description": "PixArt 900M full tune (API)",
+      "tags": ["pixart", "api"],
+      "config": .
+    }' /tmp/pixart-config.json > /tmp/pixart-update.json
+
+curl -s -X PUT http://localhost:8001/api/configs/pixart-api-demo \
+  -H 'Content-Type: application/json' \
+  --data-binary @/tmp/pixart-update.json
+```
+
+### 4. 環境を有効化
+
+```bash
+curl -s -X POST http://localhost:8001/api/configs/pixart-api-demo/activate
+```
+
+### 5. 起動前に検証
+
+`validate`はフォームエンコードされたデータを消費します。少なくとも、`num_train_epochs`または`max_train_steps`の1つが0であることを確認します:
+
+```bash
+curl -s -X POST http://localhost:8001/api/training/validate \
+  -F __active_tab__=model \
+  -F --num_train_epochs=0
+```
+
+成功ブロック（`Configuration Valid`）は、トレーナーがマージされた設定を受け入れることを意味します。
+
+### 6. トレーニング開始
+
+```bash
+curl -s -X POST http://localhost:8001/api/training/start \
+  -F __active_tab__=model \
+  -F --num_train_epochs=0
+```
+
+レスポンスにはジョブIDが含まれます。トレーニングはステップ3で保存されたパラメータで実行されます。
+
+### 7. 監視と停止
+
+```bash
+# 粗いステータスをクエリ
+curl -s http://localhost:8001/api/training/status | jq
+
+# 増分ログイベントをストリーム
+curl -s 'http://localhost:8001/api/training/events?since_index=0' | jq
+
+# キャンセルまたは停止
+curl -s -X POST http://localhost:8001/api/training/stop
+curl -s -X POST http://localhost:8001/api/training/cancel -F job_id=<JOB_ID>
+```
+
+PixArt注意事項:
+
+- 選択した`train_batch_size * gradient_accumulation_steps`に対して十分な大きさのデータセットを保持します
+- ミラーが必要な場合は`HF_ENDPOINT`を設定し、`terminusresearch/pixart-900m-1024-ft-v0.6`をダウンロードする前に認証します
+- プロンプトに応じて`--validation_guidance`を3.6から4.4の間で調整します
+
+## 例: Flux Kontext LyCORIS LoRA
+
+KontextはパイプラインのほとんどをFlux Devと共有しますが、ペアになった編集/参照画像が必要です。
+
+### 1. 環境をプロビジョニング
+
+```bash
+curl -s -X POST http://localhost:8001/api/configs/environments \
+  -H 'Content-Type: application/json' \
+  -d
+```json
+{
+        "name": "kontext-api-demo",
+        "model_family": "flux",
+        "model_flavour": "kontext",
+        "model_type": "lora",
+        "lora_type": "lycoris",
+        "description": "Flux Kontext LoRA via API"
+      }
+```
+
+### 2. ペアデータローダーを記述
+
+Kontextは編集/参照ペアとテキスト埋め込みキャッシュが必要です:
+
+```bash
+cat <<'JSON' > config/kontext-api-demo/multidatabackend.json
+[
+  {
+    "id": "kontext-edit",
+    "type": "local",
+    "dataset_type": "image",
+    "instance_data_dir": "/data/datasets/kontext/edit",
+    "conditioning_data": ["kontext-reference"],
+    "resolution": 1024,
+    "resolution_type": "pixel_area",
+    "caption_strategy": "textfile",
+    "minimum_image_size": 768,
+    "maximum_image_size": 1536,
+    "target_downsample_size": 1024,
+    "cache_dir_vae": "/data/cache/vae/kontext/edit",
+    "crop": true,
+    "crop_style": "random",
+    "crop_aspect": "square"
+  },
+  {
+    "id": "kontext-reference",
+    "type": "local",
+    "dataset_type": "conditioning",
+    "instance_data_dir": "/data/datasets/kontext/reference",
+    "conditioning_type": "reference_strict",
+    "resolution": 1024,
+    "resolution_type": "pixel_area",
+    "cache_dir_vae": "/data/cache/vae/kontext/reference"
+  },
+  {
+    "id": "kontext-text-embeds",
+    "type": "local",
+    "dataset_type": "text_embeds",
+    "default": true,
+    "cache_dir": "/data/cache/text/kontext"
+  }
+]
+JSON
+```
+
+編集フォルダーと参照フォルダー間でファイル名が一致することを確認してください。SimpleTunerは名前に基づいて埋め込みをステッチします。
+
+### 3. Kontext固有のハイパーパラメータを適用
+
+```bash
+curl -s http://localhost:8001/api/configs/kontext-api-demo \
+  | jq '.config + {
+      "--output_dir": "/workspace/output/kontext",
+      "--train_batch_size": 1,
+      "--gradient_accumulation_steps": 4,
+      "--learning_rate": 0.00001,
+      "--optimizer": "optimi-lion",
+      "--lr_scheduler": "cosine",
+      "--lr_warmup_steps": 200,
+      "--max_train_steps": 12000,
+      "--num_train_epochs": 0,
+      "--validation_prompt": "a cinematic 1024px product photo of <token>",
+      "--validation_guidance": 2.5,
+      "--validation_resolution": "1024x1024",
+      "--validation_num_inference_steps": 30,
+      "--cache_dir_vae": "/data/cache/vae/kontext",
+      "--seed": 777,
+      "--resume_from_checkpoint": "latest",
+      "--base_model_precision": "int8-quanto",
+      "--dataloader_prefetch": true,
+      "--report_to": "wandb",
+      "--lora_rank": 16,
+      "--lora_dropout": 0.05,
+      "--conditioning_multidataset_sampling": "combined",
+      "--clip_skip": 2,
+      "--data_backend_config": "kontext-api-demo/multidatabackend.json"
+    }' > /tmp/kontext-config.json
+
+jq '{
+      "name": "kontext-api-demo",
+      "description": "Flux Kontext LyCORIS (API)",
+      "tags": ["flux", "kontext", "api"],
+      "config": .
+    }' /tmp/kontext-config.json > /tmp/kontext-update.json
+
+curl -s -X PUT http://localhost:8001/api/configs/kontext-api-demo \
+  -H 'Content-Type: application/json' \
+  --data-binary @/tmp/kontext-update.json
+```
+
+### 4. 有効化、検証、起動
+
+```bash
+curl -s -X POST http://localhost:8001/api/configs/kontext-api-demo/activate
+
+curl -s -X POST http://localhost:8001/api/training/validate \
+  -F __active_tab__=model \
+  -F --num_train_epochs=0
+
+curl -s -X POST http://localhost:8001/api/training/start \
+  -F __active_tab__=model \
+  -F --num_train_epochs=0
+```
+
+Kontextのヒント:
+
+- `conditioning_type=reference_strict`はクロップを整列させます。データセットのアスペクト比が異なる場合は`reference_loose`に切り替えます
+- 1024pxで24GB VRAM内に収めるには`int8-quanto`に量子化します。フル精度にはHopper/BlackwellクラスのGPUが必要です
+- マルチノード実行の場合、サーバーを起動する前に`--accelerate_config`または`CUDA_VISIBLE_DEVICES`を設定します
+
+## GPU対応キューイングでローカルジョブを送信
+
+マルチGPUマシンで実行する場合、GPU割り当て認識でキューAPI経由でローカルトレーニングジョブを送信できます。必要なGPUが利用できない場合、ジョブはキューに入れられます。
+
+### GPU可用性の確認
+
+```bash
+curl -s "http://localhost:8001/api/system/status?include_allocation=true" | jq '.gpu_allocation'
+```
+
+レスポンスは利用可能なGPUを示します:
+
+```json
+{
+  "allocated_gpus": [0, 1],
+  "available_gpus": [2, 3],
+  "running_local_jobs": 1,
+  "devices": [
+    {"index": 0, "name": "A100", "memory_gb": 40, "allocated": true, "job_id": "abc123"},
+    {"index": 1, "name": "A100", "memory_gb": 40, "allocated": true, "job_id": "abc123"},
+    {"index": 2, "name": "A100", "memory_gb": 40, "allocated": false, "job_id": null},
+    {"index": 3, "name": "A100", "memory_gb": 40, "allocated": false, "job_id": null}
+  ]
+}
+```
+
+ローカルGPU情報を含むキュー統計も取得できます:
+
+```bash
+curl -s http://localhost:8001/api/queue/stats | jq '.local'
+```
+
+### ローカルジョブの送信
+
+```bash
+curl -s -X POST http://localhost:8001/api/queue/submit \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "config_name": "my-training-config",
+    "no_wait": false,
+    "any_gpu": false
+  }'
+```
+
+オプション:
+
+| オプション | デフォルト | 説明 |
+|--------|---------|-------------|
+| `config_name` | 必須 | 実行するトレーニング環境の名前 |
+| `no_wait` | false | trueの場合、GPUが利用できないときに即座に拒否 |
+| `any_gpu` | false | trueの場合、設定されたデバイスIDの代わりに利用可能な任意のGPUを使用 |
+
+レスポンス:
+
+```json
+{
+  "success": true,
+  "job_id": "abc123",
+  "status": "running",
+  "allocated_gpus": [0, 1],
+  "queue_position": null
+}
+```
+
+`status`フィールドは結果を示します:
+
+- `running` - 割り当てられたGPUでジョブが即座に開始
+- `queued` - ジョブがキューに入り、GPUが利用可能になると開始
+- `rejected` - GPUが利用できず、`no_wait`がtrueだった
+
+### ローカル同時実行制限の設定
+
+管理者はキュー同時実行エンドポイントを介して、使用できるローカルジョブとGPUの数を制限できます:
+
+```bash
+# 現在の制限を取得
+curl -s http://localhost:8001/api/queue/stats | jq '{local_gpu_max_concurrent, local_job_max_concurrent}'
+
+# 制限を更新（クラウド制限と一緒に）
+curl -s -X POST http://localhost:8001/api/queue/concurrency \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "local_gpu_max_concurrent": 6,
+    "local_job_max_concurrent": 2
+  }'
+```
+
+無制限のGPU使用には`local_gpu_max_concurrent`を`null`に設定します。
+
+### CLI代替
+
+同じ機能はCLI経由でも利用できます:
+
+```bash
+# デフォルトのキューイング動作で送信
+simpletuner jobs submit my-config
+
+# GPUが利用できない場合は拒否
+simpletuner jobs submit my-config --no-wait
+
+# 利用可能な任意のGPUを使用
+simpletuner jobs submit my-config --any-gpu
+
+# 何が起こるかをプレビュー（ドライラン）
+simpletuner jobs submit my-config --dry-run
+```
+
+## リモートワーカーにジョブをディスパッチ
+
+ワーカーとして登録されたリモートGPUマシンがある場合（[ワーカーオーケストレーション](../experimental/server/WORKERS.md)を参照）、キューAPI経由でジョブをディスパッチできます。
+
+### 利用可能なワーカーの確認
+
+```bash
+curl -s http://localhost:8001/api/admin/workers | jq '.workers[] | {name, status, gpu_name, gpu_count}'
+```
+
+### 特定のターゲットへの送信
+
+```bash
+# リモートワーカーを優先、ローカルGPUにフォールバック（デフォルト）
+curl -s -X POST http://localhost:8001/api/queue/submit \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "config_name": "my-training-config",
+    "target": "auto"
+  }'
+
+# リモートワーカーのみに強制ディスパッチ
+curl -s -X POST http://localhost:8001/api/queue/submit \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "config_name": "my-training-config",
+    "target": "worker"
+  }'
+
+# オーケストレーターのローカルGPUのみで実行
+curl -s -X POST http://localhost:8001/api/queue/submit \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "config_name": "my-training-config",
+    "target": "local"
+  }'
+```
+
+### ラベルによるワーカーの選択
+
+ワーカーはフィルタリング用のラベルを持つことができます（例: GPUタイプ、場所、チーム）:
+
+```bash
+curl -s -X POST http://localhost:8001/api/queue/submit \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "config_name": "my-training-config",
+    "target": "worker",
+    "worker_labels": {"gpu_type": "a100*", "team": "nlp"}
+  }'
+```
+
+ラベルはglobパターンをサポートします（`*`は任意の文字に一致）。
+
+## 便利なエンドポイント一覧
+
+- `GET /api/configs/` – 環境をリスト（トレーニング設定には`?config_type=model`を渡す）
+- `GET /api/configs/examples` – 同梱されているテンプレートを列挙
+- `POST /api/configs/{name}/dataloader` – デフォルトが必要な場合にデータローダーファイルを再生成
+- `GET /api/training/status` – 高レベルの状態、アクティブな`job_id`、起動段階情報
+- `GET /api/training/events?since_index=N` – 増分トレーナーログストリーム
+- `POST /api/training/checkpoints` – アクティブなジョブの出力ディレクトリのチェックポイントをリスト
+- `GET /api/system/status?include_allocation=true` – GPU割り当て情報を含むシステムメトリクス
+- `GET /api/queue/stats` – ローカルGPU割り当てを含むキュー統計
+- `POST /api/queue/submit` – GPU対応キューイングでローカルまたはワーカージョブを送信
+- `POST /api/queue/concurrency` – クラウドおよびローカル同時実行制限を更新
+- `GET /api/admin/workers` – 登録されたワーカーとそのステータスをリスト
+
+## 次のステップ
+
+- `documentation/OPTIONS.md`で特定のオプション定義を探索
+- これらのRESTコールを`jq`/`yq`またはPythonクライアントと組み合わせて自動化
+- リアルタイムダッシュボード用に`/api/training/events/stream`でWebSocketをフック
+- エクスポートされた設定（`GET /api/configs/<env>/export`）を再利用して、動作するセットアップをバージョン管理
+- **クラウドGPUでトレーニングを実行**するにはReplicateを使用—[クラウドトレーニングチュートリアル](../experimental/cloud/TUTORIAL.md)を参照
+
+これらのパターンを使用すると、実証済みのCLIセットアッププロセスに依存しながら、WebUIに触れることなくSimpleTunerトレーニングを完全にスクリプト化できます。

--- a/documentation/index.ja.md
+++ b/documentation/index.ja.md
@@ -1,0 +1,83 @@
+# SimpleTuner
+
+**SimpleTuner** は、シンプルさと理解しやすさに焦点を当てたマルチモーダル拡散モデルファインチューニングツールキットです。
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch:{ .lg .middle } __はじめに__
+
+    ---
+
+    SimpleTuner をインストールして、数分で最初のモデルをトレーニング
+
+    [:octicons-arrow-right-24: インストール](INSTALL.ja.md)
+
+-   :material-cog:{ .lg .middle } __Web UI__
+
+    ---
+
+    洗練された Web インターフェースでトレーニングを設定・実行
+
+    [:octicons-arrow-right-24: Web UI チュートリアル](webui/TUTORIAL.md)
+
+-   :material-api:{ .lg .middle } __REST API__
+
+    ---
+
+    HTTP API でトレーニングワークフローを自動化
+
+    [:octicons-arrow-right-24: API チュートリアル](api/TUTORIAL.md)
+
+-   :material-cloud:{ .lg .middle } __クラウドトレーニング__
+
+    ---
+
+    Replicate または分散ワーカーでトレーニングを実行
+
+    [:octicons-arrow-right-24: クラウドトレーニング](experimental/cloud/README.md)
+
+-   :material-account-group:{ .lg .middle } __マルチユーザー__
+
+    ---
+
+    エンタープライズ機能：SSO、クォータ、RBAC、ワーカーオーケストレーション
+
+    [:octicons-arrow-right-24: エンタープライズガイド](experimental/server/ENTERPRISE.md)
+
+-   :material-book-open-variant:{ .lg .middle } __モデルガイド__
+
+    ---
+
+    Flux、SD3、SDXL、動画モデルなどのステップバイステップガイド
+
+    [:octicons-arrow-right-24: モデルガイド](quickstart/index.md)
+
+</div>
+
+## 機能
+
+- **マルチモーダルトレーニング** - 画像、動画、音声生成モデル
+- **Web UI & API** - ブラウザまたは REST で自動化
+- **ワーカーオーケストレーション** - 複数の GPU マシンにジョブを分散
+- **エンタープライズ対応** - LDAP/OIDC SSO、RBAC、クォータ、監査ログ
+- **クラウド統合** - Replicate、セルフホストワーカー
+- **メモリ最適化** - DeepSpeed、FSDP2、量子化
+
+## 対応モデル
+
+| タイプ | モデル |
+|--------|--------|
+| **画像** | Flux.1/2、SD3、SDXL、Chroma、Auraflow、PixArt、Sana、Lumina2、HiDream など |
+| **動画** | Wan、LTX Video、Hunyuan Video、Kandinsky 5、LongCat |
+| **音声** | ACE-Step |
+
+詳細は[モデルガイド](quickstart/index.md)をご覧ください。
+
+## コミュニティ
+
+- [Discord](https://discord.gg/JGkSwEbjRb) - Terminus Research Group
+- [GitHub Issues](https://github.com/bghira/SimpleTuner/issues) - バグ報告・機能リクエスト
+
+## ライセンス
+
+SimpleTuner はオープンソースソフトウェアです。

--- a/documentation/quickstart/FLUX.ja.md
+++ b/documentation/quickstart/FLUX.ja.md
@@ -1,0 +1,721 @@
+# Flux[dev] / Flux[schnell] クイックスタート
+
+![image](https://github.com/user-attachments/assets/6409d790-3bb4-457c-a4b4-a51a45fc91d1)
+
+この例では、Flux.1 Krea LoRAをトレーニングします。
+
+## ハードウェア要件
+
+FluxはGPUメモリに加えて大量の**システムRAM**を必要とします。起動時にモデルを量子化するだけで約50GBのシステムメモリが必要です。起動に過度に時間がかかる場合は、ハードウェアの能力と変更が必要かどうかを評価する必要があるかもしれません。
+
+rank-16 LoRAのすべてのコンポーネント(MLP、プロジェクション、マルチモーダルブロック)をトレーニングする場合、使用するメモリは以下のようになります:
+
+- ベースモデルを量子化しない場合、30GB以上のVRAM
+- int8 + bf16ベース/LoRA重みに量子化する場合、18GB以上のVRAM
+- int4 + bf16ベース/LoRA重みに量子化する場合、13GB以上のVRAM
+- NF4 + bf16ベース/LoRA重みに量子化する場合、9GB以上のVRAM
+- int2 + bf16ベース/LoRA重みに量子化する場合、9GB以上のVRAM
+
+必要な環境:
+
+- **絶対最小要件**は単一の**3080 10G**
+- **現実的な最小要件**は単一の3090またはV100 GPU
+- **理想的には**複数の4090、A6000、L40S、またはそれ以上
+
+幸いなことに、これらは[LambdaLabs](https://lambdalabs.com)などのプロバイダーを通じて容易に利用可能です。LambdaLabsは最低料金を提供し、マルチノードトレーニングのためのローカライズされたクラスターを提供しています。
+
+**他のモデルとは異なり、Apple GPUは現在Fluxのトレーニングには対応していません。**
+
+
+## 前提条件
+
+Pythonがインストールされていることを確認してください。SimpleTunerは3.10から3.12で正常に動作します。
+
+以下のコマンドを実行して確認できます:
+
+```bash
+python --version
+```
+
+Ubuntuでpython 3.12がインストールされていない場合は、以下を試してください:
+
+```bash
+apt -y install python3.12 python3.12-venv
+```
+
+### コンテナイメージの依存関係
+
+Vast、RunPod、TensorDock(など)の場合、CUDA 12.2-12.8イメージでCUDA拡張のコンパイルを有効にするには以下が機能します:
+
+```bash
+apt -y install nvidia-cuda-toolkit
+```
+
+## インストール
+
+SimpleTunerをpip経由でインストール:
+
+```bash
+pip install simpletuner[cuda]
+```
+
+手動インストールまたは開発セットアップについては、[インストールドキュメント](../INSTALL.md)を参照してください。
+
+### AMD ROCmフォローアップ手順
+
+AMD MI300Xを使用可能にするには、以下を実行する必要があります:
+
+```bash
+apt install amd-smi-lib
+pushd /opt/rocm/share/amd_smi
+python3 -m pip install --upgrade pip
+python3 -m pip install .
+popd
+```
+
+## 環境のセットアップ
+
+### Webインターフェース方式
+
+SimpleTuner WebUIにより、セットアップがかなり簡単になります。サーバーを実行するには:
+
+```bash
+simpletuner server
+```
+
+これにより、デフォルトでポート8001にWebサーバーが作成され、http://localhost:8001にアクセスすることで利用できます。
+
+### 手動/コマンドライン方式
+
+SimpleTunerをコマンドラインツール経由で実行するには、設定ファイル、データセットとモデルのディレクトリ、およびデータローダー設定ファイルをセットアップする必要があります。
+
+#### 設定ファイル
+
+実験的なスクリプト`configure.py`を使用すると、対話的なステップバイステップの設定を通じて、このセクション全体をスキップできる可能性があります。これには、一般的な落とし穴を回避するのに役立ついくつかの安全機能が含まれています。
+
+**注意:** これはデータローダーを設定しません。後で手動で設定する必要があります。
+
+実行するには:
+
+```bash
+simpletuner configure
+```
+
+> ⚠️ Hugging Face Hubに容易にアクセスできない国にいるユーザーは、使用している`$SHELL`に応じて、`~/.bashrc`または`~/.zshrc`に`HF_ENDPOINT=https://hf-mirror.com`を追加する必要があります。
+
+手動で設定する場合:
+
+`config/config.json.example`を`config/config.json`にコピー:
+
+```bash
+cp config/config.json.example config/config.json
+```
+
+そこで、以下の変数を変更する必要がある可能性があります:
+
+- `model_type` - `lora`に設定します。
+- `model_family` - `flux`に設定します。
+- `model_flavour` - デフォルトは`krea`ですが、オリジナルのFLUX.1-Devリリースをトレーニングするには`dev`に設定できます。
+  - `krea` - デフォルトのFLUX.1-Krea [dev]モデル、BFLとKrea.aiのプロプライエタリモデルコラボレーションであるKrea 1のオープンウェイトバリアント
+  - `dev` - Devモデルフレーバー、以前のデフォルト
+  - `schnell` - Schnellモデルフレーバー。クイックスタートは高速ノイズスケジュールとアシスタントLoRAスタックを自動的に設定します
+  - `kontext` - Kontextトレーニング(具体的なガイダンスについては[このガイド](../quickstart/FLUX_KONTEXT.md)を参照)
+  - `fluxbooru` - FLUX.1-Devベースのde-distilled(CFGが必要)モデル、[FluxBooru](https://hf.co/terminusresearch/fluxbooru-v0.3)と呼ばれ、terminus research groupによって作成
+  - `libreflux` - FLUX.1-Schnellベースのde-distilledモデルで、T5テキストエンコーダー入力にアテンションマスキングが必要
+- `offload_during_startup` - VAEエンコード中にメモリ不足になる場合は`true`に設定します。
+- `pretrained_model_name_or_path` - `black-forest-labs/FLUX.1-dev`に設定します。
+- `pretrained_vae_model_name_or_path` - `black-forest-labs/FLUX.1-dev`に設定します。
+  - このモデルをダウンロードするには、Huggingfaceにログインしてアクセス権を付与される必要があることに注意してください。Huggingfaceへのログインについては、このチュートリアルの後半で説明します。
+- `output_dir` - チェックポイントと検証画像を保存するディレクトリに設定します。ここではフルパスを使用することをお勧めします。
+- `train_batch_size` - 特に非常に小さなデータセットがある場合は、これを1のままにしておく必要があります。
+- `validation_resolution` - Fluxは1024pxモデルなので、`1024x1024`に設定できます。
+  - さらに、Fluxはマルチアスペクトバケットでファインチューニングされており、カンマで区切って他の解像度を指定できます: `1024x1024,1280x768,2048x2048`
+- `validation_guidance` - Fluxの推論時に選択する通常の値を使用します。
+- `validation_guidance_real` - Flux推論でCFGを使用するには>1.0を使用します。検証が遅くなりますが、より良い結果が得られます。空の`VALIDATION_NEGATIVE_PROMPT`で最良の結果が得られます。
+- `validation_num_inference_steps` - 時間を節約しながらまともな品質を確認するには、20前後を使用します。Fluxはあまり多様性がなく、ステップ数を増やしても時間を浪費するだけかもしれません。
+- `--lora_rank=4` トレーニングされるLoRAのサイズを大幅に削減したい場合。これはVRAM使用量を削減するのに役立ちます。
+- Schnell LoRA実行では、クイックスタートのデフォルトにより高速スケジュールが自動的に使用されます。追加のフラグは不要です。
+
+- `gradient_accumulation_steps` - 以前のガイダンスでは、bf16トレーニングではモデルが劣化するため、これらを避けるように推奨していました。さらなるテストにより、Fluxの場合は必ずしもそうではないことが示されました。
+  - このオプションにより、更新ステップが複数のステップにわたって蓄積されます。これによりトレーニングランタイムが線形に増加し、値2ではトレーニングが半分の速度で実行され、2倍の時間がかかります。
+- `optimizer` - 初心者にはadamw_bf16が推奨されますが、optimi-lionやoptimi-stableadamwも良い選択肢です。
+- `mixed_precision` - 初心者は`bf16`のままにしておく必要があります
+- `gradient_checkpointing` - ほぼすべての状況、すべてのデバイスでtrueに設定します
+- `gradient_checkpointing_interval` - 大きなGPUでは、_n_ブロックごとにのみチェックポイントするように2以上の値に設定できます。値2ではブロックの半分がチェックポイントされ、3では3分の1になります。
+
+### 高度な実験的機能
+
+<details>
+<summary>高度な実験的詳細を表示</summary>
+
+
+SimpleTunerには、トレーニングの安定性とパフォーマンスを大幅に向上させることができる実験的機能が含まれています。
+
+*   **[Scheduled Sampling (Rollout)](../experimental/SCHEDULED_SAMPLING.md):** トレーニング中にモデルが独自の入力を生成できるようにすることで、露出バイアスを減らし、出力品質を向上させます。
+
+> ⚠️ これらの機能はトレーニングの計算オーバーヘッドを増加させます。
+
+</details>
+
+### メモリオフロード(オプション)
+
+Fluxはdiffusers v0.33+を介してグループ化されたモジュールオフロードをサポートしています。これにより、トランスフォーマーの重みでボトルネックになっている場合、VRAMの圧力が劇的に軽減されます。`TRAINER_EXTRA_ARGS`(またはWebUIのハードウェアページ)に以下のフラグを追加することで有効にできます:
+
+```bash
+--enable_group_offload \
+--group_offload_type block_level \
+--group_offload_blocks_per_group 1 \
+--group_offload_use_stream \
+# optional: spill offloaded weights to disk instead of RAM
+# --group_offload_to_disk_path /fast-ssd/simpletuner-offload
+```
+
+- `--group_offload_use_stream`はCUDAデバイスでのみ有効です。SimpleTunerはROCm、MPS、CPUバックエンドでストリームを自動的に無効にします。
+- `--enable_model_cpu_offload`と組み合わせ**ない**でください。2つの戦略は相互に排他的です。
+- `--group_offload_to_disk_path`を使用する場合は、高速なローカルSSD/NVMeターゲットを優先してください。
+
+#### 検証プロンプト
+
+`config/config.json`内には「プライマリ検証プロンプト」があり、これは通常、単一の被写体またはスタイルに対してトレーニングしているメインのinstance_promptです。さらに、検証中に実行する追加のプロンプトを含むJSONファイルを作成できます。
+
+サンプル設定ファイル`config/user_prompt_library.json.example`には以下の形式が含まれています:
+
+<details>
+<summary>サンプル設定を表示</summary>
+
+```json
+{
+  "nickname": "the prompt goes here",
+  "another_nickname": "another prompt goes here"
+}
+```
+</details>
+
+ニックネームは検証のファイル名なので、短く、ファイルシステムと互換性のあるものにしてください。
+
+トレーナーをこのプロンプトライブラリに指定するには、`config.json`の末尾に新しい行を追加してTRAINER_EXTRA_ARGSに追加します:
+
+<details>
+<summary>サンプル設定を表示</summary>
+
+```json
+  "--user_prompt_library": "config/user_prompt_library.json",
+```
+</details>
+
+多様なプロンプトのセットは、モデルがトレーニング中に崩壊しているかどうかを判断するのに役立ちます。この例では、`<token>`という単語を被写体名(instance_prompt)に置き換える必要があります。
+
+<details>
+<summary>サンプル設定を表示</summary>
+
+```json
+{
+    "anime_<token>": "a breathtaking anime-style portrait of <token>, capturing her essence with vibrant colors and expressive features",
+    "chef_<token>": "a high-quality, detailed photograph of <token> as a sous-chef, immersed in the art of culinary creation",
+    "just_<token>": "a lifelike and intimate portrait of <token>, showcasing her unique personality and charm",
+    "cinematic_<token>": "a cinematic, visually stunning photo of <token>, emphasizing her dramatic and captivating presence",
+    "elegant_<token>": "an elegant and timeless portrait of <token>, exuding grace and sophistication",
+    "adventurous_<token>": "a dynamic and adventurous photo of <token>, captured in an exciting, action-filled moment",
+    "mysterious_<token>": "a mysterious and enigmatic portrait of <token>, shrouded in shadows and intrigue",
+    "vintage_<token>": "a vintage-style portrait of <token>, evoking the charm and nostalgia of a bygone era",
+    "artistic_<token>": "an artistic and abstract representation of <token>, blending creativity with visual storytelling",
+    "futuristic_<token>": "a futuristic and cutting-edge portrayal of <token>, set against a backdrop of advanced technology",
+    "woman": "a beautifully crafted portrait of a woman, highlighting her natural beauty and unique features",
+    "man": "a powerful and striking portrait of a man, capturing his strength and character",
+    "boy": "a playful and spirited portrait of a boy, capturing youthful energy and innocence",
+    "girl": "a charming and vibrant portrait of a girl, emphasizing her bright personality and joy",
+    "family": "a heartwarming and cohesive family portrait, showcasing the bonds and connections between loved ones"
+}
+```
+</details>
+
+> ℹ️ Fluxはフローマッチングモデルであり、強い類似性を持つ短いプロンプトは、モデルによってほぼ同じ画像が生成されます。必ずより長く、より説明的なプロンプトを使用してください。
+
+#### CLIPスコアトラッキング
+
+モデルのパフォーマンスをスコアリングするための評価を有効にしたい場合は、CLIPスコアの設定と解釈に関する情報について[このドキュメント](../evaluation/CLIP_SCORES.md)を参照してください。
+
+# 安定した評価損失
+
+モデルのパフォーマンスをスコアリングするために安定したMSE損失を使用したい場合は、評価損失の設定と解釈に関する情報について[このドキュメント](../evaluation/EVAL_LOSS.md)を参照してください。
+
+#### 検証プレビュー
+
+SimpleTunerは、Tiny AutoEncoderモデルを使用した生成中の中間検証プレビューのストリーミングをサポートしています。これにより、Webhookコールバックを介してリアルタイムで段階的に生成される検証画像を確認できます。
+
+有効にするには:
+<details>
+<summary>サンプル設定を表示</summary>
+
+```json
+{
+  "validation_preview": true,
+  "validation_preview_steps": 1
+}
+```
+</details>
+
+**要件:**
+- Webhook設定
+- 検証が有効
+
+Tiny AutoEncoderのオーバーヘッドを削減するには、`validation_preview_steps`をより高い値(3または5など)に設定します。`validation_num_inference_steps=20`および`validation_preview_steps=5`の場合、ステップ5、10、15、20でプレビュー画像を受け取ります。
+
+#### Fluxタイムスケジュールシフト
+
+FluxやSD3などのフローマッチングモデルには、単純な10進数値を使用してタイムステップスケジュールのトレーニング部分をシフトできる「シフト」と呼ばれるプロパティがあります。
+
+##### デフォルト
+
+デフォルトでは、fluxにスケジュールシフトは適用されず、タイムステップサンプリング分布にシグモイドベル形が生じます。これはFluxにとって理想的なアプローチではない可能性がありますが、自動シフトよりも短期間でより多くの学習が得られます。
+
+##### 自動シフト
+
+一般的に推奨されるアプローチは、最近のいくつかの研究に従って、解像度依存のタイムステップシフトを有効にすることです。`--flow_schedule_auto_shift`は、大きな画像にはより高いシフト値を使用し、小さな画像にはより低いシフト値を使用します。これにより安定したトレーニング結果が得られますが、潜在的に平凡な結果になる可能性があります。
+
+##### 手動指定
+
+(_Discordのジェネラル・アウェアネスによる以下の例に感謝_)
+
+`--flow_schedule_shift`値0.1(非常に低い値)を使用すると、画像の細かいディテールのみが影響を受けます:
+![image](https://github.com/user-attachments/assets/991ca0ad-e25a-4b13-a3d6-b4f2de1fe982)
+
+`--flow_schedule_shift`値4.0(非常に高い値)を使用すると、大きな構成的特徴とモデルの色空間が潜在的に影響を受けます:
+![image](https://github.com/user-attachments/assets/857a1f8a-07ab-4b75-8e6a-eecff616a28d)
+
+#### 量子化モデルトレーニング
+
+AppleおよびNVIDIAシステムでテスト済み、Hugging Face Optimum-Quantoを使用して精度とVRAM要件を削減し、わずか16GBでFluxをトレーニングできます。
+
+`config.json`ユーザー向け:
+
+<details>
+<summary>サンプル設定を表示</summary>
+
+```json
+  "base_model_precision": "int8-quanto",
+  "text_encoder_1_precision": "no_change",
+  "text_encoder_2_precision": "no_change",
+  "lora_rank": 16,
+  "max_grad_norm": 1.0,
+  "base_model_default_dtype": "bf16"
+```
+</details>
+
+##### LoRA固有の設定(LyCORISではない)
+
+```bash
+# 'mmdit'をトレーニングすると、非常に安定したトレーニングが得られ、モデルの学習に時間がかかります。
+# 'all'をトレーニングすると、モデル分布を簡単にシフトできますが、忘却しやすく、高品質データの恩恵を受けます。
+# 'all+ffs'をトレーニングすると、すべてのアテンションレイヤーに加えてフィードフォワードがトレーニングされ、LoRAのモデル目的の適応に役立ちます。
+# - このモードは移植性に欠けると報告されており、ComfyUIなどのプラットフォームではLoRAをロードできない可能性があります。
+# 'context'ブロックのみをトレーニングするオプションも提供されていますが、その影響は不明であり、実験的な選択肢として提供されています。
+# - このモードの拡張である'context+ffs'も利用可能で、`--init_lora`を介して継続的にファインチューニングする前に、新しいトークンをLoRAに事前トレーニングするのに役立ちます。
+# その他のオプションには、1つまたは2つのレイヤーのみをトレーニングする'tiny'と'nano'が含まれます。
+"--flux_lora_target": "all",
+
+# LoftQ初期化を使用したい場合、Quantoを使用してベースモデルを量子化することはできません。
+# これにより、より良い/より速い収束が得られる可能性がありますが、NVIDIAデバイスでのみ機能し、Bits n Bytesが必要で、Quantoとは互換性がありません。
+# その他のオプションは'default'、'gaussian'(困難)、およびテストされていないオプション: 'olora'および'pissa'です。
+"--lora_init_type": "loftq",
+```
+
+#### データセットの考慮事項
+
+> ⚠️ トレーニング用の画像品質は、他のほとんどのモデルよりもFluxにとって重要です。画像内のアーティファクトを_最初に_吸収し、その後コンセプト/被写体を学習するためです。
+
+モデルをトレーニングするには、かなりのデータセットが必要です。データセットサイズには制限があり、モデルを効果的にトレーニングするためにデータセットが十分に大きいことを確認する必要があります。最小限のデータセットサイズは`train_batch_size * gradient_accumulation_steps`であり、さらに`vae_batch_size`よりも多い必要があることに注意してください。データセットが小さすぎると使用できません。
+
+> ℹ️ 画像が十分に少ない場合、**データセットに画像が検出されません**というメッセージが表示される可能性があります - `repeats`値を増やすことでこの制限を克服できます。
+
+所有しているデータセットに応じて、データセットディレクトリとデータローダー設定ファイルを異なる方法でセットアップする必要があります。この例では、データセットとして[pseudo-camera-10k](https://huggingface.co/datasets/bghira/pseudo-camera-10k)を使用します。
+
+これを含む`--data_backend_config`(`config/multidatabackend.json`)ドキュメントを作成します:
+
+<details>
+<summary>サンプル設定を表示</summary>
+
+```json
+[
+  {
+    "id": "pseudo-camera-10k-flux",
+    "type": "local",
+    "crop": true,
+    "crop_aspect": "square",
+    "crop_style": "center",
+    "resolution": 512,
+    "minimum_image_size": 512,
+    "maximum_image_size": 512,
+    "target_downsample_size": 512,
+    "resolution_type": "pixel_area",
+    "cache_dir_vae": "cache/vae/flux/pseudo-camera-10k",
+    "instance_data_dir": "datasets/pseudo-camera-10k",
+    "disabled": false,
+    "skip_file_discovery": "",
+    "caption_strategy": "filename",
+    "metadata_backend": "discovery",
+    "repeats": 0,
+    "is_regularisation_data": true
+  },
+  {
+    "id": "dreambooth-subject",
+    "type": "local",
+    "crop": false,
+    "resolution": 1024,
+    "minimum_image_size": 1024,
+    "maximum_image_size": 1024,
+    "target_downsample_size": 1024,
+    "resolution_type": "pixel_area",
+    "cache_dir_vae": "cache/vae/flux/dreambooth-subject",
+    "instance_data_dir": "datasets/dreambooth-subject",
+    "caption_strategy": "instanceprompt",
+    "instance_prompt": "the name of your subject goes here",
+    "metadata_backend": "discovery",
+    "repeats": 1000
+  },
+  {
+    "id": "dreambooth-subject-512",
+    "type": "local",
+    "crop": false,
+    "resolution": 512,
+    "minimum_image_size": 512,
+    "maximum_image_size": 512,
+    "target_downsample_size": 512,
+    "resolution_type": "pixel_area",
+    "cache_dir_vae": "cache/vae/flux/dreambooth-subject-512",
+    "instance_data_dir": "datasets/dreambooth-subject",
+    "caption_strategy": "instanceprompt",
+    "instance_prompt": "the name of your subject goes here",
+    "metadata_backend": "discovery",
+    "repeats": 1000
+  },
+  {
+    "id": "text-embeds",
+    "type": "local",
+    "dataset_type": "text_embeds",
+    "default": true,
+    "cache_dir": "cache/text/flux",
+    "disabled": false,
+    "write_batch_size": 128
+  }
+]
+```
+</details>
+
+> caption_strategyのオプションと要件については、[DATALOADER.md](../DATALOADER.md#caption_strategy)を参照してください。
+
+> ℹ️ 512pxと1024pxのデータセットを同時に実行することはサポートされており、Fluxのより良い収束をもたらす可能性があります。
+
+次に、`datasets`ディレクトリを作成します:
+
+```bash
+mkdir -p datasets
+pushd datasets
+    huggingface-cli download --repo-type=dataset bghira/pseudo-camera-10k --local-dir=pseudo-camera-10k
+    mkdir dreambooth-subject
+    # place your images into dreambooth-subject/ now
+popd
+```
+
+これにより、約10kの写真サンプルが`datasets/pseudo-camera-10k`ディレクトリにダウンロードされ、自動的に作成されます。
+
+Dreambooth画像は`datasets/dreambooth-subject`ディレクトリに配置する必要があります。
+
+#### WandBとHuggingface Hubにログイン
+
+特に`--push_to_hub`と`--report_to=wandb`を使用している場合は、トレーニングを開始する前にWandBとHF Hubにログインする必要があります。
+
+Git LFSリポジトリに手動でアイテムをプッシュする場合は、`git config --global credential.helper store`も実行する必要があります
+
+以下のコマンドを実行します:
+
+```bash
+wandb login
+```
+
+および
+
+```bash
+huggingface-cli login
+```
+
+指示に従って両方のサービスにログインします。
+
+### トレーニング実行の実行
+
+SimpleTunerディレクトリから、トレーニングを開始するためのいくつかのオプションがあります:
+
+**オプション1(推奨 - pipインストール):**
+
+```bash
+pip install simpletuner[cuda]
+simpletuner train
+```
+
+**オプション2(Gitクローン方式):**
+
+```bash
+simpletuner train
+```
+
+**オプション3(レガシー方式 - まだ機能します):**
+
+```bash
+./train.sh
+```
+
+これにより、テキスト埋め込みとVAE出力のディスクへのキャッシングが開始されます。
+
+詳細については、[データローダー](../DATALOADER.md)および[チュートリアル](../TUTORIAL.md)ドキュメントを参照してください。
+
+**注意:** 現時点では、マルチアスペクトバケットでのトレーニングがFluxで正しく機能するかどうかは不明です。`crop_style=random`および`crop_aspect=square`を使用することをお勧めします。
+
+## マルチGPU構成
+
+SimpleTunerには、WebUIを介した**自動GPU検出**が含まれています。オンボーディング中に次のように設定します:
+
+- **自動モード**: 最適な設定で検出されたすべてのGPUを自動的に使用
+- **手動モード**: 特定のGPUを選択するか、カスタムプロセス数を設定
+- **無効モード**: シングルGPUトレーニング
+
+WebUIはハードウェアを検出し、`--num_processes`と`CUDA_VISIBLE_DEVICES`を自動的に設定します。
+
+手動設定または高度なセットアップについては、インストールガイドの[マルチGPUトレーニングセクション](../INSTALL.md#multiple-gpu-training)を参照してください。
+
+## 推論のヒント
+
+### CFGトレーニングされたLoRA(flux_guidance_value > 1)
+
+ComfyUIでは、FluxをAdaptiveGuiderと呼ばれる別のノードを通す必要があります。コミュニティのメンバーの1人が、修正されたノードをここで提供しています:
+
+(**外部リンク**) [IdiotSandwichTheThird/ComfyUI-Adaptive-Guidan...](https://github.com/IdiotSandwichTheThird/ComfyUI-Adaptive-Guidance-with-disabled-init-steps) および彼らのサンプルワークフロー [こちら](https://github.com/IdiotSandwichTheThird/ComfyUI-Adaptive-Guidance-with-disabled-init-steps/blob/master/ExampleWorkflow.json)
+
+### CFG蒸留LoRA(flux_guidance_scale == 1)
+
+CFG蒸留LoRAの推論は、トレーニングされた値の周りの低いguidance_scaleを使用するのと同じくらい簡単です。
+
+## 注意事項とトラブルシューティングのヒント
+
+### 最低VRAM構成
+
+現在、最低VRAM使用率(9090M)は以下で達成できます:
+
+- OS: Ubuntu Linux 24
+- GPU: 単一のNVIDIA CUDAデバイス(10G、12G)
+- システムメモリ: 約50Gのシステムメモリ
+- ベースモデル精度: `nf4-bnb`
+- オプティマイザ: Lion 8Bit Paged、`bnb-lion8bit-paged`
+- 解像度: 512px
+  - 1024pxには >= 12G VRAMが必要
+- バッチサイズ: 1、勾配累積ステップなし
+- DeepSpeed: 無効/未設定
+- PyTorch: 2.6 Nightly(9月29日ビルド)
+- `--quantize_via=cpu`を使用して、<=16Gカードでの起動時のoutOfMemoryエラーを回避
+- `--attention_mechanism=sageattention`を使用してVRAMをさらに0.1GB削減し、トレーニング検証画像生成速度を向上
+- `--gradient_checkpointing`を必ず有効にしてください。そうしないと、何をしてもOOMが止まりません
+
+**注意**: VAE埋め込みとテキストエンコーダ出力の事前キャッシングはより多くのメモリを使用する可能性があり、OOMになる可能性があります。その場合、テキストエンコーダ量子化とVAEタイリングを`--vae_enable_tiling=true`経由で有効にできます。起動時のメモリをさらに節約するには、`--offload_during_startup=true`を使用できます。
+
+4090での速度は1秒あたり約1.4イテレーションでした。
+
+### SageAttention
+
+`--attention_mechanism=sageattention`を使用すると、検証時の推論を高速化できます。
+
+**注意**: これはすべてのモデル構成と互換性があるわけではありませんが、試してみる価値があります。
+
+### NF4量子化トレーニング
+
+簡単に言うと、NF4はモデルの4ビット的な表現であり、トレーニングには対処すべき深刻な安定性の懸念があります。
+
+初期テストでは、以下が当てはまります:
+
+- Lionオプティマイザはモデル崩壊を引き起こしますが、VRAMを最も使用しません。AdamWバリアントはそれを維持するのに役立ちます。bnb-adamw8bit、adamw_bf16は素晴らしい選択肢です
+  - AdEMAMixはうまくいきませんでしたが、設定は探索されていません
+- `--max_grad_norm=0.01`は、モデルが短時間で大きく変化するのを防ぐことでモデルの破損をさらに減らすのに役立ちます
+- NF4、AdamW8bit、およびより高いバッチサイズはすべて、トレーニングに費やす時間やVRAMの使用を犠牲にして、安定性の問題を克服するのに役立ちます
+- 解像度を512pxから1024pxに上げると、トレーニングが遅くなります。たとえば、1ステップあたり1.4秒から3.5秒になります(バッチサイズ1、4090)
+- int8またはbf16でトレーニングするのが難しいものは、NF4ではさらに難しくなります
+- SageAttentionなどのオプションとの互換性が低くなります
+
+NF4はtorch.compileで動作しないため、速度に関して得られるものが得られるものです。
+
+VRAMが問題でない場合(48G以上など)、torch.compileを使用したint8が最良で最速のオプションです。
+
+### マスク損失
+
+被写体またはスタイルをトレーニングしていて、一方または他方をマスクしたい場合は、Dreamboothガイドの[マスク損失トレーニング](../DREAMBOOTH.md#masked-loss)セクションを参照してください。
+
+### TREADトレーニング {#tread-training}
+
+> ⚠️ **実験的**: TREADは新しく実装された機能です。機能的ですが、最適な構成はまだ探索中です。
+
+[TREAD](../TREAD.md)(論文)は、**T**oken **R**outing for **E**fficient **A**rchitecture-agnostic **D**iffusionの略です。これは、トランスフォーマーレイヤーを介してトークンをインテリジェントにルーティングすることで、Fluxトレーニングを加速できる方法です。スピードアップは、ドロップするトークンの数に比例します。
+
+#### クイックセットアップ
+
+これを`config.json`に追加します:
+
+<details>
+<summary>サンプル設定を表示</summary>
+
+```json
+{
+  "tread_config": {
+    "routes": [
+      {
+        "selection_ratio": 0.5,
+        "start_layer_idx": 2,
+        "end_layer_idx": -2
+      }
+    ]
+  }
+}
+```
+</details>
+
+この構成により:
+
+- レイヤー2から最後から2番目のレイヤーまでの間、画像トークンの50%のみを保持
+- テキストトークンはドロップされません
+- 品質への影響を最小限に抑えながら、トレーニングのスピードアップは約25%
+
+#### キーポイント
+
+- **限定的なアーキテクチャサポート** - TREADはFluxおよびWanモデルに対してのみ実装されています
+- **高解像度で最適** - アテンションのO(n²)複雑性のため、1024x1024+で最大のスピードアップ
+- **マスク損失と互換性あり** - マスクされた領域は自動的に保持されます(ただし、これによりスピードアップが減少します)
+- **量子化と動作** - int8/int4/NF4トレーニングと組み合わせることができます
+- **初期損失スパイクを予想** - LoRA/LoKrトレーニングを開始すると、損失は最初は高くなりますが、すぐに修正されます
+
+#### チューニングのヒント
+
+- **保守的(品質重視)**: `selection_ratio`を0.3-0.5に使用
+- **積極的(速度重視)**: `selection_ratio`を0.6-0.8に使用
+- **早期/後期レイヤーを避ける**: レイヤー0-1または最終レイヤーでルーティングしない
+- **LoRAトレーニングの場合**: わずかな速度低下が見られる可能性があります - 異なる構成を試してください
+- **より高い解像度 = より良いスピードアップ**: 1024px以上で最も有益
+
+#### 既知の動作
+
+- ドロップされるトークンが多いほど(より高い`selection_ratio`)、トレーニングは速くなりますが、初期損失は高くなります
+- LoRA/LoKrトレーニングは初期損失スパイクを示しますが、ネットワークが適応するにつれて急速に修正されます
+- 一部のLoRA構成はわずかに遅くトレーニングされる可能性があります - 最適な構成はまだ探索中です
+- RoPE(回転位置埋め込み)実装は機能的ですが、100%正確ではない可能性があります
+
+詳細な構成オプションとトラブルシューティングについては、[完全なTREADドキュメント](../TREAD.md)を参照してください。
+
+### クラシファイアフリーガイダンス
+
+#### 問題
+
+Devモデルはガイダンス蒸留された状態で提供されます。つまり、教師モデルの出力への非常に直線的な軌道を取ります。これは、トレーニングおよび推論時にモデルに供給されるガイダンスベクトルを介して行われます - このベクトルの値は、最終的に得られるLoRAのタイプに大きく影響します:
+
+#### 解決策
+
+- 1.0の値(**デフォルト**)は、Devモデルに対して行われた初期蒸留を保持します
+  - これは最も互換性のあるモードです
+  - 推論は元のモデルと同じくらい高速です
+  - フローマッチング蒸留により、元のFlux Devモデルと同様に、モデルの創造性と出力の変動性が低下します(すべてが同じ構成/外観を保ちます)
+- より高い値(3.5-4.5前後でテスト済み)は、CFG目的をモデルに再導入します
+  - これには、推論パイプラインにCFGのサポートが必要です
+  - 推論は50%遅く、0%のVRAM増加**または**約20%遅く、バッチCFG推論による20%のVRAM増加
+  - ただし、このスタイルのトレーニングは創造性とモデル出力の変動性を改善し、特定のトレーニングタスクに必要な場合があります
+
+ベクトル値1.0を使用してモデルを継続的に調整することで、de-distilledモデルに部分的に蒸留を再導入できます。完全に回復することはありませんが、少なくともより使いやすくなります。
+
+#### 注意事項
+
+- これにより、最終的に**以下のいずれかの**影響があります:
+  - 2つの別々のフォワードパスで無条件出力を順次計算する場合など、推論レイテンシが2倍になります
+  - `num_images_per_prompt=2`を使用して推論時に2つの画像を受け取るのと同等のVRAM消費の増加、および同じパーセンテージの速度低下を伴います。
+    - この方法は、順次計算よりも極端な速度低下が少ないことが多いですが、VRAM使用量はほとんどの消費者向けトレーニングハードウェアには多すぎる可能性があります。
+    - この方法は現在SimpleTunerに統合されて_いません_が、作業は進行中です。
+- ComfyUIまたは他のアプリケーション(AUTOMATIC1111など)の推論ワークフローは、「真の」CFGを有効にするように変更する必要があります。これは、すぐには可能ではない可能性があります。
+
+### 量子化
+
+- 16Gカードでこのモデルをトレーニングするには、最低8ビット量子化が必要です
+  - bfloat16/float16では、rank-1 LoRAはメモリ使用量が30GBをわずかに超えます
+- モデルを8ビットに量子化してもトレーニングに害はありません
+  - より高いバッチサイズをプッシュでき、より良い結果が得られる可能性があります
+  - フル精度トレーニングと同じように動作します - fp32はbf16+int8よりもモデルを改善しません。
+- **int8**には、新しいNVIDIAハードウェア(3090以上)でハードウェアアクセラレーションと`torch.compile()`サポートがあります
+- **nf4-bnb**はVRAM要件を9GBに引き下げ、10Gカード(bfloat16サポート付き)に収まります
+- 後でComfyUIでLoRAをロードするときは、LoRAをトレーニングしたのと同じベースモデル精度を使用**する必要があります**。
+- **int4**はカスタムbf16カーネルに依存しており、カードがbfloat16をサポートしていない場合は機能しません
+
+### クラッシュ
+
+- テキストエンコーダがアンロードされた後にSIGKILLが発生する場合、これはFluxを量子化するのに十分なシステムメモリがないことを意味します。
+  - `--base_model_precision=bf16`をロードしてみてください。それでもうまくいかない場合は、より多くのメモリが必要になる可能性があります。
+  - GPU代わりに使用するには、`--quantize_via=accelerator`を試してください
+
+### Schnell
+
+- DevでLyCORIS LoKrをトレーニングすると、わずか4ステップ後にSchnellで**通常**非常にうまく機能します。
+  - 直接Schnellトレーニングには本当にもう少し時間が必要です - 現在、結果は良くありません
+
+> ℹ️ SchnellをDevと何らかの方法でマージすると、Devのライセンスが引き継がれ、非商用になります。これはほとんどのユーザーにとって実際には問題にならないはずですが、注意する価値があります。
+
+### 学習率
+
+#### LoRA(--lora_type=standard)
+
+- LoRAは、大規模データセットに対してLoKrよりも全体的にパフォーマンスが悪い
+- Flux LoRAはSD 1.5 LoRAと同様にトレーニングされると報告されています
+- ただし、12Bほど大きなモデルは、経験的に**より低い学習率**でより良いパフォーマンスを発揮しました。
+  - 1e-3のLoRAは完全にローストする可能性があります。1e-5のLoRAはほとんど何もしません。
+- 64から128ほど大きなランクは、ベースモデルのサイズに比例する一般的な困難性のため、12Bモデルでは望ましくない可能性があります。
+  - より小さなネットワーク(rank-1、rank-4)を最初に試して、徐々に上げていってください - より速くトレーニングされ、必要なすべてを実行できる可能性があります。
+  - コンセプトをモデルにトレーニングするのが過度に難しい場合は、より高いランクとより多くの正則化データが必要になる可能性があります。
+- PixArtやSD3などの他の拡散トランスフォーマーモデルは、`--max_grad_norm`から大きな恩恵を受け、SimpleTunerはデフォルトでFluxでこれにかなり高い値を保持しています。
+  - より低い値は、モデルがすぐに崩壊するのを防ぎますが、ベースモデルのデータ分布から遠く離れた新しいコンセプトを学習することを非常に困難にする可能性もあります。モデルが行き詰まり、改善されない可能性があります。
+
+#### LoKr(--lora_type=lycoris)
+
+- LoKrにはより高い学習率の方が良い(`1e-3`でAdamW、`2e-4`でLion)
+- 他のアルゴはさらに探索が必要です。
+- そのようなデータセットで`is_regularisation_data`を設定すると、ブリードを保持/防止し、最終的なモデルの品質を向上させるのに役立つ可能性があります。
+  - これは、トレーニングバッチサイズを2倍にすることで知られているが、結果をあまり改善しない「事前損失保存」とは異なる動作をします
+  - SimpleTunerの正則化データ実装は、ベースモデルを保存する効率的な方法を提供します
+
+### 画像アーティファクト
+
+Fluxは悪い画像アーティファクトを即座に吸収します。それがそのままです - 最後に高品質データのみでの最終トレーニング実行が、最後にそれを修正するために必要になる可能性があります。
+
+これらのこと(その他)を行うと、サンプルに正方形グリッドアーティファクトが現れ**始める可能性があります**:
+
+- 低品質データでオーバートレーニング
+- 学習率が高すぎる使用
+- オーバートレーニング(一般的に)、画像が多すぎる低容量ネットワーク
+- アンダートレーニング(また)、画像が少なすぎる高容量ネットワーク
+- 奇妙なアスペクト比またはトレーニングデータサイズの使用
+
+### アスペクトバケッティング
+
+- 正方形クロップで長時間トレーニングしても、このモデルを過度に損傷することはおそらくありません。どんどん試してください。素晴らしくて信頼性があります。
+- 一方、データセットの自然なアスペクトバケットを使用すると、推論時にこれらの形状を過度にバイアスする可能性があります。
+  - これは望ましい品質である可能性があります。シネマティックなもののようなアスペクト依存のスタイルが他の解像度に過度にブリードするのを防ぐためです。
+  - ただし、多くのアスペクトバケットで均等に結果を改善したい場合は、`crop_aspect=random`を試す必要があるかもしれません。これには独自の欠点があります。
+- 画像ディレクトリデータセットを複数回定義することでデータセット構成を混合すると、本当に良い結果とうまく一般化されたモデルが生成されました。
+
+### カスタムファインチューニングされたFluxモデルのトレーニング
+
+Hugging Face Hub上の一部のファインチューニングされたFluxモデル(Dev2Proなど)には完全なディレクトリ構造がないため、これらの特定のオプションを設定する必要があります。
+
+作成者が行ったように、これらのオプション`flux_guidance_value`、`validation_guidance_real`、`flux_attention_masked_training`もその情報が利用可能な場合は必ず設定してください。
+
+<details>
+<summary>サンプル設定を表示</summary>
+
+```json
+{
+    "model_family": "flux",
+    "pretrained_model_name_or_path": "black-forest-labs/FLUX.1-dev",
+    "pretrained_transformer_model_name_or_path": "ashen0209/Flux-Dev2Pro",
+    "pretrained_vae_model_name_or_path": "black-forest-labs/FLUX.1-dev",
+    "pretrained_transformer_subfolder": "none",
+}
+```
+</details>

--- a/documentation/quickstart/WAN.ja.md
+++ b/documentation/quickstart/WAN.ja.md
@@ -1,0 +1,740 @@
+## Wan 2.1 クイックスタート
+
+この例では、Sayak Paulの[パブリックドメインDisneyデータセット](https://hf.co/datasets/sayakpaul/video-dataset-disney-organized)を使用してWan 2.1 LoRAをトレーニングします。
+
+
+
+https://github.com/user-attachments/assets/51e6cbfd-5c46-407c-9398-5932fa5fa561
+
+
+### ハードウェア要件
+
+Wan 2.1 **1.3B**はシステムメモリ**または**GPUメモリをそれほど必要としません。**14B**モデルもサポートされていますが、より多くのリソースを必要とします。
+
+現在、WanではImage-to-Video(I2V)トレーニングはサポートされていませんが、T2V LoRAとLycorisはI2Vモデルで実行できます。
+
+#### Text to Video
+
+1.3B - https://huggingface.co/Wan-AI/Wan2.1-T2V-1.3B
+- 解像度: 832x480
+- Rank-16 LoRAは12G以上を使用(バッチサイズ4)
+
+14B - https://huggingface.co/Wan-AI/Wan2.1-T2V-14B-Diffusers
+- 解像度: 832x480
+- 24Gに収まりますが、設定を少し調整する必要があります。
+
+<!--
+#### Image to Video
+14B (720p) - https://huggingface.co/Wan-AI/Wan2.1-I2V-14B-720P-Diffusers
+- 解像度: 1280x720
+-->
+
+#### Image to Video (Wan 2.2)
+
+最新のWan 2.2 I2Vチェックポイントは同じトレーニングフローで動作します:
+
+- High stage: https://huggingface.co/Wan-AI/Wan2.2-I2V-14B-Diffusers/tree/main/high_noise_model
+- Low stage: https://huggingface.co/Wan-AI/Wan2.2-I2V-14B-Diffusers/tree/main/low_noise_model
+
+このガイドの後半で説明する`model_flavour`と`wan_validation_load_other_stage`設定でトレーニングしたいステージをターゲットできます。
+
+必要なもの:
+- **現実的な最低要件**は16GB、または単一の3090またはV100 GPU
+- **理想的には**複数の4090、A6000、L40S、またはそれ以上
+
+Wan 2.2チェックポイントを実行する際にtime embeddingレイヤーでshapeミスマッチが発生した場合は、新しい
+`wan_force_2_1_time_embedding`フラグを有効にしてください。これにより、transformerがWan 2.1スタイルのtime embeddingsにフォールバックし、
+互換性の問題が解決されます。
+
+#### ステージプリセットと検証
+
+- `model_flavour=i2v-14b-2.2-high`はWan 2.2 high-noiseステージをターゲットします。
+- `model_flavour=i2v-14b-2.2-low`はlow-noiseステージをターゲットします(同じチェックポイント、異なるサブフォルダ)。
+- `wan_validation_load_other_stage=true`を切り替えると、トレーニングしているステージとは反対のステージを検証レンダリング用に読み込みます。
+- 標準のWan 2.1 text-to-video実行には、flavourを未設定のままにする(または`t2v-480p-1.3b-2.1`を使用)してください。
+
+Apple siliconシステムではWan 2.1があまりうまく動作せず、単一のトレーニングステップに約10分かかることが予想されます。
+
+### 前提条件
+
+Pythonがインストールされていることを確認してください。SimpleTunerは3.10から3.12で動作します。
+
+以下のコマンドで確認できます:
+
+```bash
+python --version
+```
+
+Ubuntuにpython 3.12がインストールされていない場合は、以下を試してください:
+
+```bash
+apt -y install python3.12 python3.12-venv
+```
+
+#### コンテナイメージの依存関係
+
+Vast、RunPod、TensorDock(など)の場合、以下はCUDA 12.2-12.8イメージでCUDA拡張のコンパイルを有効にするために動作します:
+
+```bash
+apt -y install nvidia-cuda-toolkit
+```
+
+### インストール
+
+pipを使用してSimpleTunerをインストールします:
+
+```bash
+pip install simpletuner[cuda]
+```
+
+手動インストールまたは開発セットアップについては、[インストールドキュメント](../INSTALL.md)を参照してください。
+#### SageAttention 2
+
+SageAttention 2を使用したい場合は、いくつかの手順に従う必要があります。
+
+> 注意: SageAttentionは最小限の高速化を提供しますが、あまり効果的ではありません。理由は不明です。4090でテストしました。
+
+Python venv内で以下を実行してください:
+```bash
+git clone https://github.com/thu-ml/SageAttention
+pushd SageAttention
+  pip install . --no-build-isolation
+popd
+```
+
+#### AMD ROCmのフォローアップ手順
+
+AMD MI300Xを使用可能にするには、以下を実行する必要があります:
+
+```bash
+apt install amd-smi-lib
+pushd /opt/rocm/share/amd_smi
+python3 -m pip install --upgrade pip
+python3 -m pip install .
+popd
+```
+
+### 環境のセットアップ
+
+SimpleTunerを実行するには、設定ファイル、データセットとモデルのディレクトリ、およびデータローダー設定ファイルをセットアップする必要があります。
+
+#### 設定ファイル
+
+実験的なスクリプト`configure.py`を使用すると、インタラクティブなステップバイステップの設定を通じて、このセクションを完全にスキップできる可能性があります。これには、一般的な落とし穴を回避するのに役立つセーフティ機能が含まれています。
+
+**注意:** これはデータローダーを設定しません。後で手動で設定する必要があります。
+
+実行するには:
+
+```bash
+simpletuner configure
+```
+
+> ⚠️ Hugging Face Hubに容易にアクセスできない国に居住しているユーザーは、使用している`$SHELL`に応じて、`~/.bashrc`または`~/.zshrc`に`HF_ENDPOINT=https://hf-mirror.com`を追加する必要があります。
+
+### メモリオフロード(オプション)
+
+WanはSimpleTunerがサポートする最も重いモデルの1つです。VRAM上限に近い場合は、グループオフロードを有効にしてください:
+
+```bash
+--enable_group_offload \
+--group_offload_type block_level \
+--group_offload_blocks_per_group 1 \
+--group_offload_use_stream \
+# オプション: オフロードされたウェイトをRAMの代わりにディスクに書き出す
+# --group_offload_to_disk_path /fast-ssd/simpletuner-offload
+```
+
+- CUDAデバイスのみが`--group_offload_use_stream`を尊重します。ROCm/MPSは自動的にフォールバックします。
+- CPUメモリがボトルネックでない限り、ディスクステージングはコメントアウトしたままにしてください。
+- `--enable_model_cpu_offload`はグループオフロードと相互排他的です。
+
+### フィードフォワードチャンキング(オプション)
+
+勾配チェックポイント中に14BチェックポイントがまだOOMする場合は、Wanフィードフォワードレイヤーをチャンクしてください:
+
+```bash
+--enable_chunked_feed_forward \
+--feed_forward_chunk_size 2 \
+```
+
+これは設定ウィザード(`Training → Memory Optimisation`)の新しいトグルと一致します。チャンクサイズが小さいほどメモリを節約できますが、各ステップが遅くなります。クイック実験のために環境に`WAN_FEED_FORWARD_CHUNK_SIZE=2`を設定することもできます。
+
+
+手動で設定したい場合:
+
+`config/config.json.example`を`config/config.json`にコピーします:
+
+```bash
+cp config/config.json.example config/config.json
+```
+
+マルチGPUユーザーは、使用するGPUの数を設定する方法について、[このドキュメント](../OPTIONS.md#environment-configuration-variables)を参照してください。
+
+最終的な設定は私のものと同様になります:
+
+<details>
+<summary>設定例を表示</summary>
+
+```json
+{
+  "resume_from_checkpoint": "latest",
+  "quantize_via": "cpu",
+  "attention_mechanism": "sageattention",
+  "data_backend_config": "config/wan/multidatabackend.json",
+  "aspect_bucket_rounding": 2,
+  "seed": 42,
+  "minimum_image_size": 0,
+  "offload_during_startup": true,
+  "disable_benchmark": false,
+  "output_dir": "output/wan",
+  "lora_type": "standard",
+  "lycoris_config": "config/wan/lycoris_config.json",
+  "max_train_steps": 400000,
+  "num_train_epochs": 0,
+  "checkpoint_step_interval": 1000,
+  "checkpoints_total_limit": 5,
+  "hub_model_id": "wan-disney",
+  "push_to_hub": "true",
+  "push_checkpoints_to_hub": "true",
+  "tracker_project_name": "lora-training",
+  "tracker_run_name": "wan-adamW",
+  "report_to": "wandb",
+  "model_type": "lora",
+  "pretrained_model_name_or_path": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+  "pretrained_t5_model_name_or_path": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+  "model_family": "wan",
+  "train_batch_size": 2,
+  "gradient_checkpointing": true,
+  "gradient_accumulation_steps": 1,
+  "caption_dropout_probability": 0.1,
+  "resolution_type": "pixel_area",
+  "resolution": 480,
+  "validation_seed": 42,
+  "validation_step_interval": 100,
+  "validation_resolution": "832x480",
+  "validation_prompt": "两只拟人化的猫咪身穿舒适的拳击装备，戴着鲜艳的手套，在聚光灯照射的舞台上激烈对战",
+  "validation_negative_prompt": "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走",
+  "validation_guidance": 5.2,
+  "validation_num_inference_steps": 40,
+  "validation_num_video_frames": 81,
+  "mixed_precision": "bf16",
+  "optimizer": "optimi-lion",
+  "learning_rate": 0.00005,
+  "max_grad_norm": 0.01,
+  "grad_clip_method": "value",
+  "lr_scheduler": "cosine",
+  "lr_warmup_steps": 400000,
+  "base_model_precision": "no_change",
+  "vae_batch_size": 1,
+  "webhook_config": "config/wan/webhook.json",
+  "compress_disk_cache": true,
+  "use_ema": true,
+  "ema_validation": "ema_only",
+  "ema_update_interval": 2,
+  "delete_problematic_images": "true",
+  "disable_bucket_pruning": true,
+  "validation_guidance_skip_layers": [9],
+  "validation_guidance_skip_layers_start": 0.0,
+  "validation_guidance_skip_layers_stop": 1.0,
+  "lora_rank": 16,
+  "flow_schedule_shift": 3,
+  "validation_prompt_library": false,
+  "ignore_final_epochs": true
+}
+```
+</details>
+
+この設定で特に重要なのは検証設定です。これらがないと、出力はあまり良く見えません。
+
+### オプション: CREPA temporal regularizer
+
+Wanでより滑らかなモーションと少ないアイデンティティドリフトを実現するには:
+- **Training → Loss functions**で**CREPA**を有効にします。
+- **Block Index = 8**、**Weight = 0.5**、**Adjacent Distance = 1**、**Temporal Decay = 1.0**から始めます。
+- デフォルトエンコーダー(`dinov2_vitg14`、サイズ`518`)は良好に動作します。VRAMを削減する必要がある場合にのみ`dinov2_vits14` + `224`に切り替えてください。
+- 初回実行時にtorch hub経由でDINOv2をダウンロードします。オフラインでトレーニングする場合はキャッシュまたは事前取得してください。
+- キャッシュされたlatentsから完全にトレーニングする場合にのみ**Drop VAE Encoder**を有効にしてください。それ以外の場合は、ピクセルエンコードが引き続き機能するようにオフにしておきます。
+
+### 高度な実験的機能
+
+<details>
+<summary>高度な実験的詳細を表示</summary>
+
+
+SimpleTunerには、トレーニングの安定性とパフォーマンスを大幅に向上させる実験的機能が含まれています。
+
+*   **[Scheduled Sampling (Rollout)](../experimental/SCHEDULED_SAMPLING.md):** exposure biasを減らし、トレーニング中にモデルが独自の入力を生成できるようにすることで出力品質を向上させます。
+
+> ⚠️ これらの機能はトレーニングの計算オーバーヘッドを増加させます。
+
+</details>
+
+### TREADトレーニング
+
+> ⚠️ **実験的**: TREADは新しく実装された機能です。機能的ですが、最適な設定はまだ模索中です。
+
+[TREAD](../TREAD.md)(論文)は、**T**oken **R**outing for **E**fficient **A**rchitecture-agnostic **D**iffusionの略です。これは、transformerレイヤーを通じてトークンをインテリジェントにルーティングすることで、Fluxトレーニングを加速できる手法です。高速化はドロップするトークン数に比例します。
+
+#### クイックセットアップ
+
+bs=2と480pで約5秒/ステップに到達するためのシンプルで保守的なアプローチとして、`config.json`に以下を追加します(バニラ速度の10秒/ステップから短縮):
+
+<details>
+<summary>設定例を表示</summary>
+
+```json
+{
+  "tread_config": {
+    "routes": [
+      {
+        "selection_ratio": 0.1,
+        "start_layer_idx": 2,
+        "end_layer_idx": -2
+      }
+    ]
+  }
+}
+```
+</details>
+
+この設定は以下を行います:
+- レイヤー2から最後から2番目までの間、画像トークンの50%のみを保持
+- テキストトークンは決してドロップされません
+- トレーニングの高速化は約25%で、品質への影響は最小限
+- トレーニング品質と収束を向上させる可能性があります
+
+Wan 1.3Bの場合、全29レイヤーにわたる段階的なルート設定を使用してこのアプローチを強化し、bs=2と480pで約7.7秒/ステップの速度を達成できます:
+
+<details>
+<summary>設定例を表示</summary>
+
+```json
+{
+  "tread_config": {
+      "routes": [
+          { "selection_ratio": 0.1, "start_layer_idx": 2, "end_layer_idx": 8 },
+          { "selection_ratio": 0.25, "start_layer_idx": 9, "end_layer_idx": 11 },
+          { "selection_ratio": 0.35, "start_layer_idx": 12, "end_layer_idx": 15 },
+          { "selection_ratio": 0.25, "start_layer_idx": 16, "end_layer_idx": 23 },
+          { "selection_ratio": 0.1, "start_layer_idx": 24, "end_layer_idx": -2 }
+      ]
+  }
+}
+```
+</details>
+
+この設定は、意味的知識がそれほど重要でないモデルの内部レイヤーで、より積極的なトークンドロップアウトを使用しようとします。
+
+一部のデータセットでは、より積極的なドロップアウトが許容される場合がありますが、0.5の値はWan 2.1にとってかなり高いです。
+
+#### 重要なポイント
+
+- **限定的なアーキテクチャサポート** - TREADはFluxとWanモデルにのみ実装されています
+- **高解像度で最適** - 1024x1024以上でアテンションのO(n²)複雑性により最大の高速化
+- **マスク損失と互換性あり** - マスク領域は自動的に保持されます(ただし、これにより高速化が減少します)
+- **量子化と動作** - int8/int4/NF4トレーニングと組み合わせることができます
+- **初期損失スパイクを予想** - LoRA/LoKrトレーニングを開始する際、損失は最初に高くなりますが、すぐに修正されます
+
+#### チューニングのヒント
+
+- **保守的(品質重視)**: `selection_ratio`を0.1-0.3に設定
+- **積極的(速度重視)**: `selection_ratio`を0.3-0.5に設定し、品質への影響を受け入れる
+- **初期/後期レイヤーを避ける**: レイヤー0-1または最終レイヤーでルーティングしない
+- **LoRAトレーニングの場合**: わずかな速度低下が見られる可能性があります - 異なる設定で実験してください
+- **高解像度 = より良い高速化**: 1024px以上で最も有益
+
+#### 既知の動作
+
+- ドロップされるトークンが多いほど(より高い`selection_ratio`)、トレーニングは速くなりますが、初期損失が高くなります
+- LoRA/LoKrトレーニングでは、ネットワークが適応するにつれて急速に修正される初期損失スパイクが表示されます
+  - より積極的でないトレーニング設定、または内部レイヤーがより高いレベルを持つ複数のルートを使用すると、これが軽減されます
+- 一部のLoRA設定ではトレーニングがわずかに遅くなる可能性があります - 最適な設定はまだ模索中です
+- RoPE(回転位置エンベッディング)実装は機能していますが、100%正確ではない可能性があります
+
+詳細な設定オプションとトラブルシューティングについては、[完全なTREADドキュメント](../TREAD.md)を参照してください。
+
+
+#### 検証プロンプト
+
+`config/config.json`内には「プライマリ検証プロンプト」があり、これは通常、トレーニングしている単一のサブジェクトまたはスタイルのメインinstance_promptです。さらに、検証中に実行する追加のプロンプトを含むJSONファイルを作成できます。
+
+例の設定ファイル`config/user_prompt_library.json.example`には以下の形式が含まれています:
+
+<details>
+<summary>設定例を表示</summary>
+
+```json
+{
+  "nickname": "the prompt goes here",
+  "another_nickname": "another prompt goes here"
+}
+```
+</details>
+
+nicknamesは検証のファイル名なので、短くファイルシステムと互換性のあるものにしてください。
+
+トレーナーにこのプロンプトライブラリを指定するには、`config.json`の末尾に新しい行を追加してTRAINER_EXTRA_ARGSに追加します:
+<details>
+<summary>設定例を表示</summary>
+
+```json
+  "--user_prompt_library": "config/user_prompt_library.json",
+```
+</details>
+
+多様なプロンプトのセットは、トレーニング中にモデルが崩壊しているかどうかを判断するのに役立ちます。この例では、`<token>`という単語をサブジェクト名(instance_prompt)に置き換える必要があります。
+
+<details>
+<summary>設定例を表示</summary>
+
+```json
+{
+    "anime_<token>": "a breathtaking anime-style video featuring <token>, capturing her essence with vibrant colors, dynamic motion, and expressive storytelling",
+    "chef_<token>": "a high-quality, detailed video of <token> as a sous-chef, immersed in the art of culinary creation with captivating close-ups and engaging sequences",
+    "just_<token>": "a lifelike and intimate video portrait of <token>, showcasing her unique personality and charm through nuanced movement and expression",
+    "cinematic_<token>": "a cinematic, visually stunning video of <token>, emphasizing her dramatic and captivating presence through fluid camera movements and atmospheric effects",
+    "elegant_<token>": "an elegant and timeless video portrait of <token>, exuding grace and sophistication with smooth transitions and refined visuals",
+    "adventurous_<token>": "a dynamic and adventurous video featuring <token>, captured in an exciting, action-filled sequence that highlights her energy and spirit",
+    "mysterious_<token>": "a mysterious and enigmatic video portrait of <token>, shrouded in shadows and intrigue with a narrative that unfolds in subtle, cinematic layers",
+    "vintage_<token>": "a vintage-style video of <token>, evoking the charm and nostalgia of a bygone era through sepia tones and period-inspired visual storytelling",
+    "artistic_<token>": "an artistic and abstract video representation of <token>, blending creativity with visual storytelling through experimental techniques and fluid visuals",
+    "futuristic_<token>": "a futuristic and cutting-edge video portrayal of <token>, set against a backdrop of advanced technology with sleek, high-tech visuals",
+    "woman": "a beautifully crafted video portrait of a woman, highlighting her natural beauty and unique features through elegant motion and storytelling",
+    "man": "a powerful and striking video portrait of a man, capturing his strength and character with dynamic sequences and compelling visuals",
+    "boy": "a playful and spirited video portrait of a boy, capturing youthful energy and innocence through lively scenes and engaging motion",
+    "girl": "a charming and vibrant video portrait of a girl, emphasizing her bright personality and joy with colorful visuals and fluid movement",
+    "family": "a heartwarming and cohesive family video, showcasing the bonds and connections between loved ones through intimate moments and shared experiences"
+}
+```
+</details>
+
+> ℹ️ Wan 2.1はUMT5テキストエンコーダーのみを使用し、エンベッディングに多くのローカル情報があるため、短いプロンプトではモデルが良い仕事をするのに十分な情報がない可能性があります。より長く、より詳細なプロンプトを使用してください。
+
+#### CLIPスコア追跡
+
+これは現時点では動画モデルのトレーニングには有効にすべきではありません。
+
+# 安定した評価損失
+
+安定したMSE損失を使用してモデルのパフォーマンスをスコアリングしたい場合は、評価損失の設定と解釈に関する情報について[このドキュメント](../evaluation/EVAL_LOSS.md)を参照してください。
+
+#### 検証プレビュー
+
+SimpleTunerは、Tiny AutoEncoderモデルを使用して生成中の中間検証プレビューのストリーミングをサポートしています。これにより、webhookコールバックを介してリアルタイムでステップバイステップで生成される検証画像を確認できます。
+
+有効にするには:
+<details>
+<summary>設定例を表示</summary>
+
+```json
+{
+  "validation_preview": true,
+  "validation_preview_steps": 1
+}
+```
+</details>
+
+**要件:**
+- Webhook設定
+- 検証が有効
+
+Tiny AutoEncoderのオーバーヘッドを減らすために、`validation_preview_steps`をより高い値(例: 3または5)に設定してください。`validation_num_inference_steps=20`と`validation_preview_steps=5`の場合、ステップ5、10、15、20でプレビュー画像を受け取ります。
+
+#### フローマッチングスケジュールシフト
+
+Flux、Sana、SD3、LTX Video、Wan 2.1などのフローマッチングモデルには、単純な小数値を使用してタイムステップスケジュールのトレーニング部分をシフトできる`shift`というプロパティがあります。
+
+##### デフォルト
+デフォルトでは、スケジュールシフトは適用されず、タイムステップサンプリング分布のシグモイドベル形状が生成されます。これは`logit_norm`として知られています。
+
+##### 自動シフト
+一般的に推奨されるアプローチは、最近のいくつかの研究に従い、解像度に依存したタイムステップシフト`--flow_schedule_auto_shift`を有効にすることです。これにより、より大きな画像に対してはより高いシフト値が使用され、より小さな画像に対してはより低いシフト値が使用されます。これにより、安定しているが潜在的に平凡なトレーニング結果が得られます。
+
+##### 手動指定
+_以下の例は、DiscordのGeneral Awarenessに感謝します_
+
+> ℹ️ これらの例は、Flux Devを使用して値がどのように機能するかを示していますが、Wan 2.1は非常に似ているはずです。
+
+`--flow_schedule_shift`値0.1(非常に低い値)を使用すると、画像の細かい詳細のみが影響を受けます:
+![image](https://github.com/user-attachments/assets/991ca0ad-e25a-4b13-a3d6-b4f2de1fe982)
+
+`--flow_schedule_shift`値4.0(非常に高い値)を使用すると、大きな構成特徴と潜在的にモデルの色空間が影響を受けます:
+![image](https://github.com/user-attachments/assets/857a1f8a-07ab-4b75-8e6a-eecff616a28d)
+
+
+#### 量子化モデルトレーニング
+
+AppleおよびNVIDIAシステムでテストされ、Hugging Face Optimum-Quantoを使用して精度とVRAM要件を削減し、わずか16GBでトレーニングできます。
+
+
+
+`config.json`ユーザーの場合:
+<details>
+<summary>設定例を表示</summary>
+
+```json
+  "base_model_precision": "int8-quanto",
+  "text_encoder_1_precision": "no_change",
+  "text_encoder_2_precision": "no_change",
+  "lora_rank": 16,
+  "max_grad_norm": 1.0,
+  "base_model_default_dtype": "bf16"
+```
+</details>
+
+#### 検証設定
+
+SimpleTunerへのWan 2.1の追加を探索する初期段階では、Wan 2.1から恐ろしい悪夢のような出力が出てきましたが、これはいくつかの理由に帰着します:
+
+- 推論のステップ数が不十分
+  - UniPCを使用していない限り、おそらく少なくとも40ステップが必要です。UniPCは数を少し減らすことができますが、実験する必要があります。
+- 不正なスケジューラー設定
+  - 通常のEulerフローマッチングスケジュールを使用していましたが、Betas分布が最も機能するようです
+  - この設定に触れていない場合は、今は問題ないはずです
+- 不正な解像度
+  - Wan 2.1はトレーニングされた解像度でのみ正しく動作し、うまくいけば運が良ければ機能しますが、悪い結果になることが一般的です
+- 悪いCFG値
+  - Wan 2.1 1.3Bは特にCFG値に敏感なようですが、約4.0-5.0の値は安全なようです
+- 悪いプロンプティング
+  - もちろん、動画モデルはプロンプティングの神聖な芸術を学ぶために神秘主義者のチームが山で数か月過ごす禅の隠遁を必要とするようです。なぜなら、データセットとキャプションスタイルは聖杯のように守られているからです。
+  - つまり、異なるプロンプトを試してください。
+
+これらすべてにもかかわらず、バッチサイズが低すぎる、および/または学習率が高すぎる場合を除き、モデルはお気に入りの推論ツール(既に良い結果が得られるツールがあると仮定)で正しく実行されます。
+
+#### データセットの考慮事項
+
+データセットサイズには、処理とトレーニングにかかる計算と時間以外の制限はほとんどありません。
+
+データセットがモデルを効果的にトレーニングするのに十分な大きさであることを確認する必要がありますが、利用可能な計算量に対して大きすぎないようにしてください。
+
+最小データセットサイズは`train_batch_size * gradient_accumulation_steps`であり、`vae_batch_size`より大きい必要があることに注意してください。データセットが小さすぎると使用できません。
+
+> ℹ️ サンプルが十分に少ない場合、**no samples detected in dataset**というメッセージが表示される可能性があります - `repeats`値を増やすと、この制限を克服できます。
+
+持っているデータセットに応じて、データセットディレクトリとデータローダー設定ファイルを異なる方法でセットアップする必要があります。
+
+この例では、データセットとして[video-dataset-disney-organized](https://huggingface.co/datasets/sayakpaul/video-dataset-disney-organized)を使用します。
+
+以下を含む`--data_backend_config` (`config/multidatabackend.json`)ドキュメントを作成します:
+
+<details>
+<summary>設定例を表示</summary>
+
+```json
+[
+  {
+    "id": "disney-black-and-white",
+    "type": "local",
+    "dataset_type": "video",
+    "crop": false,
+    "resolution": 480,
+    "minimum_image_size": 480,
+    "maximum_image_size": 480,
+    "target_downsample_size": 480,
+    "resolution_type": "pixel_area",
+    "cache_dir_vae": "cache/vae/wan/disney-black-and-white",
+    "instance_data_dir": "datasets/disney-black-and-white",
+    "disabled": false,
+    "caption_strategy": "textfile",
+    "metadata_backend": "discovery",
+    "repeats": 0,
+    "video": {
+        "num_frames": 75,
+        "min_frames": 75,
+        "bucket_strategy": "aspect_ratio"
+    }
+  },
+  {
+    "id": "text-embeds",
+    "type": "local",
+    "dataset_type": "text_embeds",
+    "default": true,
+    "cache_dir": "cache/text/wan",
+    "disabled": false,
+    "write_batch_size": 128
+  }
+]
+```
+</details>
+
+> caption_strategyオプションと要件については、[DATALOADER.md](../DATALOADER.md#caption_strategy)を参照してください。
+
+- Wan 2.2 image-to-video実行はCLIPコンディショニングキャッシュを作成します。**video**データセットエントリで、専用のバックエンドを指定し、(オプションで)キャッシュパスをオーバーライドします:
+
+<details>
+<summary>設定例を表示</summary>
+
+```json
+  {
+    "id": "disney-black-and-white",
+    "type": "local",
+    "dataset_type": "video",
+    "conditioning_image_embeds": "disney-conditioning",
+    "cache_dir_conditioning_image_embeds": "cache/conditioning_image_embeds/disney-black-and-white"
+  }
+```
+</details>
+
+- コンディショニングバックエンドを一度定義し、必要に応じてデータセット間で再利用します(明確にするために完全なオブジェクトをここに示します):
+
+<details>
+<summary>設定例を表示</summary>
+
+```json
+  {
+    "id": "disney-conditioning",
+    "type": "local",
+    "dataset_type": "conditioning_image_embeds",
+    "cache_dir": "cache/conditioning_image_embeds/disney-conditioning",
+    "disabled": false
+  }
+```
+</details>
+
+- `video`サブセクションには、設定できる以下のキーがあります:
+  - `num_frames`(オプション、int)は、トレーニングするフレームデータの数です。
+    - 15 fpsでは、75フレームは5秒の動画で、標準出力です。これをターゲットにする必要があります。
+  - `min_frames`(オプション、int)は、トレーニングに考慮される動画の最小長を決定します。
+    - これは少なくとも`num_frames`と等しくなければなりません。設定しない場合は等しくなります。
+  - `max_frames`(オプション、int)は、トレーニングに考慮される動画の最大長を決定します。
+  - `bucket_strategy`(オプション、string)は、動画がバケットにグループ化される方法を決定します:
+    - `aspect_ratio`(デフォルト): 空間的アスペクト比のみでグループ化します(例: `1.78`、`0.75`)。
+    - `resolution_frames`: 解像度とフレーム数で`WxH@F`形式でグループ化します(例: `832x480@75`)。混合解像度/期間データセットに便利です。
+  - `frame_interval`(オプション、int) `resolution_frames`を使用する場合、フレーム数をこの間隔に丸めます。
+<!--  - `is_i2v`(オプション、bool)は、データセットでi2vトレーニングを行うかどうかを決定します。
+    - これはWan 2.1ではデフォルトでTrueに設定されています。ただし、無効にできます。
+-->
+
+次に、`datasets`ディレクトリを作成します:
+
+```bash
+mkdir -p datasets
+pushd datasets
+    huggingface-cli download --repo-type=dataset sayakpaul/video-dataset-disney-organized --local-dir=disney-black-and-white
+popd
+```
+
+これにより、すべてのDisney動画サンプルが自動的に作成される`datasets/disney-black-and-white`ディレクトリにダウンロードされます。
+
+#### WandBとHuggingface Hubへのログイン
+
+トレーニングを開始する前に、特に`--push_to_hub`と`--report_to=wandb`を使用している場合は、WandBとHF Hubにログインする必要があります。
+
+Git LFSリポジトリに手動でアイテムをプッシュする場合は、`git config --global credential.helper store`も実行する必要があります
+
+以下のコマンドを実行します:
+
+```bash
+wandb login
+```
+
+および
+
+```bash
+huggingface-cli login
+```
+
+指示に従って両方のサービスにログインします。
+
+### トレーニング実行の実行
+
+SimpleTunerディレクトリから、トレーニングを開始するいくつかのオプションがあります:
+
+**オプション1(推奨 - pipインストール):**
+```bash
+pip install simpletuner[cuda]
+simpletuner train
+```
+
+**オプション2(Gitクローン方式):**
+```bash
+simpletuner train
+```
+
+> ℹ️ Wan 2.2をトレーニングする際は、`TRAINER_EXTRA_ARGS`内またはCLI呼び出しで`--model_flavour i2v-14b-2.2-high`(または`low`)を追加し、必要に応じて`--wan_validation_load_other_stage`を追加してください。チェックポイントがtime-embedding shapeミスマッチを報告する場合にのみ`--wan_force_2_1_time_embedding`を追加してください。
+
+**オプション3(レガシー方式 - まだ動作します):**
+```bash
+./train.sh
+```
+
+これにより、テキストエンベッドとVAE出力のディスクへのキャッシングが開始されます。
+
+詳細については、[dataloader](../DATALOADER.md)および[tutorial](../TUTORIAL.md)ドキュメントを参照してください。
+
+## 注意事項とトラブルシューティングのヒント
+
+### 最低VRAM設定
+
+Wan 2.1は量子化に敏感であり、現在NF4またはINT4では使用できません。
+
+- OS: Ubuntu Linux 24
+- GPU: 単一のNVIDIA CUDAデバイス(10G、12G)
+- システムメモリ: 約12Gのシステムメモリ
+- ベースモデル精度: `int8-quanto`
+- オプティマイザー: Lion 8Bit Paged、`bnb-lion8bit-paged`
+- 解像度: 480px
+- バッチサイズ: 1、ゼロ勾配累積ステップ
+- DeepSpeed: 無効/未設定
+- PyTorch: 2.6
+- OOMを防ぐために`--gradient_checkpointing`を有効にしてください
+- 画像のみでトレーニングするか、動画データセットの`num_frames`を1に設定してください
+
+**注意**: VAEエンベッドとテキストエンコーダー出力の事前キャッシングはより多くのメモリを使用し、まだOOMする可能性があります。そのため、`--offload_during_startup=true`が基本的に必要です。その場合、テキストエンコーダー量子化とVAEタイリングを有効にできます。(WanはVAEタイリング/スライシングを現在サポートしていません)
+
+速度:
+- M3 Max Macbook Proで665.8秒/イテレーション
+- NVIDIA 4090でバッチサイズ1で2秒/イテレーション
+- NVIDIA 4090でバッチサイズ4で11秒/イテレーション
+
+### SageAttention
+
+`--attention_mechanism=sageattention`を使用する場合、検証時に推論を高速化できます。
+
+**注意**: これは最終的なVAEデコードステップと互換性がなく、その部分は高速化されません。
+
+### マスク損失
+
+これはWan 2.1では使用しないでください。
+
+### 量子化
+- このモデルを24Gでトレーニングするために量子化は必要ありません
+
+### 画像アーティファクト
+Wanは、Euler Betasフローマッチングスケジュール、または(デフォルトで)UniPCマルチステップソルバー(より強い予測を行う高次スケジューラー)を使用する必要があります。
+
+他のDiTモデルと同様に、以下のようなことを行うと(他にも)、サンプルに正方形のグリッドアーティファクトが現れ**始める可能性があります**:
+- 低品質データで過剰トレーニング
+- 学習率が高すぎる
+- 過剰トレーニング(一般的に)、画像が多すぎる低容量ネットワーク
+- 不十分なトレーニング(同様に)、画像が少なすぎる高容量ネットワーク
+- 奇妙なアスペクト比またはトレーニングデータサイズの使用
+
+### アスペクトバケット化
+- 動画は画像のようにバケット化されます。
+- 正方形のクロップで長時間トレーニングしても、このモデルはそれほど損傷しません。自由に使ってください、素晴らしく信頼性があります。
+- 一方、データセットの自然なアスペクトバケットを使用すると、推論時にこれらの形状が過度にバイアスされる可能性があります。
+  - これは望ましい品質である可能性があります。シネマティックなものなどのアスペクト依存スタイルが他の解像度に過度に浸透するのを防ぐためです。
+  - ただし、多くのアスペクトバケット全体で結果を均等に改善したい場合は、`crop_aspect=random`を試す必要がありますが、これには独自の欠点があります。
+- 画像ディレクトリデータセットを複数回定義することでデータセット設定を混合すると、非常に良い結果と適切に一般化されたモデルが生成されました。
+
+### カスタムファインチューンされたWan 2.1モデルのトレーニング
+
+Hugging Face Hub上の一部のファインチューンされたモデルには完全なディレクトリ構造がなく、特定のオプションを設定する必要があります。
+
+<details>
+<summary>設定例を表示</summary>
+
+```json
+{
+    "model_family": "wan",
+    "pretrained_model_name_or_path": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+    "pretrained_transformer_model_name_or_path": "path/to-the-other-model",
+    "pretrained_vae_model_name_or_path": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+    "pretrained_transformer_subfolder": "none",
+}
+```
+</details>
+
+> 注意: `pretrained_transformer_name_or_path`に単一ファイルの`.safetensors`へのパスを提供できます

--- a/documentation/webui/TUTORIAL.ja.md
+++ b/documentation/webui/TUTORIAL.ja.md
@@ -1,0 +1,348 @@
+# SimpleTuner WebUI チュートリアル
+
+## はじめに
+
+このチュートリアルでは、SimpleTuner Web インターフェースの使い方をご案内します。
+
+## 必要なパッケージのインストール
+
+Ubuntu システムの場合、まず必要なパッケージをインストールします:
+
+```bash
+apt -y install python3.12-venv python3.12-dev
+apt -y install libopenmpi-dev openmpi-bin cuda-toolkit-12-8 libaio-dev # DeepSpeed を使用する場合
+apt -y install ffmpeg # ビデオモデルをトレーニングする場合
+```
+
+## ワークスペースディレクトリの作成
+
+ワークスペースには、設定ファイル、出力モデル、検証画像、そして場合によってはデータセットが含まれます。
+
+Vast などのプロバイダーでは、`/workspace/simpletuner` ディレクトリを使用できます:
+
+```bash
+mkdir -p /workspace/simpletuner
+export SIMPLETUNER_WORKSPACE=/workspace/simpletuner
+cd $SIMPLETUNER_WORKSPACE
+```
+
+ホームディレクトリに作成する場合は:
+```bash
+mkdir ~/simpletuner-workspace
+export SIMPLETUNER_WORKSPACE=~/simpletuner-workspace
+cd $SIMPLETUNER_WORKSPACE
+```
+
+## SimpleTuner をワークスペースにインストール
+
+依存関係をインストールするための仮想環境を作成します:
+
+```bash
+python3.12 -m venv .venv
+. .venv/bin/activate
+```
+
+### CUDA 固有の依存関係
+
+NVIDIA ユーザーは、すべての正しい依存関係を取得するために CUDA extras を使用する必要があります:
+
+```bash
+pip install -e 'simpletuner[cuda]'
+# または、git 経由でクローンした場合:
+# pip install -e '.[cuda]'
+```
+
+Apple や ROCm ハードウェアのユーザー向けの他の extras については、[インストール手順](../INSTALL.md)を参照してください。
+
+## サーバーの起動
+
+ポート 8080 で SSL を有効にしてサーバーを起動するには:
+
+```bash
+# DeepSpeed の場合、CUDA_HOME を正しい場所に向ける必要があります
+export CUDA_HOME=/usr/local/cuda-12.8
+export LIBRARY_PATH=$CUDA_HOME/targets/x86_64-linux/lib/stubs:$LIBRARY_PATH
+export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$CUDA_HOME/targets/x86_64-linux/lib/stubs:$LD_LIBRARY_PATH
+
+simpletuner server --ssl --port 8080
+```
+
+次に、ウェブブラウザで https://localhost:8080 にアクセスします。
+
+SSH 経由でポートをフォワーディングする必要がある場合があります。例えば:
+
+```bash
+ssh -L 8080:localhost:8080 user@remote-server
+```
+
+> **ヒント:** 既存の設定環境(例: 以前の CLI 使用から)がある場合、`--env` を使ってサーバーを起動すると、サーバーの準備が整い次第、自動的にトレーニングを開始できます:
+>
+> ```bash
+> simpletuner server --ssl --port 8080 --env my-training-config
+> ```
+>
+> これは、サーバーを起動してから WebUI で手動で「トレーニング開始」をクリックするのと同等ですが、無人起動が可能です。
+
+## 初回セットアップ: 管理者アカウントの作成
+
+初回起動時、SimpleTuner は管理者アカウントの作成を要求します。初めて WebUI にアクセスすると、最初の管理者ユーザーを作成するよう促すセットアップ画面が表示されます。
+
+メールアドレス、ユーザー名、および安全なパスワードを入力してください。このアカウントは完全な管理者権限を持ちます。
+
+### ユーザー管理
+
+セットアップ後、**ユーザー管理**ページ(管理者としてログインしているときにサイドバーからアクセス可能)からユーザーを管理できます:
+
+- **ユーザータブ**: ユーザーアカウントの作成、編集、削除。権限レベル(閲覧者、研究者、リーダー、管理者)の割り当て。
+- **レベルタブ**: きめ細かいアクセス制御を持つカスタム権限レベルの定義。
+- **認証プロバイダータブ**: シングルサインオンのための外部認証(OIDC、LDAP)の設定。
+- **登録タブ**: 新しいユーザーの自己登録を許可するかどうかの制御(デフォルトでは無効)。
+
+### 自動化のための API キー
+
+ユーザーは、プロフィールまたは管理者パネルからスクリプトアクセス用の API キーを生成できます。API キーは `st_` プレフィックスを使用し、`X-API-Key` ヘッダーで使用できます:
+
+```bash
+curl -s http://localhost:8080/api/training/status \
+  -H 'X-API-Key: st_your_key_here'
+```
+
+> **注意:** プライベート/内部デプロイメントの場合、公開登録を無効にしたままにし、管理者パネルを通じて手動でユーザーアカウントを作成してください。
+
+## WebUI の使用
+
+### オンボーディングステップ
+
+ページが読み込まれると、環境をセットアップするためのオンボーディング質問が表示されます。
+
+#### 設定ディレクトリ
+
+特別な設定値 `configs_dir` は、すべての SimpleTuner 設定を含むフォルダを指すために導入されました。サブディレクトリに整理することが推奨されます - **Web UI がこれを自動的に行います**:
+
+```
+configs/
+├── an-environment-named-something
+│   ├── config.json
+│   ├── lycoris_config.json
+│   └── multidatabackend-DataBackend-Name.json
+```
+
+<img width="788" height="465" alt="image" src="https://github.com/user-attachments/assets/656aa287-3b59-476d-ac45-6ede325fe858" />
+
+##### コマンドライン使用からの移行
+
+以前に WebUI なしで SimpleTuner を使用していた場合、既存の config/ フォルダを指すことで、すべての環境が自動的に検出されます。
+
+新規ユーザーの場合、設定とデータセットのデフォルトの場所は `~/.simpletuner/` となり、データセットをより多くのスペースがある場所に移動することが推奨されます:
+
+<img width="775" height="454" alt="image" src="https://github.com/user-attachments/assets/39238810-da26-4bde-8fc9-1002251f778a" />
+
+
+#### (マルチ-)GPU の選択と設定
+
+デフォルトパスの設定後、マルチ GPU を設定できるステップに到達します(Macbook で撮影)
+
+<img width="755" height="646" alt="image" src="https://github.com/user-attachments/assets/de43a09d-06a7-45c0-8111-7a0b014499c8" />
+
+複数の GPU があり、2 番目のものだけを使用したい場合は、ここで設定できます。
+
+> **マルチ GPU ユーザーへの注意:** 複数の GPU でトレーニングする場合、データセットサイズの要件は比例して増加します。有効なバッチサイズは `train_batch_size × num_gpus × gradient_accumulation_steps` として計算されます。データセットがこの値より小さい場合は、データセット設定で `repeats` 設定を増やすか、詳細設定で `--allow_dataset_oversubscription` オプションを有効にする必要があります。詳細については、以下の[バッチサイズセクション](#マルチ-gpu-バッチサイズの考慮事項)を参照してください。
+
+#### 最初のトレーニング環境の作成
+
+`configs_dir` に既存の設定が見つからなかった場合、**最初のトレーニング環境**を作成するよう求められます:
+
+<img width="750" height="1381" alt="image" src="https://github.com/user-attachments/assets/4a3ee88f-c70f-416c-ae5d-6593deb9ca35" />
+
+**例から起動**を使用して、開始する例の設定を選択するか、説明的な名前を入力してランダムな環境を作成することもできます。セットアップウィザードを使用したい場合は後者を選択してください。
+
+### トレーニング環境の切り替え
+
+既存の設定環境がある場合、このドロップダウンメニューに表示されます。
+
+それ以外の場合、オンボーディング中に作成したオプションが既に選択されアクティブになっています。
+
+<img width="965" height="449" alt="image" src="https://github.com/user-attachments/assets/d8c73cef-ecbb-4229-ad54-9ccd55f8175a" />
+
+**設定の管理**を使用して、環境、データローダー、その他の設定のリストがある `Environment` タブに移動します。
+
+### 設定ウィザード
+
+最も重要な設定のいくつかを、分かりやすいブートストラップで設定するための包括的なセットアップウィザードを提供するために努力しました。
+
+<img width="394" height="286" alt="image" src="https://github.com/user-attachments/assets/21e99854-1d75-4ba9-8be6-15e715d77f4e" />
+
+左上のナビゲーションメニューで、ウィザードボタンをクリックすると選択ダイアログが表示されます:
+
+<img width="1186" height="1756" alt="image" src="https://github.com/user-attachments/assets/f6d4ac57-e3f6-4060-a4d3-b7f0829d7350" />
+
+そして、すべての組み込みモデルバリアントが提供されます。各バリアントは、アテンションマスキングや拡張トークン制限などの必要な設定を事前に有効にします。
+
+#### LoRA モデルオプション
+
+LoRA をトレーニングしたい場合、ここでモデルの量子化オプションを設定できます。
+
+一般的に、Stable Diffusion タイプのモデルをトレーニングしている場合を除き、int8-quanto が推奨されます。品質を損なうことなく、より高いバッチサイズを可能にします。
+
+Cosmos2、Sana、PixArt などの一部の小さなモデルは、量子化を好みません。
+
+<img width="1106" height="1464" alt="image" src="https://github.com/user-attachments/assets/0284d987-6060-4692-934a-0905ef2d5ca1" />
+
+#### フルランクトレーニング
+
+フルランクトレーニングは推奨されません。通常、同じデータセットの場合、LoRA/LyCORIS よりもはるかに長い時間がかかり、リソースのコストも高くなります。
+
+ただし、完全なチェックポイントをトレーニングしたい場合は、Auraflow、Flux などの大きなモデルに必要な DeepSpeed ZeRO ステージをここで設定できます。
+
+FSDP2 はサポートされていますが、このウィザードでは設定できません。DeepSpeed を無効のままにして、後で使用したい場合は FSDP2 を手動で設定してください
+
+<img width="1097" height="1278" alt="image" src="https://github.com/user-attachments/assets/60475318-facd-4da1-a2a1-67cecff18e04" />
+
+
+#### トレーニング期間の設定
+
+トレーニング時間をエポックまたはステップのどちらで測定するかを決定する必要があります。最終的にはほぼ同じですが、人によって好みが分かれることがあります。
+
+<img width="1136" height="1091" alt="image" src="https://github.com/user-attachments/assets/9146cdcd-f277-45e5-92cb-f74f23039d51" />
+
+#### Hugging Face Hub を介したモデルの共有
+
+オプションで、最終的な*および*中間チェックポイントを [Hugging Face Hub](https://hf.co) に公開できますが、アカウントが必要です - ウィザードまたは公開タブからハブにログインできます。いずれにしても、いつでも気が変わって有効または無効にすることができます。
+
+モデルを公開する場合、モデルを一般公開したくない場合は `Private repo` を選択することを忘れないでください。
+
+<img width="1090" height="859" alt="image" src="https://github.com/user-attachments/assets/d1f86b6b-b0d5-4caa-b3ff-6bd106928094" />
+
+#### モデルの検証
+
+トレーナーに定期的に画像を生成させたい場合は、ウィザードのこの時点で単一の検証プロンプトを設定できます。複数のプロンプトライブラリは、ウィザード完了後に `Validations & Output` タブで設定できます。
+
+検証を独自のスクリプトやサービスにアウトソースしたいですか? ウィザード後に検証タブで**検証方法**を `external-script` に切り替え、`--validation_external_script` を指定してください。`{local_checkpoint_path}`、`{global_step}`、`{tracker_run_name}`、`{tracker_project_name}`、`{model_family}`、`{huggingface_path}` などのプレースホルダーを使用して、トレーニングコンテキストをスクリプトに渡すことができます。また、任意の `validation_*` 設定値(例: `validation_num_inference_steps`、`validation_guidance`、`validation_noise_scheduler`)も使用できます。トレーニングをブロックせずに実行するには、`--validation_external_background` を有効にしてください。
+
+チェックポイントがディスクに保存された瞬間にフックが必要ですか? 各保存の直後(アップロード開始前)にスクリプトを実行するには、`--post_checkpoint_script` を使用してください。同じプレースホルダーを受け入れ、`{remote_checkpoint_path}` は空のままです。
+
+SimpleTuner の組み込み公開プロバイダー(または Hugging Face Hub アップロード)を保持しながら、リモート URL で独自の自動化をトリガーしたい場合は、代わりに `--post_upload_script` を使用してください。プレースホルダー `{remote_checkpoint_path}`、`{local_checkpoint_path}`、`{global_step}`、`{tracker_run_name}`、`{tracker_project_name}`、`{model_family}`、`{huggingface_path}` を使用して、アップロードごとに 1 回実行されます。SimpleTuner はスクリプトの出力をキャプチャしません—スクリプトから直接トラッカーの更新を発行してください。
+
+フックの例:
+
+```bash
+--post_upload_script='/opt/hooks/notify.sh {remote_checkpoint_path} {tracker_project_name} {tracker_run_name}'
+```
+
+ここで、`notify.sh` は URL をトラッカーの Web API に投稿します。Slack、カスタムダッシュボード、またはその他の統合に自由に適応させてください。
+
+実際のサンプル: `simpletuner/examples/external-validation/replicate_post_upload.py` は、`{remote_checkpoint_path}`、`{model_family}`、`{model_type}`、`{lora_type}`、`{huggingface_path}` を使用して、アップロード後に Replicate 推論をトリガーする方法を示しています。
+
+別のサンプル: `simpletuner/examples/external-validation/wavespeed_post_upload.py` は WaveSpeed API を呼び出し、同じプレースホルダーを使用して結果をポーリングします。
+
+Flux に焦点を当てたサンプル: `simpletuner/examples/external-validation/fal_post_upload.py` は fal.ai Flux LoRA エンドポイントを呼び出します。`FAL_KEY` が必要で、`model_family` に `flux` が含まれている場合にのみ実行されます。
+
+ローカル GPU サンプル: `simpletuner/examples/external-validation/use_second_gpu.py` は別の GPU(デフォルトは `cuda:1`)で Flux LoRA 推論を実行し、アップロードが発生しない場合でも使用できます。
+
+<img width="1101" height="1357" alt="image" src="https://github.com/user-attachments/assets/97bdd3f1-b54c-4087-b4d5-05da8b271751" />
+
+#### トレーニング統計のログ記録
+
+SimpleTuner は、トレーニング統計を送信したい場合、複数のターゲット API をサポートしています。
+
+注意: 個人データ、トレーニングログ、キャプション、またはデータは SimpleTuner プロジェクト開発者に**決して**送信されません。データの制御は**あなた**の手にあります。
+
+<img width="1099" height="1067" alt="image" src="https://github.com/user-attachments/assets/c9be9a20-12ad-402a-9605-66ba5771e630" />
+
+#### データセット設定
+
+この時点で、既存のデータセットを保持するか、データセット作成ウィザードを通じて新しい設定を作成する(他のデータセットはそのまま)かを決定できます。クリックすると表示されます。
+
+<img width="1103" height="877" alt="image" src="https://github.com/user-attachments/assets/3d3cc391-52ed-422e-a4a1-676ca342df10" />
+
+##### データセットウィザード
+
+新しいデータセットを作成することを選択した場合、次のウィザードが表示され、ローカルまたはクラウドのデータセットの追加を案内されます。
+
+<img width="1110" height="857" alt="image" src="https://github.com/user-attachments/assets/3719e0f5-774e-461d-be02-902e08a679f6" />
+
+<img width="1082" height="1255" alt="image" src="https://github.com/user-attachments/assets/ac38a3de-364a-447f-a734-cab2bdd5338d" />
+
+ローカルデータセットの場合、**ディレクトリを参照**ボタンを使用してデータセットブラウザモーダルにアクセスできます。
+
+<img width="1201" height="1160" alt="image" src="https://github.com/user-attachments/assets/66a333d0-30fa-45d1-a5b2-1e859d789677" />
+
+オンボーディング中にデータセットディレクトリを正しく指定した場合、ここにファイルが表示されます。
+
+追加したいディレクトリをクリックして、**ディレクトリを選択**してください。
+
+<img width="907" height="709" alt="image" src="https://github.com/user-attachments/assets/1d482655-158a-4e3f-93b7-ef158396813c" />
+
+その後、解像度値とクロッピングの設定を案内されます。
+
+**注意**: SimpleTuner は画像を*アップスケール*しないため、設定した解像度以上のサイズであることを確認してください。
+
+キャプションを設定するステップに到達したら、どのオプションが正しいか**慎重に検討**してください。
+
+単一のトリガーワードを使用したい場合は、**インスタンスプロンプト**オプションになります。
+
+<img width="1146" height="896" alt="image" src="https://github.com/user-attachments/assets/6252bf9a-5e68-41c6-8a95-906993f2f546" />
+
+##### オプション: ブラウザからデータセットをアップロード
+
+画像とキャプションがまだボックスにない場合、データセットウィザードには**ディレクトリを参照**の横に**アップロード**ボタンが含まれるようになりました。次のことができます:
+
+- 設定されたデータセットディレクトリの下に新しいサブフォルダを作成し、個々のファイルまたは ZIP をアップロードします(画像と .txt/.jsonl/.csv メタデータが受け入れられます)。
+- SimpleTuner にそのフォルダに ZIP を展開させます(ローカルバックエンド用にサイズ設定されています。非常に大きなアーカイブは拒否されます)。
+- UI を離れることなく、ブラウザで新しくアップロードされたフォルダをすぐに選択し、ウィザードを続行します。
+
+#### 学習率、バッチサイズ、オプティマイザ
+
+データセットウィザードを完了すると(または既存のデータセットを保持することを選択した場合)、オプティマイザ/学習率とバッチサイズのプリセットが提供されます。
+
+これらは、初心者が最初のいくつかのトレーニング実行でやや良い選択をするのに役立つ出発点です - 経験豊富なユーザーは、完全な制御のために**手動設定**を使用してください。
+
+**注意**: 後で DeepSpeed を使用する予定がある場合、ここでのオプティマイザの選択はあまり重要ではありません。
+
+##### マルチ GPU バッチサイズの考慮事項 {#マルチ-gpu-バッチサイズの考慮事項}
+
+複数の GPU でトレーニングする場合、データセットは**有効なバッチサイズ**に対応する必要があることに注意してください:
+
+```
+effective_batch_size = train_batch_size × num_gpus × gradient_accumulation_steps
+```
+
+データセットがこの値より小さい場合、SimpleTuner は特定のガイダンスを含むエラーを発生させます。次のことができます:
+- バッチサイズを減らす
+- データセット設定で `repeats` 値を増やす
+- 詳細設定で**データセットオーバーサブスクリプションを許可**を有効にして、繰り返しを自動的に調整する
+
+データセットのサイズ設定の詳細については、[DATALOADER.md](../DATALOADER.md#multi-gpu-training-and-dataset-sizing) を参照してください。
+
+<img width="1118" height="1015" alt="image" src="https://github.com/user-attachments/assets/25d5650d-e77b-42fe-b749-06c0ec92b1e2" />
+
+#### メモリ最適化プリセット
+
+コンシューマーハードウェアでのより簡単なセットアップのために、各モデルには、軽量、バランス、または積極的なメモリ節約を選択できるカスタムプリセットが含まれています。
+
+**トレーニング**タブの**メモリ最適化**セクションに、**プリセットの読み込み**ボタンがあります:
+
+<img width="1048" height="940" alt="image" src="https://github.com/user-attachments/assets/804e84f6-7eb8-493e-95d2-a89d930bafa5" />
+
+このインターフェースが表示されます:
+
+<img width="1048" height="940" alt="image" src="https://github.com/user-attachments/assets/775aaee5-c3c0-4659-bbea-ebb39e3eb098" />
+
+
+#### 確認と保存
+
+選択したすべての値に満足している場合は、ウィザードを**完了**してください。
+
+そして、新しい環境がアクティブに選択され、トレーニングの準備ができていることがわかります!
+
+ほとんどの場合、これらの設定がすべて設定する必要があったものです。追加のデータセットを追加したり、他の設定をいじったりすることもできます。
+
+<img width="1096" height="1403" alt="image" src="https://github.com/user-attachments/assets/29fd0bb3-aab2-4455-9612-583ed949ce64" />
+
+**環境**ページには、新しく設定されたトレーニングジョブと、テンプレートとして使用したい場合に設定をダウンロードまたは複製するボタンが表示されます。
+
+<img width="1881" height="874" alt="image" src="https://github.com/user-attachments/assets/33c0cafa-3fd8-40ee-b6fa-3704b6e698da" />
+
+**注意**: **デフォルト**環境は特別であり、一般的なトレーニング環境として使用することは推奨されません。その設定は、そのオプションを有効にする任意の環境に自動的にマージできます、**環境のデフォルトを使用**:
+
+<img width="1521" height="991" alt="image" src="https://github.com/user-attachments/assets/9d18b0c1-608e-4ab2-be14-65b98907ec69" />


### PR DESCRIPTION
This pull request adds comprehensive Japanese documentation for SimpleTuner, including a full README, installation guide, quickstart, tutorial, and index page. The new docs provide detailed explanations of features, supported models, hardware requirements, installation steps, and advanced usage, making the toolkit much more accessible to Japanese-speaking users.

**Documentation Additions and Improvements:**

* Added a detailed Japanese `README.ja.md` describing SimpleTuner's philosophy, features, supported models, hardware requirements, setup, troubleshooting, and links to further guides.
* Created a thorough Japanese installation guide in `documentation/INSTALL.ja.md`, covering pip and git installation, platform-specific steps (NVIDIA, AMD, Apple), multi-GPU setup, dataset preparation, and debugging.
* Added a Japanese quickstart guide in `documentation/QUICKSTART.ja.md` with a model compatibility matrix and explanations for advanced and experimental features.
* Provided a Japanese tutorial in `documentation/TUTORIAL.ja.md` that integrates with the installation guide and links to all major documentation resources for deeper learning.
* Introduced a Japanese documentation index in `documentation/index.ja.md`, presenting a feature overview and navigation cards for all major documentation sections.