### PR TITLE
(#2374) final export respect --lora_format

### DIFF
--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -5694,9 +5694,7 @@ class Trainer:
                     text_encoder_lora_layers = None
                     text_encoder_2_lora_layers = None
 
-                from simpletuner.helpers.models.common import PipelineTypes
-
-                self.model.PIPELINE_CLASSES[PipelineTypes.TEXT2IMG].save_lora_weights(
+                self.model.save_lora_weights(
                     **lora_save_kwargs,
                 )
                 del text_encoder_lora_layers


### PR DESCRIPTION
This pull request simplifies the process of saving LoRA weights during model training by removing an unnecessary reference to `PipelineTypes` and calling `save_lora_weights` directly on the model.

- **Training process simplification:**
  * In `simpletuner/helpers/training/trainer.py`, removed the import and usage of `PipelineTypes`, and now directly calls `self.model.save_lora_weights` to save LoRA weights, making the code cleaner and more straightforward.

Closes #2374 