### PR TITLE
enhance log retention for event dock (UI)

### DIFF
--- a/simpletuner/simpletuner_sdk/server/app.py
+++ b/simpletuner/simpletuner_sdk/server/app.py
@@ -773,10 +773,14 @@ def create_unified_app() -> FastAPI:
     app = create_app(mode=ServerMode.UNIFIED)
 
     # Set up shared event store for unified mode
+    import os
+
     from .services.callback_service import CallbackService
     from .services.event_store import EventStore
 
-    event_store = EventStore()
+    # Allow configuring event buffer size via environment variable
+    max_events = int(os.environ.get("SIMPLETUNER_EVENT_BUFFER_SIZE", "1000"))
+    event_store = EventStore(max_events=max_events)
     callback_service = CallbackService(event_store)
 
     # Store event service in app state for access by routes

--- a/simpletuner/simpletuner_sdk/server/services/event_store.py
+++ b/simpletuner/simpletuner_sdk/server/services/event_store.py
@@ -15,7 +15,7 @@ logger = logging.getLogger("EventStore")
 class EventStore:
     """Thread-safe event storage with circular buffer."""
 
-    def __init__(self, max_events: int = 100):
+    def __init__(self, max_events: int = 1000):
         self.max_events = max_events
         self.events: deque = deque(maxlen=max_events)
         self.lock = threading.Lock()
@@ -91,10 +91,13 @@ _store_lock = threading.Lock()
 
 def get_default_store() -> EventStore:
     """Get or create the default event store."""
+    import os
+
     global _default_store
     with _store_lock:
         if _default_store is None:
-            _default_store = EventStore()
+            max_events = int(os.environ.get("SIMPLETUNER_EVENT_BUFFER_SIZE", "1000"))
+            _default_store = EventStore(max_events=max_events)
         return _default_store
 
 


### PR DESCRIPTION
This pull request introduces a configurable event buffer size for the unified server mode in `simpletuner_sdk`. The main change allows the maximum number of events stored in the `EventStore` to be set via an environment variable, improving flexibility for deployments with varying resource requirements.

Configuration improvements:

* [`simpletuner/simpletuner_sdk/server/app.py`](diffhunk://#diff-322297c6a32fecb5f4097f95e16c3f1b6c9ba8efdb2c0f986f5a820a8320bda3R776-R783): Added support for setting the event buffer size through the `SIMPLETUNER_EVENT_BUFFER_SIZE` environment variable when initializing `EventStore` in the unified app creation function.