### PR TITLE
qwen edit: fix unexpected argument max sequence length

### DIFF
--- a/simpletuner/helpers/models/qwen_image/pipeline.py
+++ b/simpletuner/helpers/models/qwen_image/pipeline.py
@@ -272,6 +272,7 @@ class QwenImageEditPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
         num_images_per_prompt: int = 1,
         prompt_embeds: Optional[torch.Tensor] = None,
         prompt_embeds_mask: Optional[torch.Tensor] = None,
+        max_sequence_length: int = 512,
     ):
         r"""
 

--- a/simpletuner/helpers/models/qwen_image/pipeline_edit_plus.py
+++ b/simpletuner/helpers/models/qwen_image/pipeline_edit_plus.py
@@ -286,6 +286,7 @@ class QwenImageEditPlusPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
         num_images_per_prompt: int = 1,
         prompt_embeds: Optional[torch.Tensor] = None,
         prompt_embeds_mask: Optional[torch.Tensor] = None,
+        max_sequence_length: int = 512,
     ):
         r"""
 


### PR DESCRIPTION
This pull request introduces a small change to the `encode_prompt` function in both `pipeline.py` and `pipeline_edit_plus.py` for the Qwen image model helpers. The change adds a new parameter, `max_sequence_length`, with a default value of 512, to the function signature.

- Added a `max_sequence_length` parameter (default: 512) to the `encode_prompt` function in `simpletuner/helpers/models/qwen_image/pipeline.py` to allow for configurable sequence length.
- Added a `max_sequence_length` parameter (default: 512) to the `encode_prompt` function in `simpletuner/helpers/models/qwen_image/pipeline_edit_plus.py` for the same purpose.