### PR TITLE
structured error reporting

### DIFF
--- a/simpletuner/helpers/training/error_reporter.py
+++ b/simpletuner/helpers/training/error_reporter.py
@@ -1,0 +1,108 @@
+"""Structured error reporting for subprocess-to-parent communication.
+
+When training runs as a subprocess (via accelerate launch), this module writes
+structured error information to a JSON file that the parent process can read.
+This avoids parsing stdout/stderr for error messages.
+"""
+
+import json
+import os
+import traceback as tb_module
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Environment variable used to pass error file path from parent to subprocess
+ERROR_FILE_ENV_VAR = "SIMPLETUNER_ERROR_FILE"
+
+
+def get_error_file_path() -> Path | None:
+    """Get the error file path from environment, if set by parent."""
+    path_str = os.environ.get(ERROR_FILE_ENV_VAR)
+    if path_str:
+        return Path(path_str)
+    return None
+
+
+def write_error(
+    exception: BaseException,
+    traceback_str: str | None = None,
+    context: dict[str, Any] | None = None,
+) -> bool:
+    """Write structured error information to the error file.
+
+    Args:
+        exception: The exception that occurred.
+        traceback_str: Full traceback string. If None, will be extracted from exception.
+        context: Optional additional context (e.g., current step, epoch).
+
+    Returns:
+        True if error was written successfully, False otherwise.
+    """
+    error_path = get_error_file_path()
+    if error_path is None:
+        return False
+
+    if traceback_str is None:
+        traceback_str = "".join(tb_module.format_exception(type(exception), exception, exception.__traceback__))
+
+    error_data = {
+        "type": "training.error",
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+        "exception_type": type(exception).__name__,
+        "message": str(exception),
+        "traceback": traceback_str,
+    }
+
+    if context:
+        error_data["context"] = context
+
+    try:
+        error_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(error_path, "w", encoding="utf-8") as f:
+            json.dump(error_data, f, indent=2)
+        return True
+    except Exception:
+        return False
+
+
+def read_error(error_path: Path | str) -> dict[str, Any] | None:
+    """Read structured error information from an error file.
+
+    Args:
+        error_path: Path to the error file.
+
+    Returns:
+        Parsed error data dict, or None if file doesn't exist or is invalid.
+    """
+    path = Path(error_path)
+    if not path.exists():
+        return None
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict) and data.get("type") == "training.error":
+            return data
+    except Exception:
+        pass
+    return None
+
+
+def cleanup_error_file(error_path: Path | str | None = None) -> None:
+    """Remove error file if it exists.
+
+    Args:
+        error_path: Path to error file. If None, uses environment variable.
+    """
+    if error_path is None:
+        error_path = get_error_file_path()
+    if error_path is None:
+        return
+
+    path = Path(error_path)
+    try:
+        if path.exists():
+            path.unlink()
+    except Exception:
+        pass

--- a/simpletuner/train.py
+++ b/simpletuner/train.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 # Import WebhookLogger setup FIRST before creating any loggers
 from simpletuner.helpers.logging import get_logger
+from simpletuner.helpers.training.error_reporter import write_error as write_error_file
 
 # Quiet down, you.
 ds_logger1 = logging.getLogger("DeepSpeed")
@@ -235,6 +236,9 @@ if __name__ == "__main__":
             )
     except Exception as e:
         import traceback
+
+        # Write structured error file for parent process to read
+        write_error_file(e, traceback.format_exc())
 
         # If webhook handler isn't configured yet (crash happened early), try to configure it now
         if StateTracker.get_webhook_handler() is None:

