### PR TITLE
ltx2: compatibility with UniPC for fewer step gen

### DIFF
--- a/simpletuner/helpers/models/ltxvideo2/pipeline_ltx2.py
+++ b/simpletuner/helpers/models/ltxvideo2/pipeline_ltx2.py
@@ -1038,6 +1038,11 @@ class LTX2Pipeline(DiffusionPipeline, FromSingleFileMixin, LTXVideoLoraLoaderMix
             self.scheduler.config.get("base_shift", 0.95),
             self.scheduler.config.get("max_shift", 2.05),
         )
+        # Check if scheduler supports custom sigmas
+        accept_sigmas = "sigmas" in set(inspect.signature(self.scheduler.set_timesteps).parameters.keys())
+        sigmas_to_pass = sigmas if accept_sigmas else None
+        mu_to_pass = mu if accept_sigmas else None
+
         # For now, duplicate the scheduler for use with the audio latents
         audio_scheduler = copy.deepcopy(self.scheduler)
         _, _ = retrieve_timesteps(
@@ -1045,16 +1050,16 @@ class LTX2Pipeline(DiffusionPipeline, FromSingleFileMixin, LTXVideoLoraLoaderMix
             num_inference_steps,
             device,
             timesteps,
-            sigmas=sigmas,
-            mu=mu,
+            sigmas=sigmas_to_pass,
+            mu=mu_to_pass,
         )
         timesteps, num_inference_steps = retrieve_timesteps(
             self.scheduler,
             num_inference_steps,
             device,
             timesteps,
-            sigmas=sigmas,
-            mu=mu,
+            sigmas=sigmas_to_pass,
+            mu=mu_to_pass,
         )
         num_warmup_steps = max(len(timesteps) - num_inference_steps * self.scheduler.order, 0)
         self._num_timesteps = len(timesteps)

--- a/simpletuner/helpers/models/ltxvideo2/pipeline_ltx2_image2video.py
+++ b/simpletuner/helpers/models/ltxvideo2/pipeline_ltx2_image2video.py
@@ -1106,6 +1106,10 @@ class LTX2ImageToVideoPipeline(DiffusionPipeline, FromSingleFileMixin, LTXVideoL
             self.scheduler.config.get("base_shift", 0.95),
             self.scheduler.config.get("max_shift", 2.05),
         )
+        # Check if scheduler supports custom sigmas
+        accept_sigmas = "sigmas" in set(inspect.signature(self.scheduler.set_timesteps).parameters.keys())
+        sigmas_to_pass = sigmas if accept_sigmas else None
+        mu_to_pass = mu if accept_sigmas else None
 
         # For now, duplicate the scheduler for use with the audio latents
         audio_scheduler = copy.deepcopy(self.scheduler)
@@ -1114,16 +1118,16 @@ class LTX2ImageToVideoPipeline(DiffusionPipeline, FromSingleFileMixin, LTXVideoL
             num_inference_steps,
             device,
             timesteps,
-            sigmas=sigmas,
-            mu=mu,
+            sigmas=sigmas_to_pass,
+            mu=mu_to_pass,
         )
         timesteps, num_inference_steps = retrieve_timesteps(
             self.scheduler,
             num_inference_steps,
             device,
             timesteps,
-            sigmas=sigmas,
-            mu=mu,
+            sigmas=sigmas_to_pass,
+            mu=mu_to_pass,
         )
         num_warmup_steps = max(len(timesteps) - num_inference_steps * self.scheduler.order, 0)
         self._num_timesteps = len(timesteps)


### PR DESCRIPTION
This pull request updates the pipeline logic for both video and image-to-video models to improve compatibility with different scheduler implementations. The main change is to ensure that custom `sigmas` and `mu` parameters are only passed to the scheduler if it supports them, preventing potential errors with schedulers that do not accept these arguments.

Scheduler compatibility improvements:

* In both `pipeline_ltx2.py` and `pipeline_ltx2_image2video.py`, added logic to check if the scheduler's `set_timesteps` method accepts `sigmas` and `mu` parameters before passing them. (`[[1]](diffhunk://#diff-b9cc82b4506feb32453508f2f7fd01e24e55a4a6de585dbbbe0990c27a2febbcR1041-R1062)`, `[[2]](diffhunk://#diff-21b42e4f0da5716787ffe36232b6aeb71fb7faa101daad1f21b5e31116c19e55R1109-R1112)`)
* Updated calls to `retrieve_timesteps` in both pipelines to conditionally pass `sigmas` and `mu` only if supported, improving robustness across different scheduler implementations. (`[[1]](diffhunk://#diff-b9cc82b4506feb32453508f2f7fd01e24e55a4a6de585dbbbe0990c27a2febbcR1041-R1062)`, `[[2]](diffhunk://#diff-21b42e4f0da5716787ffe36232b6aeb71fb7faa101daad1f21b5e31116c19e55L1117-R1130)`)