### PR TITLE
add cuda13 install target

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simpletuner"
-dynamic = ["version", "dependencies"]
+dynamic = ["version", "dependencies", "optional-dependencies"]
 description = "Stable Diffusion 2.x and XL tuner."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -39,77 +39,7 @@ keywords = [
 ]
 requires-python = ">=3.12,<3.14"
 
-# Dynamic fields are handled by setup.py above
-
-[project.optional-dependencies]
-# Platform-specific extras (for manual override)
-cuda = [
-    "torch>=2.9.1",
-    "torchvision>=0.24.0",
-    "torchaudio>=2.4.1",
-    "triton>=3.3.0",
-    "bitsandbytes>=0.45.0",
-    "deepspeed>=0.17.2",
-    "torchao>=0.12.0",
-    "nvidia-cudnn-cu12",
-    "nvidia-nccl-cu12",
-    "lm-eval>=0.4.4",
-]
-rocm = [
-    "torch>=2.9.0",
-    "torchvision>=0.24.0",
-    "torchaudio>=2.4.1",
-    "torchao>=0.11.0",
-]
-apple = [
-    "torch>=2.9.1",
-    "torchvision>=0.24.0",
-    "torchaudio>=2.4.1",
-    "torchao>=0.11.0",
-]
-cpu = [
-    "torch>=2.9.1",
-    "torchvision>=0.24.0",
-    "torchaudio>=2.4.1",
-    "torchao>=0.11.0",
-]
-
-# Feature extras
-jxl = [
-    "pillow-jxl-plugin>=1.3.1",
-]
-
-# Development extras
-dev = [
-    "selenium>=4.0.0",
-    "coverage>=7.0.0",
-    "black>=23.0.0",
-    "isort>=5.12.0",
-    "flake8>=6.0.0",
-    "mypy>=1.0.0",
-    "pre-commit>=3.0.0",
-]
-
-# Testing extras
-test = ["selenium>=4.0.0", "coverage>=7.0.0"]
-
-# Documentation extras
-docs = [
-    "mkdocs>=1.6.0",
-    "mkdocs-material>=9.5.0",
-    "mkdocs-static-i18n>=1.2.0",
-    "pymdown-extensions>=10.0",
-]
-
-# All extras combined
-all = [
-    "pillow-jxl-plugin>=1.3.1",
-    "selenium>=4.0.0",
-    "coverage>=7.0.0",
-    "black>=23.0.0",
-    "isort>=5.12.0",
-    "flake8>=6.0.0",
-]
+# Dynamic fields (dependencies, optional-dependencies) are handled by setup.py
 
 [project.scripts]
 simpletuner = "st_cli:main"


### PR DESCRIPTION
This pull request refactors how optional and platform-specific dependencies are managed for the `simpletuner` project. Instead of listing all optional dependencies directly in `pyproject.toml`, these are now dynamically generated and managed in `setup.py`. A new `cuda13` platform extra is introduced with logic for constructing direct download URLs for CUDA 13 PyTorch wheels. The installation process is clarified, and the handling of combined extras is improved.

Dependency management refactor:

* Removed all `[project.optional-dependencies]` from `pyproject.toml`, making `optional-dependencies` a dynamic field handled by `setup.py` instead. This centralizes dependency management and avoids duplication.
* The `all` extra (combining non-platform extras) is now defined in `setup.py` rather than in `pyproject.toml`.

Platform-specific and CUDA 13 support:

* Added a new `cuda13` platform extra with functions to construct direct wheel URLs for PyTorch and related packages targeting CUDA 13, supporting environment variable overrides for flexibility. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R200-R239) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L374-R435)
* Updated the `extras_require` dictionary in `setup.py` to include the new `cuda13` extra and restructured other platform extras for clarity.

Installation and documentation improvements:

* The installation instructions printed during setup now clearly show how to install with each platform extra, including the new `cuda13` option.
* The main install requirements (`install_requires`) now exclude platform-specific dependencies, which are instead installed via the appropriate extra.