### PR TITLE
enhanced ipc event emissions for Accelerate subprocess failures

### DIFF
--- a/simpletuner/train.py
+++ b/simpletuner/train.py
@@ -94,6 +94,67 @@ def _build_signal_consumer(signal_path_text: str | None, key: str):
     return _consume
 
 
+def _configure_last_ditch_webhook():
+    """
+    Attempt to configure a webhook handler when no Trainer instance is available.
+    This is a last-ditch effort to send error notifications when training fails
+    before the normal webhook configuration happens.
+    """
+    import json
+    import sys
+
+    # Try to extract webhook_config from CLI args
+    webhook_config = None
+    for i, arg in enumerate(sys.argv):
+        if arg == "--webhook_config" and i + 1 < len(sys.argv):
+            webhook_config = sys.argv[i + 1]
+            break
+        if arg.startswith("--webhook_config="):
+            webhook_config = arg.split("=", 1)[1]
+            break
+
+    if not webhook_config:
+        return
+
+    # Parse the webhook config
+    if webhook_config.startswith("{") or webhook_config.startswith("["):
+        try:
+            parsed_config = json.loads(webhook_config)
+            if isinstance(parsed_config, dict):
+                webhook_config = [parsed_config]
+            elif isinstance(parsed_config, list):
+                webhook_config = parsed_config
+            else:
+                return
+        except json.JSONDecodeError:
+            return
+    elif Path(webhook_config).is_file():
+        try:
+            with open(webhook_config, "r") as f:
+                parsed_config = json.load(f)
+                if isinstance(parsed_config, dict):
+                    webhook_config = [parsed_config]
+                elif isinstance(parsed_config, list):
+                    webhook_config = parsed_config
+                else:
+                    return
+        except Exception:
+            return
+    else:
+        return
+
+    # Create a minimal webhook handler without accelerator
+    from simpletuner.helpers.webhooks.handler import WebhookHandler
+
+    handler = WebhookHandler(
+        accelerator=None,
+        project_name="SimpleTuner (emergency)",
+        webhook_config=webhook_config,
+    )
+    StateTracker.set_webhook_handler(handler)
+    logger.info("Configured last-ditch webhook handler for error reporting")
+
+
 if __name__ == "__main__":
     trainer = None
 
@@ -174,6 +235,13 @@ if __name__ == "__main__":
             )
     except Exception as e:
         import traceback
+
+        # If webhook handler isn't configured yet (crash happened early), try to configure it now
+        if StateTracker.get_webhook_handler() is None:
+            try:
+                _configure_last_ditch_webhook()
+            except Exception as webhook_err:
+                logger.warning(f"Failed to configure last-ditch webhook: {webhook_err}")
 
         if StateTracker.get_webhook_handler() is not None:
             StateTracker.get_webhook_handler().send(

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -881,6 +881,22 @@ class TestTrainer(unittest.TestCase):
         self.assertTrue("SIGKILL" in summary or "signal 9" in summary)
         self.assertIsNotNone(excerpt)
 
+    def test_accelerate_failure_summary_highlights_signal_received_by_pid(self):
+        """Test parsing of accelerate's 'Signal N (SIGNAME) received by PID' format."""
+        from simpletuner.helpers.training import trainer as trainer_module
+
+        lines = [
+            "2025-11-04 16:21:12,847 - SimpleTuner - INFO - starting...",
+            "traceback : Signal 9 (SIGKILL) received by PID 2963915",
+            "RuntimeError: Some wrapper error",
+        ]
+
+        summary, excerpt = trainer_module._summarize_accelerate_failure(1, lines)
+
+        # Should extract the SIGKILL message even though exit code is 1
+        self.assertIn("SIGKILL", summary)
+        self.assertIsNotNone(excerpt)
+
     def test_launch_with_accelerate_fallback_imports(self):
         from simpletuner.helpers.training import trainer as trainer_module
 


### PR DESCRIPTION
Closes #2306

This pull request improves the robustness of error detection and reporting in the training and process management components, particularly for failures wrapped by the Accelerate library. It enhances log parsing to better identify fatal signals, ensures more informative error messages are sent to webhooks, and introduces a fallback mechanism for error reporting when the main webhook handler is not yet configured. Comprehensive tests are added to cover these new cases.

**Error Detection and Log Parsing Improvements:**

- Enhanced log parsing in both `trainer.py` and `process_keeper.py` to detect and extract signal information from Accelerate's "Signal N (SIGNAME) received by PID" format, ensuring that signal-based failures (like SIGKILL) are correctly identified and reported even when wrapped by Accelerate. [[1]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R169-R175) [[2]](diffhunk://#diff-9189b7669099b8835588eb18e71254fe6877e815a04b148799bbe7edebea0ee7R747-R754)
- Updated logic to prefer signal-based error messages over generic `RuntimeError` messages for more actionable diagnostics, especially for OOM or killed processes.

**Error Reporting and Webhook Handling:**

- Improved error event payloads to include log excerpts and recent log lines when available, providing more context in error notifications.
- Enhanced the failure relay mechanism to supplement generic error messages with more specific log-derived details, including better messages and log excerpts as needed.
- Added a "last-ditch" webhook configuration routine to attempt error notification setup if a crash occurs before the normal webhook handler is available, increasing the chance of error delivery in early-failure scenarios. [[1]](diffhunk://#diff-612c91ac3c60bd876f96ae085dc6ac960812213123606fc423a3d29226d90327R97-R157) [[2]](diffhunk://#diff-612c91ac3c60bd876f96ae085dc6ac960812213123606fc423a3d29226d90327R239-R245)

**Testing:**

- Added new tests to verify that the updated log parsing correctly identifies Accelerate's signal format and that error summaries highlight these cases. [[1]](diffhunk://#diff-6ee20d14f6cd27a9775fb1a5a65b8dcd596f1ee5382ac1ed07a55058437f024aR286-R307) [[2]](diffhunk://#diff-9f4241cfae54a446e69be20582f2536fa636341a35714881b1ad7dcf7000e371R884-R899)