### PR TITLE
fix: videos not copied to checkpoint assets folder

### DIFF
--- a/simpletuner/helpers/publishing/metadata.py
+++ b/simpletuner/helpers/publishing/metadata.py
@@ -376,9 +376,16 @@ def model_card_note(args):
 
 def save_metadata_sample(
     image_path: str,
-    image: Union[Image.Image, np.ndarray, list],
+    image: Union[Image.Image, np.ndarray, list, str],
 ):
-    if isinstance(image, list):
+    if isinstance(image, str):
+        # Video file path - copy it to the destination
+        import shutil
+
+        file_extension = os.path.splitext(image)[1][1:]  # Get extension without dot
+        output_path = f"{image_path}.{file_extension}"
+        shutil.copy2(image, output_path)
+    elif isinstance(image, list):
         file_extension = "gif"
         output_path = f"{image_path}.{file_extension}"
         export_to_gif(


### PR DESCRIPTION
This pull request enhances support for validation assets by adding handling for video files alongside images during checkpoint uploads and metadata saving. The changes ensure that video files are properly filtered, processed, and copied, improving compatibility and robustness in publishing workflows.

**Validation asset handling improvements:**

* Updated the checkpoint upload logic in `huggingface.py` to filter and process both images and videos (e.g., `.mp4`, `.avi`, `.mov`, `.webm`) when collecting validation assets for a given step. Video files are now stored as file path markers, and error messages have been generalized to "validation asset" instead of "validation image".

**Metadata saving enhancements:**

* Modified the `save_metadata_sample` function in `metadata.py` to support video file paths (`str` type). Video files are now copied to the destination path with the correct file extension, ensuring they are handled appropriately during metadata export.