### PR TITLE
add envrc for direnv support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+if [ -d ".venv" ]; then
+  # shellcheck disable=SC1091
+  source .venv/bin/activate
+fi


### PR DESCRIPTION
This pull request adds logic to the `.envrc` file to automatically activate the Python virtual environment if the `.venv` directory exists.

- Environment setup improvement:
  * [`.envrc`](diffhunk://#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430R1-R4): Added a check for the `.venv` directory and automatically sources the virtual environment activation script, streamlining local Python development setup.