### PR TITLE
add missing action for api key usage event

### DIFF
--- a/simpletuner/simpletuner_sdk/server/services/cloud/auth/middleware.py
+++ b/simpletuner/simpletuner_sdk/server/services/cloud/auth/middleware.py
@@ -274,7 +274,8 @@ class AuthMiddleware:
 
                     asyncio.get_running_loop().create_task(
                         audit_log(
-                            event_type=AuditEventType.API_KEY_USED,
+                            event_type=AuditEventType.AUTH_API_KEY_USED,
+                            action=f"API key '{key.key_prefix}' used by '{user.username}'",
                             actor_id=user.id,
                             actor_ip=client_ip,
                             target_type="api_key",
@@ -318,6 +319,7 @@ class AuthMiddleware:
                         asyncio.get_running_loop().create_task(
                             audit_log(
                                 event_type=AuditEventType.SESSION_EXPIRED,
+                                action=f"Session expired for user id {expired_user_id}",
                                 actor_id=expired_user_id,
                                 actor_ip=client_ip,
                                 target_type="session",


### PR DESCRIPTION
This pull request updates the audit logging in the authentication middleware to improve clarity and consistency of audit events. The main changes are focused on making audit log entries more descriptive and using more specific event types.

Audit logging improvements:

* Changed the audit event type from `API_KEY_USED` to `AUTH_API_KEY_USED` and added a descriptive `action` message that includes the API key prefix and the username in audit logs for API key usage.
* Added a descriptive `action` message to session expiration audit logs, specifying which user ID's session expired.