### PR TITLE
add --modelspec_comment option and parsing for env var contents within it

### DIFF
--- a/documentation/OPTIONS.es.md
+++ b/documentation/OPTIONS.es.md
@@ -403,6 +403,30 @@ Esto es útil para herramientas de monitoreo que reciben webhooks de múltiples 
 - **Qué**: El nombre del modelo en Huggingface Hub y el directorio de resultados locales.
 - **Por qué**: Este valor se usa como nombre de directorio bajo la ubicación especificada como `--output_dir`. Si se proporciona `--push_to_hub`, este se convertirá en el nombre del modelo en Huggingface Hub.
 
+### `--modelspec_comment`
+
+- **Qué**: Texto incorporado en los metadatos del archivo safetensors como `modelspec.comment`
+- **Por defecto**: None (deshabilitado)
+- **Notas**:
+  - Visible en visualizadores de modelos externos (ComfyUI, herramientas de info de modelos)
+  - Acepta una cadena o un array de cadenas (unidas con saltos de línea)
+  - Soporta marcadores `{env:VAR_NAME}` para sustitución de variables de entorno
+  - Cada checkpoint usa el valor de configuración actual en el momento del guardado
+
+**Ejemplo (cadena)**:
+```json
+"modelspec_comment": "Entrenado en mi dataset personalizado v2.1"
+```
+
+**Ejemplo (array para múltiples líneas)**:
+```json
+"modelspec_comment": [
+  "Ejecución de entrenamiento: experiment-42",
+  "Dataset: custom-portraits-v2",
+  "Notas: {env:TRAINING_NOTES}"
+]
+```
+
 ### `--disable_benchmark`
 
 - **Qué**: Desactiva la validación/benchmark de arranque que ocurre en el paso 0 sobre el modelo base. Estas salidas se concatenan al lado izquierdo de tus imágenes de validación del modelo entrenado.
@@ -1275,6 +1299,7 @@ usage: train.py [-h] --model_family
                 [--model_card_private [MODEL_CARD_PRIVATE]]
                 [--model_card_safe_for_work [MODEL_CARD_SAFE_FOR_WORK]]
                 [--model_card_note MODEL_CARD_NOTE]
+                [--modelspec_comment MODELSPEC_COMMENT]
                 [--report_to {tensorboard,wandb,comet_ml,all,none}]
                 [--checkpoint_step_interval CHECKPOINT_STEP_INTERVAL]
                 [--checkpoint_epoch_interval CHECKPOINT_EPOCH_INTERVAL]
@@ -1945,6 +1970,9 @@ options:
   --model_card_note MODEL_CARD_NOTE
                         Optional note that appears at the top of the generated
                         model card.
+  --modelspec_comment MODELSPEC_COMMENT
+                        Text embedded in safetensors file metadata as
+                        modelspec.comment, visible in external model viewers.
   --report_to {tensorboard,wandb,comet_ml,all,none}
                         Where to log training metrics
   --checkpoint_step_interval CHECKPOINT_STEP_INTERVAL

--- a/documentation/OPTIONS.hi.md
+++ b/documentation/OPTIONS.hi.md
@@ -403,6 +403,30 @@ Alternative attention mechanisms समर्थित हैं, जिनक�
 - **What**: Huggingface Hub मॉडल और local results directory का नाम।
 - **Why**: यह मान `--output_dir` द्वारा निर्दिष्ट स्थान के अंतर्गत directory नाम के रूप में उपयोग होता है। यदि `--push_to_hub` दिया गया है, तो यही Huggingface Hub पर मॉडल का नाम होगा।
 
+### `--modelspec_comment`
+
+- **What**: safetensors फ़ाइल metadata में `modelspec.comment` के रूप में embedded text
+- **Default**: None (disabled)
+- **Notes**:
+  - बाहरी model viewers (ComfyUI, model info tools) में दिखाई देता है
+  - string या strings की array (newlines से जुड़ी) स्वीकार करता है
+  - environment variable substitution के लिए `{env:VAR_NAME}` placeholders support करता है
+  - प्रत्येक checkpoint save के समय current config value उपयोग करता है
+
+**Example (string)**:
+```json
+"modelspec_comment": "मेरे custom dataset v2.1 पर trained"
+```
+
+**Example (array multi-line के लिए)**:
+```json
+"modelspec_comment": [
+  "Training run: experiment-42",
+  "Dataset: custom-portraits-v2",
+  "Notes: {env:TRAINING_NOTES}"
+]
+```
+
 ### `--disable_benchmark`
 
 - **What**: step 0 पर base model के लिए होने वाली startup validation/benchmark को disable करता है। ये outputs आपकी trained model validation images के बाएँ हिस्से में stitched होते हैं।
