### PR TITLE
use TEXT_JSON field type for TREAD

### DIFF
--- a/simpletuner/simpletuner_sdk/server/services/configs_service.py
+++ b/simpletuner/simpletuner_sdk/server/services/configs_service.py
@@ -1547,13 +1547,6 @@ class ConfigsService:
                     except json.JSONDecodeError:
                         # Keep original string if parsing fails; validation will surface errors later
                         pass
-            if config_key in {"--tread_config", "tread_config"} and isinstance(converted_value, str):
-                trimmed = converted_value.strip()
-                if trimmed.startswith("{") or trimmed.startswith("["):
-                    try:
-                        converted_value = json.loads(trimmed)
-                    except json.JSONDecodeError:
-                        pass
 
             config_dict[config_key] = converted_value
 

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/model.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/model.py
@@ -683,12 +683,12 @@ def register_model_fields(registry: "FieldRegistry") -> None:
             name="tread_config",
             arg_name="--tread_config",
             ui_label="TREAD Configuration",
-            field_type=FieldType.TEXT,
+            field_type=FieldType.TEXT_JSON,
             tab="model",
             section="architecture",
             subsection="advanced",
             default_value=None,
-            placeholder="path/to/tread_config.json",
+            placeholder='{"enable": true, "rank": 64}',
             dependencies=[
                 FieldDependency(
                     field="model_family",

--- a/tests/test_text_json_field.py
+++ b/tests/test_text_json_field.py
@@ -103,8 +103,8 @@ class TestTextJsonConversion(unittest.TestCase):
         self.assertEqual(result, ["line1", "{env:MY_VAR}", "line3"])
 
 
-class TestModelspecCommentFieldRegistration(unittest.TestCase):
-    """Test that modelspec_comment field is registered with TEXT_JSON type."""
+class TestTextJsonFieldRegistration(unittest.TestCase):
+    """Test that TEXT_JSON fields are registered correctly."""
 
     def test_modelspec_comment_is_text_json(self):
         """modelspec_comment should be registered as TEXT_JSON field type."""
@@ -114,6 +114,14 @@ class TestModelspecCommentFieldRegistration(unittest.TestCase):
         self.assertEqual(field.field_type, FieldType.TEXT_JSON)
         self.assertEqual(field.arg_name, "--modelspec_comment")
         self.assertTrue(field.allow_empty)
+
+    def test_tread_config_is_text_json(self):
+        """tread_config should be registered as TEXT_JSON field type."""
+        registry = FieldRegistry()
+        field = registry.get_field("tread_config")
+        self.assertIsNotNone(field, "tread_config field should be registered")
+        self.assertEqual(field.field_type, FieldType.TEXT_JSON)
+        self.assertEqual(field.arg_name, "--tread_config")
 
 
 class TestTextJsonRoundTrip(unittest.TestCase):


### PR DESCRIPTION
This pull request updates the handling and registration of the `tread_config` field to treat it as a JSON-typed field rather than plain text. This ensures better validation, user experience, and consistency for fields intended to hold JSON data. The changes also add and update tests to verify the new behavior.

Field registration and validation improvements:

* Changed the `tread_config` field's type from `FieldType.TEXT` to `FieldType.TEXT_JSON` in `model.py`, updated its placeholder to show an example JSON object, and ensured it is registered as a JSON field.
* Removed redundant JSON parsing logic for `tread_config` in `configs_service.py`, as the field is now explicitly typed as JSON and handled accordingly.

Testing updates:

* Added a new test to verify that the `tread_config` field is registered as `TEXT_JSON` in the field registry, and updated the test class name and docstring for clarity. [[1]](diffhunk://#diff-9b8b7f9e296bb5972200d330010b4b42b03d5c48c32c8d4ebe49d32868a5c274L106-R107) [[2]](diffhunk://#diff-9b8b7f9e296bb5972200d330010b4b42b03d5c48c32c8d4ebe49d32868a5c274R118-R125)