### PR TITLE
fix name assignment from metadata; validate before appending config; log warning instead of blowing up and fallback; filter null entries after mapping

### DIFF
--- a/simpletuner/simpletuner_sdk/server/services/config_store.py
+++ b/simpletuner/simpletuner_sdk/server/services/config_store.py
@@ -465,7 +465,9 @@ class ConfigStore:
                                 sidecar = self._load_metadata_sidecar(config_file)
                                 if isinstance(sidecar, dict):
                                     metadata = sidecar.copy()
-                                    metadata.setdefault("name", subdir.name)
+                                    # Ensure name is always a valid non-empty string
+                                    if not metadata.get("name") or not isinstance(metadata.get("name"), str):
+                                        metadata["name"] = subdir.name
                             if metadata is None:
                                 metadata = {
                                     "name": subdir.name,
@@ -510,7 +512,9 @@ class ConfigStore:
                             else:
                                 metadata.setdefault("has_dataloader", False)
 
-                            configs.append(metadata)
+                            # Only append configs with valid non-empty names
+                            if metadata.get("name") and isinstance(metadata["name"], str) and metadata["name"].strip():
+                                configs.append(metadata)
 
             # Also check root-level JSON files for backward compatibility
             # But exclude files that are clearly dataloader configs
@@ -548,7 +552,9 @@ class ConfigStore:
                             sidecar = self._load_metadata_sidecar(config_file)
                             if isinstance(sidecar, dict):
                                 metadata = sidecar.copy()
-                                metadata.setdefault("name", config_file.stem)
+                                # Ensure name is always a valid non-empty string
+                                if not metadata.get("name") or not isinstance(metadata.get("name"), str):
+                                    metadata["name"] = config_file.stem
                         if metadata is None:
                             metadata = {
                                 "name": config_file.stem,
@@ -592,7 +598,9 @@ class ConfigStore:
                         else:
                             metadata.setdefault("has_dataloader", False)
 
-                        configs.append(metadata)
+                        # Only append configs with valid non-empty names
+                        if metadata.get("name") and isinstance(metadata["name"], str) and metadata["name"].strip():
+                            configs.append(metadata)
         elif self.config_type == "dataloader":
             # For dataloader configs, look for multidatabackend.json in the dedicated
             # dataloaders directory as well as alongside trainer configs.

--- a/simpletuner/templates/environments_tab.html
+++ b/simpletuner/templates/environments_tab.html
@@ -23,11 +23,16 @@ const localSanitizeConfigEntry = window.sanitizeConfigEntry
     ? window.sanitizeConfigEntry
     : (entry) => {
         if (!entry || typeof entry !== 'object') {
-            return entry;
+            return null;  // Return null for invalid entries
         }
         const clone = { ...entry };
-        if (clone.name) {
+        if (clone.name && typeof clone.name === 'string') {
             clone.name = localSanitizeConfigName(clone.name);
+        }
+        // Return null if name is missing, empty, or not a string after sanitization
+        if (!clone.name || typeof clone.name !== 'string' || !clone.name.trim()) {
+            console.warn('[localSanitizeConfigEntry] Skipping config entry with invalid name:', entry);
+            return null;
         }
         return clone;
     };
@@ -657,7 +662,7 @@ window.environmentsTabComponent = function environmentsTabComponent() {
                 const response = await fetch(`/api/configs/?config_type=${this.configType}`);
                 const data = await response.json();
                 const configs = Array.isArray(data.configs)
-                    ? data.configs.map((entry) => this.normalizeConfigEntry(entry))
+                    ? data.configs.map((entry) => this.normalizeConfigEntry(entry)).filter(Boolean)
                     : [];
                 this.configs = configs;
 

--- a/simpletuner/templates/trainer_htmx.html
+++ b/simpletuner/templates/trainer_htmx.html
@@ -367,11 +367,16 @@ const sanitizeConfigName = (name) => {
 
 const sanitizeConfigEntry = (entry) => {
     if (!entry || typeof entry !== 'object') {
-        return entry;
+        return null;  // Return null for invalid entries
     }
     const clone = { ...entry };
-    if (clone.name) {
+    if (clone.name && typeof clone.name === 'string') {
         clone.name = sanitizeConfigName(clone.name);
+    }
+    // Return null if name is missing, empty, or not a string after sanitization
+    if (!clone.name || typeof clone.name !== 'string' || !clone.name.trim()) {
+        console.warn('[sanitizeConfigEntry] Skipping config entry with invalid name:', entry);
+        return null;
     }
     return clone;
 };
@@ -757,7 +762,7 @@ function trainerComponent() {
                      return;
                 }
                 const data = await response.json();
-                const configs = Array.isArray(data.configs) ? data.configs.map(sanitizeConfigEntry) : [];
+                const configs = Array.isArray(data.configs) ? data.configs.map(sanitizeConfigEntry).filter(Boolean) : [];
                 const active = sanitizeConfigName(data.active || null);
                 this.environments = configs;
                 this.activeEnvironment = active || (configs.length > 0 ? configs[0].name : null);
@@ -6441,7 +6446,7 @@ function trainerComponent() {
                             }
                             const data = await response.json();
                             const configs = Array.isArray(data.configs)
-                                ? data.configs.map(sanitizeConfigEntry)
+                                ? data.configs.map(sanitizeConfigEntry).filter(Boolean)
                                 : [];
                             const active = sanitizeConfigName(data.active || (configs.length > 0 ? configs[0].name : ''));
                             this.configs = configs;
@@ -6733,7 +6738,7 @@ function trainerComponent() {
                             </div>
                         </div>
 
-                        <template x-for="config in (configs || [])" :key="config.name || $id('config')">
+                        <template x-for="(config, index) in (configs || [])" :key="config.name || `config-fallback-${index}`">
                             <a @click.prevent="Alpine.store('trainer').switchEnvironment(config.name); open = false;"
                                class="dropdown-item"
                                :class="{'active': config.name === activeConfig}"


### PR DESCRIPTION
This pull request improves the robustness of config entry handling throughout both the backend (`config_store.py`) and frontend templates (`environments_tab.html`, `trainer_htmx.html`). It ensures that only config entries with valid, non-empty string names are processed and displayed, preventing issues caused by malformed or missing config names. The changes affect both the extraction of configs in Python and their sanitization and filtering in JavaScript, leading to more reliable UI behavior and data integrity.

**Backend validation of config names:**

* Added checks in `_extract_backend_path` to ensure that the `name` field in config metadata is always a valid, non-empty string when extracting configs from both subdirectories and root-level JSON files. [[1]](diffhunk://#diff-baf015f29f03b6467d8c6f05827979239243d69a35b92614ecfdb454efeda411L468-R470) [[2]](diffhunk://#diff-baf015f29f03b6467d8c6f05827979239243d69a35b92614ecfdb454efeda411L551-R557)
* Only append config entries to the list if their `name` field passes the validity check (non-empty string), filtering out invalid configs at the source. [[1]](diffhunk://#diff-baf015f29f03b6467d8c6f05827979239243d69a35b92614ecfdb454efeda411R515-R516) [[2]](diffhunk://#diff-baf015f29f03b6467d8c6f05827979239243d69a35b92614ecfdb454efeda411R601-R602)

**Frontend sanitization and filtering:**

* Updated `sanitizeConfigEntry` and `localSanitizeConfigEntry` functions to return `null` for invalid config entries and to log a warning when a config name is missing, empty, or not a string after sanitization. [[1]](diffhunk://#diff-26e44464205afd23e49aa1265016ff31fd2a67915f7ced57c8caf0e020a28488L26-R36) [[2]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14L370-R380)
* Applied `.filter(Boolean)` after mapping config entries to remove any invalid or null entries before displaying them in the UI. [[1]](diffhunk://#diff-26e44464205afd23e49aa1265016ff31fd2a67915f7ced57c8caf0e020a28488L660-R665) [[2]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14L760-R765) [[3]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14L6444-R6449)

**UI rendering improvements:**

* Changed the key binding in Alpine.js templates to use a fallback key (`config-fallback-${index}`) when `config.name` is missing, ensuring stable rendering of config lists even if a name is absent.