### PR TITLE
discovery backend should use ffprobe to identify video metadata

### DIFF
--- a/simpletuner/helpers/metadata/backends/discovery.py
+++ b/simpletuner/helpers/metadata/backends/discovery.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import shutil
 import traceback
 from io import BytesIO
 from typing import Optional
@@ -35,6 +36,15 @@ if should_log():
 else:
     target_level = "ERROR"
 logger.setLevel(target_level)
+
+_ffprobe_available: Optional[bool] = None
+
+
+def _is_ffprobe_available() -> bool:
+    global _ffprobe_available
+    if _ffprobe_available is None:
+        _ffprobe_available = shutil.which("ffprobe") is not None
+    return _ffprobe_available
 
 
 class DiscoveryMetadataBackend(MetadataBackend):
@@ -83,6 +93,138 @@ class DiscoveryMetadataBackend(MetadataBackend):
             cache_file_suffix=cache_file_suffix,
             repeats=repeats,
         )
+
+    def _should_use_metadata_only_for_video(self) -> bool:
+        if not _is_ffprobe_available():
+            return False
+        if self.dataset_type is not DatasetType.VIDEO:
+            return False
+        crop_enabled = bool(self.dataset_config.get("crop", False))
+        crop_style = str(self.dataset_config.get("crop_style") or "random").lower()
+        if crop_enabled and crop_style == "face":
+            return False
+        return True
+
+    def _needs_video_frame_count(self) -> bool:
+        if self.bucket_strategy == "resolution_frames":
+            return True
+        return self.minimum_num_frames is not None or self.maximum_num_frames is not None
+
+    @staticmethod
+    def _parse_frame_rate(value: object) -> Optional[float]:
+        if value in (None, "", "N/A"):
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        text = str(value).strip()
+        if not text or text.upper() == "N/A":
+            return None
+        if "/" in text:
+            num_text, denom_text = text.split("/", 1)
+            try:
+                denom = float(denom_text)
+                if denom == 0:
+                    return None
+                return float(num_text) / denom
+            except (TypeError, ValueError):
+                return None
+        try:
+            return float(text)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _safe_int(value: object) -> Optional[int]:
+        if value in (None, "", "N/A"):
+            return None
+        try:
+            return int(float(value))
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _safe_float(value: object) -> Optional[float]:
+        if value in (None, "", "N/A"):
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _probe_video_metadata(self, video_path: str, payload: Optional[bytes]) -> Optional[dict]:
+        if not _is_ffprobe_available():
+            return None
+
+        import subprocess
+        import tempfile
+        from pathlib import Path
+
+        cleanup_temp = False
+        probe_path = video_path
+        suffix = Path(video_path).suffix or ".mp4"
+
+        if payload is not None:
+            try:
+                with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+                    tmp.write(payload)
+                    probe_path = tmp.name
+                cleanup_temp = True
+            except Exception as exc:
+                logger.debug("Failed to write temp video for ffprobe: %s", exc)
+                return None
+
+        try:
+            cmd = [
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=width,height,nb_frames,avg_frame_rate,r_frame_rate,duration",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "json",
+                probe_path,
+            ]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)
+            raw_payload = json.loads(result.stdout) if result.stdout else {}
+            streams = raw_payload.get("streams") or []
+            stream = streams[0] if streams else {}
+
+            width = self._safe_int(stream.get("width"))
+            height = self._safe_int(stream.get("height"))
+            if not width or not height:
+                return None
+
+            metadata: dict = {"original_size": (width, height)}
+
+            fps = self._parse_frame_rate(stream.get("avg_frame_rate") or stream.get("r_frame_rate"))
+            if fps:
+                metadata["fps"] = fps
+
+            num_frames = self._safe_int(stream.get("nb_frames"))
+            duration = self._safe_float(stream.get("duration"))
+            if duration is None:
+                duration = self._safe_float((raw_payload.get("format") or {}).get("duration"))
+            if num_frames is None and fps and duration:
+                num_frames = int(round(fps * duration))
+            if num_frames:
+                metadata["num_frames"] = num_frames
+            if duration:
+                metadata["video_duration"] = duration
+
+            return metadata
+        except Exception as exc:
+            logger.debug("ffprobe metadata extraction failed for %s: %s", video_path, exc)
+            return None
+        finally:
+            if cleanup_temp:
+                try:
+                    Path(probe_path).unlink(missing_ok=True)
+                except Exception:
+                    pass
 
     def _discover_new_files(self, for_metadata: bool = False, ignore_existing_cache: bool = False):
         """
@@ -224,27 +366,69 @@ class DiscoveryMetadataBackend(MetadataBackend):
 
         try:
             image_metadata = {}
-            image_data = self.data_backend.read(image_path_str)
-            if image_data is None:
-                logger.debug(f"Image {image_path_str} was not found on the backend. Skipping image.")
-                statistics.setdefault("skipped", {}).setdefault("not_found", 0)
-                statistics["skipped"]["not_found"] += 1
-                return aspect_ratio_bucket_indices
-
+            image_data = None
+            image = None
             file_extension = os.path.splitext(image_path_str)[1].lower()
-            file_loader = load_image
-            if file_extension.strip(".") in video_file_extensions:
-                file_loader = load_video
-            image = file_loader(BytesIO(image_data))
-            if not self.meets_resolution_requirements(image=image):
-                if not self.delete_unwanted_images:
-                    logger.debug(f"Image {image_path_str} does not meet minimum size requirements. Skipping image.")
+            is_video_file = file_extension.strip(".") in video_file_extensions
+
+            use_metadata_only = False
+            if is_video_file and self._should_use_metadata_only_for_video():
+                if getattr(self.data_backend, "type", None) == "local":
+                    video_metadata = self._probe_video_metadata(image_path_str, None)
                 else:
-                    logger.debug(f"Image {image_path_str} does not meet minimum size requirements. Deleting image.")
-                    self.data_backend.delete(image_path_str)
-                statistics.setdefault("skipped", {}).setdefault("too_small", 0)
-                statistics["skipped"]["too_small"] += 1
-                return aspect_ratio_bucket_indices
+                    image_data = self.data_backend.read(image_path_str)
+                    if image_data is None:
+                        logger.debug(f"Image {image_path_str} was not found on the backend. Skipping image.")
+                        statistics.setdefault("skipped", {}).setdefault("not_found", 0)
+                        statistics["skipped"]["not_found"] += 1
+                        return aspect_ratio_bucket_indices
+                    video_metadata = self._probe_video_metadata(image_path_str, image_data)
+
+                if video_metadata and self._needs_video_frame_count() and "num_frames" not in video_metadata:
+                    logger.debug(
+                        "(id=%s) ffprobe metadata missing num_frames for %s; falling back to full decode.",
+                        self.id,
+                        image_path_str,
+                    )
+                    video_metadata = None
+
+                if video_metadata:
+                    use_metadata_only = True
+                    image_metadata.update(video_metadata)
+                    logger.debug("(id=%s) Using ffprobe metadata-only scan for %s", self.id, image_path_str)
+
+            if use_metadata_only:
+                if not self.meets_resolution_requirements(image_metadata=image_metadata):
+                    if not self.delete_unwanted_images:
+                        logger.debug(f"Image {image_path_str} does not meet minimum size requirements. Skipping image.")
+                    else:
+                        logger.debug(f"Image {image_path_str} does not meet minimum size requirements. Deleting image.")
+                        self.data_backend.delete(image_path_str)
+                    statistics.setdefault("skipped", {}).setdefault("too_small", 0)
+                    statistics["skipped"]["too_small"] += 1
+                    return aspect_ratio_bucket_indices
+            else:
+                if image_data is None:
+                    image_data = self.data_backend.read(image_path_str)
+                if image_data is None:
+                    logger.debug(f"Image {image_path_str} was not found on the backend. Skipping image.")
+                    statistics.setdefault("skipped", {}).setdefault("not_found", 0)
+                    statistics["skipped"]["not_found"] += 1
+                    return aspect_ratio_bucket_indices
+
+                file_loader = load_image
+                if is_video_file:
+                    file_loader = load_video
+                image = file_loader(BytesIO(image_data))
+                if not self.meets_resolution_requirements(image=image):
+                    if not self.delete_unwanted_images:
+                        logger.debug(f"Image {image_path_str} does not meet minimum size requirements. Skipping image.")
+                    else:
+                        logger.debug(f"Image {image_path_str} does not meet minimum size requirements. Deleting image.")
+                        self.data_backend.delete(image_path_str)
+                    statistics.setdefault("skipped", {}).setdefault("too_small", 0)
+                    statistics["skipped"]["too_small"] += 1
+                    return aspect_ratio_bucket_indices
 
             if hasattr(image, "shape"):
                 image_metadata["original_size"] = (image.shape[2], image.shape[1])
@@ -264,8 +448,9 @@ class DiscoveryMetadataBackend(MetadataBackend):
                 "target_size": prepared_sample.target_size,
                 "intermediary_size": prepared_sample.intermediary_size,
                 "aspect_ratio": prepared_sample.aspect_ratio,
-                "luminance": calculate_luminance(image),
             }
+            if image is not None:
+                cur_image_metadata["luminance"] = calculate_luminance(image)
             image_metadata.update(cur_image_metadata)
             logger.debug(f"Image {image_path_str} has metadata: {cur_image_metadata}")
 


### PR DESCRIPTION
This pull request introduces improved handling for video files in the `DiscoveryMetadataBackend` by adding metadata-only scanning using `ffprobe` when possible, which can significantly speed up processing and reduce resource usage. It also refactors the metadata extraction logic to be more robust and modular, and ensures that luminance is only calculated when an image is actually loaded.

**Video processing improvements:**

* Added a check for `ffprobe` availability and new logic to use metadata-only scanning for video files when possible, avoiding full video decoding unless necessary. This can greatly improve performance for large video datasets. [[1]](diffhunk://#diff-304c0cb845b07bb4c79ff82b99e240f431b30debb67b76bf44b55411ffd1afa7R4) [[2]](diffhunk://#diff-304c0cb845b07bb4c79ff82b99e240f431b30debb67b76bf44b55411ffd1afa7R40-R48) [[3]](diffhunk://#diff-304c0cb845b07bb4c79ff82b99e240f431b30debb67b76bf44b55411ffd1afa7R97-R228) [[4]](diffhunk://#diff-304c0cb845b07bb4c79ff82b99e240f431b30debb67b76bf44b55411ffd1afa7R369-R420)

* Implemented helper methods (`_should_use_metadata_only_for_video`, `_needs_video_frame_count`, `_probe_video_metadata`, and safe parsing utilities) to cleanly extract and handle video metadata such as frame rate, frame count, resolution, and duration using `ffprobe`.

**Image and video metadata handling:**

* Updated `_process_for_bucket` to use the new video metadata extraction logic, falling back to full decoding only if required metadata is missing, and skipping or deleting images/videos that do not meet resolution requirements.

**Luminance calculation:**

* Changed luminance calculation to only occur if an image is actually loaded, preventing errors and unnecessary computation for metadata-only video scans.