### PR TITLE
remove z-image references, unify on z_image

### DIFF
--- a/simpletuner/examples/z-image-turbo.peft-lora/config.json
+++ b/simpletuner/examples/z-image-turbo.peft-lora/config.json
@@ -18,7 +18,7 @@
     "max_train_steps": 1000,
     "minimum_image_size": 0,
     "mixed_precision": "bf16",
-    "model_family": "z-image",
+    "model_family": "z_image",
     "model_flavour": "turbo",
     "model_type": "lora",
     "num_eval_images": 25,

--- a/simpletuner/examples/z-image.peft-lora/config.json
+++ b/simpletuner/examples/z-image.peft-lora/config.json
@@ -18,7 +18,7 @@
     "max_train_steps": 1000,
     "minimum_image_size": 0,
     "mixed_precision": "bf16",
-    "model_family": "z-image",
+    "model_family": "z_image",
     "model_type": "lora",
     "num_eval_images": 25,
     "num_train_epochs": 0,

--- a/simpletuner/helpers/models/z_image/model.py
+++ b/simpletuner/helpers/models/z_image/model.py
@@ -389,4 +389,4 @@ class ZImage(ImageModelFoundation):
         return {"model_prediction": noise_pred, "hidden_states_buffer": hidden_states_buffer}
 
 
-ModelRegistry.register("z-image", ZImage)
+ModelRegistry.register("z_image", ZImage)

--- a/simpletuner/helpers/models/z_image_omni/model.py
+++ b/simpletuner/helpers/models/z_image_omni/model.py
@@ -479,4 +479,4 @@ class ZImageOmni(ImageModelFoundation):
         return {"model_prediction": noise_pred}
 
 
-ModelRegistry.register("z-image-omni", ZImageOmni)
+ModelRegistry.register("z_image_omni", ZImageOmni)

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/lora.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/lora.py
@@ -250,7 +250,7 @@ def register_lora_fields(registry: "FieldRegistry") -> None:
 
     assistant_dependencies = [
         FieldDependency(field="model_type", value="lora"),
-        FieldDependency(field="model_family", operator="in", values=["flux", "z-image"]),
+        FieldDependency(field="model_family", operator="in", values=["flux", "z_image"]),
         FieldDependency(field="model_flavour", operator="in", values=["schnell", "turbo"]),
     ]
 

--- a/tests/test_assistant_lora.py
+++ b/tests/test_assistant_lora.py
@@ -208,7 +208,7 @@ class AssistantLoraModelDefaultsTests(unittest.TestCase):
 
     def _build_zimage_config(self, flavour: str):
         config = MagicMock()
-        config.model_family = "z-image"
+        config.model_family = "z_image"
         config.model_flavour = flavour
         config.model_type = "lora"
         config.assistant_lora_path = None
@@ -281,7 +281,7 @@ class AssistantLoraModelDefaultsTests(unittest.TestCase):
 
     def test_disable_flag_skips_requirements(self):
         config = MagicMock()
-        config.model_family = "z-image"
+        config.model_family = "z_image"
         config.model_flavour = "turbo"
         config.model_type = "lora"
         config.assistant_lora_path = None

--- a/tests/test_z_image_model.py
+++ b/tests/test_z_image_model.py
@@ -27,7 +27,7 @@ class ZImageModelTests(unittest.TestCase):
         model.accelerator = DummyAccelerator()
         model.config = types.SimpleNamespace(
             weight_dtype=torch.float32,
-            model_family="z-image",
+            model_family="z_image",
             pretrained_model_name_or_path=None,
             pretrained_vae_model_name_or_path=None,
             vae_path=None,


### PR DESCRIPTION
This pull request standardizes the naming convention for the `model_family` identifier from `"z-image"` to `"z_image"` across configuration files, model registration, dependency checks, and tests. This change ensures consistency throughout the codebase and prevents potential mismatches or errors related to model family identification.

### Model registration and configuration updates

* Updated all model registration calls to use `"z_image"` and `"z_image_omni"` instead of `"z-image"` and `"z-image-omni"` in `simpletuner/helpers/models/z_image/model.py` and `simpletuner/helpers/models/z_image_omni/model.py`. [[1]](diffhunk://#diff-94c8914f6bde4c38e67569d5db5b505121ced3f271a817cf5cee5fd1bc19a498L392-R392) [[2]](diffhunk://#diff-44b11764582a14e7420e5e75dda99071127e8137b477d3565765f365d87e1ca1L482-R482)
* Changed the `model_family` field in example configuration files to `"z_image"` in `simpletuner/examples/z-image-turbo.peft-lora/config.json` and `simpletuner/examples/z-image.peft-lora/config.json`. [[1]](diffhunk://#diff-378aa2036ebaf97d463589a64cf3e3ea3aa903a34f8ae9cbd64bea442671e991L21-R21) [[2]](diffhunk://#diff-eeb0f67bc43b820325977283732274c77e9e270d3054c70c3027a87c3a7ec2f5L21-R21)

### Dependency and test updates

* Updated dependency checks for `model_family` to use `"z_image"` in the LoRA field registry (`simpletuner/simpletuner_sdk/server/services/field_registry/sections/lora.py`).
* Modified test mocks and configuration to use `"z_image"` for the `model_family` attribute in `tests/test_assistant_lora.py` and `tests/test_z_image_model.py`. [[1]](diffhunk://#diff-4f4c7901cc80b6c7346ff3bbbb3fdd23607736a2754895044ae48df578190639L211-R211) [[2]](diffhunk://#diff-4f4c7901cc80b6c7346ff3bbbb3fdd23607736a2754895044ae48df578190639L284-R284) [[3]](diffhunk://#diff-ae1ac7d46ce7abab232e41101b60a52b0b8fa330553e120dbb0796bafe9bec47L30-R30)