### PR TITLE
skip comfyui format conversion for models which support natively

### DIFF
--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -1520,6 +1520,9 @@ class ModelFoundation(ABC):
                 adapter_metadata.update(value)
 
         lora_format = normalize_lora_format(getattr(self.config, "lora_format", None))
+        if lora_format == PEFTLoRAFormat.COMFYUI and getattr(self, "NATIVE_COMFYUI_LORA_SUPPORT", False):
+            logger.info("Skipping ComfyUI LoRA conversion - model has native ComfyUI support")
+            lora_format = PEFTLoRAFormat.DIFFUSERS  # Treat as diffusers format (no-op)
         if lora_format == PEFTLoRAFormat.COMFYUI:
             import safetensors.torch
             from diffusers.loaders.lora_base import LORA_ADAPTER_METADATA_KEY

--- a/simpletuner/helpers/models/flux2/model.py
+++ b/simpletuner/helpers/models/flux2/model.py
@@ -87,6 +87,7 @@ class Flux2(ImageModelFoundation):
     PREDICTION_TYPE = PredictionTypes.FLOW_MATCHING
     MODEL_TYPE = ModelTypes.TRANSFORMER
     AUTO_LORA_FORMAT_DETECTION = True
+    NATIVE_COMFYUI_LORA_SUPPORT = True  # Flux2 has native ComfyUI LoRA support, no conversion needed
     AUTOENCODER_CLASS = AutoencoderKLFlux2
     LATENT_CHANNEL_COUNT = 128  # 32 VAE channels × 4 (2×2 pixel shuffle) = 128 transformer channels
     VAE_SCALE_FACTOR = 16  # 8x spatial + 2x pixel shuffle


### PR DESCRIPTION
flux2 is now supported.