### PR TITLE
twinflow: adversarial loss, doc updates

### DIFF
--- a/documentation/distillation/TWINFLOW.hi.md
+++ b/documentation/distillation/TWINFLOW.hi.md
@@ -6,7 +6,7 @@ SimpleTuner में TwinFlow:
 * Flow-matching केवल तभी, जब तक आप diffusion मॉडल्स को `diff2flow_enabled` + `twinflow_allow_diff2flow` से ब्रिज न करें।
 * EMA teacher डिफ़ॉल्ट है; teacher/CFG passes के आसपास RNG capture/restore **हमेशा चालू** रहता है ताकि reference TwinFlow run जैसा व्यवहार मिले।
 * negative-time semantics के लिए optional sign embeddings transformers पर wired हैं, लेकिन केवल तब उपयोग होते हैं जब `twinflow_enabled` true हो; HF configs में flag न होने पर कोई व्यवहार परिवर्तन नहीं होता।
-* मौजूदा losses केवल RCGM + real-velocity का उपयोग करते हैं (adversarial/fake branch बंद रहता है); guidance `0.0` पर 1–4 step generation अपेक्षित है।
+* डिफ़ॉल्ट losses RCGM + real-velocity का उपयोग करते हैं; वैकल्पिक रूप से `twinflow_adversarial_enabled: true` से पूर्ण self-adversarial training (L_adv और L_rectify losses) सक्षम करें। guidance `0.0` पर 1–4 step generation अपेक्षित है।
 * W&B logging डिबग के लिए experimental TwinFlow trajectory scatter (थ्योरी अभी unverified) emit कर सकता है।
 
 ---
