### PR TITLE
environment creation wizard size constraints for smaller (1920x1080) viewports under 4k

### DIFF
--- a/simpletuner/templates/environments_tab.html
+++ b/simpletuner/templates/environments_tab.html
@@ -3834,7 +3834,11 @@ window.environmentsTabComponent = function environmentsTabComponent() {
     background: #1c1f2e;
     border-radius: 0.75rem;
     width: 100%;
-    max-width: 520px;
+    max-width: 32.5rem;
+    max-height: calc(100vh - 3rem);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
     box-shadow: 0 20px 50px rgba(0, 0, 0, 0.6);
     border: 1px solid rgba(255, 255, 255, 0.08);
     pointer-events: auto;
@@ -3846,6 +3850,7 @@ window.environmentsTabComponent = function environmentsTabComponent() {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    flex-shrink: 0;
 }
 
 .environment-modal-backdrop .modal-title {
@@ -3856,8 +3861,27 @@ window.environmentsTabComponent = function environmentsTabComponent() {
     align-items: center;
 }
 
+.environment-modal-backdrop .modal-dialog > div:not(.modal-header):not(.modal-footer) {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.environment-modal-backdrop .modal-dialog form {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+}
+
 .environment-modal-backdrop .modal-body {
     padding: 1.25rem;
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
 }
 
 .environment-modal-backdrop .modal-footer {
@@ -3866,6 +3890,7 @@ window.environmentsTabComponent = function environmentsTabComponent() {
     display: flex;
     justify-content: flex-end;
     gap: 0.75rem;
+    flex-shrink: 0;
 }
 
 .environment-modal-backdrop .btn-close {


### PR DESCRIPTION
Closes #2485 

This pull request updates the modal dialog styles in `environments_tab.html` to improve layout flexibility, responsiveness, and scrolling behavior. The changes ensure that modal content is better contained and adapts to different viewport sizes.

**Modal layout and responsiveness improvements:**

* Changed the modal dialog's maximum width from `520px` to `32.5rem`, added a maximum height, and set up a flex column layout with overflow handling for better responsiveness and containment.
* Ensured that the modal header and footer do not shrink and always remain visible by adding `flex-shrink: 0;` to both sections. [[1]](diffhunk://#diff-26e44464205afd23e49aa1265016ff31fd2a67915f7ced57c8caf0e020a28488R3853) [[2]](diffhunk://#diff-26e44464205afd23e49aa1265016ff31fd2a67915f7ced57c8caf0e020a28488R3893)

**Content containment and scrolling:**

* Added flex column layouts and overflow handling to modal dialog children and forms, ensuring that the main content area expands and scrolls as needed without affecting the header or footer.
* Updated the modal body to fill available space and allow vertical scrolling when content overflows, improving usability on smaller screens.