### PR TITLE
Add exclude LoRA targets and exclude connectors in LTX-2 by default

### DIFF
--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -446,6 +446,7 @@ class ModelFoundation(ABC):
     AUTO_LORA_FORMAT_DETECTION = False
     SUPPORTS_MUON_CLIP = False
     DEFAULT_AUDIO_CHANNELS = 1
+    DEFAULT_LORA_EXCLUDE_TARGETS = None # regex, not list
 
     # Acceleration backend support - models declare what they DON'T support
     UNSUPPORTED_BACKENDS: set = set()  # Empty = supports all backends
@@ -797,6 +798,7 @@ class ModelFoundation(ABC):
                 module_dropout=0.0,
                 use_effective_conv2d=True,
                 target_modules=target_modules,
+                exclude_modules=self.DEFAULT_LORA_EXCLUDE_TARGETS,
                 modules_to_save=save_modules,
             )
         else:
@@ -820,6 +822,7 @@ class ModelFoundation(ABC):
                 init_lora_weights=self.config.lora_initialisation_style,
                 target_modules=target_modules,
                 modules_to_save=save_modules,
+                exclude_modules=self.DEFAULT_LORA_EXCLUDE_TARGETS,
                 use_dora=getattr(self.config, "use_dora", False),
                 **lora_config_kwargs,
             )

--- a/simpletuner/helpers/models/ltxvideo2/model.py
+++ b/simpletuner/helpers/models/ltxvideo2/model.py
@@ -70,6 +70,7 @@ class LTXVideo2(VideoModelFoundation):
     DEFAULT_LORA_TARGET = ["to_k", "to_q", "to_v", "to_out.0"]
     # Only training the Attention blocks by default.
     DEFAULT_LYCORIS_TARGET = ["Attention"]
+    DEFAULT_LORA_EXCLUDE_TARGETS = ".*connector.*|.*embedding.*"
 
     MODEL_CLASS = LTX2VideoTransformer3DModel
     MODEL_SUBFOLDER = "transformer"


### PR DESCRIPTION
Closes #2349.