### PR TITLE
Support aws_session_token for S3 backends

### DIFF
--- a/simpletuner/helpers/data_backend/aws.py
+++ b/simpletuner/helpers/data_backend/aws.py
@@ -63,6 +63,7 @@ class S3DataBackend(BaseDataBackend):
         endpoint_url: str = None,
         aws_access_key_id: str = None,
         aws_secret_access_key: str = None,
+        aws_session_token: str = None,
         read_retry_limit: int = 5,
         write_retry_limit: int = 5,
         read_retry_interval: int = 5,
@@ -79,6 +80,7 @@ class S3DataBackend(BaseDataBackend):
         self.write_retry_interval = write_retry_interval
         self.compress_cache = compress_cache
         self.max_pool_connections = max_pool_connections
+        self.aws_session_token = aws_session_token
         self.type = "aws"
 
         extra_args = {"region_name": region_name}
@@ -91,6 +93,7 @@ class S3DataBackend(BaseDataBackend):
             "s3",
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
             config=s3_config,
             **extra_args,
         )
@@ -354,6 +357,7 @@ def test_s3_connection(
     endpoint_url: Optional[str] = None,
     aws_access_key_id: Optional[str] = None,
     aws_secret_access_key: Optional[str] = None,
+    aws_session_token: Optional[str] = None,
     max_keys: int = 5,
 ) -> Dict[str, Any]:
     """Run a minimal connectivity check against an S3 bucket."""
@@ -372,6 +376,7 @@ def test_s3_connection(
             "s3",
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
             config=s3_config,
             **extra_args,
         )

--- a/simpletuner/helpers/data_backend/builders/aws.py
+++ b/simpletuner/helpers/data_backend/builders/aws.py
@@ -30,6 +30,7 @@ class AwsBackendBuilder(BaseBackendBuilder):
         aws_endpoint_url = getattr(config, "aws_endpoint_url", None)
         aws_access_key_id = getattr(config, "aws_access_key_id", None)
         aws_secret_access_key = getattr(config, "aws_secret_access_key", None)
+        aws_session_token = getattr(config, "aws_session_token", None)
 
         compress_cache = self._get_compression_setting(config)
         max_pool_connections = self._resolve_max_pool_connections(config)
@@ -42,6 +43,7 @@ class AwsBackendBuilder(BaseBackendBuilder):
             endpoint_url=aws_endpoint_url,
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
             compress_cache=compress_cache,
             max_pool_connections=max_pool_connections,
         )

--- a/simpletuner/helpers/data_backend/config/image.py
+++ b/simpletuner/helpers/data_backend/config/image.py
@@ -34,6 +34,7 @@ class ImageBackendConfig(BaseBackendConfig):
     aws_endpoint_url: Optional[str] = None
     aws_access_key_id: Optional[str] = None
     aws_secret_access_key: Optional[str] = None
+    aws_session_token: Optional[str] = None
     aws_max_pool_connections: Optional[int] = None
 
     dataset_name: Optional[str] = None
@@ -131,6 +132,7 @@ class ImageBackendConfig(BaseBackendConfig):
             config.aws_endpoint_url = backend_dict.get("aws_endpoint_url")
             config.aws_access_key_id = backend_dict.get("aws_access_key_id")
             config.aws_secret_access_key = backend_dict.get("aws_secret_access_key")
+            config.aws_session_token = backend_dict.get("aws_session_token")
             config.aws_max_pool_connections = backend_dict.get(
                 "aws_max_pool_connections", _get_arg("aws_max_pool_connections")
             )
@@ -422,6 +424,8 @@ class ImageBackendConfig(BaseBackendConfig):
             config["aws_endpoint_url"] = self.aws_endpoint_url
             config["aws_access_key_id"] = self.aws_access_key_id
             config["aws_secret_access_key"] = self.aws_secret_access_key
+            if self.aws_session_token is not None:
+                config["aws_session_token"] = self.aws_session_token
             if self.aws_max_pool_connections is not None:
                 config["aws_max_pool_connections"] = self.aws_max_pool_connections
 

--- a/simpletuner/helpers/data_backend/config/text_embed.py
+++ b/simpletuner/helpers/data_backend/config/text_embed.py
@@ -45,6 +45,7 @@ class TextEmbedBackendConfig(BaseBackendConfig):
             "aws_endpoint_url",
             "aws_access_key_id",
             "aws_secret_access_key",
+            "aws_session_token",
             "aws_region_name",
         }
         for key in passthrough_keys:


### PR DESCRIPTION
This pull request adds support for AWS session tokens throughout the S3 data backend, ensuring compatibility with temporary AWS credentials (such as those used with IAM roles or STS). The changes update the configuration, backend initialization, and S3 connection logic to accept and use an `aws_session_token` parameter.

Key changes include:

**AWS session token support in configuration:**
* Added `aws_session_token` as an optional field to `ImageBackendConfig` and included it in serialization and deserialization logic in `simpletuner/helpers/data_backend/config/image.py`. [[1]](diffhunk://#diff-718521d71eaac98526a7ba3d118d263b3822f5d0d93969f35ca40a0e8597843fR37) [[2]](diffhunk://#diff-718521d71eaac98526a7ba3d118d263b3822f5d0d93969f35ca40a0e8597843fR135) [[3]](diffhunk://#diff-718521d71eaac98526a7ba3d118d263b3822f5d0d93969f35ca40a0e8597843fR427-R428)
* Included `aws_session_token` in the passthrough keys for `TextEmbedConfig` in `simpletuner/helpers/data_backend/config/text_embed.py`.

**Backend and connection logic updates:**
* Updated `S3DataBackend` and its builder to accept and propagate the `aws_session_token` parameter, ensuring it is passed to the underlying boto3 S3 client in `simpletuner/helpers/data_backend/aws.py` and `simpletuner/helpers/data_backend/builders/aws.py`. [[1]](diffhunk://#diff-0630d600fa394b81391faec56b65fd5bac1a414057974d03d2ba31ea14013bf6R66) [[2]](diffhunk://#diff-0630d600fa394b81391faec56b65fd5bac1a414057974d03d2ba31ea14013bf6R83) [[3]](diffhunk://#diff-0630d600fa394b81391faec56b65fd5bac1a414057974d03d2ba31ea14013bf6R96) [[4]](diffhunk://#diff-1c3f065f530a22218b3945182bbb3ddece82a47829bf9a3ea4b3317805b66a9aR33) [[5]](diffhunk://#diff-1c3f065f530a22218b3945182bbb3ddece82a47829bf9a3ea4b3317805b66a9aR46)
* Modified the S3 connectivity test function to accept and use `aws_session_token` for authentication in `simpletuner/helpers/data_backend/aws.py`. [[1]](diffhunk://#diff-0630d600fa394b81391faec56b65fd5bac1a414057974d03d2ba31ea14013bf6R360) [[2]](diffhunk://#diff-0630d600fa394b81391faec56b65fd5bac1a414057974d03d2ba31ea14013bf6R379)