### PR TITLE
cuda-stable, cuda-nightly, and cuda13-stable, cuda13-nightly install targets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -205,6 +205,38 @@ def _cuda13_base_url() -> str:
     )
 
 
+def _cuda_stable_base_url() -> str:
+    """Return the base URL for CUDA 12 stable/pre-release PyTorch wheels."""
+    return os.environ.get(
+        "SIMPLETUNER_CUDA_STABLE_BASE_URL",
+        "https://download.pytorch.org/whl/test/cu126",
+    )
+
+
+def _cuda13_stable_base_url() -> str:
+    """Return the base URL for CUDA 13 stable/pre-release PyTorch wheels."""
+    return os.environ.get(
+        "SIMPLETUNER_CUDA13_STABLE_BASE_URL",
+        "https://download.pytorch.org/whl/test/cu130",
+    )
+
+
+def _cuda_nightly_base_url() -> str:
+    """Return the base URL for CUDA 12 nightly PyTorch wheels."""
+    return os.environ.get(
+        "SIMPLETUNER_CUDA_NIGHTLY_BASE_URL",
+        "https://download.pytorch.org/whl/nightly/cu126",
+    )
+
+
+def _cuda13_nightly_base_url() -> str:
+    """Return the base URL for CUDA 13 nightly PyTorch wheels."""
+    return os.environ.get(
+        "SIMPLETUNER_CUDA13_NIGHTLY_BASE_URL",
+        "https://download.pytorch.org/whl/nightly/cu130",
+    )
+
+
 def build_cuda13_wheel_url(package: str, version: str) -> str:
     """Build a direct wheel URL for CUDA 13 PyTorch packages."""
     py_tag = _python_tag()
@@ -212,6 +244,50 @@ def build_cuda13_wheel_url(package: str, version: str) -> str:
     platform_tag = os.environ.get("SIMPLETUNER_CUDA13_PLATFORM_TAG", "manylinux_2_28_x86_64")
     filename = f"{package}-{version}%2Bcu130-{py_tag}-{py_tag}-{platform_tag}.whl"
     return f"{package} @ {base_url}/{filename}"
+
+
+def build_cuda_stable_wheel_url(package: str, version: str) -> str:
+    """Build a direct wheel URL for CUDA 12 stable/pre-release PyTorch packages."""
+    py_tag = _python_tag()
+    base_url = _cuda_stable_base_url()
+    platform_tag = os.environ.get("SIMPLETUNER_CUDA_STABLE_PLATFORM_TAG", "manylinux_2_28_x86_64")
+    filename = f"{package}-{version}%2Bcu126-{py_tag}-{py_tag}-{platform_tag}.whl"
+    return f"{package} @ {base_url}/{filename}"
+
+
+def build_cuda13_stable_wheel_url(package: str, version: str) -> str:
+    """Build a direct wheel URL for CUDA 13 stable/pre-release PyTorch packages."""
+    py_tag = _python_tag()
+    base_url = _cuda13_stable_base_url()
+    platform_tag = os.environ.get("SIMPLETUNER_CUDA13_STABLE_PLATFORM_TAG", "manylinux_2_28_x86_64")
+    filename = f"{package}-{version}%2Bcu130-{py_tag}-{py_tag}-{platform_tag}.whl"
+    return f"{package} @ {base_url}/{filename}"
+
+
+def build_cuda_nightly_wheel_url(package: str, version: str) -> str:
+    """Build a direct wheel URL for CUDA 12 nightly PyTorch packages."""
+    py_tag = _python_tag()
+    base_url = _cuda_nightly_base_url()
+    platform_tag = os.environ.get("SIMPLETUNER_CUDA_NIGHTLY_PLATFORM_TAG", "manylinux_2_28_x86_64")
+    filename = f"{package}-{version}%2Bcu126-{py_tag}-{py_tag}-{platform_tag}.whl"
+    return f"{package} @ {base_url}/{filename}"
+
+
+def build_cuda13_nightly_wheel_url(package: str, version: str) -> str:
+    """Build a direct wheel URL for CUDA 13 nightly PyTorch packages."""
+    py_tag = _python_tag()
+    base_url = _cuda13_nightly_base_url()
+    platform_tag = os.environ.get("SIMPLETUNER_CUDA13_NIGHTLY_PLATFORM_TAG", "manylinux_2_28_x86_64")
+    filename = f"{package}-{version}%2Bcu130-{py_tag}-{py_tag}-{platform_tag}.whl"
+    return f"{package} @ {base_url}/{filename}"
+
+
+def build_triton_wheel_url(version: str, base_url: str) -> str:
+    """Build a direct wheel URL for triton from PyTorch wheel indices."""
+    py_tag = _python_tag()
+    platform_tag = os.environ.get("SIMPLETUNER_TRITON_PLATFORM_TAG", "manylinux_2_27_x86_64.manylinux_2_28_x86_64")
+    filename = f"triton-{version}-{py_tag}-{py_tag}-{platform_tag}.whl"
+    return f"triton @ {base_url}/{filename}"
 
 
 def get_cuda13_dependencies():
