### PR TITLE
fix: validation videos not appearing in event log dock

### DIFF
--- a/simpletuner/simpletuner_sdk/server/middleware/security_middleware.py
+++ b/simpletuner/simpletuner_sdk/server/middleware/security_middleware.py
@@ -123,6 +123,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com https://cdn.jsdelivr.net",  # Allow HTMX, Alpine.js, Bootstrap
             "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",  # Allow inline styles, Bootstrap CSS, Font Awesome
             "img-src 'self' data: blob:",
+            "media-src 'self' data: blob:",  # Allow video/audio from same origin, data URIs, and blob URLs
             "font-src 'self' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",  # Allow Bootstrap and Font Awesome fonts
             "connect-src 'self'",
             "frame-ancestors 'none'",


### PR DESCRIPTION
This pull request makes a small update to the Content Security Policy (CSP) in the security middleware to improve support for media resources.

* Added a `media-src` directive to the CSP in `simpletuner/simpletuner_sdk/server/middleware/security_middleware.py`, allowing video and audio resources from the same origin, data URIs, and blob URLs.