### PR TITLE
submit huggingface hub token to service when the user has selected huggingface publication

### DIFF
--- a/simpletuner/simpletuner_sdk/server/services/cloud/job_submission.py
+++ b/simpletuner/simpletuner_sdk/server/services/cloud/job_submission.py
@@ -402,7 +402,28 @@ class JobSubmissionService:
         if not push_to_hub:
             return None
 
-        return os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+        for env_key in (
+            "HF_TOKEN",
+            "HUGGINGFACE_HUB_TOKEN",
+            "HUGGINGFACEHUB_API_TOKEN",
+            "HF_API_TOKEN",
+            "HUGGING_FACE_HUB_TOKEN",
+        ):
+            token = os.environ.get(env_key)
+            if token:
+                return token
+
+        from huggingface_hub import HfFolder
+
+        token = HfFolder.get_token()
+        if token:
+            return token
+
+        token_path = Path.home() / ".cache" / "huggingface" / "token"
+        if token_path.exists():
+            return token_path.read_text().strip()
+
+        return None
 
     def _load_lycoris_config(self, config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Load lycoris config if specified."""


### PR DESCRIPTION
This pull request improves the robustness of Hugging Face token retrieval in the `simpletuner/simpletuner_sdk/server/services/cloud/job_submission.py` service. The updated logic now checks multiple environment variables, uses the Hugging Face SDK, and falls back to reading from a local cache file, ensuring the token is found in a wider range of scenarios.

Improvements to Hugging Face token retrieval:

* Enhanced `_get_hf_token_if_needed` to check several environment variables (`HF_TOKEN`, `HUGGINGFACE_HUB_TOKEN`, `HUGGINGFACEHUB_API_TOKEN`, `HF_API_TOKEN`, `HUGGING_FACE_HUB_TOKEN`) for the token, increasing compatibility with different setups.
* Added fallback to retrieve the token using `HfFolder.get_token()` from the Hugging Face SDK if environment variables are not set.
* Further fallback to reading the token from the local cache file at `~/.cache/huggingface/token` if previous methods fail.