--- a/tests/test_error_reporter.py
+++ b/tests/test_error_reporter.py
@@ -1,0 +1,165 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    from tests import test_setup
+except ModuleNotFoundError:
+    import test_setup  # noqa: F401
+
+from simpletuner.helpers.training.error_reporter import (
+    ERROR_FILE_ENV_VAR,
+    cleanup_error_file,
+    get_error_file_path,
+    read_error,
+    write_error,
+)
+
+
+class TestErrorReporter(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.error_file = Path(self.temp_dir) / "error.json"
+        self._orig_env = os.environ.get(ERROR_FILE_ENV_VAR)
+
+    def tearDown(self):
+        if self._orig_env is not None:
+            os.environ[ERROR_FILE_ENV_VAR] = self._orig_env
+        elif ERROR_FILE_ENV_VAR in os.environ:
+            del os.environ[ERROR_FILE_ENV_VAR]
+        cleanup_error_file(self.error_file)
+        try:
+            os.rmdir(self.temp_dir)
+        except OSError:
+            pass
+
+    def test_get_error_file_path_returns_none_when_not_set(self):
+        if ERROR_FILE_ENV_VAR in os.environ:
+            del os.environ[ERROR_FILE_ENV_VAR]
+        self.assertIsNone(get_error_file_path())
+
+    def test_get_error_file_path_returns_path_when_set(self):
+        os.environ[ERROR_FILE_ENV_VAR] = str(self.error_file)
+        result = get_error_file_path()
+        self.assertEqual(result, self.error_file)
+
+    def test_write_error_returns_false_when_no_path(self):
+        if ERROR_FILE_ENV_VAR in os.environ:
+            del os.environ[ERROR_FILE_ENV_VAR]
+        try:
+            raise ValueError("test error")
+        except ValueError as e:
+            result = write_error(e)
+        self.assertFalse(result)
+
+    def test_write_error_creates_file(self):
+        os.environ[ERROR_FILE_ENV_VAR] = str(self.error_file)
+        try:
+            raise ValueError("test error message")
+        except ValueError as e:
+            result = write_error(e)
+        self.assertTrue(result)
+        self.assertTrue(self.error_file.exists())
+
+    def test_write_error_contains_expected_fields(self):
+        os.environ[ERROR_FILE_ENV_VAR] = str(self.error_file)
+        try:
+            raise FileNotFoundError("/path/to/file.txt")
+        except FileNotFoundError as e:
+            write_error(e)
+
+        with open(self.error_file) as f:
+            data = json.load(f)
+
+        self.assertEqual(data["type"], "training.error")
+        self.assertEqual(data["exception_type"], "FileNotFoundError")
+        self.assertEqual(data["message"], "/path/to/file.txt")
+        self.assertIn("timestamp", data)
+        self.assertIn("traceback", data)
+        self.assertIn("FileNotFoundError", data["traceback"])
+
+    def test_write_error_with_custom_traceback(self):
+        os.environ[ERROR_FILE_ENV_VAR] = str(self.error_file)
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError as e:
+            write_error(e, traceback_str="custom traceback text")
+
+        with open(self.error_file) as f:
+            data = json.load(f)
+
+        self.assertEqual(data["traceback"], "custom traceback text")
+
+    def test_write_error_with_context(self):
+        os.environ[ERROR_FILE_ENV_VAR] = str(self.error_file)
+        try:
+            raise RuntimeError("training failed")
+        except RuntimeError as e:
+            write_error(e, context={"step": 1000, "epoch": 5})
+
+        with open(self.error_file) as f:
+            data = json.load(f)
+
+        self.assertEqual(data["context"]["step"], 1000)
+        self.assertEqual(data["context"]["epoch"], 5)
+
+    def test_read_error_returns_none_for_missing_file(self):
+        result = read_error(self.error_file)
+        self.assertIsNone(result)
+
+    def test_read_error_returns_none_for_invalid_json(self):
+        self.error_file.write_text("not valid json")
+        result = read_error(self.error_file)
+        self.assertIsNone(result)
+
+    def test_read_error_returns_none_for_wrong_type(self):
+        self.error_file.write_text('{"type": "other.event"}')
+        result = read_error(self.error_file)
+        self.assertIsNone(result)
+
+    def test_read_error_returns_data_for_valid_error(self):
+        os.environ[ERROR_FILE_ENV_VAR] = str(self.error_file)
+        try:
+            raise KeyError("missing_key")
+        except KeyError as e:
+            write_error(e)
+
+        data = read_error(self.error_file)
+        self.assertIsNotNone(data)
+        self.assertEqual(data["type"], "training.error")
+        self.assertEqual(data["exception_type"], "KeyError")
+
+    def test_cleanup_error_file_removes_file(self):
+        self.error_file.write_text("{}")
+        self.assertTrue(self.error_file.exists())
+        cleanup_error_file(self.error_file)
+        self.assertFalse(self.error_file.exists())
+
+    def test_cleanup_error_file_handles_missing_file(self):
+        cleanup_error_file(self.error_file)  # Should not raise
+
+    def test_cleanup_error_file_uses_env_var_when_no_path(self):
+        os.environ[ERROR_FILE_ENV_VAR] = str(self.error_file)
+        self.error_file.write_text("{}")
+        cleanup_error_file()  # No path argument
+        self.assertFalse(self.error_file.exists())
+
+    def test_write_error_creates_parent_directories(self):
+        nested_path = Path(self.temp_dir) / "nested" / "dir" / "error.json"
+        os.environ[ERROR_FILE_ENV_VAR] = str(nested_path)
+        try:
+            raise ValueError("nested test")
+        except ValueError as e:
+            result = write_error(e)
+        self.assertTrue(result)
+        self.assertTrue(nested_path.exists())
+        # Cleanup
+        nested_path.unlink()
+        nested_path.parent.rmdir()
+        nested_path.parent.parent.rmdir()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces structured error reporting for training subprocesses, allowing errors to be communicated from subprocesses to the parent process via a JSON file rather than parsing stdout/stderr. This improves reliability and clarity of error handling, especially for subprocess failures during training. The implementation includes a new helper module for error reporting, integration with the training process, and comprehensive unit tests.

**Structured error reporting infrastructure:**

* Added a new module `error_reporter.py` that provides functions to write, read, and clean up structured error files for subprocess-to-parent error communication. The error information includes exception type, message, traceback, and optional context.
* Added unit tests in `test_error_reporter.py` to verify all aspects of the error reporting helper, including file creation, reading, cleanup, and handling of edge cases.

**Integration with training process:**

* Modified `trainer.py` to set up the error file path in the environment when launching training subprocesses, so that subprocesses can write error information if they fail.
* Updated the subprocess error handling logic to first attempt to read structured error information from the error file. If available, this structured error is used to summarize the failure; otherwise, the fallback is to parse recent stdout/stderr output. The error file is cleaned up after use.
* Integrated `write_error_file` into the main training script (`train.py`) to ensure that uncaught exceptions in the subprocess are written to the error file for the parent process to consume. [[1]](diffhunk://#diff-612c91ac3c60bd876f96ae085dc6ac960812213123606fc423a3d29226d90327R9) [[2]](diffhunk://#diff-612c91ac3c60bd876f96ae085dc6ac960812213123606fc423a3d29226d90327R240-R242)