### PR TITLE
(#2484) fix use of spread operator on ES6 object with getters

### DIFF
--- a/simpletuner/static/js/dataset-wizard.js
+++ b/simpletuner/static/js/dataset-wizard.js
@@ -51,6 +51,20 @@
     window.datasetWizardComponent = function() {
         console.log('[WIZARD] datasetWizardComponent function called (Alpine initializing component)');
         return {
+            // Hint management (must be spread inside component to preserve getters)
+            ...window.HintMixin.createMultiHint({
+                useApi: false,
+                storageKey: 'st_datasets_hints',
+                hintKeys: ['hero']
+            }),
+            showHeroCTA() { return this.hints.hero; },
+            dismissHeroCTA() { this.dismissHint('hero'); },
+            restoreHeroCTA() { this.showHint('hero'); },
+            launchWizardFromHero() {
+                this.dismissHeroCTA();
+                this.$nextTick(() => this.openWizard());
+            },
+
             // Modal state
             wizardOpen: false,
             wizardStep: 1,

--- a/simpletuner/templates/datasets_tab.html
+++ b/simpletuner/templates/datasets_tab.html
@@ -93,21 +93,7 @@
 </style>
 
 <div class="tab-fragment" id="datasets-tab-content" data-tab-name="datasets"
-     x-data="{
-         ...datasetWizardComponent(),
-         ...window.HintMixin.createMultiHint({
-             useApi: false,
-             storageKey: 'st_datasets_hints',
-             hintKeys: ['hero']
-         }),
-         showHeroCTA() { return this.hints.hero; },
-         dismissHeroCTA() { this.dismissHint('hero'); },
-         restoreHeroCTA() { this.showHint('hero'); },
-         launchWizardFromHero() {
-             this.dismissHeroCTA();
-             this.$nextTick(() => this.openWizard());
-         }
-     }"
+     x-data="datasetWizardComponent()"
      x-init="loadHints(); init()">
 
     <!-- Hero CTA - Introduction to datasets -->

--- a/tests/js/auth_waiting.test.js
+++ b/tests/js/auth_waiting.test.js
@@ -200,6 +200,27 @@ describe('Auth Waiting Behavior', () => {
             global.Alpine._components = {};
             // Reset waitForAuthReady mock
             window.waitForAuthReady = jest.fn();
+            // Mock HintMixin (required by datasetWizardComponent)
+            window.HintMixin = {
+                createMultiHint: jest.fn(({ hintKeys }) => {
+                    const hints = {};
+                    hintKeys.forEach((key) => {
+                        hints[key] = true;
+                    });
+                    return {
+                        hints,
+                        hintsLoading: false,
+                        loadHints: jest.fn(),
+                        dismissHint: jest.fn(),
+                        showHint: jest.fn(),
+                        restoreAllHints: jest.fn(),
+                        anyHintsDismissed: function () {
+                            return hintKeys.some((k) => !this.hints[k]);
+                        },
+                        _saveHintsToStorage: jest.fn(),
+                    };
+                }),
+            };
         });
 
         test('skips API calls when auth not ready', async () => {
@@ -259,6 +280,28 @@ describe('Auth Waiting Behavior', () => {
                         ok: true,
                         json: () => Promise.resolve({ datasets: [], blueprints: [] }),
                     });
+                }),
+            };
+
+            // Re-mock HintMixin after resetModules
+            window.HintMixin = {
+                createMultiHint: jest.fn(({ hintKeys }) => {
+                    const hints = {};
+                    hintKeys.forEach((key) => {
+                        hints[key] = true;
+                    });
+                    return {
+                        hints,
+                        hintsLoading: false,
+                        loadHints: jest.fn(),
+                        dismissHint: jest.fn(),
+                        showHint: jest.fn(),
+                        restoreAllHints: jest.fn(),
+                        anyHintsDismissed: function () {
+                            return hintKeys.some((k) => !this.hints[k]);
+                        },
+                        _saveHintsToStorage: jest.fn(),
+                    };
                 }),
             };
 


### PR DESCRIPTION
Closes #2484 

This pull request refactors how the `HintMixin` is integrated into the `datasetWizardComponent`, streamlining the initialization and improving maintainability. It also adds comprehensive tests for the wizard's getter reactivity and HintMixin integration, ensuring the wizard's logic and hint management behave as expected.

### Refactoring and Integration

* Moved the HintMixin initialization into the `datasetWizardComponent` itself, removing duplicate logic from the Alpine `x-data` attribute in `datasets_tab.html`. This centralizes hint management and avoids redundancy. [[1]](diffhunk://#diff-0686ced55e44778d6e58196ffd127349b6a648cd15a7da1748a0a055f275bbadR54-R67) [[2]](diffhunk://#diff-3e24b366ce029a395b533299f766d134dc412c4ab01cbc8d5431d4d83cc31827L96-R96)

### Testing Improvements

* Added a robust mock for `HintMixin` in both `auth_waiting.test.js` and `dataset_wizard.test.js` to support tests that depend on hint functionality. Ensures tests run reliably regardless of hint state. [[1]](diffhunk://#diff-eb840c048f284ab18942138df69ee2605dff4021bee3d9ac99b887bf8a976a42R203-R223) [[2]](diffhunk://#diff-eb840c048f284ab18942138df69ee2605dff4021bee3d9ac99b887bf8a976a42R286-R307) [[3]](diffhunk://#diff-2ba279620a05559840ed6bdb73783cf7ed84f08993e9d6a83966b298ce99da4cR46-R72)
* Introduced a new test suite for `datasetWizardComponent` getters (`canProceed`, `stepDefinitions`, `currentStepDef`, `totalSteps`) to verify their reactivity and correct behavior in different wizard states.
* Added tests for HintMixin integration, confirming that the wizard component exposes the correct hint properties and hero CTA helper methods.