@@ -1273,6 +1297,7 @@ usage: train.py [-h] --model_family
                 [--model_card_private [MODEL_CARD_PRIVATE]]
                 [--model_card_safe_for_work [MODEL_CARD_SAFE_FOR_WORK]]
                 [--model_card_note MODEL_CARD_NOTE]
+                [--modelspec_comment MODELSPEC_COMMENT]
                 [--report_to {tensorboard,wandb,comet_ml,all,none}]
                 [--checkpoint_step_interval CHECKPOINT_STEP_INTERVAL]
                 [--checkpoint_epoch_interval CHECKPOINT_EPOCH_INTERVAL]
@@ -1943,6 +1968,9 @@ options:
   --model_card_note MODEL_CARD_NOTE
                         Optional note that appears at the top of the generated
                         model card.
+  --modelspec_comment MODELSPEC_COMMENT
+                        Text embedded in safetensors file metadata as
+                        modelspec.comment, visible in external model viewers.
   --report_to {tensorboard,wandb,comet_ml,all,none}
                         Where to log training metrics
   --checkpoint_step_interval CHECKPOINT_STEP_INTERVAL

--- a/documentation/OPTIONS.ja.md
+++ b/documentation/OPTIONS.ja.md
@@ -404,6 +404,30 @@ Accelerate の既定値を使いたい項目は省略してください（例: �
 - **内容**: Hugging Face Hub のモデル名およびローカル結果ディレクトリ名。
 - **理由**: `--output_dir` で指定した場所の配下にこの名前のディレクトリが作成されます。`--push_to_hub` を指定した場合、Hugging Face Hub 上のモデル名になります。
 
+### `--modelspec_comment`
+
+- **内容**: safetensors ファイルのメタデータに `modelspec.comment` として埋め込まれるテキスト
+- **デフォルト**: None（無効）
+- **注記**:
+  - 外部モデルビューア（ComfyUI、モデル情報ツール）で表示可能
+  - 文字列または文字列配列（改行で結合）を受け付けます
+  - 環境変数置換用の `{env:VAR_NAME}` プレースホルダをサポート
+  - 各チェックポイントは保存時の現在の設定値を使用
+
+**例（文字列）**:
+```json
+"modelspec_comment": "カスタムデータセット v2.1 で学習"
+```
+
+**例（配列、複数行）**:
+```json
+"modelspec_comment": [
+  "学習ラン: experiment-42",
+  "データセット: custom-portraits-v2",
+  "メモ: {env:TRAINING_NOTES}"
+]
+```
+
 ### `--disable_benchmark`
 
 - **内容**: step 0 で行う起動時の検証/ベンチマークを無効化します。これらの出力は学習済みモデルの検証画像の左側に連結されます。
@@ -1277,6 +1301,7 @@ usage: train.py [-h] --model_family
                 [--model_card_private [MODEL_CARD_PRIVATE]]
                 [--model_card_safe_for_work [MODEL_CARD_SAFE_FOR_WORK]]
                 [--model_card_note MODEL_CARD_NOTE]
+                [--modelspec_comment MODELSPEC_COMMENT]
                 [--report_to {tensorboard,wandb,comet_ml,all,none}]
                 [--checkpoint_step_interval CHECKPOINT_STEP_INTERVAL]
                 [--checkpoint_epoch_interval CHECKPOINT_EPOCH_INTERVAL]
@@ -1947,6 +1972,9 @@ options:
   --model_card_note MODEL_CARD_NOTE
                         Optional note that appears at the top of the generated
                         model card.
+  --modelspec_comment MODELSPEC_COMMENT
+                        Text embedded in safetensors file metadata as
+                        modelspec.comment, visible in external model viewers.
   --report_to {tensorboard,wandb,comet_ml,all,none}
                         Where to log training metrics
   --checkpoint_step_interval CHECKPOINT_STEP_INTERVAL

--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -403,6 +403,30 @@ This is useful for monitoring tools receiving webhooks from multiple training ru
 - **What**: The name of the Huggingface Hub model and local results directory.
 - **Why**: This value is used as the directory name under the location specified as `--output_dir`. If `--push_to_hub` is provided, this will become the name of the model on Huggingface Hub.
 
