### PR TITLE
show error message when crash occurs due to config parser

### DIFF
--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -6516,6 +6516,8 @@ def run_trainer_job(config):
             if helper is None:
 
                 def helper(exit_code, lines):
+                    import re
+
                     cleaned = [_strip_ansi(line.rstrip("\n")) for line in lines]
                     # Look for actual trainer [ERROR] messages - these are the meaningful ones
                     error_lines = []
@@ -6527,12 +6529,24 @@ def run_trainer_job(config):
                             if error_msg:
                                 error_lines.append(error_msg)
 
+                    # Also look for Python exceptions (e.g., "FileNotFoundError: ...")
+                    exception_pattern = re.compile(r"^(\w+(?:Error|Exception|Warning)):\s*(.+)$")
+                    exception_line = None
+                    for line in reversed(cleaned):
+                        stripped = line.strip()
+                        match = exception_pattern.match(stripped)
+                        if match:
+                            exception_line = stripped
+                            break
+
                     excerpt_lines = [line.strip() for line in cleaned[-10:] if line.strip()]
                     excerpt_text = "\n".join(excerpt_lines) if excerpt_lines else None
 
-                    # Use the first trainer error as the summary, not the accelerate wrapper error
+                    # Priority: [ERROR] messages first, then Python exceptions
                     if error_lines:
                         summary_text = error_lines[0]
+                    elif exception_line:
+                        summary_text = exception_line
                     else:
                         summary_text = f"Accelerate launch exited with status {exit_code}"
                         if excerpt_lines:


### PR DESCRIPTION
This pull request improves the error reporting in the training output helper by extracting and prioritizing meaningful trainer error messages over generic wrapper errors.

Error reporting improvements:

* In `simpletuner/helpers/training/trainer.py`, the error handling logic in `_forward_output()` was updated to strip ANSI codes from lines, search for `[ERROR]` messages, and use the first such message as the summary error if present, instead of defaulting to the generic "Accelerate launch exited" message.