### PR TITLE
send logout event on session expiry

### DIFF
--- a/simpletuner/templates/base_htmx.html
+++ b/simpletuner/templates/base_htmx.html
@@ -476,7 +476,15 @@
         // Global error handler
         document.body.addEventListener('htmx:responseError', function(evt) {
             console.error('HTMX Error:', evt.detail);
-            showToast('Network error occurred', 'error');
+            const status = evt.detail.xhr?.status;
+            if (status === 401) {
+                // Session expired or not authenticated
+                window.handleSessionExpired?.('Your session has expired. Please log in again.');
+            } else if (status === 403) {
+                showToast('Permission denied', 'error');
+            } else {
+                showToast('Network error occurred', 'error');
+            }
         });
 
         // Global success handler

--- a/simpletuner/templates/components/training_events_sse.html
+++ b/simpletuner/templates/components/training_events_sse.html
@@ -1597,6 +1597,21 @@
             trackListener('callback:' + category, callbackHandler);
         });
 
+        // Auth event handler for session invalidation
+        var authHandler = function(data) {
+            console.log('[SSE] Auth event received:', data);
+            if (data && data.type === 'session_invalidated') {
+                var reason = data.reason || 'session_expired';
+                var message = reason === 'user_deleted'
+                    ? 'Your account has been deleted. Please contact an administrator.'
+                    : 'Your session has expired. Please log in again.';
+                if (window.handleSessionExpired) {
+                    window.handleSessionExpired(message);
+                }
+            }
+        };
+        trackListener('auth', authHandler);
+
     managerRegistered = true;
     return true;
     }
@@ -1626,6 +1641,25 @@
                     console.error('Failed to parse callback event', error);
                 }
             });
+        });
+
+        // Auth event listener for session invalidation
+        source.addEventListener('auth', function(event) {
+            try {
+                const data = JSON.parse(event.data);
+                console.log('[SSE] Auth event received:', data);
+                if (data && data.type === 'session_invalidated') {
+                    var reason = data.reason || 'session_expired';
+                    var message = reason === 'user_deleted'
+                        ? 'Your account has been deleted. Please contact an administrator.'
+                        : 'Your session has expired. Please log in again.';
+                    if (window.handleSessionExpired) {
+                        window.handleSessionExpired(message);
+                    }
+                }
+            } catch (error) {
+                console.error('Failed to parse auth event', error);
+            }
         });
 
         managerRegistered = true;

--- a/simpletuner/templates/trainer_htmx.html
+++ b/simpletuner/templates/trainer_htmx.html
@@ -293,8 +293,35 @@ document.addEventListener('alpine:init', () => {
                 );
             }
             return this.shouldShowApp;
+        },
+        handleSessionExpired(message) {
+            // Only handle if auth is in use and user was logged in
+            if (!this.authStatus.inUse) return;
+
+            // Clear current user to show login form
+            this.currentUser = null;
+            this.loaded = false;
+
+            // Show message to user
+            if (window.showToast) {
+                window.showToast(message || 'Your session has expired. Please log in again.', 'warning', 5000);
+            }
+
+            // Reset login form
+            this.loginForm.error = null;
+            this.loginForm.username = '';
+            this.loginForm.password = '';
+            this.loginForm.submitting = false;
         }
     });
+
+    // Global handler for session expiration (called from HTMX error handler and SSE)
+    window.handleSessionExpired = function(message) {
+        const store = Alpine.store('cloudAuth');
+        if (store) {
+            store.handleSessionExpired(message);
+        }
+    };
 });
 
 /**


### PR DESCRIPTION
This pull request improves how the application handles session expiration and authentication errors, ensuring users are properly notified and redirected to the login form when their session is invalidated. The changes include adding global handlers for session expiration events from both HTMX responses and server-sent events (SSE), and centralizing the logic for handling session expiry in the authentication store.

**Session Expiration Handling Improvements**

* Added a global `handleSessionExpired` function to the authentication store in `trainer_htmx.html`, which resets the user state, clears login forms, and displays a warning toast when a session expires or the user is deleted. This function is now used as the central handler for session expiration events.

* Updated the HTMX global error handler in `base_htmx.html` to call `handleSessionExpired` when a 401 Unauthorized response is detected, and to show a permission denied toast for 403 errors.

**Server-Sent Events (SSE) Authentication Events**

* Added an SSE listener in `training_events_sse.html` for `auth` events, which triggers `handleSessionExpired` if a `session_invalidated` event is received (e.g., due to session expiry or user deletion). The handler parses the event data and displays an appropriate message to the user. [[1]](diffhunk://#diff-d4ca8ed491f5aea477034c7687a93e33cab0541bb434998b6c6234c601958827R1600-R1614) [[2]](diffhunk://#diff-d4ca8ed491f5aea477034c7687a93e33cab0541bb434998b6c6234c601958827R1646-R1664)