+### `--modelspec_comment`
+
+- **What**: Text embedded in safetensors file metadata as `modelspec.comment`
+- **Default**: None (disabled)
+- **Notes**:
+  - Visible in external model viewers (ComfyUI, model info tools)
+  - Accepts a string or array of strings (joined with newlines)
+  - Supports `{env:VAR_NAME}` placeholders for environment variable substitution
+  - Each checkpoint uses the current config value at save time
+
+**Example (string)**:
+```json
+"modelspec_comment": "Trained on my custom dataset v2.1"
+```
+
+**Example (array for multi-line)**:
+```json
+"modelspec_comment": [
+  "Training run: experiment-42",
+  "Dataset: custom-portraits-v2",
+  "Notes: {env:TRAINING_NOTES}"
+]
+```
+
 ### `--disable_benchmark`
 
 - **What**: Disable the startup validation/benchmark that occurs at step 0 on the base model. These outputs are stitchd to the left side of your trained model validation images.
@@ -1273,6 +1297,7 @@ usage: train.py [-h] --model_family
                 [--model_card_private [MODEL_CARD_PRIVATE]]
                 [--model_card_safe_for_work [MODEL_CARD_SAFE_FOR_WORK]]
                 [--model_card_note MODEL_CARD_NOTE]
+                [--modelspec_comment MODELSPEC_COMMENT]
                 [--report_to {tensorboard,wandb,comet_ml,all,none}]
                 [--checkpoint_step_interval CHECKPOINT_STEP_INTERVAL]
                 [--checkpoint_epoch_interval CHECKPOINT_EPOCH_INTERVAL]
@@ -1943,6 +1968,9 @@ options:
   --model_card_note MODEL_CARD_NOTE
                         Optional note that appears at the top of the generated
                         model card.
+  --modelspec_comment MODELSPEC_COMMENT
+                        Text embedded in safetensors file metadata as
+                        modelspec.comment, visible in external model viewers.
   --report_to {tensorboard,wandb,comet_ml,all,none}
                         Where to log training metrics
   --checkpoint_step_interval CHECKPOINT_STEP_INTERVAL

--- a/documentation/OPTIONS.pt-BR.md
+++ b/documentation/OPTIONS.pt-BR.md
@@ -402,6 +402,30 @@ Isso e util para ferramentas de monitoramento que recebem webhooks de varios tre
 - **O que**: Nome do modelo no Huggingface Hub e diretorio local de resultados.
 - **Por que**: Esse valor e usado como nome de diretorio sob `--output_dir`. Se `--push_to_hub` for fornecido, isso vira o nome do modelo no Huggingface Hub.
 
+### `--modelspec_comment`
+
+- **O que**: Texto incorporado nos metadados do arquivo safetensors como `modelspec.comment`
+- **Padrao**: None (desabilitado)
+- **Notas**:
+  - Visivel em visualizadores de modelo externos (ComfyUI, ferramentas de info de modelo)
+  - Aceita uma string ou array de strings (unidas com quebras de linha)
+  - Suporta placeholders `{env:VAR_NAME}` para substituicao de variaveis de ambiente
+  - Cada checkpoint usa o valor de configuracao atual no momento do salvamento
+
+**Exemplo (string)**:
+```json
+"modelspec_comment": "Treinado no meu dataset customizado v2.1"
+```
+
+**Exemplo (array para multiplas linhas)**:
+```json
+"modelspec_comment": [
+  "Execucao de treino: experiment-42",
+  "Dataset: custom-portraits-v2",
+  "Notas: {env:TRAINING_NOTES}"
+]
+```
+
 ### `--disable_benchmark`
 
 - **O que**: Desabilita a validacao/benchmark inicial que ocorre no passo 0 do modelo base. Essas saidas sao costuradas no lado esquerdo das imagens de validacao do modelo treinado.
@@ -1271,6 +1295,7 @@ usage: train.py [-h] --model_family
                 [--model_card_private [MODEL_CARD_PRIVATE]]
                 [--model_card_safe_for_work [MODEL_CARD_SAFE_FOR_WORK]]
                 [--model_card_note MODEL_CARD_NOTE]
+                [--modelspec_comment MODELSPEC_COMMENT]
                 [--report_to {tensorboard,wandb,comet_ml,all,none}]
                 [--checkpoint_step_interval CHECKPOINT_STEP_INTERVAL]
                 [--checkpoint_epoch_interval CHECKPOINT_EPOCH_INTERVAL]
@@ -1941,6 +1966,9 @@ options:
   --model_card_note MODEL_CARD_NOTE
                         Optional note that appears at the top of the generated
                         model card.
