### PR TITLE
remove env name badge from dataloader env selector

### DIFF
--- a/simpletuner/static/css/dataloader-builder.css
+++ b/simpletuner/static/css/dataloader-builder.css
@@ -1528,11 +1528,6 @@
         line-height: 1.3;
     }
 
-    #datasets-tab-content #current-env-badge {
-        font-size: 0.65rem;
-        padding: 0.15rem 0.35rem;
-    }
-
     /* Mode switcher - compact buttons */
     .mode-switcher {
         margin-bottom: 0.75rem;

--- a/simpletuner/templates/datasets_tab.html
+++ b/simpletuner/templates/datasets_tab.html
@@ -263,7 +263,6 @@
                            id="filterByEnvironment">
                     <label class="form-check-label small" for="filterByEnvironment">
                         Only show configs from<br>current environment
-                        <span class="badge bg-info text-dark" id="current-env-badge">none</span>
                     </label>
                 </div>
             </div>
@@ -288,9 +287,8 @@
             // Note: ID uses underscores, not hyphens
             const selector = document.getElementById('datasets_page_data_backend_config');
             const dropdown = document.querySelector('[data-field-id="datasets_page_data_backend_config"]');
-            const badge = document.getElementById('current-env-badge');
 
-            console.log('initDatasetPageSelector called (attempt ' + (retryCount + 1) + ')', { selector, dropdown, badge });
+            console.log('initDatasetPageSelector called (attempt ' + (retryCount + 1) + ')', { selector, dropdown });
 
             if (!dropdown) {
                 if (retryCount < maxRetries) {
@@ -322,15 +320,6 @@
                 return;
             }
             dropdown.dataset.initialized = 'true';
-
-            // Function to sync the environment badge with the trainer store
-            function syncEnvironmentBadge() {
-                const trainerStore = Alpine.store('trainer');
-                if (trainerStore && badge) {
-                    const env = trainerStore.selectedEnvironment || '';
-                    badge.textContent = env || 'none';
-                }
-            }
 
             // Function to sync the dropdown value from the trainer store's configValues
             function syncDropdownFromStore() {
@@ -401,8 +390,6 @@
                 }
             }
 
-            // Initial sync
-            syncEnvironmentBadge();
             // Delay the dropdown sync to ensure store is populated
             setTimeout(syncDropdownFromStore, 100);
 
@@ -411,8 +398,7 @@
                 Alpine.effect(() => {
                     const trainerStore = Alpine.store('trainer');
                     if (trainerStore) {
-                        syncEnvironmentBadge();
-                        // Also sync dropdown when configValues or activeEnvironmentConfig changes
+                        // Sync dropdown when configValues or activeEnvironmentConfig changes
                         const _ = trainerStore.configValues;
                         const __ = trainerStore.activeEnvironmentConfig;
                         syncDropdownFromStore();

--- a/simpletuner/templates/partials/dataset_selector.html
+++ b/simpletuner/templates/partials/dataset_selector.html
@@ -102,11 +102,6 @@
             const config = trainerStore.configValues || {};
             const path = config.data_backend_config || config['--data_backend_config'] || '';
             currentEnv = trainerStore.selectedEnvironment || '';
-            const badge = document.getElementById('current-env-badge');
-            if (badge) {
-                badge.textContent = currentEnv || 'none';
-            }
-
             if (path) {
                 const matchingConfig = allConfigs.find(c => c.path === path);
                 if (matchingConfig && window.__setDatasetSelection) {


### PR DESCRIPTION
This pull request removes the display and related logic for the "current environment" badge from the dataset configuration UI. The badge previously showed the active environment, but all associated code and styling have now been deleted to simplify the interface.

UI and logic cleanup:

* Removed the "current environment" badge element from the dataset configuration label in `datasets_tab.html`, along with its associated CSS styling in `dataloader-builder.css`. [[1]](diffhunk://#diff-3e24b366ce029a395b533299f766d134dc412c4ab01cbc8d5431d4d83cc31827L266) [[2]](diffhunk://#diff-ade0168e7aadcc561ae25a10c4d97146bbf2fd10e7a77642aca84d7f216cf0efL1531-L1535)
* Deleted all JavaScript logic for updating and syncing the badge with the environment state in both `datasets_tab.html` and `dataset_selector.html`. [[1]](diffhunk://#diff-3e24b366ce029a395b533299f766d134dc412c4ab01cbc8d5431d4d83cc31827L291-R291) [[2]](diffhunk://#diff-3e24b366ce029a395b533299f766d134dc412c4ab01cbc8d5431d4d83cc31827L326-L334) [[3]](diffhunk://#diff-3e24b366ce029a395b533299f766d134dc412c4ab01cbc8d5431d4d83cc31827L404-L405) [[4]](diffhunk://#diff-3e24b366ce029a395b533299f766d134dc412c4ab01cbc8d5431d4d83cc31827L414-R401) [[5]](diffhunk://#diff-ee67d2d2c8323ae1bcfa80bfa4676fac704d50c86d291dfddf616e5e8ba9199cL105-L109)