### PR TITLE
set default batch sizes for read and processing and encoding to 1 when caching videos

### DIFF
--- a/simpletuner/helpers/data_backend/factory.py
+++ b/simpletuner/helpers/data_backend/factory.py
@@ -3433,6 +3433,57 @@ class FactoryRegistry:
             if candidate is not None:
                 vae = candidate
 
+        process_queue_size = backend.get("image_processing_batch_size")
+        read_batch_size = backend.get("read_batch_size")
+        write_batch_size = backend.get("write_batch_size")
+        vae_batch_size = backend.get("vae_batch_size")
+
+        if dataset_type_enum is DatasetType.VIDEO:
+            if process_queue_size is None:
+                process_queue_size = self.args.image_processing_batch_size
+                if process_queue_size != 1:
+                    info_log(
+                        f"(id={init_backend['id']}) Defaulting image_processing_batch_size to 1 for video dataset "
+                        "to reduce memory usage. Set image_processing_batch_size to override."
+                    )
+                process_queue_size = 1
+
+            if read_batch_size is None:
+                read_batch_size = self.args.read_batch_size
+                if read_batch_size != 1:
+                    info_log(
+                        f"(id={init_backend['id']}) Defaulting read_batch_size to 1 for video dataset "
+                        "to reduce memory usage. Set read_batch_size to override."
+                    )
+                read_batch_size = 1
+
+            if write_batch_size is None:
+                write_batch_size = self.args.write_batch_size
+                if write_batch_size != 1:
+                    info_log(
+                        f"(id={init_backend['id']}) Defaulting write_batch_size to 1 for video dataset "
+                        "to reduce memory usage. Set write_batch_size to override."
+                    )
+                write_batch_size = 1
+
+            if vae_batch_size is None:
+                vae_batch_size = self.args.vae_batch_size
+                if vae_batch_size != 1:
+                    info_log(
+                        f"(id={init_backend['id']}) Defaulting vae_batch_size to 1 for video dataset "
+                        "to reduce memory usage. Set vae_batch_size to override."
+                    )
+                vae_batch_size = 1
+        else:
+            if process_queue_size is None:
+                process_queue_size = self.args.image_processing_batch_size
+            if read_batch_size is None:
+                read_batch_size = self.args.read_batch_size
+            if write_batch_size is None:
+                write_batch_size = self.args.write_batch_size
+            if vae_batch_size is None:
+                vae_batch_size = self.args.vae_batch_size
+
         init_backend["vaecache"] = VAECache(
             id=init_backend["id"],
             dataset_type=init_backend["dataset_type"],
@@ -3445,12 +3496,12 @@ class FactoryRegistry:
             instance_data_dir=init_backend["instance_data_dir"],
             delete_problematic_images=backend.get("delete_problematic_images", self.args.delete_problematic_images),
             num_video_frames=video_config.get("num_frames", None),
-            vae_batch_size=backend.get("vae_batch_size", self.args.vae_batch_size),
-            write_batch_size=backend.get("write_batch_size", self.args.write_batch_size),
-            read_batch_size=backend.get("read_batch_size", self.args.read_batch_size),
+            vae_batch_size=vae_batch_size,
+            write_batch_size=write_batch_size,
+            read_batch_size=read_batch_size,
             cache_dir=vae_cache_dir,
             max_workers=backend.get("max_workers", self.args.max_workers),
-            process_queue_size=backend.get("image_processing_batch_size", self.args.image_processing_batch_size),
+            process_queue_size=process_queue_size,
             vae_cache_ondemand=self.args.vae_cache_ondemand,
             vae_cache_disable=getattr(self.args, "vae_cache_disable", False),
             hash_filenames=True,  # always enabled


### PR DESCRIPTION
Closes #2351 

This pull request updates the logic for configuring batch sizes in the VAE cache setup, with a focus on optimizing memory usage for video datasets. The main change is that when the dataset type is video, batch sizes are now defaulted to 1 unless explicitly overridden, and informative log messages are provided when this defaulting occurs.

Batch size configuration improvements for video datasets:

* When `dataset_type_enum` is `DatasetType.VIDEO`, the `image_processing_batch_size`, `read_batch_size`, `write_batch_size`, and `vae_batch_size` are each set to 1 by default if not specified, with a log message explaining the reason for the default to help users understand the memory optimization.
* For non-video datasets, the batch sizes fall back to their respective argument values if not specified in the backend configuration.

Initialization consistency:

* The batch size values passed to the `VAECache` constructor (`vae_batch_size`, `write_batch_size`, `read_batch_size`, and `process_queue_size`) now use the resolved variables rather than reading from the backend configuration again, ensuring consistency with the new logic.