+  --modelspec_comment MODELSPEC_COMMENT
+                        Text embedded in safetensors file metadata as
+                        modelspec.comment, visible in external model viewers.
   --report_to {tensorboard,wandb,comet_ml,all,none}
                         Where to log training metrics
   --checkpoint_step_interval CHECKPOINT_STEP_INTERVAL

--- a/documentation/OPTIONS.zh.md
+++ b/documentation/OPTIONS.zh.md
@@ -406,6 +406,30 @@ TRAINING_DYNAMO_BACKEND=inductor
 - **内容**：Hugging Face Hub 模型名称与本地结果目录名。
 - **原因**：该值用作 `--output_dir` 下的目录名称。若设置 `--push_to_hub`，这将成为 Hugging Face Hub 上的模型名。
 
+### `--modelspec_comment`
+
+- **内容**：嵌入到 safetensors 文件元数据中的文本，键为 `modelspec.comment`
+- **默认值**：None（禁用）
+- **说明**：
+  - 在外部模型查看器（ComfyUI、模型信息工具）中可见
+  - 接受字符串或字符串数组（用换行符连接）
+  - 支持 `{env:VAR_NAME}` 占位符用于环境变量替换
+  - 每个检查点使用保存时的当前配置值
+
+**示例（字符串）**：
+```json
+"modelspec_comment": "在我的自定义数据集 v2.1 上训练"
+```
+
+**示例（数组，多行）**：
+```json
+"modelspec_comment": [
+  "训练运行：experiment-42",
+  "数据集：custom-portraits-v2",
+  "备注：{env:TRAINING_NOTES}"
+]
+```
+
 ### `--disable_benchmark`
 
 - **内容**：禁用启动时在 step 0 的验证/基准测试。其输出会拼接到训练模型验证图像的左侧。
@@ -1279,6 +1303,7 @@ usage: train.py [-h] --model_family
                 [--model_card_private [MODEL_CARD_PRIVATE]]
                 [--model_card_safe_for_work [MODEL_CARD_SAFE_FOR_WORK]]
                 [--model_card_note MODEL_CARD_NOTE]
+                [--modelspec_comment MODELSPEC_COMMENT]
                 [--report_to {tensorboard,wandb,comet_ml,all,none}]
                 [--checkpoint_step_interval CHECKPOINT_STEP_INTERVAL]
                 [--checkpoint_epoch_interval CHECKPOINT_EPOCH_INTERVAL]
@@ -1949,6 +1974,9 @@ options:
   --model_card_note MODEL_CARD_NOTE
                         Optional note that appears at the top of the generated
                         model card.
+  --modelspec_comment MODELSPEC_COMMENT
+                        Text embedded in safetensors file metadata as
+                        modelspec.comment, visible in external model viewers.
   --report_to {tensorboard,wandb,comet_ml,all,none}
                         Where to log training metrics
   --checkpoint_step_interval CHECKPOINT_STEP_INTERVAL

--- a/simpletuner/helpers/training/save_hooks.py
+++ b/simpletuner/helpers/training/save_hooks.py
@@ -307,6 +307,10 @@ class SaveHookManager:
         trigger_words_metadata = self._build_trigger_words_metadata()
         metadata.update(trigger_words_metadata)
 
+        comment = getattr(self.args, "modelspec_comment", None)
+        if comment:
+            metadata["modelspec.comment"] = str(comment)
+
         return {k: str(v) for k, v in metadata.items() if v is not None}
 
     def _append_metadata_to_safetensors(self, target_path: str, metadata: dict[str, str]) -> bool:

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/publishing.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/publishing.py
@@ -191,3 +191,22 @@ def register_publishing_fields(registry: "FieldRegistry") -> None:
             order=2,
         )
     )
+
+    registry._add_field(
+        ConfigField(
+            name="modelspec_comment",
+            arg_name="--modelspec_comment",
+            ui_label="Modelspec Comment",
+            field_type=FieldType.TEXTAREA,
+            tab="publishing",
+            section="model_card",
+            default_value=None,
+            allow_empty=True,
+            placeholder="Optional comment embedded in safetensors metadata",
+            help_text="Text embedded in safetensors file metadata, visible in external model viewers. Accepts string, array of strings (joined by newlines), or {env:VAR_NAME} placeholders.",
+            tooltip="Use this to add notes, version info, or training context visible in tools like ComfyUI model info.",
+            importance=ImportanceLevel.ADVANCED,
+            order=3,
+            documentation="OPTIONS.md#--modelspec_comment",
+        )
+    )