@@ -226,6 +302,102 @@ def get_cuda13_dependencies():
         build_cuda13_wheel_url("torchvision", torchvision_version),
         build_cuda13_wheel_url("torchaudio", torchaudio_version),
         "triton>=3.3.0",
+        "deepspeed>=0.17.2",
+        "torchao>=0.14.1",
+        "bitsandbytes>=0.45.0",
+        "nvidia-cudnn-cu13",
+        "nvidia-nccl-cu13",
+        "nvidia-ml-py>=12.555",
+        "lm-eval>=0.4.4",
+        ramtorch_dep,
+    ]
+
+
+def get_cuda_stable_dependencies():
+    """Get CUDA 12 stable/pre-release dependencies (PyTorch 2.10.0) with direct wheel URLs."""
+    ramtorch_dep = _resolve_ramtorch_dependency()
+    torch_version = os.environ.get("SIMPLETUNER_CUDA_STABLE_TORCH_VERSION", "2.10.0")
+    torchvision_version = os.environ.get("SIMPLETUNER_CUDA_STABLE_TORCHVISION_VERSION", "0.25.0")
+    torchaudio_version = os.environ.get("SIMPLETUNER_CUDA_STABLE_TORCHAUDIO_VERSION", "2.10.0")
+    triton_version = os.environ.get("SIMPLETUNER_CUDA_STABLE_TRITON_VERSION", "3.6.0")
+
+    return [
+        build_cuda_stable_wheel_url("torch", torch_version),
+        build_cuda_stable_wheel_url("torchvision", torchvision_version),
+        build_cuda_stable_wheel_url("torchaudio", torchaudio_version),
+        build_triton_wheel_url(triton_version, "https://download.pytorch.org/whl/test"),
+        "bitsandbytes>=0.45.0",
+        "deepspeed>=0.17.2",
+        "torchao>=0.14.1",
+        "nvidia-cudnn-cu12",
+        "nvidia-nccl-cu12",
+        "nvidia-ml-py>=12.555",
+        "lm-eval>=0.4.4",
+        ramtorch_dep,
+    ]
+
+
+def get_cuda_nightly_dependencies():
+    """Get CUDA 12 nightly dependencies (PyTorch 2.11.0.dev) with direct wheel URLs."""
+    ramtorch_dep = _resolve_ramtorch_dependency()
+    torch_version = os.environ.get("SIMPLETUNER_CUDA_NIGHTLY_TORCH_VERSION", "2.11.0.dev20251223")
+    torchvision_version = os.environ.get("SIMPLETUNER_CUDA_NIGHTLY_TORCHVISION_VERSION", "0.25.0.dev20251222")
+    torchaudio_version = os.environ.get("SIMPLETUNER_CUDA_NIGHTLY_TORCHAUDIO_VERSION", "2.10.0.dev20251223")
+    triton_version = os.environ.get("SIMPLETUNER_CUDA_NIGHTLY_TRITON_VERSION", "3.6.0+git9844da95")
+
+    return [
+        build_cuda_nightly_wheel_url("torch", torch_version),
+        build_cuda_nightly_wheel_url("torchvision", torchvision_version),
+        build_cuda_nightly_wheel_url("torchaudio", torchaudio_version),
+        build_triton_wheel_url(triton_version, "https://download.pytorch.org/whl/nightly"),
+        "bitsandbytes>=0.45.0",
+        "deepspeed>=0.17.2",
+        "torchao>=0.14.1",
+        "nvidia-cudnn-cu12",
+        "nvidia-nccl-cu12",
+        "nvidia-ml-py>=12.555",
+        "lm-eval>=0.4.4",
+        ramtorch_dep,
+    ]
+
+
+def get_cuda13_stable_dependencies():
+    """Get CUDA 13 stable/pre-release dependencies (PyTorch 2.10.0) with direct wheel URLs."""
+    ramtorch_dep = _resolve_ramtorch_dependency()
+    torch_version = os.environ.get("SIMPLETUNER_CUDA13_STABLE_TORCH_VERSION", "2.10.0")
+    torchvision_version = os.environ.get("SIMPLETUNER_CUDA13_STABLE_TORCHVISION_VERSION", "0.25.0")
+    torchaudio_version = os.environ.get("SIMPLETUNER_CUDA13_STABLE_TORCHAUDIO_VERSION", "2.10.0")
+    triton_version = os.environ.get("SIMPLETUNER_CUDA13_STABLE_TRITON_VERSION", "3.6.0")
+
+    return [
+        build_cuda13_stable_wheel_url("torch", torch_version),
+        build_cuda13_stable_wheel_url("torchvision", torchvision_version),
+        build_cuda13_stable_wheel_url("torchaudio", torchaudio_version),
+        build_triton_wheel_url(triton_version, "https://download.pytorch.org/whl/test"),
+        "deepspeed>=0.17.2",
+        "torchao>=0.14.1",
+        "bitsandbytes>=0.45.0",
+        "nvidia-cudnn-cu13",
+        "nvidia-nccl-cu13",
+        "nvidia-ml-py>=12.555",
+        "lm-eval>=0.4.4",
+        ramtorch_dep,
+    ]
+
+
+def get_cuda13_nightly_dependencies():
+    """Get CUDA 13 nightly dependencies (PyTorch 2.11.0.dev) with direct wheel URLs."""
+    ramtorch_dep = _resolve_ramtorch_dependency()
+    torch_version = os.environ.get("SIMPLETUNER_CUDA13_NIGHTLY_TORCH_VERSION", "2.11.0.dev20251224")
+    torchvision_version = os.environ.get("SIMPLETUNER_CUDA13_NIGHTLY_TORCHVISION_VERSION", "0.25.0.dev20251221")
+    torchaudio_version = os.environ.get("SIMPLETUNER_CUDA13_NIGHTLY_TORCHAUDIO_VERSION", "2.10.0.dev20251222")
+    triton_version = os.environ.get("SIMPLETUNER_CUDA13_NIGHTLY_TRITON_VERSION", "3.6.0+git9844da95")
+
+    return [
+        build_cuda13_nightly_wheel_url("torch", torch_version),
+        build_cuda13_nightly_wheel_url("torchvision", torchvision_version),
+        build_cuda13_nightly_wheel_url("torchaudio", torchaudio_version),
+        build_triton_wheel_url(triton_version, "https://download.pytorch.org/whl/nightly"),
         "deepspeed>=0.17.2",
         "torchao>=0.14.1",
         "bitsandbytes>=0.45.0",
@@ -434,6 +606,10 @@ extras_require = {
     # Platform-specific extras - user must choose one
     "cuda": list(PLATFORM_DEPENDENCIES["cuda"]),
     "cuda13": get_cuda13_dependencies(),
+    "cuda-stable": get_cuda_stable_dependencies(),
+    "cuda-nightly": get_cuda_nightly_dependencies(),
+    "cuda13-stable": get_cuda13_stable_dependencies(),
+    "cuda13-nightly": get_cuda13_nightly_dependencies(),
     "rocm": list(PLATFORM_DEPENDENCIES["rocm"]),
     "apple": list(PLATFORM_DEPENDENCIES["apple"]),
     "cpu": list(PLATFORM_DEPENDENCIES["cpu"]),
@@ -516,8 +692,12 @@ if __name__ == "__main__":
     print(f"Python version: {sys.version}")
     print(f"Platform: {platform.platform()}")
     print("\nInstall with a platform extra:")
-    print("  pip install .[cuda]    # CUDA 12")
-    print("  pip install .[cuda13]  # CUDA 13")
-    print("  pip install .[rocm]    # ROCm")
-    print("  pip install .[apple]   # macOS")
-    print("  pip install .[cpu]     # CPU only")
+    print("  pip install .[cuda]          # CUDA 12 (PyTorch 2.9.1 release)")
+    print("  pip install .[cuda13]        # CUDA 13 (PyTorch 2.9.1 release)")
+    print("  pip install .[cuda-stable]   # CUDA 12 (PyTorch 2.10.0 pre-release)")
+    print("  pip install .[cuda13-stable] # CUDA 13 (PyTorch 2.10.0 pre-release)")
+    print("  pip install .[cuda-nightly]  # CUDA 12 (PyTorch 2.11.0 nightly)")
+    print("  pip install .[cuda13-nightly]# CUDA 13 (PyTorch 2.11.0 nightly)")
+    print("  pip install .[rocm]          # ROCm")
+    print("  pip install .[apple]         # macOS")
+    print("  pip install .[cpu]           # CPU only")


### PR DESCRIPTION
This pull request significantly expands the CUDA dependency management in `setup.py` by introducing new functions and dependency groups for both CUDA 12 and CUDA 13, covering stable, pre-release, and nightly PyTorch builds. This allows users to easily install the appropriate dependencies for various CUDA and PyTorch versions using platform extras.

**Dependency Management Enhancements:**

* Added new functions to generate base URLs for CUDA 12 and CUDA 13 stable, pre-release, and nightly PyTorch wheels, supporting environment variable overrides for flexibility.
* Introduced builder functions for direct wheel URLs for CUDA 12 and CUDA 13 stable and nightly packages, mirroring the structure of the existing CUDA 13 builder.
* Added dependency group functions: `get_cuda_stable_dependencies`, `get_cuda_nightly_dependencies`, `get_cuda13_stable_dependencies`, and `get_cuda13_nightly_dependencies`, each returning the correct set of dependencies for their respective CUDA and PyTorch versions.

**Platform Extras and Documentation:**

* Registered new platform extras in the `EXTRAS_REQUIRE` dictionary: `cuda-stable`, `cuda-nightly`, `cuda13-stable`, and `cuda13-nightly`, making these new dependency sets selectable during installation.
* Updated the install instructions printed by `setup.py` to document the new extras, clarifying which CUDA and PyTorch versions each extra corresponds to.