### PR TITLE
enhance coverage for quantize_via pipeline to work for more types

### DIFF
--- a/documentation/OPTIONS.es.md
+++ b/documentation/OPTIONS.es.md
@@ -191,16 +191,17 @@ Donde `foo` es tu entorno de configuración; o simplemente usa `config/config.js
 - **Opciones**: `cpu`, `accelerator`, `pipeline`
   - En `accelerator`, puede funcionar moderadamente más rápido con el riesgo de posibles OOM en tarjetas de 24G para un modelo tan grande como Flux.
   - En `cpu`, la cuantización tarda unos 30 segundos. (**Predeterminado**)
-  - `pipeline` delega la cuantización a Diffusers usando `--quantization_config` o presets compatibles con pipeline (p. ej., `nf4-bnb`, `int4-torchao`, o checkpoints `.gguf`). Los presets manuales de Quanto/TorchAO no son compatibles cuando este modo está habilitado.
+  - `pipeline` delega la cuantización a Diffusers usando `--quantization_config` o presets compatibles con pipeline (p. ej., `nf4-bnb`, `int8-torchao`, `fp8-torchao`, `int8-quanto`, o checkpoints `.gguf`).
 
 ### `--base_model_precision`
 
-- **Qué**: Reduce la precisión del modelo y entrena usando menos memoria. Hay tres backends de cuantización compatibles: BitsAndBytes (pipeline), TorchAO (pipeline o manual) y Optimum Quanto (manual).
+- **Qué**: Reduce la precisión del modelo y entrena usando menos memoria. Hay tres backends de cuantización compatibles: BitsAndBytes (pipeline), TorchAO (pipeline o manual) y Optimum Quanto (pipeline o manual).
 
 #### Presets de pipeline de Diffusers
 
 - `nf4-bnb` se carga a través de Diffusers con una configuración BitsAndBytes NF4 de 4 bits (solo CUDA). Requiere `bitsandbytes` y una build de diffusers con soporte BnB.
-- `int4-torchao` usa un TorchAoConfig con `Int4WeightOnlyConfig` vía Diffusers (CUDA). Requiere `torchao` y `transformers>=4.39`.
+- `int4-torchao`, `int8-torchao` y `fp8-torchao` usan TorchAoConfig vía Diffusers (CUDA). Requiere `torchao` y diffusers/transformers recientes.
+- `int8-quanto`, `int4-quanto`, `int2-quanto`, `fp8-quanto` y `fp8uz-quanto` usan QuantoConfig vía Diffusers. Diffusers asigna FP8-NUZ a pesos float8; usa cuantización manual de quanto si necesitas la variante NUZ.
 - `.gguf` checkpoints se detectan automáticamente y se cargan con `GGUFQuantizationConfig` cuando está disponible. Instala versiones recientes de diffusers/transformers para soporte GGUF.
 
 #### Optimum Quanto

--- a/documentation/OPTIONS.hi.md
+++ b/documentation/OPTIONS.hi.md
@@ -191,16 +191,17 @@ simpletuner configure config/foo/config.json
 - **Choices**: `cpu`, `accelerator`, `pipeline`
   - `accelerator` पर यह मध्यम रूप से तेज़ हो सकता है लेकिन Flux जैसे बड़े मॉडल के लिए 24G cards पर OOM का जोखिम रहता है।
   - `cpu` पर quantisation में लगभग 30 seconds लगते हैं। (**Default**)
-  - `pipeline` Diffusers को `--quantization_config` या pipeline‑capable presets (उदा. `nf4-bnb`, `int4-torchao`, या `.gguf` checkpoints) के साथ quantization delegate करता है। यह मोड enabled होने पर manual Quanto/TorchAO presets समर्थित नहीं हैं।
+  - `pipeline` Diffusers को `--quantization_config` या pipeline‑capable presets (उदा. `nf4-bnb`, `int8-torchao`, `fp8-torchao`, `int8-quanto`, या `.gguf` checkpoints) के साथ quantization delegate करता है।
 
 ### `--base_model_precision`
 
-- **What**: model precision घटाएँ और कम memory में training करें। तीन समर्थित quantisation backends हैं: BitsAndBytes (pipeline), TorchAO (pipeline या manual), और Optimum Quanto (manual)।
+- **What**: model precision घटाएँ और कम memory में training करें। तीन समर्थित quantisation backends हैं: BitsAndBytes (pipeline), TorchAO (pipeline या manual), और Optimum Quanto (pipeline या manual)।
 
 #### Diffusers pipeline presets
 
 - `nf4-bnb` Diffusers के माध्यम से 4‑bit NF4 BitsAndBytes config के साथ लोड होता है (CUDA only)। `bitsandbytes` और BnB support वाली diffusers build आवश्यक है।
-- `int4-torchao` Diffusers के माध्यम से TorchAoConfig with `Int4WeightOnlyConfig` का उपयोग करता है (CUDA)। `torchao` और `transformers>=4.39` आवश्यक है।
+- `int4-torchao`, `int8-torchao`, और `fp8-torchao` Diffusers के माध्यम से TorchAoConfig का उपयोग करते हैं (CUDA)। `torchao` और recent diffusers/transformers आवश्यक है।
+- `int8-quanto`, `int4-quanto`, `int2-quanto`, `fp8-quanto`, और `fp8uz-quanto` Diffusers के माध्यम से QuantoConfig का उपयोग करते हैं। Diffusers FP8-NUZ को float8 weights पर map करता है; NUZ variant के लिए manual quanto quantization उपयोग करें।
 - `.gguf` checkpoints auto‑detect होकर उपलब्ध होने पर `GGUFQuantizationConfig` के साथ लोड होते हैं। GGUF support के लिए recent diffusers/transformers install करें।
 
 #### Optimum Quanto

--- a/documentation/OPTIONS.ja.md
+++ b/documentation/OPTIONS.ja.md
@@ -192,16 +192,17 @@ simpletuner configure config/foo/config.json
 - **選択肢**: `cpu`、`accelerator`、`pipeline`
   - `accelerator` では若干高速になる可能性がありますが、Flux のように大きなモデルでは 24G カードで OOM するリスクがあります。
   - `cpu` では量子化に約 30 秒かかります。（**既定**）
-  - `pipeline` は `--quantization_config` またはパイプライン対応のプリセット（例: `nf4-bnb`、`int4-torchao`、`.gguf` チェックポイント）を使って Diffusers に量子化を委譲します。手動の Quanto/TorchAO プリセットはこのモードでは非対応です。
+  - `pipeline` は `--quantization_config` またはパイプライン対応のプリセット（例: `nf4-bnb`、`int8-torchao`、`fp8-torchao`、`int8-quanto`、`.gguf` チェックポイント）を使って Diffusers に量子化を委譲します。
 
 ### `--base_model_precision`
 
-- **内容**: モデル精度を下げ、少ないメモリで学習します。対応する量子化バックエンドは BitsAndBytes（pipeline）、TorchAO（pipeline または手動）、Optimum Quanto（手動）の 3 つです。
+- **内容**: モデル精度を下げ、少ないメモリで学習します。対応する量子化バックエンドは BitsAndBytes（pipeline）、TorchAO（pipeline または手動）、Optimum Quanto（pipeline または手動）の 3 つです。
 
 #### Diffusers のパイプラインプリセット
 
 - `nf4-bnb` は Diffusers 経由で 4-bit NF4 BitsAndBytes 設定で読み込みます（CUDA のみ）。`bitsandbytes` と BnB 対応の diffusers が必要です。
-- `int4-torchao` は Diffusers 経由で TorchAoConfig と `Int4WeightOnlyConfig` を使用します（CUDA）。`torchao` と `transformers>=4.39` が必要です。
+- `int4-torchao`、`int8-torchao`、`fp8-torchao` は Diffusers 経由で TorchAoConfig を使用します（CUDA）。`torchao` と最新の diffusers/transformers が必要です。
+- `int8-quanto`、`int4-quanto`、`int2-quanto`、`fp8-quanto`、`fp8uz-quanto` は Diffusers 経由で QuantoConfig を使用します。Diffusers は FP8-NUZ を float8 重みにマップするため、NUZ 変種が必要な場合は手動の quanto 量子化を使ってください。
 - `.gguf` チェックポイントは自動検出され、`GGUFQuantizationConfig` で読み込まれます。GGUF 対応には最新の diffusers/transformers をインストールしてください。
 
 #### Optimum Quanto

--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -191,16 +191,17 @@ Where `foo` is your config environment - or just use `config/config.json` if you
 - **Choices**: `cpu`, `accelerator`, `pipeline`
   - On `accelerator`, it may work moderately faster at the risk of possibly OOM'ing on 24G cards for a model as large as Flux.
   - On `cpu`, quantisation takes about 30 seconds. (**Default**)
-  - `pipeline` delegates quantization to Diffusers using `--quantization_config` or pipeline-capable presets (e.g., `nf4-bnb`, `int4-torchao`, or `.gguf` checkpoints). Manual Quanto/TorchAO presets are not supported when this mode is enabled.
+  - `pipeline` delegates quantization to Diffusers using `--quantization_config` or pipeline-capable presets (e.g., `nf4-bnb`, `int8-torchao`, `fp8-torchao`, `int8-quanto`, or `.gguf` checkpoints).
 
 ### `--base_model_precision`
 
-- **What**: Reduce model precision and train using less memory. There are three supported quantisation backends: BitsAndBytes (pipeline), TorchAO (pipeline or manual), and Optimum Quanto (manual).
+- **What**: Reduce model precision and train using less memory. There are three supported quantisation backends: BitsAndBytes (pipeline), TorchAO (pipeline or manual), and Optimum Quanto (pipeline or manual).
 
 #### Diffusers pipeline presets
 
 - `nf4-bnb` loads through Diffusers with a 4-bit NF4 BitsAndBytes config (CUDA only). Requires `bitsandbytes` and a diffusers build with BnB support.
-- `int4-torchao` uses a TorchAoConfig with `Int4WeightOnlyConfig` via Diffusers (CUDA). Requires `torchao` and `transformers>=4.39`.
+- `int4-torchao`, `int8-torchao`, and `fp8-torchao` use a TorchAoConfig via Diffusers (CUDA). Requires `torchao` and a recent diffusers/transformers build.
+- `int8-quanto`, `int4-quanto`, `int2-quanto`, `fp8-quanto`, and `fp8uz-quanto` use QuantoConfig via Diffusers. Diffusers maps FP8-NUZ to float8 weights; use manual quanto quantization if you need the NUZ variant.
 - `.gguf` checkpoints are auto-detected and loaded with `GGUFQuantizationConfig` when available. Install recent diffusers/transformers for GGUF support.
 
 #### Optimum Quanto

--- a/documentation/OPTIONS.pt-BR.md
+++ b/documentation/OPTIONS.pt-BR.md
@@ -191,16 +191,17 @@ Onde `foo` e seu ambiente de config — ou use `config/config.json` se nao estiv
 - **Opcoes**: `cpu`, `accelerator`, `pipeline`
   - Em `accelerator`, pode funcionar um pouco mais rapido com risco de OOM em placas 24G para modelos grandes como Flux.
   - Em `cpu`, a quantizacao leva cerca de 30 segundos. (**Padrao**)
-  - `pipeline` delega a quantizacao para o Diffusers usando `--quantization_config` ou presets compatíveis com pipeline (ex.: `nf4-bnb`, `int4-torchao` ou checkpoints `.gguf`). Presets manuais de Quanto/TorchAO nao sao suportados quando esse modo esta habilitado.
+  - `pipeline` delega a quantizacao para o Diffusers usando `--quantization_config` ou presets compatíveis com pipeline (ex.: `nf4-bnb`, `int8-torchao`, `fp8-torchao`, `int8-quanto` ou checkpoints `.gguf`).
 
 ### `--base_model_precision`
 
-- **O que**: Reduz a precisao do modelo e treina com menos memoria. Existem tres backends de quantizacao suportados: BitsAndBytes (pipeline), TorchAO (pipeline ou manual) e Optimum Quanto (manual).
+- **O que**: Reduz a precisao do modelo e treina com menos memoria. Existem tres backends de quantizacao suportados: BitsAndBytes (pipeline), TorchAO (pipeline ou manual) e Optimum Quanto (pipeline ou manual).
 
 #### Presets de pipeline Diffusers
 
 - `nf4-bnb` carrega via Diffusers com config BitsAndBytes NF4 4-bit (apenas CUDA). Requer `bitsandbytes` e um build do diffusers com suporte BnB.
-- `int4-torchao` usa um TorchAoConfig com `Int4WeightOnlyConfig` via Diffusers (CUDA). Requer `torchao` e `transformers>=4.39`.
+- `int4-torchao`, `int8-torchao` e `fp8-torchao` usam TorchAoConfig via Diffusers (CUDA). Requer `torchao` e diffusers/transformers recentes.
+- `int8-quanto`, `int4-quanto`, `int2-quanto`, `fp8-quanto` e `fp8uz-quanto` usam QuantoConfig via Diffusers. O diffusers mapeia FP8-NUZ para pesos float8; use quantizacao manual do quanto se precisar da variante NUZ.
 - Checkpoints `.gguf` sao auto-detectados e carregados com `GGUFQuantizationConfig` quando disponivel. Instale diffusers/transformers recentes para suporte GGUF.
 
 #### Optimum Quanto

--- a/documentation/OPTIONS.zh.md
+++ b/documentation/OPTIONS.zh.md
@@ -192,16 +192,17 @@ simpletuner configure config/foo/config.json
 - **选项**：`cpu`、`accelerator`、`pipeline`
   - `accelerator` 可能稍快，但在 Flux 等大模型上 24G 卡可能 OOM。
   - `cpu` 量化约需 30 秒。（**默认**）
-  - `pipeline` 将量化交给 Diffusers，通过 `--quantization_config` 或管线可用的预设（如 `nf4-bnb`、`int4-torchao`、`.gguf` 检查点）。启用该模式时不支持手动 Quanto/TorchAO 预设。
+  - `pipeline` 将量化交给 Diffusers，通过 `--quantization_config` 或管线可用的预设（如 `nf4-bnb`、`int8-torchao`、`fp8-torchao`、`int8-quanto`、`.gguf` 检查点）。
 
 ### `--base_model_precision`
 
-- **内容**：降低模型精度并用更少内存训练。支持三种量化后端：BitsAndBytes（pipeline）、TorchAO（pipeline 或手动）、Optimum Quanto（手动）。
+- **内容**：降低模型精度并用更少内存训练。支持三种量化后端：BitsAndBytes（pipeline）、TorchAO（pipeline 或手动）、Optimum Quanto（pipeline 或手动）。
 
 #### Diffusers 管线预设
 
 - `nf4-bnb` 通过 Diffusers 加载 4-bit NF4 BitsAndBytes 配置（仅 CUDA）。需要 `bitsandbytes` 与支持 BnB 的 diffusers。
-- `int4-torchao` 通过 Diffusers 使用 TorchAoConfig 与 `Int4WeightOnlyConfig`（CUDA）。需要 `torchao` 与 `transformers>=4.39`。
+- `int4-torchao`、`int8-torchao`、`fp8-torchao` 通过 Diffusers 使用 TorchAoConfig（CUDA）。需要 `torchao` 与较新的 diffusers/transformers。
+- `int8-quanto`、`int4-quanto`、`int2-quanto`、`fp8-quanto`、`fp8uz-quanto` 通过 Diffusers 使用 QuantoConfig。Diffusers 会将 FP8-NUZ 映射为 float8 权重；如需 NUZ 变体请使用手动 quanto 量化。
 - `.gguf` 检查点会被自动检测，并在可用时使用 `GGUFQuantizationConfig` 加载。需安装较新的 diffusers/transformers 以支持 GGUF。
 
 #### Optimum Quanto

--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -54,6 +54,7 @@ from simpletuner.helpers.training.lora_format import (
 from simpletuner.helpers.training.min_snr_gamma import compute_snr
 from simpletuner.helpers.training.multi_process import _get_rank
 from simpletuner.helpers.training.quantisation import (
+    PIPELINE_ONLY_PRESETS,
     PIPELINE_QUANTIZATION_PRESETS,
     build_gguf_quantization_config,
     get_pipeline_quantization_builder,
@@ -1869,7 +1870,15 @@ class ModelFoundation(ABC):
                 text_encoder_precision = getattr(
                     self.config, precision_attr, getattr(self.config, f"{attr_name}_precision", None)
                 )
-                pipeline_preset = text_encoder_precision if text_encoder_precision in PIPELINE_QUANTIZATION_PRESETS else None
+                quantize_via_pipeline = getattr(self.config, "quantize_via", None) == "pipeline"
+                pipeline_preset = (
+                    text_encoder_precision
+                    if (
+                        text_encoder_precision in PIPELINE_ONLY_PRESETS
+                        or (quantize_via_pipeline and text_encoder_precision in PIPELINE_QUANTIZATION_PRESETS)
+                    )
+                    else None
+                )
                 # load_tes returns a variant and three text encoders
                 signature = inspect.signature(text_encoder_config["model"])
                 extra_kwargs = {}
@@ -2106,14 +2115,17 @@ class ModelFoundation(ABC):
         if raw_config is None:
             return None
         try:
-            from diffusers import DiffusersPipelineQuantizationConfig
+            from diffusers import PipelineQuantizationConfig
 
-            if isinstance(raw_config, DiffusersPipelineQuantizationConfig):
-                for key in component_keys:
-                    entry = getattr(raw_config, key, None)
-                    if entry is not None:
-                        return entry
-                return getattr(raw_config, "default", None)
+            if isinstance(raw_config, PipelineQuantizationConfig):
+                quant_mapping = getattr(raw_config, "quant_mapping", None) or {}
+                if isinstance(quant_mapping, Mapping):
+                    for key in component_keys:
+                        if key in quant_mapping:
+                            return quant_mapping[key]
+                    if "default" in quant_mapping:
+                        return quant_mapping["default"]
+                return raw_config
         except Exception:
             # Avoid failing when diffusers is unavailable or the config type differs.
             pass
@@ -2131,6 +2143,8 @@ class ModelFoundation(ABC):
 
     def _build_component_quantization_config(self, component_keys: list[str], preset: Optional[str] = None):
         raw_config = getattr(self.config, "quantization_config", None)
+        if raw_config is None:
+            raw_config = getattr(self.config, "pipeline_quantization_config", None)
         entry = self._extract_quantization_entry(raw_config, component_keys)
         preset_candidate = preset
         if isinstance(entry, str):
@@ -2139,16 +2153,92 @@ class ModelFoundation(ABC):
         builder = get_pipeline_quantization_builder(preset_candidate)
         if builder is None and isinstance(entry, Mapping):
             entry_keys = set(entry.keys())
-            if any(key.startswith("bnb_") or key == "load_in_4bit" for key in entry_keys):
+            if any(key.startswith("bnb_") or key in {"load_in_4bit", "load_in_8bit"} for key in entry_keys):
                 builder = get_pipeline_quantization_builder("nf4-bnb")
-            elif "quant_type" in entry_keys or "modules_to_not_convert" in entry_keys:
+            elif "weights_dtype" in entry_keys or "weights" in entry_keys:
+                builder = get_pipeline_quantization_builder("int8-quanto")
+            elif "quant_type" in entry_keys or "quant_type_kwargs" in entry_keys or "modules_to_not_convert" in entry_keys:
                 builder = get_pipeline_quantization_builder("int4-torchao")
         # If we have a known preset builder, prefer it and treat mapping entries as overrides.
         if builder is not None and (entry is None or isinstance(entry, (Mapping, str))):
             overrides = entry if isinstance(entry, Mapping) else None
-            return builder(getattr(self.config, "weight_dtype", None), overrides)
+            component_type = "transformers" if any("text_encoder" in key for key in component_keys) else "diffusers"
+            quantization_config = builder(getattr(self.config, "weight_dtype", None), overrides, component_type)
+            self._register_pipeline_quantization_config(component_keys, quantization_config)
+            return quantization_config
 
+        if entry is not None:
+            try:
+                from diffusers import PipelineQuantizationConfig
+            except Exception:
+                PipelineQuantizationConfig = None
+            if PipelineQuantizationConfig is not None and isinstance(entry, PipelineQuantizationConfig):
+                component_type = "transformers" if any("text_encoder" in key for key in component_keys) else "diffusers"
+                quantization_config = self._resolve_pipeline_backend_config(entry, component_keys, component_type)
+                self._register_pipeline_quantization_config(component_keys, quantization_config)
+                return quantization_config
+        if entry is not None:
+            self._register_pipeline_quantization_config(component_keys, entry)
         return entry
+
+    def _resolve_pipeline_backend_config(self, pipeline_config, component_keys: list[str], component_type: str):
+        quant_backend = getattr(pipeline_config, "quant_backend", None)
+        if not quant_backend:
+            return None
+        components_to_quantize = getattr(pipeline_config, "components_to_quantize", None)
+        if components_to_quantize:
+            if not any(key in components_to_quantize for key in component_keys):
+                return None
+
+        quant_kwargs = getattr(pipeline_config, "quant_kwargs", None) or {}
+        if component_type == "transformers":
+            try:
+                from transformers.quantizers.auto import AUTO_QUANTIZATION_CONFIG_MAPPING as auto_mapping
+            except ImportError as exc:
+                raise ImportError(
+                    "Pipeline quantization for text encoders requires transformers with quantization config support."
+                ) from exc
+        else:
+            try:
+                from diffusers.quantizers.auto import AUTO_QUANTIZATION_CONFIG_MAPPING as auto_mapping
+            except ImportError as exc:
+                raise ImportError(
+                    "Pipeline quantization for diffusion components requires diffusers quantization config support."
+                ) from exc
+
+        config_cls = auto_mapping.get(quant_backend)
+        if config_cls is None:
+            raise ValueError(f"Unknown pipeline quantization backend: {quant_backend}")
+        return config_cls(**quant_kwargs)
+
+    def _register_pipeline_quantization_config(self, component_keys: list[str], quantization_config) -> None:
+        if (
+            quantization_config is None
+            or isinstance(quantization_config, Mapping)
+            or getattr(self.config, "quantize_via", None) != "pipeline"
+        ):
+            return
+        try:
+            from diffusers import PipelineQuantizationConfig
+        except ImportError as exc:
+            raise ImportError("Pipeline quantization requires diffusers with PipelineQuantizationConfig support.") from exc
+
+        if isinstance(quantization_config, PipelineQuantizationConfig):
+            setattr(self.config, "pipeline_quantization_config", quantization_config)
+            return
+
+        pipeline_config = getattr(self.config, "pipeline_quantization_config", None)
+        if pipeline_config is None:
+            pipeline_config = PipelineQuantizationConfig(quant_mapping={key: quantization_config for key in component_keys})
+            setattr(self.config, "pipeline_quantization_config", pipeline_config)
+            return
+
+        quant_mapping = getattr(pipeline_config, "quant_mapping", None)
+        if quant_mapping is None:
+            quant_mapping = {}
+            pipeline_config.quant_mapping = quant_mapping
+        for key in component_keys:
+            quant_mapping.setdefault(key, quantization_config)
 
     def load_model(self, move_to_device: bool = True):
         self._group_offload_configured = False
@@ -2191,11 +2281,16 @@ class ModelFoundation(ABC):
         if is_gguf:
             setattr(self.config, "pipeline_quantization", True)
             setattr(self.config, "pipeline_quantization_base", True)
-        if getattr(self.config, "quantize_via", None) == "pipeline":
+        quantize_via_pipeline = getattr(self.config, "quantize_via", None) == "pipeline"
+        if quantize_via_pipeline:
             setattr(self.config, "pipeline_quantization", True)
 
+        pipeline_only_precision = self.config.base_model_precision in PIPELINE_ONLY_PRESETS
+        pipeline_capable_precision = self.config.base_model_precision in PIPELINE_QUANTIZATION_PRESETS
         base_pipeline_preset = (
-            self.config.base_model_precision if self.config.base_model_precision in PIPELINE_QUANTIZATION_PRESETS else None
+            self.config.base_model_precision
+            if (pipeline_only_precision or (quantize_via_pipeline and pipeline_capable_precision))
+            else None
         )
         if base_pipeline_preset is not None:
             setattr(self.config, "pipeline_quantization", True)

--- a/simpletuner/helpers/training/quantisation/__init__.py
+++ b/simpletuner/helpers/training/quantisation/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from functools import partial
 from typing import Any, Callable, Mapping, Optional
 
 import torch
@@ -13,7 +14,16 @@ if should_log():
 else:
     logger.setLevel(logging.ERROR)
 
-PIPELINE_QUANTIZATION_PRESETS = {"nf4-bnb", "int4-torchao"}
+PIPELINE_ONLY_PRESETS = {"nf4-bnb", "int4-torchao"}
+PIPELINE_QUANTIZATION_PRESETS = PIPELINE_ONLY_PRESETS | {
+    "int8-torchao",
+    "fp8-torchao",
+    "int8-quanto",
+    "int4-quanto",
+    "int2-quanto",
+    "fp8-quanto",
+    "fp8uz-quanto",
+}
 MANUAL_QUANTO_PRESETS = {"int2-quanto", "int4-quanto", "int8-quanto", "fp8-quanto", "fp8uz-quanto"}
 MANUAL_TORCHAO_PRESETS = {"int8-torchao", "fp8-torchao"}
 MANUAL_SDNQ_PRESETS = {
@@ -40,12 +50,29 @@ def _normalize_dtype(weight_dtype: Any):
     return weight_dtype
 
 
-def _bnb_nf4_config(weight_dtype=None, overrides: Optional[Mapping[str, Any]] = None):
+def _get_bnb_config_cls(component_type: str):
+    if component_type == "transformers":
+        try:
+            from transformers import BitsAndBytesConfig
+        except ImportError as exc:
+            raise ImportError(
+                "Pipeline BitsAndBytes quantization for text encoders requires transformers with BitsAndBytesConfig."
+            ) from exc
+        return BitsAndBytesConfig
     try:
         from diffusers import BitsAndBytesConfig
     except ImportError as exc:
+        raise ImportError("Pipeline BitsAndBytes quantization requires diffusers with BitsAndBytesConfig support.") from exc
+    return BitsAndBytesConfig
+
+
+def _bnb_nf4_config(weight_dtype=None, overrides: Optional[Mapping[str, Any]] = None, component_type: str = "diffusers"):
+    try:
+        bitsandbytes_cls = _get_bnb_config_cls(component_type)
+    except ImportError as exc:
         raise ImportError(
-            "nf4-bnb quantization requires diffusers[torch] with BitsAndBytes support. Please install diffusers and bitsandbytes."
+            "nf4-bnb quantization requires diffusers[torch] with BitsAndBytes support. "
+            "Please install diffusers and bitsandbytes."
         ) from exc
 
     kwargs = {
@@ -57,7 +84,7 @@ def _bnb_nf4_config(weight_dtype=None, overrides: Optional[Mapping[str, Any]] = 
     if isinstance(overrides, Mapping):
         kwargs.update(overrides)
     try:
-        return BitsAndBytesConfig(**kwargs)
+        return bitsandbytes_cls(**kwargs)
     except Exception as exc:
         # BitsAndBytesConfig.post_init() checks for bitsandbytes package metadata,
         # which raises PackageNotFoundError if bitsandbytes is not installed.
@@ -69,33 +96,136 @@ def _bnb_nf4_config(weight_dtype=None, overrides: Optional[Mapping[str, Any]] = 
         raise
 
 
-def _torchao_int4_config(weight_dtype=None, overrides: Optional[Mapping[str, Any]] = None):
+def _get_torchao_config_cls(component_type: str):
+    if component_type == "transformers":
+        try:
+            from transformers import TorchAoConfig
+        except ImportError as exc:
+            raise ImportError(
+                "Pipeline TorchAO quantization for text encoders requires transformers with TorchAoConfig."
+            ) from exc
+        return TorchAoConfig
     try:
-        from torchao.quantization import Int4WeightOnlyConfig
-        from transformers import TorchAoConfig
+        from diffusers import TorchAoConfig
+    except ImportError as exc:
+        raise ImportError("Pipeline TorchAO quantization requires diffusers with TorchAoConfig support.") from exc
+    return TorchAoConfig
+
+
+def _build_torchao_config(
+    weight_dtype=None,
+    overrides: Optional[Mapping[str, Any]] = None,
+    component_type: str = "diffusers",
+    *,
+    default_quant_type: str,
+):
+    try:
+        torchao_cls = _get_torchao_config_cls(component_type)
     except ImportError as exc:
         raise ImportError(
-            "TorchAO int4 quantization requires torchao and transformers with TorchAoConfig. Please install torchao and transformers>=4.39."
+            "TorchAO quantization requires torchao and a compatible TorchAoConfig implementation. "
+            "Please install torchao and a recent diffusers/transformers."
         ) from exc
 
     override_dict = dict(overrides) if isinstance(overrides, Mapping) else {}
     quant_type_override = override_dict.pop("quant_type", None)
-    group_size = override_dict.pop("group_size", None)
-    if quant_type_override is None:
-        quant_kwargs = {}
-        if group_size is not None:
-            quant_kwargs["group_size"] = group_size
-        quant_type_override = Int4WeightOnlyConfig(**quant_kwargs)
-    return TorchAoConfig(quant_type=quant_type_override, **override_dict)
+    quant_type_kwargs = override_dict.pop("quant_type_kwargs", None)
+    if isinstance(quant_type_kwargs, Mapping):
+        override_dict.update(quant_type_kwargs)
+    quant_type_override = quant_type_override or default_quant_type
+    return torchao_cls(quant_type=quant_type_override, **override_dict)
 
 
-PIPELINE_PRESET_BUILDERS: dict[str, Callable[[Any, Optional[Mapping[str, Any]]], Any]] = {
+def _get_quanto_config_cls(component_type: str):
+    if component_type == "transformers":
+        try:
+            from transformers import QuantoConfig
+        except ImportError as exc:
+            raise ImportError(
+                "Pipeline Quanto quantization for text encoders requires transformers with QuantoConfig."
+            ) from exc
+        return QuantoConfig
+    try:
+        from diffusers import QuantoConfig
+    except ImportError as exc:
+        raise ImportError("Pipeline Quanto quantization requires diffusers with QuantoConfig support.") from exc
+    return QuantoConfig
+
+
+def _build_quanto_config(
+    weight_dtype=None,
+    overrides: Optional[Mapping[str, Any]] = None,
+    component_type: str = "diffusers",
+    *,
+    default_weights_dtype: str,
+):
+    try:
+        quanto_cls = _get_quanto_config_cls(component_type)
+    except ImportError as exc:
+        raise ImportError(
+            "Quanto quantization requires diffusers/transformers with QuantoConfig support. "
+            "Please install a recent diffusers/transformers and optimum-quanto."
+        ) from exc
+
+    override_dict = dict(overrides) if isinstance(overrides, Mapping) else {}
+    if component_type == "transformers":
+        weight_key = "weights"
+        if "weights_dtype" in override_dict and weight_key not in override_dict:
+            override_dict[weight_key] = override_dict.pop("weights_dtype")
+    else:
+        weight_key = "weights_dtype"
+        if "weights" in override_dict and weight_key not in override_dict:
+            override_dict[weight_key] = override_dict.pop("weights")
+    weights_value = override_dict.pop(weight_key, default_weights_dtype)
+    return quanto_cls(**{weight_key: weights_value}, **override_dict)
+
+
+def _build_quanto_fp8uz_config(
+    weight_dtype=None,
+    overrides: Optional[Mapping[str, Any]] = None,
+    component_type: str = "diffusers",
+):
+    logger.warning(
+        "fp8uz-quanto pipeline quantization maps to diffusers float8 weights (qfloat8_e4m3fn). "
+        "Use manual quanto quantization if you require the FP8-NUZ variant."
+    )
+    return _build_quanto_config(
+        weight_dtype=weight_dtype,
+        overrides=overrides,
+        component_type=component_type,
+        default_weights_dtype="float8",
+    )
+
+
+TORCHAO_PIPELINE_PRESET_MAP = {
+    "int4-torchao": "int4wo",
+    "int8-torchao": "int8wo",
+    "fp8-torchao": "float8wo_e4m3",
+}
+QUANTO_PIPELINE_PRESET_MAP = {
+    "int8-quanto": "int8",
+    "int4-quanto": "int4",
+    "int2-quanto": "int2",
+    "fp8-quanto": "float8",
+}
+
+PIPELINE_PRESET_BUILDERS: dict[str, Callable[[Any, Optional[Mapping[str, Any]], str], Any]] = {
     "nf4-bnb": _bnb_nf4_config,
-    "int4-torchao": _torchao_int4_config,
+    **{
+        preset: partial(_build_torchao_config, default_quant_type=quant_type)
+        for preset, quant_type in TORCHAO_PIPELINE_PRESET_MAP.items()
+    },
+    **{
+        preset: partial(_build_quanto_config, default_weights_dtype=weights_dtype)
+        for preset, weights_dtype in QUANTO_PIPELINE_PRESET_MAP.items()
+    },
+    "fp8uz-quanto": _build_quanto_fp8uz_config,
 }
 
 
-def get_pipeline_quantization_builder(preset: Optional[str]) -> Optional[Callable[[Any, Optional[Mapping[str, Any]]], Any]]:
+def get_pipeline_quantization_builder(
+    preset: Optional[str],
+) -> Optional[Callable[[Any, Optional[Mapping[str, Any]], str], Any]]:
     if preset is None:
         return None
     return PIPELINE_PRESET_BUILDERS.get(str(preset))

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -70,7 +70,7 @@ from simpletuner.helpers.training.optimizer_param import (
 )
 from simpletuner.helpers.training.optimizers.adamw_bfloat16 import AdamWBF16
 from simpletuner.helpers.training.peft_init import init_lokr_network_with_perturbed_normal
-from simpletuner.helpers.training.quantisation import PIPELINE_QUANTIZATION_PRESETS
+from simpletuner.helpers.training.quantisation import PIPELINE_ONLY_PRESETS, PIPELINE_QUANTIZATION_PRESETS
 from simpletuner.helpers.training.script_runner import run_hook_script
 from simpletuner.helpers.training.state_tracker import StateTracker
 from simpletuner.helpers.training.validation import Validation, prepare_validation_prompt_list
@@ -2173,7 +2173,9 @@ class Trainer:
             return isinstance(candidate, str) and candidate.endswith(".gguf")
 
         gguf_requested = any(_is_gguf_path(path) for path in base_paths if path)
-        base_pipeline_precision = base_model_precision in PIPELINE_QUANTIZATION_PRESETS
+        pipeline_only_precision = base_model_precision in PIPELINE_ONLY_PRESETS
+        pipeline_capable_precision = base_model_precision in PIPELINE_QUANTIZATION_PRESETS
+        base_pipeline_precision = pipeline_only_precision or (quantize_via_pipeline and pipeline_capable_precision)
         self.config.is_quanto = False
         self.config.is_torchao = False
         self.config.is_bnb = False

--- a/tests/test_quantization_config_parsing.py
+++ b/tests/test_quantization_config_parsing.py
@@ -16,14 +16,14 @@ def _base_args():
 
 class TestQuantizationConfigParsing(unittest.TestCase):
     def test_pipeline_quantize_via_rejects_manual_precision(self):
-        args_list = _base_args() + ["--quantize_via=pipeline", "--base_model_precision=int8-quanto"]
+        args_list = _base_args() + ["--quantize_via=pipeline", "--base_model_precision=int8-sdnq"]
         with self.assertRaises(ValueError):
             parse_cmdline_args(input_args=args_list, exit_on_error=True)
 
     def test_quantization_config_requires_pipeline_compatible_base(self):
         qconfig = json.dumps({"unet": {"load_in_4bit": True}})
         args_list = _base_args() + [
-            "--base_model_precision=int8-quanto",
+            "--base_model_precision=int8-sdnq",
             f"--quantization_config={qconfig}",
         ]
         with self.assertRaises(ValueError):
@@ -40,3 +40,13 @@ class TestQuantizationConfigParsing(unittest.TestCase):
         self.assertIsInstance(args.quantization_config, dict)
         self.assertIn("unet", args.quantization_config)
         self.assertEqual(args.quantization_config["unet"]["bnb_4bit_quant_type"], "nf4")
+
+    def test_pipeline_quantize_via_allows_torchao_preset(self):
+        args_list = _base_args() + ["--quantize_via=pipeline", "--base_model_precision=int8-torchao"]
+        args = parse_cmdline_args(input_args=args_list, exit_on_error=False)
+        self.assertEqual(args.base_model_precision, "int8-torchao")
+
+    def test_pipeline_quantize_via_allows_quanto_preset(self):
+        args_list = _base_args() + ["--quantize_via=pipeline", "--base_model_precision=int8-quanto"]
+        args = parse_cmdline_args(input_args=args_list, exit_on_error=False)
+        self.assertEqual(args.base_model_precision, "int8-quanto")


### PR DESCRIPTION
This pull request updates quantization support and documentation across multiple languages and improves the logic for handling quantization presets in the codebase. The main focus is to expand support for more pipeline-compatible quantization presets, clarify backend compatibility, and refine validation logic to better distinguish between manual-only and pipeline-compatible quantization options.

**Documentation updates (all languages):**

* Expanded the list of supported pipeline quantization presets in all `OPTIONS.*.md` files to include `int8-torchao`, `fp8-torchao`, `int8-quanto`, and others, and clarified that Optimum Quanto now supports both pipeline and manual modes. Also, backend compatibility notes were updated for new presets. [[1]](diffhunk://#diff-45e063db3ebcffb55dde68f083e92399a74f4cefbb464e8cd36911971c50933fL194-R204) [[2]](diffhunk://#diff-3f0cd39e3a7f176d81408ae40dc4f8c6271347f75b1cee5cf71c4e701d7db561L194-R204) [[3]](diffhunk://#diff-2c007ae9176f9f69b3ae16558be55b46d524f460a626f4e5c31e1e9a1d1b14b8L194-R204) [[4]](diffhunk://#diff-39b5789a705b2e70400106934436b619d10413ca5e37bd7a2b5fa7aa0c0fb8cfL194-R204) [[5]](diffhunk://#diff-fd629904ab3e1ecdd5b568c3ef6ac61e71e3d7741700e360820849938158a1d9L195-R205) [[6]](diffhunk://#diff-cddcc50c252e719be92644d65ea8542cc51d08f15e67d918bfae737904142b1fL195-R205)

**Configuration and validation logic improvements:**

* In `cmd_args.py`, introduced `manual_only_precisions` and `quantization_precisions` to clearly separate manual-only from pipeline-compatible quantization presets. Updated validation logic to prevent invalid combinations of quantization modes and presets, and to ensure correct error messages when mixing manual and pipeline quantization options. [[1]](diffhunk://#diff-2eb2bdca165b022325e9401eb998e8aa0f66d16deea3d8b7cd0fd68e5814ffa0R701-R702) [[2]](diffhunk://#diff-2eb2bdca165b022325e9401eb998e8aa0f66d16deea3d8b7cd0fd68e5814ffa0L709-R711) [[3]](diffhunk://#diff-2eb2bdca165b022325e9401eb998e8aa0f66d16deea3d8b7cd0fd68e5814ffa0L718-R720) [[4]](diffhunk://#diff-2eb2bdca165b022325e9401eb998e8aa0f66d16deea3d8b7cd0fd68e5814ffa0L737-R739) [[5]](diffhunk://#diff-2eb2bdca165b022325e9401eb998e8aa0f66d16deea3d8b7cd0fd68e5814ffa0L754-R759)

**Model loading and quantization config handling:**

* In `common.py`, updated logic for determining if a text encoder preset should be treated as pipeline-compatible, especially when `quantize_via=pipeline` is set. This ensures that only valid presets are passed to the pipeline. [[1]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR57) [[2]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbL1872-R1881)
* Improved extraction of quantization entries from pipeline quantization configs to support the new `PipelineQuantizationConfig` API, including proper mapping for component-specific and default entries.
* Added support for reading `pipeline_quantization_config` as a fallback if `quantization_config` is not set, ensuring compatibility with new config naming conventions.