### PR TITLE
add plumbing for model to report custom loss back

### DIFF
--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -4152,6 +4152,12 @@ class ModelFoundation(ABC):
         loss = loss.mean()
         return loss
 
+    def loss_with_logs(self, prepared_batch: dict, model_output, apply_conditioning_mask: bool = True):
+        """
+        Computes loss and optional per-batch metrics for logging.
+        """
+        return self.loss(prepared_batch, model_output, apply_conditioning_mask=apply_conditioning_mask), None
+
     def auxiliary_loss(
         self,
         model_output,

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -5126,7 +5126,7 @@ class Trainer:
                     model_pred = self.model_predict(
                         prepared_batch=prepared_batch,
                     )
-                    loss = self.model.loss(
+                    loss, loss_logs = self.model.loss_with_logs(
                         prepared_batch=prepared_batch,
                         model_output=model_pred,
                         apply_conditioning_mask=True,
@@ -5346,6 +5346,8 @@ class Trainer:
                         for key, value in aux_loss_logs.items():
                             wandb_logs[f"aux_loss/{key}"] = value
                         wandb_logs["diffusion_loss"] = self.train_diffusion_loss
+                    if loss_logs is not None:
+                        wandb_logs.update(loss_logs)
                     self._update_grad_metrics(wandb_logs)
                     if self.validation is not None and hasattr(self.validation, "evaluation_result"):
                         eval_result = self.validation.get_eval_result()
@@ -5536,6 +5538,8 @@ class Trainer:
                     "step_loss": loss.detach().item(),
                     "lr": float(self.lr),
                 }
+                if loss_logs is not None:
+                    logs.update(loss_logs)
                 if aux_loss_logs is not None:
                     logs_to_print = {}
                     for key, value in aux_loss_logs.items():


### PR DESCRIPTION
This pull request introduces a new standardized `loss_with_logs` method for model classes and updates the training loop to utilize it, enabling more detailed per-batch loss logging. The main focus is on improved logging of video and audio losses during training, especially for models handling multimodal data.

### Enhanced loss computation and logging for multimodal models

* Added a `loss_with_logs` method to the base model class in `common.py`, allowing all models to return both loss and optional logging metrics in a consistent interface.
* In the `ltxvideo2` model, restructured the loss computation to use a new `_compute_av_loss` helper, which calculates both video and audio losses and returns detailed logging information, including weighted audio loss when applicable.

### Training loop updates for improved logging

* Updated the training loop in `trainer.py` to call `loss_with_logs` instead of `loss`, capturing both the loss value and associated logs for each batch.
* Modified the training loop to include loss logs in the metrics sent to Weights & Biases (`wandb_logs`), ensuring that video and audio loss metrics are tracked during training.
* Enhanced printed logs during training to include loss logs for easier debugging and monitoring.