### PR DESCRIPTION
Closes #2294 

This pull request adds support for a new `--modelspec_comment` option, allowing users to embed custom comments in the metadata of safetensors model files. The feature is fully documented in all supported languages, processed correctly in the codebase (including environment variable substitution and multi-line support), and exposed in the UI configuration. Below are the most important changes:

**Documentation updates (all languages):**
- Added detailed documentation for the `--modelspec_comment` option in English, Spanish, Portuguese (Brazil), Japanese, Hindi, and Chinese. Documentation includes descriptions, usage notes, and examples for both string and array input, as well as environment variable substitution. [[1]](diffhunk://#diff-45e063db3ebcffb55dde68f083e92399a74f4cefbb464e8cd36911971c50933fR406-R429) [[2]](diffhunk://#diff-3f0cd39e3a7f176d81408ae40dc4f8c6271347f75b1cee5cf71c4e701d7db561R406-R429) [[3]](diffhunk://#diff-2c007ae9176f9f69b3ae16558be55b46d524f460a626f4e5c31e1e9a1d1b14b8R405-R428) [[4]](diffhunk://#diff-fd629904ab3e1ecdd5b568c3ef6ac61e71e3d7741700e360820849938158a1d9R407-R430) [[5]](diffhunk://#diff-39b5789a705b2e70400106934436b619d10413ca5e37bd7a2b5fa7aa0c0fb8cfR406-R429) [[6]](diffhunk://#diff-cddcc50c252e719be92644d65ea8542cc51d08f15e67d918bfae737904142b1fR409-R432)
- Updated the CLI usage and options sections in all language files to include the new `--modelspec_comment` argument. [[1]](diffhunk://#diff-45e063db3ebcffb55dde68f083e92399a74f4cefbb464e8cd36911971c50933fR1300) [[2]](diffhunk://#diff-45e063db3ebcffb55dde68f083e92399a74f4cefbb464e8cd36911971c50933fR1971-R1973) [[3]](diffhunk://#diff-3f0cd39e3a7f176d81408ae40dc4f8c6271347f75b1cee5cf71c4e701d7db561R1302) [[4]](diffhunk://#diff-3f0cd39e3a7f176d81408ae40dc4f8c6271347f75b1cee5cf71c4e701d7db561R1973-R1975) [[5]](diffhunk://#diff-2c007ae9176f9f69b3ae16558be55b46d524f460a626f4e5c31e1e9a1d1b14b8R1298) [[6]](diffhunk://#diff-2c007ae9176f9f69b3ae16558be55b46d524f460a626f4e5c31e1e9a1d1b14b8R1969-R1971) [[7]](diffhunk://#diff-fd629904ab3e1ecdd5b568c3ef6ac61e71e3d7741700e360820849938158a1d9R1304) [[8]](diffhunk://#diff-fd629904ab3e1ecdd5b568c3ef6ac61e71e3d7741700e360820849938158a1d9R1975-R1977) [[9]](diffhunk://#diff-39b5789a705b2e70400106934436b619d10413ca5e37bd7a2b5fa7aa0c0fb8cfR1300) [[10]](diffhunk://#diff-39b5789a705b2e70400106934436b619d10413ca5e37bd7a2b5fa7aa0c0fb8cfR1971-R1973) [[11]](diffhunk://#diff-cddcc50c252e719be92644d65ea8542cc51d08f15e67d918bfae737904142b1fR1306) [[12]](diffhunk://#diff-cddcc50c252e719be92644d65ea8542cc51d08f15e67d918bfae737904142b1fR1977-R1979)

**Core logic and processing:**
- Implemented the `_process_modelspec_comment` function in `cmd_args.py` to handle string/array input, environment variable substitution, and whitespace trimming for `modelspec_comment`. Integrated this processing in the argument normalization flow. [[1]](diffhunk://#diff-2eb2bdca165b022325e9401eb998e8aa0f66d16deea3d8b7cd0fd68e5814ffa0R209-R230) [[2]](diffhunk://#diff-2eb2bdca165b022325e9401eb998e8aa0f66d16deea3d8b7cd0fd68e5814ffa0R704-R706)
- Updated the safetensors metadata builder to include the processed `modelspec_comment` in the model file metadata if provided.

**UI/SDK integration:**
- Registered the `modelspec_comment` field in the publishing section of the UI configuration, making it available as an advanced, optional textarea field with documentation and tooltips for end users.

**Dependency update:**
- Added import of `re` to `cmd_args.py` to support environment variable placeholder substitution.