@@ -51,7 +51,7 @@ Diffusion मॉडल्स (epsilon/v prediction) के लिए स्प�
 }
 ```
 
-> TwinFlow जानबूझकर सरल रखा गया है: कोई अतिरिक्त discriminator या fake branch wired नहीं है; केवल RCGM और real-velocity terms उपयोग होते हैं।
+> डिफ़ॉल्ट रूप से, TwinFlow RCGM + real-velocity losses का उपयोग करता है। `twinflow_adversarial_enabled: true` सक्षम करें पूर्ण self-adversarial training के लिए L_adv और L_rectify losses के साथ (कोई बाहरी discriminator आवश्यक नहीं)।
 
 ---
 
@@ -78,6 +78,18 @@ arXiv:2512.05150 (PDF text) से:
 * `twinflow_allow_diff2flow`: epsilon/v-prediction मॉडल्स को ब्रिज करने देता है जब `diff2flow_enabled` भी true हो।
 * RNG capture/restore: reference TwinFlow implementation जैसा व्यवहार पाने के लिए हमेशा सक्षम रहता है। opt-out स्विच नहीं है।
 * Sign embeddings: जब `twinflow_enabled` true होता है, मॉडल `twinflow_time_sign` को उन transformers में पास करते हैं जो `timestep_sign` सपोर्ट करते हैं; अन्यथा कोई अतिरिक्त embedding नहीं।
+
+### Adversarial Branch (पूर्ण TwinFlow)
+
+बेहतर गुणवत्ता के लिए मूल पेपर से self-adversarial training सक्षम करें:
+
+* `twinflow_adversarial_enabled` (डिफ़ॉल्ट false): L_adv और L_rectify losses सक्षम करता है। ये negative time का उपयोग करके "fake" trajectory को train करते हैं, बिना बाहरी discriminator के distribution matching सक्षम करते हैं।
+* `twinflow_adversarial_weight` (डिफ़ॉल्ट 1.0): adversarial loss (L_adv) के लिए weight multiplier।
+* `twinflow_rectify_weight` (डिफ़ॉल्ट 1.0): rectification loss (L_rectify) के लिए weight multiplier।
+
+सक्षम होने पर, training one-step generation के माध्यम से fake samples उत्पन्न करता है, फिर दोनों को train करता है:
+- **L_adv**: Negative time के साथ fake velocity loss—मॉडल को fake samples को वापस noise में map करना सिखाता है।
+- **L_rectify**: Distribution matching loss—straighter paths के लिए real और fake trajectory predictions को align करता है।
 
 ---
 

--- a/simpletuner/helpers/models/heartmula/codec/flow_matching.py
+++ b/simpletuner/helpers/models/heartmula/codec/flow_matching.py
@@ -7,7 +7,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from tqdm import tqdm
-from vector_quantize_pytorch import ResidualVQ
 
 from .transformer import LlamaTransformer
 
@@ -32,6 +31,13 @@ class FlowMatching(nn.Module):
         out_channels: int = 256,
     ):
         super().__init__()
+        try:
+            from vector_quantize_pytorch import ResidualVQ
+        except ImportError as e:
+            raise ImportError(
+                "vector_quantize_pytorch is required for FlowMatching. "
+                "Install it with: pip install vector-quantize-pytorch"
+            ) from e
         self.vq_embed = ResidualVQ(
             dim=dim,
             codebook_size=codebook_size,

--- a/tests/test_twinflow_adversarial.py
+++ b/tests/test_twinflow_adversarial.py
@@ -1,0 +1,193 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+import torch.nn.functional as F
+
+
+class TwinFlowAdversarialTest(unittest.TestCase):
+    """Tests for TwinFlow adversarial losses (L_adv and L_rectify)."""
+
+    def test_adversarial_settings_defaults(self):
+        """Test that adversarial settings have correct defaults."""
+        from simpletuner.helpers.models.common import ModelFoundation
+
+        # Create a minimal mock for testing settings
+        mock_config = MagicMock()
+        mock_config.twinflow_adversarial_enabled = False
+        mock_config.twinflow_adversarial_weight = None
+        mock_config.twinflow_rectify_weight = None
+        mock_config.twinflow_estimate_order = None
+        mock_config.twinflow_enhanced_ratio = None
+        mock_config.twinflow_target_step_count = None
+        mock_config.twinflow_delta_t = None
+        mock_config.twinflow_target_clamp = None
+        mock_config.twinflow_require_ema = True
+
+        # Manually call the settings method logic
+        settings = {
+            "adversarial_enabled": bool(getattr(mock_config, "twinflow_adversarial_enabled", False)),
+            "adversarial_weight": float(getattr(mock_config, "twinflow_adversarial_weight", 1.0) or 1.0),
+            "rectify_weight": float(getattr(mock_config, "twinflow_rectify_weight", 1.0) or 1.0),
+        }
+
+        self.assertFalse(settings["adversarial_enabled"])
+        self.assertEqual(settings["adversarial_weight"], 1.0)
+        self.assertEqual(settings["rectify_weight"], 1.0)
+
+    def test_adversarial_enabled_when_set(self):
+        """Test that adversarial_enabled is True when config sets it."""
+        mock_config = MagicMock()
+        mock_config.twinflow_adversarial_enabled = True
+        mock_config.twinflow_adversarial_weight = 0.5
+        mock_config.twinflow_rectify_weight = 0.8
+
+        settings = {
+            "adversarial_enabled": bool(getattr(mock_config, "twinflow_adversarial_enabled", False)),
+            "adversarial_weight": float(getattr(mock_config, "twinflow_adversarial_weight", 1.0) or 1.0),
+            "rectify_weight": float(getattr(mock_config, "twinflow_rectify_weight", 1.0) or 1.0),
+        }
+
+        self.assertTrue(settings["adversarial_enabled"])
+        self.assertEqual(settings["adversarial_weight"], 0.5)
+        self.assertEqual(settings["rectify_weight"], 0.8)
+
+    def test_fake_trajectory_uses_negative_time(self):
+        """Test that fake trajectory time sampling produces negative values."""
+        bsz = 4
+        device = torch.device("cpu")
+        dtype = torch.float32
+
+        # Sample positive time and negate for fake trajectory
+        t = torch.rand(bsz, device=device, dtype=dtype).clamp(min=0.01, max=0.99)
+        neg_t = -t
+
+        # Verify all negative
+        self.assertTrue((neg_t < 0).all(), "Fake trajectory time should be negative")
+        self.assertTrue((neg_t > -1).all(), "Fake trajectory time should be > -1")
+
+    def test_fake_sample_interpolation(self):
+        """Test that fake trajectory interpolation is correct."""
+        bsz = 2
+        channels = 4
+        size = 8
+
+        x_fake = torch.randn(bsz, channels, size, size)
+        z = torch.randn(bsz, channels, size, size)
+        t = torch.tensor([0.5, 0.3]).view(bsz, 1, 1, 1)
+
+        # Interpolation: x_t_fake = t * z + (1 - t) * x_fake
+        x_t_fake = t * z + (1 - t) * x_fake
+
+        # Verify shapes match
+        self.assertEqual(x_t_fake.shape, x_fake.shape)
+
+        # Verify interpolation at extremes
+        t_zero = torch.zeros(bsz, 1, 1, 1)
+        t_one = torch.ones(bsz, 1, 1, 1)
+
+        x_t_at_zero = t_zero * z + (1 - t_zero) * x_fake
+        x_t_at_one = t_one * z + (1 - t_one) * x_fake
+
+        self.assertTrue(torch.allclose(x_t_at_zero, x_fake), "At t=0, should equal x_fake")
+        self.assertTrue(torch.allclose(x_t_at_one, z), "At t=1, should equal z")
+
+    def test_adversarial_loss_target(self):
+        """Test that adversarial loss target is z - x_fake."""
+        x_fake = torch.randn(2, 4, 8, 8)
+        z = torch.randn(2, 4, 8, 8)
+
+        target_fake = z - x_fake
+
+        # Verify target is the velocity from x_fake to z
+        self.assertEqual(target_fake.shape, x_fake.shape)
+        self.assertTrue(torch.allclose(x_fake + target_fake, z))
+
+    def test_rectify_loss_gradient_computation(self):
+        """Test that rectify loss computes F_grad = F_neg - F_pos correctly."""
+        F_pos = torch.randn(2, 4, 8, 8)
+        F_neg = torch.randn(2, 4, 8, 8)
+
+        F_grad = F_neg - F_pos.detach()
+
+        # Target: base_pred - F_grad (stop gradient)
+        rectify_target = (F_pos.detach() - F_grad).detach()
+
+        # Loss should be MSE between F_pos and rectify_target
+        loss = F.mse_loss(F_pos, rectify_target, reduction="mean")
+
+        # Verify loss is a scalar
+        self.assertEqual(loss.dim(), 0)
+        self.assertTrue(loss.item() >= 0)
+
+    def test_sign_extraction_from_negative_sigma(self):
+        """Test that sign is correctly extracted from negative sigma values."""
+        sigmas = torch.tensor([-0.5, -0.3, -0.8])
+
+        sigma_sign = torch.sign(sigmas)
+        sigma_abs = sigmas.abs()
+
+        self.assertTrue((sigma_sign == -1).all(), "Sign should be -1 for negative sigmas")
+        self.assertTrue((sigma_abs > 0).all(), "Absolute values should be positive")
+        self.assertTrue(torch.allclose(sigma_abs, torch.tensor([0.5, 0.3, 0.8])))
+
+    def test_match_time_shape_broadcasting(self):
+        """Test that time tensors are correctly broadcast to latent shapes."""
+
+        def match_time_shape(time_tensor, like):
+            if time_tensor is None:
+                return None
+            while time_tensor.dim() < like.dim():
+                time_tensor = time_tensor.unsqueeze(-1)
+            return time_tensor
+
+        time = torch.tensor([0.5, 0.3])  # Shape: (2,)
+        latents = torch.randn(2, 4, 8, 8)  # Shape: (2, 4, 8, 8)
+
+        time_broadcast = match_time_shape(time, latents)
+
+        self.assertEqual(time_broadcast.shape, (2, 1, 1, 1))
+        # Verify broadcasting works for multiplication
+        result = time_broadcast * latents
+        self.assertEqual(result.shape, latents.shape)
+
+
+class TwinFlowAdversarialIntegrationTest(unittest.TestCase):
+    """Integration tests for TwinFlow adversarial branch."""
+
+    def test_loss_components_summed(self):
+        """Test that all loss components are properly summed."""
+        loss_base = torch.tensor(0.5)
+        loss_real = torch.tensor(0.3)
+        loss_adv = torch.tensor(0.2)
+        loss_rectify = torch.tensor(0.1)
+
+        adv_weight = 1.0
+        rectify_weight = 1.0
+
+        twin_losses = [loss_base, loss_real]
+        twin_losses.append(adv_weight * loss_adv)
+        twin_losses.append(rectify_weight * loss_rectify)
+
+        total = torch.stack(twin_losses).sum()
+
+        expected = 0.5 + 0.3 + 0.2 + 0.1
+        self.assertAlmostEqual(total.item(), expected, places=5)
+
+    def test_weighted_losses(self):
+        """Test that loss weights are applied correctly."""
+        loss_adv = torch.tensor(1.0)
+        loss_rectify = torch.tensor(1.0)
+
+        adv_weight = 0.5
+        rectify_weight = 0.3
+
+        weighted_adv = adv_weight * loss_adv
+        weighted_rectify = rectify_weight * loss_rectify
+
+        self.assertAlmostEqual(weighted_adv.item(), 0.5, places=5)
+        self.assertAlmostEqual(weighted_rectify.item(), 0.3, places=5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2452 

This pull request adds support for the full self-adversarial training branch of TwinFlow, as described in the original paper, across all documentation and the core model helper code. It introduces new configuration options to enable and control adversarial and rectification losses (L_adv and L_rectify), and implements the corresponding loss computations and fake sample generation in the training pipeline. Documentation in English, Spanish, Portuguese, Hindi, Japanese, and Chinese is updated to explain these new features and settings.

**TwinFlow adversarial branch support**

* Added new configuration options to enable adversarial training: `twinflow_adversarial_enabled`, `twinflow_adversarial_weight`, and `twinflow_rectify_weight` in `_twinflow_settings` within `simpletuner/helpers/models/common.py`.
* Implemented methods in `simpletuner/helpers/models/common.py` for generating fake samples (`_twinflow_generate_fake_samples`) and computing the adversarial (`_twinflow_compute_adversarial_loss`) and rectification (`_twinflow_compute_rectify_loss`) losses, following the TwinFlow paper.

**Documentation updates (all languages)**

* Updated English, Spanish, Portuguese, Hindi, Japanese, and Chinese documentation (`documentation/distillation/TWINFLOW.md`, `.es.md`, `.pt-BR.md`, `.hi.md`, `.ja.md`, `.zh.md`) to describe the new adversarial branch, configuration flags, and the behavior and purpose of L_adv and L_rectify losses. [[1]](diffhunk://#diff-7408c4dba5647831856f934cc327a1732e4963a0b58364e9d9f8fd56082d7f11L9-R9) [[2]](diffhunk://#diff-7408c4dba5647831856f934cc327a1732e4963a0b58364e9d9f8fd56082d7f11L54-R54) [[3]](diffhunk://#diff-7408c4dba5647831856f934cc327a1732e4963a0b58364e9d9f8fd56082d7f11R82-R93) [[4]](diffhunk://#diff-7cb42f6dadaa05c88eb4b29f7d2b8b6857567cb259f432a9a078be6221fd3675L9-R9) [[5]](diffhunk://#diff-7cb42f6dadaa05c88eb4b29f7d2b8b6857567cb259f432a9a078be6221fd3675L54-R54) [[6]](diffhunk://#diff-7cb42f6dadaa05c88eb4b29f7d2b8b6857567cb259f432a9a078be6221fd3675R82-R93) [[7]](diffhunk://#diff-5ee7f099c6946a3b0d69419555665ab995c049fd9ea528072ab2f43015db41b2L9-R9) [[8]](diffhunk://#diff-5ee7f099c6946a3b0d69419555665ab995c049fd9ea528072ab2f43015db41b2L54-R54) [[9]](diffhunk://#diff-5ee7f099c6946a3b0d69419555665ab995c049fd9ea528072ab2f43015db41b2R82-R93) [[10]](diffhunk://#diff-9a52ca48cd52fef774906baaf66947940749a59115d195986d3ceec6e78e978dL9-R9) [[11]](diffhunk://#diff-9a52ca48cd52fef774906baaf66947940749a59115d195986d3ceec6e78e978dL54-R54) [[12]](diffhunk://#diff-9a52ca48cd52fef774906baaf66947940749a59115d195986d3ceec6e78e978dR82-R93) [[13]](diffhunk://#diff-91e452e5e212622178f2e50c09bf9d62f4dec8ab87f27fa75d911e8647b48031L9-R9) [[14]](diffhunk://#diff-91e452e5e212622178f2e50c09bf9d62f4dec8ab87f27fa75d911e8647b48031L54-R54) [[15]](diffhunk://#diff-91e452e5e212622178f2e50c09bf9d62f4dec8ab87f27fa75d911e8647b48031R82-R93) [[16]](diffhunk://#diff-22d7e639ac85d43ed2a4b2eda3ead8471dc3a0c42884ecce62bb2c83f020333dL9-R9) [[17]](diffhunk://#diff-22d7e639ac85d43ed2a4b2eda3ead8471dc3a0c42884ecce62bb2c83f020333dL54-R54) [[18]](diffhunk://#diff-22d7e639ac85d43ed2a4b2eda3ead8471dc3a0c42884ecce62bb2c83f020333dR82-R93)

These changes make it possible to optionally enable full self-adversarial training in TwinFlow, allowing for improved distribution matching and trajectory alignment without the need for an external discriminator, and ensure that documentation is clear and up-to-date in all supported languages.