### PR TITLE
better validation ux for attention mechanism selection

### DIFF
--- a/simpletuner/helpers/configuration/cmd_args.py
+++ b/simpletuner/helpers/configuration/cmd_args.py
@@ -18,7 +18,11 @@ from accelerate.utils import ProjectConfiguration
 
 from simpletuner.helpers.configuration.cli_utils import mapping_to_cli_args, normalize_lr_scheduler_value
 from simpletuner.helpers.logging import get_logger
-from simpletuner.helpers.training.attention_backend import AttentionBackendMode
+from simpletuner.helpers.training.attention_backend import (
+    AttentionBackendMode,
+    is_sageattention_available,
+    xformers_compute_capability_error,
+)
 from simpletuner.helpers.training.multi_process import should_log
 from simpletuner.helpers.training.optimizer_param import is_optimizer_deprecated, is_optimizer_grad_fp32
 from simpletuner.helpers.training.quantisation import MANUAL_QUANTIZATION_PRESETS, PIPELINE_QUANTIZATION_PRESETS
@@ -1281,6 +1285,18 @@ def parse_cmdline_args(input_args=None, exit_on_error: bool = False):
 
     if hasattr(args, "sageattention_usage"):
         args.sageattention_usage = AttentionBackendMode.from_raw(args.sageattention_usage)
+
+    attention_mech = getattr(args, "attention_mechanism", "diffusers")
+    if attention_mech == "xformers":
+        xformers_error = xformers_compute_capability_error()
+        if xformers_error:
+            raise ValueError(xformers_error)
+
+    if attention_mech.startswith("sage") and not is_sageattention_available():
+        raise ValueError(
+            f"SageAttention is not installed but --attention_mechanism={attention_mech} was requested. "
+            "Install it with: pip install sageattention"
+        )
 
     deprecated_options = {
         # how to deprecate options:

--- a/simpletuner/helpers/training/attention_backend.py
+++ b/simpletuner/helpers/training/attention_backend.py
@@ -93,6 +93,32 @@ class AttentionPhase(Enum):
     EVAL = "eval"
 
 
+def is_sageattention_available() -> bool:
+    """Check if sageattention package is importable."""
+    try:
+        import sageattention  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def xformers_compute_capability_error() -> Optional[str]:
+    """Return an error message if xformers is unsupported on the current GPU, else None.
+
+    xformers does not support compute capability 9.0+ (Hopper architecture).
+    """
+    if not torch.cuda.is_available():
+        return None
+    major, _ = torch.cuda.get_device_capability()
+    if major >= 9:
+        return (
+            f"xformers is not supported on GPUs with compute capability 9.0+ "
+            f"(detected {major}.x). Use a different attention mechanism such as 'diffusers'."
+        )
+    return None
+
+
 SLAKey = Tuple[int, str, Optional[int], torch.dtype]
 
 


### PR DESCRIPTION
This pull request introduces improved validation for attention mechanism selection in both configuration normalization and server-side validation logic. The main focus is to ensure users receive clear error messages when selecting unsupported attention mechanisms, specifically addressing compatibility issues with `xformers` on certain GPUs and the availability of `sageattention`.

**Attention mechanism validation improvements:**

* Added `is_sageattention_available` and `xformers_compute_capability_error` helper functions to `attention_backend.py` to check for SageAttention installation and xformers GPU compatibility, respectively.
* Updated `_normalize_input_args` in `cmd_args.py` to raise a `ValueError` if `xformers` is selected on unsupported GPUs, or if `sageattention` is requested but not installed.
* Enhanced server-side validation in `validation_service.py` to add configuration errors for unsupported `xformers` or missing `sageattention`, improving feedback to users during config validation.

**Internal API changes:**

* Imported the new attention mechanism validation helpers into both `cmd_args.py` and `validation_service.py` to enable their use in argument normalization and validation logic. [[1]](diffhunk://#diff-2eb2bdca165b022325e9401eb998e8aa0f66d16deea3d8b7cd0fd68e5814ffa0L21-R25) [[2]](diffhunk://#diff-e3e32c24beba8e0dc91887b07f26192cb68f865b6bec87cd5b6a4cb8a236e8b1R17)