### PR TITLE
boost default unauthenticated rate-limit

### DIFF
--- a/simpletuner/simpletuner_sdk/server/middleware/security_middleware.py
+++ b/simpletuner/simpletuner_sdk/server/middleware/security_middleware.py
@@ -68,7 +68,7 @@ DEFAULT_RATE_LIMIT_RULES: List[Tuple[str, int, int, Optional[List[str]]]] = [
 
 # Default rate limit for unauthenticated/anonymous requests
 # Set high enough to allow page loads (which trigger 10+ API calls each)
-DEFAULT_ANONYMOUS_RATE_LIMIT = 180  # calls per period
+DEFAULT_ANONYMOUS_RATE_LIMIT = 360  # calls per period
 
 # Multiplier for authenticated users (they get this many times more requests)
 # e.g., if anonymous limit is 60/min, authenticated users get 600/min


### PR DESCRIPTION
This pull request makes a small adjustment to the default rate limiting for unauthenticated requests in the `security_middleware.py` file. The change increases the allowed number of anonymous API calls per period to better support page loads.

* Increased `DEFAULT_ANONYMOUS_RATE_LIMIT` from 180 to 360 in `simpletuner/simpletuner_sdk/server/middleware/security_middleware.py` to allow more API calls for unauthenticated users.