### PR TITLE
add --ramtorch_transformer_percent and --ramtorch_text_encoder_percent to treat it more like block swap

### DIFF
--- a/documentation/OPTIONS.es.md
+++ b/documentation/OPTIONS.es.md
@@ -156,6 +156,20 @@ Donde `foo` es tu entorno de configuración; o simplemente usa `config/config.js
 - **Qué**: Aplica reemplazos RamTorch a las capas Linear de ControlNet cuando se entrena un ControlNet.
 - **Predeterminado**: `False`
 
+### `--ramtorch_transformer_percent`
+
+- **Qué**: Porcentaje (0-100) de capas Linear del transformer a descargar con RamTorch.
+- **Predeterminado**: `100` (todas las capas elegibles)
+- **Por qué**: Permite una descarga parcial para equilibrar el ahorro de VRAM con el rendimiento. Valores más bajos mantienen más capas en la GPU para un entrenamiento más rápido, mientras se reduce el uso de memoria.
+- **Notas**: Las capas se seleccionan desde el inicio del orden de recorrido del módulo. Se puede combinar con `--ramtorch_target_modules`.
+
+### `--ramtorch_text_encoder_percent`
+
+- **Qué**: Porcentaje (0-100) de capas Linear del codificador de texto a descargar con RamTorch.
+- **Predeterminado**: `100` (todas las capas elegibles)
+- **Por qué**: Permite la descarga parcial de codificadores de texto cuando `--ramtorch_text_encoder` está habilitado.
+- **Notas**: Solo aplica cuando `--ramtorch_text_encoder` está habilitado.
+
 ### `--pretrained_model_name_or_path`
 
 - **Qué**: Ruta al modelo preentrenado o su identificador en <https://huggingface.co/models>.

--- a/documentation/OPTIONS.hi.md
+++ b/documentation/OPTIONS.hi.md
@@ -156,6 +156,20 @@ simpletuner configure config/foo/config.json
 - **What**: ControlNet training के दौरान ControlNet Linear layers पर RamTorch replacements लागू करता है।
 - **Default**: `False`
 
+### `--ramtorch_transformer_percent`
+
+- **What**: RamTorch के साथ offload करने के लिए transformer Linear layers का प्रतिशत (0-100)।
+- **Default**: `100` (सभी eligible layers)
+- **Why**: VRAM बचत और performance के बीच संतुलन के लिए partial offloading की अनुमति देता है। कम values GPU पर अधिक layers रखती हैं जिससे training तेज होती है जबकि memory usage भी कम होती है।
+- **Notes**: Layers module traversal order की शुरुआत से select की जाती हैं। `--ramtorch_target_modules` के साथ combine किया जा सकता है।
+
+### `--ramtorch_text_encoder_percent`
+
+- **What**: RamTorch के साथ offload करने के लिए text encoder Linear layers का प्रतिशत (0-100)।
+- **Default**: `100` (सभी eligible layers)
+- **Why**: जब `--ramtorch_text_encoder` enabled हो तब text encoders की partial offloading की अनुमति देता है।
+- **Notes**: केवल तब लागू होता है जब `--ramtorch_text_encoder` enabled हो।
+
 ### `--pretrained_model_name_or_path`
 
 - **What**: pretrained model का path या <https://huggingface.co/models> से उसका identifier.

--- a/documentation/OPTIONS.ja.md
+++ b/documentation/OPTIONS.ja.md
@@ -157,6 +157,20 @@ simpletuner configure config/foo/config.json
 - **内容**: ControlNet を学習する際、ControlNet の Linear レイヤーに RamTorch 置換を適用。
 - **既定**: `False`
 
+### `--ramtorch_transformer_percent`
+
+- **内容**: RamTorch でオフロードする transformer Linear レイヤーの割合（0-100）。
+- **既定**: `100`（対象となるすべてのレイヤー）
+- **理由**: 部分的なオフロードにより、VRAM 節約とパフォーマンスのバランスを取ることができます。低い値はより多くのレイヤーを GPU に保持し、メモリ使用量を削減しながら高速な学習を可能にします。
+- **注記**: レイヤーはモジュール走査順の先頭から選択されます。`--ramtorch_target_modules` と組み合わせ可能。
+
+### `--ramtorch_text_encoder_percent`
+
+- **内容**: RamTorch でオフロードするテキストエンコーダー Linear レイヤーの割合（0-100）。
+- **既定**: `100`（対象となるすべてのレイヤー）
+- **理由**: `--ramtorch_text_encoder` 有効時にテキストエンコーダーの部分的なオフロードを可能にします。
+- **注記**: `--ramtorch_text_encoder` が有効な場合のみ適用。
+
 ### `--pretrained_model_name_or_path`
 
 - **内容**: 事前学習済みモデルのパス、または <https://huggingface.co/models> の識別子。

--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -156,6 +156,20 @@ Where `foo` is your config environment - or just use `config/config.json` if you
 - **What**: Applies RamTorch replacements to ControlNet Linear layers when training a ControlNet.
 - **Default**: `False`
 
+### `--ramtorch_transformer_percent`
+
+- **What**: Percentage (0-100) of transformer Linear layers to offload with RamTorch.
+- **Default**: `100` (all eligible layers)
+- **Why**: Allows partial offloading to balance VRAM savings against performance. Lower values keep more layers on GPU for faster training while still reducing memory usage.
+- **Notes**: Layers are selected from the beginning of module traversal order. Can be combined with `--ramtorch_target_modules`.
+
+### `--ramtorch_text_encoder_percent`
+
+- **What**: Percentage (0-100) of text encoder Linear layers to offload with RamTorch.
+- **Default**: `100` (all eligible layers)
+- **Why**: Allows partial offloading of text encoders when `--ramtorch_text_encoder` is enabled.
+- **Notes**: Only applies when `--ramtorch_text_encoder` is enabled.
+
 ### `--pretrained_model_name_or_path`
 
 - **What**: Path to the pretrained model or its identifier from <https://huggingface.co/models>.

--- a/documentation/OPTIONS.pt-BR.md
+++ b/documentation/OPTIONS.pt-BR.md
@@ -156,6 +156,20 @@ Onde `foo` e seu ambiente de config — ou use `config/config.json` se nao estiv
 - **O que**: Aplica substituicoes RamTorch a camadas Linear do ControlNet ao treinar um ControlNet.
 - **Padrao**: `False`
 
+### `--ramtorch_transformer_percent`
+
+- **O que**: Porcentagem (0-100) de camadas Linear do transformer a serem descarregadas com RamTorch.
+- **Padrao**: `100` (todas as camadas elegiveis)
+- **Por que**: Permite descarregamento parcial para equilibrar economia de VRAM com desempenho. Valores mais baixos mantem mais camadas na GPU para treinamento mais rapido, enquanto ainda reduz o uso de memoria.
+- **Notas**: As camadas sao selecionadas desde o inicio da ordem de travessia do modulo. Pode ser combinado com `--ramtorch_target_modules`.
+
+### `--ramtorch_text_encoder_percent`
+
+- **O que**: Porcentagem (0-100) de camadas Linear do codificador de texto a serem descarregadas com RamTorch.
+- **Padrao**: `100` (todas as camadas elegiveis)
+- **Por que**: Permite descarregamento parcial de codificadores de texto quando `--ramtorch_text_encoder` esta habilitado.
+- **Notas**: Aplica-se apenas quando `--ramtorch_text_encoder` esta habilitado.
+
 ### `--pretrained_model_name_or_path`
 
 - **O que**: Caminho para o modelo pre-treinado ou seu identificador em <https://huggingface.co/models>.

--- a/documentation/OPTIONS.zh.md
+++ b/documentation/OPTIONS.zh.md
@@ -157,6 +157,20 @@ simpletuner configure config/foo/config.json
 - **内容**：训练 ControlNet 时对其 Linear 层应用 RamTorch 替换。
 - **默认**：`False`
 
+### `--ramtorch_transformer_percent`
+
+- **内容**：使用 RamTorch 卸载的 transformer Linear 层的百分比（0-100）。
+- **默认**：`100`（所有符合条件的层）
+- **原因**：允许部分卸载以平衡显存节省与性能。较低的值保留更多层在 GPU 上以加快训练，同时仍减少内存使用。
+- **说明**：层按模块遍历顺序从头开始选择。可与 `--ramtorch_target_modules` 结合使用。
+
+### `--ramtorch_text_encoder_percent`
+
+- **内容**：使用 RamTorch 卸载的文本编码器 Linear 层的百分比（0-100）。
+- **默认**：`100`（所有符合条件的层）
+- **原因**：当启用 `--ramtorch_text_encoder` 时，允许部分卸载文本编码器。
+- **说明**：仅在启用 `--ramtorch_text_encoder` 时适用。
+
 ### `--pretrained_model_name_or_path`
 
 - **内容**：预训练模型路径或 <https://huggingface.co/models> 上的标识符。

--- a/simpletuner/helpers/models/ace_step/model.py
+++ b/simpletuner/helpers/models/ace_step/model.py
@@ -346,7 +346,7 @@ class ACEStep(AudioModelFoundation):
             text_encoder.to(self.accelerator.device, dtype=self.config.weight_dtype)
 
         if self._ramtorch_text_encoders_requested():
-            self._apply_ramtorch_layers(text_encoder, "text_encoder_1")
+            self._apply_ramtorch_layers(text_encoder, "text_encoder_1", percent=self._ramtorch_text_encoder_percent())
 
         self.text_encoders = [text_encoder]
         self.text_encoder_1 = text_encoder

--- a/simpletuner/helpers/models/flux2/model.py
+++ b/simpletuner/helpers/models/flux2/model.py
@@ -414,7 +414,7 @@ class Flux2(ImageModelFoundation):
             )
             self._qwen_model.to(target_device, dtype=dtype)
         if self._ramtorch_text_encoders_requested():
-            self._apply_ramtorch_layers(self._qwen_model, "text_encoder_1")
+            self._apply_ramtorch_layers(self._qwen_model, "text_encoder_1", percent=self._ramtorch_text_encoder_percent())
         self._qwen_model.requires_grad_(False)
         self._qwen_model.eval()
 
@@ -465,7 +465,7 @@ class Flux2(ImageModelFoundation):
             )
             self._mistral_model.to(target_device, dtype=dtype)
         if self._ramtorch_text_encoders_requested():
-            self._apply_ramtorch_layers(self._mistral_model, "text_encoder_1")
+            self._apply_ramtorch_layers(self._mistral_model, "text_encoder_1", percent=self._ramtorch_text_encoder_percent())
         self._mistral_model.requires_grad_(False)
         self._mistral_model.eval()
 

--- a/simpletuner/helpers/models/hunyuanvideo/model.py
+++ b/simpletuner/helpers/models/hunyuanvideo/model.py
@@ -264,7 +264,7 @@ class HunyuanVideo(VideoModelFoundation):
         if move_to_device and not self._ramtorch_text_encoders_requested():
             text_encoder = text_encoder.to(device)
         if self._ramtorch_text_encoders_requested():
-            self._apply_ramtorch_layers(text_encoder, "text_encoder_1")
+            self._apply_ramtorch_layers(text_encoder, "text_encoder_1", percent=self._ramtorch_text_encoder_percent())
 
         glyph_repo = getattr(self.config, "glyph_byt5_repo", self.GLYPH_BYT5_REPO)
         fallback_glyph_repo = getattr(self.config, "glyph_byt5_fallback_repo", "google/byt5-small")
@@ -306,7 +306,7 @@ class HunyuanVideo(VideoModelFoundation):
         if move_to_device and not self._ramtorch_text_encoders_requested():
             byt5_model = byt5_model.to(device)
         if self._ramtorch_text_encoders_requested():
-            self._apply_ramtorch_layers(byt5_model, "text_encoder_2")
+            self._apply_ramtorch_layers(byt5_model, "text_encoder_2", percent=self._ramtorch_text_encoder_percent())
 
         self.text_encoder = text_encoder
         self.tokenizer = tokenizer

--- a/simpletuner/helpers/models/ltxvideo2/model.py
+++ b/simpletuner/helpers/models/ltxvideo2/model.py
@@ -534,7 +534,7 @@ class LTXVideo2(VideoModelFoundation):
             raise RuntimeError("LTX-2 transformer parameters remain on the meta device after loading.")
 
         if self._ramtorch_enabled() and self.model is not None:
-            self._apply_ramtorch_layers(self.model, self.MODEL_TYPE.value)
+            self._apply_ramtorch_layers(self.model, self.MODEL_TYPE.value, percent=self._ramtorch_transformer_percent())
         if move_to_device and self.model is not None:
             self.model.to(self.accelerator.device, dtype=self.config.weight_dtype)
 

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/training.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/training.py
@@ -346,6 +346,50 @@ def register_training_fields(registry: "FieldRegistry") -> None:
 
     registry._add_field(
         ConfigField(
+            name="ramtorch_transformer_percent",
+            arg_name="--ramtorch_transformer_percent",
+            ui_label="RamTorch Transformer Percent",
+            field_type=FieldType.NUMBER,
+            tab="model",
+            section="memory_optimization",
+            default_value=100,
+            validation_rules=[
+                ValidationRule(ValidationRuleType.MIN, value=0, message="Percent must be >= 0"),
+                ValidationRule(ValidationRuleType.MAX, value=100, message="Percent must be <= 100"),
+            ],
+            help_text="Percentage (0-100) of transformer Linear layers to offload with RamTorch.",
+            tooltip="Offload only a portion of the transformer's Linear layers. 100 = all layers (default), 50 = half the layers.",
+            importance=ImportanceLevel.ADVANCED,
+            order=10,
+            dependencies=[FieldDependency(field="ramtorch", operator="equals", value=True, action="show")],
+            documentation="OPTIONS.md#--ramtorch_transformer_percent",
+        )
+    )
+
+    registry._add_field(
+        ConfigField(
+            name="ramtorch_text_encoder_percent",
+            arg_name="--ramtorch_text_encoder_percent",
+            ui_label="RamTorch Text Encoder Percent",
+            field_type=FieldType.NUMBER,
+            tab="model",
+            section="memory_optimization",
+            default_value=100,
+            validation_rules=[
+                ValidationRule(ValidationRuleType.MIN, value=0, message="Percent must be >= 0"),
+                ValidationRule(ValidationRuleType.MAX, value=100, message="Percent must be <= 100"),
+            ],
+            help_text="Percentage (0-100) of text encoder Linear layers to offload with RamTorch.",
+            tooltip="Offload only a portion of the text encoder's Linear layers. 100 = all layers (default), 50 = half the layers.",
+            importance=ImportanceLevel.ADVANCED,
+            order=11,
+            dependencies=[FieldDependency(field="ramtorch_text_encoder", operator="equals", value=True, action="show")],
+            documentation="OPTIONS.md#--ramtorch_text_encoder_percent",
+        )
+    )
+
+    registry._add_field(
+        ConfigField(
             name="group_offload_type",
             arg_name="--group_offload_type",
             ui_label="Group Offload Granularity",


### PR DESCRIPTION
This pull request introduces support for partial offloading of Linear layers to RamTorch, allowing users to specify the percentage of eligible layers to offload for both transformer and text encoder components. This provides finer control over VRAM usage and training speed. The changes update documentation in multiple languages and modify the codebase to support and utilize the new percentage-based offloading.

**Feature: Partial RamTorch Offloading**

* Added new configuration options `ramtorch_transformer_percent` and `ramtorch_text_encoder_percent` to allow specifying the percentage (0-100) of eligible Linear layers to offload for transformers and text encoders, respectively. These are documented in English, Spanish, Portuguese, Japanese, Hindi, and Chinese option files. [[1]](diffhunk://#diff-45e063db3ebcffb55dde68f083e92399a74f4cefbb464e8cd36911971c50933fR159-R172) [[2]](diffhunk://#diff-3f0cd39e3a7f176d81408ae40dc4f8c6271347f75b1cee5cf71c4e701d7db561R159-R172) [[3]](diffhunk://#diff-2c007ae9176f9f69b3ae16558be55b46d524f460a626f4e5c31e1e9a1d1b14b8R159-R172) [[4]](diffhunk://#diff-fd629904ab3e1ecdd5b568c3ef6ac61e71e3d7741700e360820849938158a1d9R160-R173) [[5]](diffhunk://#diff-cddcc50c252e719be92644d65ea8542cc51d08f15e67d918bfae737904142b1fR160-R173) [[6]](diffhunk://#diff-39b5789a705b2e70400106934436b619d10413ca5e37bd7a2b5fa7aa0c0fb8cfR159-R172)

**Core Logic Updates**

* Updated the `_apply_ramtorch_layers` method and its usage across all model helper files to accept and pass the `percent` argument, enabling partial offloading for both transformer models and text encoders. [[1]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbL2142-R2147) [[2]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbL2565-R2570) [[3]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR3014-R3035) [[4]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR3046) [[5]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR3061) [[6]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR3089) [[7]](diffhunk://#diff-e34e7b7e69a677399426b34f91fd1a10bb8e9f9f5a9eea54c8de088c103acebbL349-R349) [[8]](diffhunk://#diff-2390d666883fb499d80e71fbe6b05b21e5141f934149c7fc66937368b6ae0c02L417-R417) [[9]](diffhunk://#diff-2390d666883fb499d80e71fbe6b05b21e5141f934149c7fc66937368b6ae0c02L468-R468) [[10]](diffhunk://#diff-7415b0e19fb3d9edd0f57963ccdbfc2ea8946e23297f845a1f4948b75bead27bL267-R267) [[11]](diffhunk://#diff-7415b0e19fb3d9edd0f57963ccdbfc2ea8946e23297f845a1f4948b75bead27bL309-R309) [[12]](diffhunk://#diff-64820a284b076801c442da19649e63dc4a2e00e645d7f92abbc5754b3dbae22fL537-R537)

**RamTorch Utility Enhancements**

* Refactored `replace_linear_layers_with_ramtorch` in `ramtorch.py` to support percentage-based layer replacement, including logic to count eligible layers and select only the specified percentage for replacement. [[1]](diffhunk://#diff-35085c1320aeab677e8f229708eb17ff88af3495d0da5f1c1162af961acefd08R96-R130) [[2]](diffhunk://#diff-35085c1320aeab677e8f229708eb17ff88af3495d0da5f1c1162af961acefd08R140-R157) [[3]](diffhunk://#diff-35085c1320aeab677e8f229708eb17ff88af3495d0da5f1c1162af961acefd08L132-L142) [[4]](diffhunk://#diff-35085c1320aeab677e8f229708eb17ff88af3495d0da5f1c1162af961acefd08L165-L171)

These changes collectively provide users with more flexibility in managing memory and performance trade-offs during model training.