### PR TITLE
(#2480) adjust num_frames automatically by limit instead of throwing error

### DIFF
--- a/tests/test_ltxvideo2_frame_validation.py
+++ b/tests/test_ltxvideo2_frame_validation.py
@@ -1,10 +1,12 @@
 import unittest
+from unittest.mock import patch
 
 from simpletuner.helpers.data_backend.factory import init_backend_config
 
 
 class TestLTXVideo2FrameValidation(unittest.TestCase):
-    def test_ltxvideo2_requires_num_frames_mod_8_eq_1(self):
+    def test_ltxvideo2_auto_adjusts_invalid_frame_count(self):
+        """Invalid frame counts should be auto-adjusted with a warning, not raise an error."""
         backend = {
             "id": "ltx2-video",
             "dataset_type": "video",
@@ -19,10 +21,55 @@ class TestLTXVideo2FrameValidation(unittest.TestCase):
             "framerate": 25,
         }
 
-        with self.assertRaises(ValueError) as ctx:
-            init_backend_config(backend, args, accelerator=None)
+        with patch("simpletuner.helpers.data_backend.factory.warning_log") as mock_warning:
+            result = init_backend_config(backend, args, accelerator=None)
 
-        self.assertIn("frame_count % 8 == 1", str(ctx.exception))
+            # Should auto-adjust 48 -> 41 (nearest valid: (48-1)//8*8+1 = 41)
+            self.assertEqual(result["config"]["video"]["min_frames"], 41)
+            self.assertEqual(result["config"]["video"]["num_frames"], 41)
+
+            # Should emit warnings for both adjustments
+            self.assertGreaterEqual(mock_warning.call_count, 2)
+            warning_messages = [str(call) for call in mock_warning.call_args_list]
+            self.assertTrue(
+                any("min_frames" in msg and "48" in msg and "41" in msg for msg in warning_messages),
+                f"Expected warning about min_frames adjustment, got: {warning_messages}",
+            )
+            self.assertTrue(
+                any("num_frames" in msg and "48" in msg and "41" in msg for msg in warning_messages),
+                f"Expected warning about num_frames adjustment, got: {warning_messages}",
+            )
+
+    def test_ltxvideo2_valid_frame_count_unchanged(self):
+        """Valid frame counts should pass through unchanged."""
+        backend = {
+            "id": "ltx2-video",
+            "dataset_type": "video",
+            "video": {
+                "num_frames": 49,
+                "min_frames": 49,
+            },
+        }
+        args = {
+            "model_family": "ltxvideo2",
+            "model_flavour": "dev",
+            "framerate": 25,
+        }
+
+        with patch("simpletuner.helpers.data_backend.factory.warning_log") as mock_warning:
+            result = init_backend_config(backend, args, accelerator=None)
+
+            # Should remain unchanged
+            self.assertEqual(result["config"]["video"]["min_frames"], 49)
+            self.assertEqual(result["config"]["video"]["num_frames"], 49)
+
+            # Check that no frame adjustment warnings were emitted
+            # (other warnings may still be emitted for is_i2v etc.)
+            warning_messages = [str(call) for call in mock_warning.call_args_list]
+            frame_adjustment_warnings = [
+                msg for msg in warning_messages if "Adjusted video->min_frames" in msg or "Adjusted video->num_frames" in msg
+            ]
+            self.assertEqual(len(frame_adjustment_warnings), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #2480 

This pull request updates the frame count validation and adjustment logic for video backends, especially for the `ltxvideo2` model family. Instead of raising errors for invalid frame counts, the code now automatically adjusts them to the nearest valid value according to model-specific constraints and emits warnings when such adjustments occur. The test suite is updated to reflect and verify this new behavior.

**Frame count validation and adjustment improvements:**

* Refactored `_maybe_convert_pixel_edge` in `factory.py` to use model-specific `adjust_video_frames` methods (if available) for automatically adjusting `min_frames` and `num_frames` to valid values, replacing the previous hard error for `ltxvideo2` frame count constraints. Warnings are now logged when adjustments are made.

**Testing updates:**

* Updated `TestLTXVideo2FrameValidation` tests to expect auto-adjustment and warning logs instead of errors for invalid frame counts, and added a new test to check that valid frame counts are left unchanged and do not emit adjustment warnings. [[1]](diffhunk://#diff-f1a11a918586437713bd64525d61ebf2740e5e38b6b24d047fcc06859e797bd0R2-R9) [[2]](diffhunk://#diff-f1a11a918586437713bd64525d61ebf2740e5e38b6b24d047fcc06859e797bd0L22-R72)