### PR TITLE
initialise wizard with full defaults so that bindings resolve immediately

### DIFF
--- a/simpletuner/static/js/dataset-wizard.js
+++ b/simpletuner/static/js/dataset-wizard.js
@@ -18,6 +18,36 @@
         { value: 'superresolution', label: 'Super Resolution', description: 'Reconstructs high-res conditioning frames.' },
     ];
 
+    const buildDefaultDataset = () => ({
+        id: '',
+        type: 'local',
+        dataset_type: 'image',
+        is_regularisation_data: false,
+        resolution: 1024,
+        resolution_type: 'pixel_area',
+        crop: false,
+        crop_style: 'random',
+        crop_aspect: 'square',
+        crop_aspect_buckets: [],
+        caption_strategy: 'textfile',
+        instance_prompt: '',
+        prepend_instance_prompt: false,
+        metadata_backend: 'discovery',
+        cache_dir_vae: '{output_dir}/cache/vae/{model_family}/{id}',
+        cache_dir_text: '{output_dir}/cache/text/{model_family}/{id}',
+        probability: 1,
+        repeats: 0,
+        parquet: {
+            path: '',
+            filename_column: 'id',
+            caption_column: 'caption',
+            width_column: '',
+            height_column: '',
+            fallback_caption_column: '',
+            identifier_includes_extension: false
+        }
+    });
+
     window.datasetWizardComponent = function() {
         console.log('[WIZARD] datasetWizardComponent function called (Alpine initializing component)');
         return {
@@ -33,7 +63,7 @@
             selectedBlueprint: null,
 
             // Current dataset being configured
-            currentDataset: {},
+            currentDataset: buildDefaultDataset(),
             datasetQueue: [],
             editingQueuedDataset: false,
             editingIndex: -1,
@@ -382,35 +412,7 @@
             },
 
             getDefaultDataset() {
-                return {
-                    id: '',
-                    type: 'local',
-                    dataset_type: 'image',
-                    is_regularisation_data: false,
-                    resolution: 1024,
-                    resolution_type: 'pixel_area',
-                    crop: false,
-                    crop_style: 'random',
-                    crop_aspect: 'square',
-                    crop_aspect_buckets: [],
-                    caption_strategy: 'textfile',
-                    instance_prompt: '',
-                    prepend_instance_prompt: false,
-                    metadata_backend: 'discovery',
-                    cache_dir_vae: '{output_dir}/cache/vae/{model_family}/{id}',
-                    cache_dir_text: '{output_dir}/cache/text/{model_family}/{id}',
-                    probability: 1,
-                    repeats: 0,
-                    parquet: {
-                        path: '',
-                        filename_column: 'id',
-                        caption_column: 'caption',
-                        width_column: '',
-                        height_column: '',
-                        fallback_caption_column: '',
-                        identifier_includes_extension: false
-                    }
-                };
+                return buildDefaultDataset();
             },
 
             selectDatasetType(type) {


### PR DESCRIPTION
This pull request refactors how default dataset objects are created and managed in the dataset wizard JavaScript component, and updates the end-to-end test to verify the default values for parquet dataset fields. The main focus is on improving code reuse and maintainability by centralizing the default dataset structure, and ensuring that the UI initializes parquet-related fields with the correct defaults.

### Refactoring and code reuse

* Introduced a new `buildDefaultDataset` function in `dataset-wizard.js` to centralize the creation of default dataset objects, replacing duplicated default object literals. All references to the default dataset now use this function. [[1]](diffhunk://#diff-0686ced55e44778d6e58196ffd127349b6a648cd15a7da1748a0a055f275bbadR21-R50) [[2]](diffhunk://#diff-0686ced55e44778d6e58196ffd127349b6a648cd15a7da1748a0a055f275bbadL36-R66) [[3]](diffhunk://#diff-0686ced55e44778d6e58196ffd127349b6a648cd15a7da1748a0a055f275bbadL385-R415)

### Testing improvements

* Updated the end-to-end test in `test_webui_e2e.py` to programmatically navigate to the captions step, set the dataset type and caption strategy, and assert that the parquet dataset fields (`filename_column`, `caption_column`, and `identifier_includes_extension`) are initialized with the expected default values.