### PR TITLE
(#2274) add end_step / end_epoch scheduling for datasets

### DIFF
--- a/documentation/DATALOADER.es.md
+++ b/documentation/DATALOADER.es.md
@@ -577,6 +577,38 @@ Esto seleccionará de forma determinista 1000 muestras del dataset, con la misma
 - Los datasets que nunca cumplen su condición de inicio (por ejemplo, `start_epoch` más allá de `--num_train_epochs`) se omitirán y se anotarán en la model card.
 - Las estimaciones de pasos en la barra de progreso son aproximadas cuando los datasets programados se activan a mitad de ejecución porque la longitud de la época puede aumentar cuando nuevos datos entran en línea.
 
+### `end_epoch` / `end_step`
+
+- Programa cuándo un dataset **deja** de muestrear (complementando `start_epoch`/`start_step`).
+- `end_epoch` (default: `null` = sin límite) detiene el muestreo después de esta época; `end_step` (default: `null` = sin límite) detiene el muestreo después de este paso de optimizador.
+- Cualquiera de las condiciones que termine detendrá el dataset; funcionan de forma independiente.
+- Útil para flujos de trabajo de **aprendizaje curricular** donde deseas:
+  - Entrenar con datos de baja resolución primero, luego cambiar a datos de mayor resolución.
+  - Eliminar gradualmente los datos de regularización después de cierto punto.
+  - Crear entrenamiento multi-etapa dentro de un solo archivo de configuración.
+
+**Ejemplo: Aprendizaje Curricular**
+```json
+[
+  {
+    "id": "lowres-512",
+    "type": "local",
+    "dataset_type": "image",
+    "instance_data_dir": "/data/512",
+    "end_step": 300
+  },
+  {
+    "id": "highres-1024",
+    "type": "local",
+    "dataset_type": "image",
+    "instance_data_dir": "/data/1024",
+    "start_step": 300
+  }
+]
+```
+
+En este ejemplo, el dataset de 512px se usa para los pasos 1-300, luego el dataset de 1024px toma el control desde el paso 300 en adelante.
+
 ### `is_regularisation_data`
 
 - También puede escribirse `is_regularization_data`

--- a/documentation/DATALOADER.hi.md
+++ b/documentation/DATALOADER.hi.md
@@ -577,6 +577,38 @@ effective_batch_size = train_batch_size × num_gpus × gradient_accumulation_ste
 - जिन datasets की start condition कभी पूरी नहीं होती (उदा., `start_epoch` `--num_train_epochs` से आगे), उन्हें skip किया जाएगा और model card में नोट किया जाएगा।
 - जब scheduled datasets mid‑run में active होते हैं, तो progress‑bar step estimates approximate हो जाते हैं क्योंकि epoch length बढ़ सकती है।
 
+### `end_epoch` / `end_step`
+
+- यह schedule करता है कि dataset sampling कब **बंद** होगी (`start_epoch`/`start_step` का पूरक)।
+- `end_epoch` (डिफ़ॉल्ट: `null` = कोई सीमा नहीं) इस epoch के बाद sampling बंद कर देता है; `end_step` (डिफ़ॉल्ट: `null` = कोई सीमा नहीं) इस optimizer step के बाद sampling बंद कर देता है।
+- कोई भी condition समाप्त होने पर dataset बंद हो जाएगा; वे स्वतंत्र रूप से काम करते हैं।
+- **Curriculum learning** workflows के लिए उपयोगी जहाँ आप चाहते हैं:
+  - पहले low-resolution data पर train करें, फिर high-resolution data पर switch करें।
+  - एक निश्चित बिंदु के बाद regularisation data को धीरे-धीरे हटाएं।
+  - एक single config file में multi-stage training बनाएं।
+
+**उदाहरण: Curriculum Learning**
+```json
+[
+  {
+    "id": "lowres-512",
+    "type": "local",
+    "dataset_type": "image",
+    "instance_data_dir": "/data/512",
+    "end_step": 300
+  },
+  {
+    "id": "highres-1024",
+    "type": "local",
+    "dataset_type": "image",
+    "instance_data_dir": "/data/1024",
+    "start_step": 300
+  }
+]
+```
+
+इस उदाहरण में, 512px dataset steps 1-300 के लिए उपयोग होता है, फिर 1024px dataset step 300 से आगे संभाल लेता है।
+
 ### `is_regularisation_data`
 
 - इसे `is_regularization_data` भी लिखा जा सकता है

--- a/documentation/DATALOADER.ja.md
+++ b/documentation/DATALOADER.ja.md
@@ -578,6 +578,38 @@ effective_batch_size = train_batch_size × num_gpus × gradient_accumulation_ste
 - 開始条件を満たさないデータセット（例: `start_epoch` が `--num_train_epochs` を超える）はスキップされ、モデルカードに記載されます。
 - 進行中にスケジュールされたデータセットが有効になるとエポック長が増えるため、進捗バーのステップ見積もりは概算になります。
 
+### `end_epoch` / `end_step`
+
+- データセットのサンプリング**終了**タイミングをスケジュールします（`start_epoch`/`start_step` を補完）。
+- `end_epoch`（既定: `null` = 制限なし）はこのエポック後にサンプリングを停止；`end_step`（既定: `null` = 制限なし）はこの最適化ステップ後にサンプリングを停止。
+- どちらかの条件が終了するとデータセットは停止します。両者は独立して動作します。
+- **カリキュラム学習**ワークフローに有用です：
+  - 早期に低解像度データで訓練し、その後高解像度データに切り替える。
+  - ある時点以降、正則化データを段階的に廃止する。
+  - 単一の設定ファイル内で多段階訓練を作成する。
+
+**例：カリキュラム学習**
+```json
+[
+  {
+    "id": "lowres-512",
+    "type": "local",
+    "dataset_type": "image",
+    "instance_data_dir": "/data/512",
+    "end_step": 300
+  },
+  {
+    "id": "highres-1024",
+    "type": "local",
+    "dataset_type": "image",
+    "instance_data_dir": "/data/1024",
+    "start_step": 300
+  }
+]
+```
+
+この例では、512px データセットはステップ 1-300 で使用され、その後ステップ 300 から 1024px データセットに引き継がれます。
+
 ### `is_regularisation_data`
 
 - `is_regularization_data` と綴ることもできます。

--- a/documentation/DATALOADER.md
+++ b/documentation/DATALOADER.md
@@ -611,6 +611,38 @@ This will deterministically select 1000 samples from the dataset, with the same 
 - Datasets that never meet their start condition (for example, `start_epoch` beyond `--num_train_epochs`) will be skipped and noted in the model card.
 - Progress-bar step estimates are approximate when scheduled datasets activate mid-run because epoch length can increase once new data comes online.
 
+### `end_epoch` / `end_step`
+
+- Schedule when a dataset **stops** sampling (complementing `start_epoch`/`start_step`).
+- `end_epoch` (default: `null` = no limit) stops sampling after this epoch; `end_step` (default: `null` = no limit) stops sampling after this optimizer step.
+- Either condition ending will stop the dataset; they work independently.
+- Useful for **curriculum learning** workflows where you want to:
+  - Train on lower-resolution data early, then switch to higher-resolution data.
+  - Phase out regularisation data after a certain point.
+  - Create multi-stage training within a single config file.
+
+**Example: Curriculum Learning**
+```json
+[
+  {
+    "id": "lowres-512",
+    "type": "local",
+    "dataset_type": "image",
+    "instance_data_dir": "/data/512",
+    "end_step": 300
+  },
+  {
+    "id": "highres-1024",
+    "type": "local",
+    "dataset_type": "image",
+    "instance_data_dir": "/data/1024",
+    "start_step": 300
+  }
+]
+```
+
+In this example, the 512px dataset is used for steps 1-300, then the 1024px dataset takes over from step 300 onward.
+
 ### `is_regularisation_data`
 
 - Also may be spelt `is_regularization_data`

--- a/documentation/DATALOADER.pt-BR.md
+++ b/documentation/DATALOADER.pt-BR.md
@@ -577,6 +577,38 @@ Isso selecionará deterministicamente 1000 amostras do dataset, com a mesma sele
 - Datasets que nunca atendem sua condição de início (por exemplo, `start_epoch` além de `--num_train_epochs`) serão ignorados e anotados no model card.
 - Estimativas de steps na barra de progresso são aproximadas quando datasets programados ativam no meio da execução, porque o tamanho da época pode aumentar quando novos dados entram.
 
+### `end_epoch` / `end_step`
+
+- Agenda quando um dataset **para** de amostrar (complementando `start_epoch`/`start_step`).
+- `end_epoch` (padrão: `null` = sem limite) para de amostrar após esta época; `end_step` (padrão: `null` = sem limite) para de amostrar após este step do otimizador.
+- Qualquer uma das condições que terminar irá parar o dataset; funcionam independentemente.
+- Útil para workflows de **aprendizado curricular** onde você deseja:
+  - Treinar com dados de baixa resolução primeiro, depois mudar para dados de maior resolução.
+  - Eliminar gradualmente dados de regularização após certo ponto.
+  - Criar treinamento multi-estágio em um único arquivo de configuração.
+
+**Exemplo: Aprendizado Curricular**
+```json
+[
+  {
+    "id": "lowres-512",
+    "type": "local",
+    "dataset_type": "image",
+    "instance_data_dir": "/data/512",
+    "end_step": 300
+  },
+  {
+    "id": "highres-1024",
+    "type": "local",
+    "dataset_type": "image",
+    "instance_data_dir": "/data/1024",
+    "start_step": 300
+  }
+]
+```
+
+Neste exemplo, o dataset de 512px é usado para steps 1-300, então o dataset de 1024px assume a partir do step 300 em diante.
+
 ### `is_regularisation_data`
 
 - Também pode ser escrito como `is_regularization_data`

--- a/documentation/DATALOADER.zh.md
+++ b/documentation/DATALOADER.zh.md
@@ -578,6 +578,38 @@ effective_batch_size = train_batch_size × num_gpus × gradient_accumulation_ste
 - 永远达不到开始条件的数据集（例如 `start_epoch` 超过 `--num_train_epochs`）会被跳过，并在模型卡中注明。
 - 当计划的数据集在训练中途激活时，epoch 长度可能增加，因此进度条步数估计为近似值。
 
+### `end_epoch` / `end_step`
+
+- 规划数据集**停止**采样的时间点（与 `start_epoch`/`start_step` 相辅相成）。
+- `end_epoch`（默认：`null` = 无限制）在此 epoch 后停止采样；`end_step`（默认：`null` = 无限制）在此优化器步数后停止采样。
+- 任一条件达成即停止数据集，两者独立工作。
+- 适用于**课程学习**工作流，例如：
+  - 早期使用低分辨率数据训练，然后切换到高分辨率数据。
+  - 在某个时间点后逐步淘汰正则化数据。
+  - 在单个配置文件中创建多阶段训练。
+
+**示例：课程学习**
+```json
+[
+  {
+    "id": "lowres-512",
+    "type": "local",
+    "dataset_type": "image",
+    "instance_data_dir": "/data/512",
+    "end_step": 300
+  },
+  {
+    "id": "highres-1024",
+    "type": "local",
+    "dataset_type": "image",
+    "instance_data_dir": "/data/1024",
+    "start_step": 300
+  }
+]
+```
+
+在此示例中，512px 数据集用于步骤 1-300，然后 1024px 数据集从步骤 300 开始接管。
+
 ### `is_regularisation_data`
 
 - 也可写作 `is_regularization_data`

--- a/simpletuner/helpers/data_backend/runtime/schedule.py
+++ b/simpletuner/helpers/data_backend/runtime/schedule.py
@@ -25,6 +25,30 @@ def normalize_start_step(value: Any) -> int:
     return max(parsed, 0)
 
 
+def normalize_end_epoch(value: Any) -> int | None:
+    """Parse end_epoch: returns int >= 1 or None for infinite."""
+    if value is None or value == "":
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    # 0 or negative means no end (infinite)
+    return parsed if parsed >= 1 else None
+
+
+def normalize_end_step(value: Any) -> int | None:
+    """Parse end_step: returns int >= 1 or None for infinite."""
+    if value is None or value == "":
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    # 0 or negative means no end (infinite)
+    return parsed if parsed >= 1 else None
+
+
 def _extract_backend_config(backend_id: str, backend: Any) -> Dict[str, Any]:
     if isinstance(backend, dict):
         return backend
@@ -35,7 +59,13 @@ def _extract_backend_config(backend_id: str, backend: Any) -> Dict[str, Any]:
 
 
 def _next_optimizer_step(step_hint: int | None = None) -> int:
-    """Return the next optimizer step number (1-based)."""
+    """Return the next optimizer step number (1-based).
+
+    If step_hint is provided, it's used as the current step value.
+    Otherwise, StateTracker.get_global_step() is used.
+    """
+    if step_hint is not None:
+        return step_hint + 1
     try:
         current_step = int(StateTracker.get_global_step() or 0)
     except Exception:
@@ -55,11 +85,18 @@ def dataset_is_active(
     Determine whether a dataset is eligible for sampling based on schedule.
 
     Returns (is_active, schedule_metadata).
-    schedule_metadata contains normalized start_epoch/start_step and activation state.
+    schedule_metadata contains normalized start/end epoch/step and activation state.
+
+    A dataset is active when:
+    - current_epoch >= start_epoch AND next_step >= start_step (has started)
+    - AND (end_epoch is None OR current_epoch <= end_epoch) (hasn't ended by epoch)
+    - AND (end_step is None OR next_step <= end_step) (hasn't ended by step)
     """
     backend_config = _extract_backend_config(backend_id, backend)
     start_epoch = normalize_start_epoch(backend_config.get("start_epoch", 1))
     start_step = normalize_start_step(backend_config.get("start_step", 0))
+    end_epoch = normalize_end_epoch(backend_config.get("end_epoch"))
+    end_step = normalize_end_step(backend_config.get("end_step"))
 
     try:
         current_epoch = int(epoch_hint if epoch_hint is not None else StateTracker.get_epoch() or 1)
@@ -67,11 +104,25 @@ def dataset_is_active(
         current_epoch = 1
 
     next_step = _next_optimizer_step(step_hint)
-    is_active = current_epoch >= start_epoch and next_step >= start_step
+
+    # Check start conditions
+    has_started = current_epoch >= start_epoch and next_step >= start_step
+
+    # Check end conditions (None means infinite, no end)
+    not_ended_by_epoch = end_epoch is None or current_epoch <= end_epoch
+    not_ended_by_step = end_step is None or next_step <= end_step
+
+    is_active = has_started and not_ended_by_epoch and not_ended_by_step
 
     schedule_state = StateTracker.get_dataset_schedule(backend_id)
     if not schedule_state:
-        StateTracker.set_dataset_schedule(backend_id, start_epoch=start_epoch, start_step=start_step)
+        StateTracker.set_dataset_schedule(
+            backend_id,
+            start_epoch=start_epoch,
+            start_step=start_step,
+            end_epoch=end_epoch,
+            end_step=end_step,
+        )
         schedule_state = StateTracker.get_dataset_schedule(backend_id)
 
     if is_active and update_state and not schedule_state.get("reached", False):

--- a/simpletuner/helpers/training/state_tracker.py
+++ b/simpletuner/helpers/training/state_tracker.py
@@ -371,7 +371,14 @@ class StateTracker:
         cls.exhausted_backends = []
 
     @classmethod
-    def set_dataset_schedule(cls, data_backend_id: str, start_epoch: int | None = None, start_step: int | None = None):
+    def set_dataset_schedule(
+        cls,
+        data_backend_id: str,
+        start_epoch: int | None = None,
+        start_step: int | None = None,
+        end_epoch: int | None = None,
+        end_step: int | None = None,
+    ):
         schedule = cls.dataset_schedule.get(data_backend_id, {})
         if start_epoch is not None:
             try:
@@ -383,6 +390,21 @@ class StateTracker:
                 schedule["start_step"] = int(start_step)
             except (TypeError, ValueError):
                 schedule["start_step"] = 0
+        # end_epoch and end_step: None means infinite (no end)
+        if end_epoch is not None:
+            try:
+                schedule["end_epoch"] = int(end_epoch)
+            except (TypeError, ValueError):
+                schedule["end_epoch"] = None
+        else:
+            schedule["end_epoch"] = None
+        if end_step is not None:
+            try:
+                schedule["end_step"] = int(end_step)
+            except (TypeError, ValueError):
+                schedule["end_step"] = None
+        else:
+            schedule["end_step"] = None
         schedule.setdefault("start_epoch", 1)
         schedule.setdefault("start_step", 0)
         schedule.setdefault("reached", False)

--- a/simpletuner/simpletuner_sdk/server/services/dataset_plan.py
+++ b/simpletuner/simpletuner_sdk/server/services/dataset_plan.py
@@ -382,6 +382,46 @@ def compute_validations(
                 )
             )
 
+        # Validate end_epoch/end_step scheduling
+        for dataset in training_datasets:
+            dataset_id = dataset.get("id", "unknown")
+            start_epoch = dataset.get("start_epoch")
+            start_step = dataset.get("start_step")
+            end_epoch = dataset.get("end_epoch")
+            end_step = dataset.get("end_step")
+
+            # Validate end_epoch >= start_epoch when both are set
+            if end_epoch is not None and start_epoch is not None:
+                try:
+                    end_e = int(end_epoch)
+                    start_e = int(start_epoch) if start_epoch else 1
+                    if end_e > 0 and end_e < start_e:
+                        validations.append(
+                            ValidationMessage(
+                                field=f"{_normalise_identifier(dataset)}.scheduling",
+                                message=f"end_epoch ({end_e}) must be >= start_epoch ({start_e})",
+                                level="error",
+                            )
+                        )
+                except (TypeError, ValueError):
+                    pass
+
+            # Validate end_step >= start_step when both are set
+            if end_step is not None and start_step is not None:
+                try:
+                    end_s = int(end_step)
+                    start_s = int(start_step) if start_step else 0
+                    if end_s > 0 and end_s < start_s:
+                        validations.append(
+                            ValidationMessage(
+                                field=f"{_normalise_identifier(dataset)}.scheduling",
+                                message=f"end_step ({end_s}) must be >= start_step ({start_s})",
+                                level="error",
+                            )
+                        )
+                except (TypeError, ValueError):
+                    pass
+
     if blueprints is None:
         blueprints = get_dataset_blueprints()
 

--- a/simpletuner/static/js/dataloader-section-component.js
+++ b/simpletuner/static/js/dataloader-section-component.js
@@ -469,6 +469,16 @@ function dataloaderSectionComponent() {
                 dataset._scheduleMode = 'none';
             }
         }
+        // Initialize end schedule mode based on end_epoch and end_step values
+        if (dataset._endScheduleMode === undefined) {
+            if (dataset.end_step !== undefined && dataset.end_step !== null && dataset.end_step > 0) {
+                dataset._endScheduleMode = 'step';
+            } else if (dataset.end_epoch !== undefined && dataset.end_epoch !== null && dataset.end_epoch > 0) {
+                dataset._endScheduleMode = 'epoch';
+            } else {
+                dataset._endScheduleMode = 'none';
+            }
+        }
         if (this._collapseStateLoaded) {
             this.applyCollapsedStateToDataset(dataset);
         }

--- a/simpletuner/templates/components/dataloader/sections/scheduling_body.html
+++ b/simpletuner/templates/components/dataloader/sections/scheduling_body.html
@@ -1,16 +1,17 @@
 <!-- Scheduling Settings Body -->
 <div class="modal-section-body">
     <!-- Dataset Activation Scheduling -->
-    <div class="section-group" x-show="matchesParamFilter('schedule', 'start', 'epoch', 'step', 'delay', 'activation')">
+    <div class="section-group" x-show="matchesParamFilter('schedule', 'start', 'end', 'epoch', 'step', 'delay', 'activation', 'curriculum')">
         <h6 class="modal-section-title">Dataset Activation</h6>
         <div class="form-text small text-muted mb-3">
-            Control when this dataset becomes active during training. By default, datasets are active from the start.
+            Control when this dataset becomes active during training. Optionally set an end point for curriculum learning workflows.
         </div>
 
+        <!-- Start Scheduling -->
         <div class="row g-2">
             <!-- Schedule Mode Selector -->
             <div class="col-md-4">
-                <label class="form-label small">Delay Mode <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#scheduling') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                <label class="form-label small">Start Mode <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#scheduling') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
                 <select class="form-select form-select-sm"
                         x-model="editingDataset._scheduleMode"
                         @change="
@@ -59,16 +60,87 @@
             </div>
         </div>
 
-        <!-- Status indicator - no row wrapper, flows naturally -->
+        <!-- End Scheduling -->
+        <div class="row g-2 mt-2">
+            <!-- End Mode Selector -->
+            <div class="col-md-4">
+                <label class="form-label small">End Mode <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#end_epoch--end_step') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                <select class="form-select form-select-sm"
+                        x-model="editingDataset._endScheduleMode"
+                        @change="
+                            if (editingDataset._endScheduleMode === 'none') {
+                                editingDataset.end_epoch = undefined;
+                                editingDataset.end_step = undefined;
+                            } else if (editingDataset._endScheduleMode === 'epoch') {
+                                editingDataset.end_step = undefined;
+                                if (!editingDataset.end_epoch || editingDataset.end_epoch < 1) editingDataset.end_epoch = (editingDataset.start_epoch || 1) + 1;
+                            } else if (editingDataset._endScheduleMode === 'step') {
+                                editingDataset.end_epoch = undefined;
+                                if (!editingDataset.end_step || editingDataset.end_step < 1) editingDataset.end_step = (editingDataset.start_step || 0) + 100;
+                            }
+                            markAsUnsaved()
+                        ">
+                    <option value="none">Never (runs indefinitely)</option>
+                    <option value="epoch">By Epoch</option>
+                    <option value="step">By Step</option>
+                </select>
+            </div>
+
+            <!-- End Epoch -->
+            <div class="col-md-4" x-show="editingDataset._endScheduleMode === 'epoch'" x-cloak>
+                <label class="form-label small">End Epoch <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#end_epoch--end_step') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                <input type="number"
+                       class="form-control form-control-sm"
+                       min="1"
+                       step="1"
+                       x-model.number.lazy="editingDataset.end_epoch"
+                       @input="markAsUnsaved()"
+                       placeholder="5">
+                <div class="form-text small">Stops after this epoch</div>
+            </div>
+
+            <!-- End Step -->
+            <div class="col-md-4" x-show="editingDataset._endScheduleMode === 'step'" x-cloak>
+                <label class="form-label small">End Step <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#end_epoch--end_step') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                <input type="number"
+                       class="form-control form-control-sm"
+                       min="1"
+                       step="1"
+                       x-model.number.lazy="editingDataset.end_step"
+                       @input="markAsUnsaved()"
+                       placeholder="300">
+                <div class="form-text small">Stops after this step</div>
+            </div>
+        </div>
+
+        <!-- Status indicator -->
         <div class="alert alert-info small py-2 px-3 mb-0 mt-2">
-            <span x-show="editingDataset._scheduleMode === 'none' || !editingDataset._scheduleMode">
-                <i class="fas fa-check-circle me-1"></i> This dataset is available from the start of training
+            <span x-show="(editingDataset._scheduleMode === 'none' || !editingDataset._scheduleMode) && (editingDataset._endScheduleMode === 'none' || !editingDataset._endScheduleMode)">
+                <i class="fas fa-check-circle me-1"></i> This dataset is available throughout training
             </span>
-            <span x-show="editingDataset._scheduleMode === 'epoch'" x-cloak>
-                <i class="fas fa-clock me-1"></i> This dataset will be skipped until epoch <strong x-text="editingDataset.start_epoch || 2"></strong>
+            <span x-show="editingDataset._scheduleMode === 'epoch' && (editingDataset._endScheduleMode === 'none' || !editingDataset._endScheduleMode)" x-cloak>
+                <i class="fas fa-clock me-1"></i> Skipped until epoch <strong x-text="editingDataset.start_epoch || 2"></strong>, then active indefinitely
             </span>
-            <span x-show="editingDataset._scheduleMode === 'step'" x-cloak>
-                <i class="fas fa-clock me-1"></i> This dataset will be skipped until step <strong x-text="editingDataset.start_step || 1"></strong>
+            <span x-show="editingDataset._scheduleMode === 'step' && (editingDataset._endScheduleMode === 'none' || !editingDataset._endScheduleMode)" x-cloak>
+                <i class="fas fa-clock me-1"></i> Skipped until step <strong x-text="editingDataset.start_step || 1"></strong>, then active indefinitely
+            </span>
+            <span x-show="(editingDataset._scheduleMode === 'none' || !editingDataset._scheduleMode) && editingDataset._endScheduleMode === 'epoch'" x-cloak>
+                <i class="fas fa-hourglass-end me-1"></i> Active from start, stops after epoch <strong x-text="editingDataset.end_epoch || 1"></strong>
+            </span>
+            <span x-show="(editingDataset._scheduleMode === 'none' || !editingDataset._scheduleMode) && editingDataset._endScheduleMode === 'step'" x-cloak>
+                <i class="fas fa-hourglass-end me-1"></i> Active from start, stops after step <strong x-text="editingDataset.end_step || 1"></strong>
+            </span>
+            <span x-show="editingDataset._scheduleMode === 'epoch' && editingDataset._endScheduleMode === 'epoch'" x-cloak>
+                <i class="fas fa-arrows-alt-h me-1"></i> Active from epoch <strong x-text="editingDataset.start_epoch || 2"></strong> to <strong x-text="editingDataset.end_epoch || 1"></strong>
+            </span>
+            <span x-show="editingDataset._scheduleMode === 'step' && editingDataset._endScheduleMode === 'step'" x-cloak>
+                <i class="fas fa-arrows-alt-h me-1"></i> Active from step <strong x-text="editingDataset.start_step || 1"></strong> to <strong x-text="editingDataset.end_step || 1"></strong>
+            </span>
+            <span x-show="editingDataset._scheduleMode === 'epoch' && editingDataset._endScheduleMode === 'step'" x-cloak>
+                <i class="fas fa-arrows-alt-h me-1"></i> Starts at epoch <strong x-text="editingDataset.start_epoch || 2"></strong>, stops at step <strong x-text="editingDataset.end_step || 1"></strong>
+            </span>
+            <span x-show="editingDataset._scheduleMode === 'step' && editingDataset._endScheduleMode === 'epoch'" x-cloak>
+                <i class="fas fa-arrows-alt-h me-1"></i> Starts at step <strong x-text="editingDataset.start_step || 1"></strong>, stops at epoch <strong x-text="editingDataset.end_epoch || 1"></strong>
             </span>
         </div>
     </div>

--- a/tests/test_dataset_schedule.py
+++ b/tests/test_dataset_schedule.py
@@ -1,0 +1,401 @@
+"""
+Tests for dataset scheduling functions in schedule.py.
+
+Covers:
+- normalize_start_epoch / normalize_start_step
+- normalize_end_epoch / normalize_end_step
+- dataset_is_active with start and end conditions
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Import at module level for simpler test code
+try:
+    from simpletuner.helpers.data_backend.runtime.schedule import (
+        dataset_is_active,
+        normalize_end_epoch,
+        normalize_end_step,
+        normalize_start_epoch,
+        normalize_start_step,
+    )
+    from simpletuner.helpers.training.state_tracker import StateTracker
+
+    IMPORT_ERROR = None
+except ImportError as e:
+    IMPORT_ERROR = e
+    normalize_start_epoch = None
+    normalize_start_step = None
+    normalize_end_epoch = None
+    normalize_end_step = None
+    dataset_is_active = None
+    StateTracker = None
+
+
+class TestNormalizeStartEpoch(unittest.TestCase):
+    """Tests for normalize_start_epoch function."""
+
+    @classmethod
+    def setUpClass(cls):
+        if IMPORT_ERROR is not None:
+            raise unittest.SkipTest(f"Import failed: {IMPORT_ERROR}")
+
+    def test_valid_int(self):
+        """Valid integer >= 1 should be returned as-is."""
+        self.assertEqual(normalize_start_epoch(5), 5)
+
+    def test_valid_string_int(self):
+        """Valid string integer should be converted."""
+        self.assertEqual(normalize_start_epoch("3"), 3)
+
+    def test_clamps_to_1_for_zero(self):
+        """Zero should be clamped to 1."""
+        self.assertEqual(normalize_start_epoch(0), 1)
+
+    def test_clamps_to_1_for_negative(self):
+        """Negative values should be clamped to 1."""
+        self.assertEqual(normalize_start_epoch(-5), 1)
+
+    def test_returns_1_for_none(self):
+        """None should return default of 1."""
+        self.assertEqual(normalize_start_epoch(None), 1)
+
+    def test_returns_1_for_invalid_string(self):
+        """Invalid string should return default of 1."""
+        self.assertEqual(normalize_start_epoch("invalid"), 1)
+
+    def test_float_is_truncated(self):
+        """Float values should be truncated to int."""
+        self.assertEqual(normalize_start_epoch(3.7), 3)
+
+
+class TestNormalizeStartStep(unittest.TestCase):
+    """Tests for normalize_start_step function."""
+
+    @classmethod
+    def setUpClass(cls):
+        if IMPORT_ERROR is not None:
+            raise unittest.SkipTest(f"Import failed: {IMPORT_ERROR}")
+
+    def test_valid_int(self):
+        """Valid integer >= 0 should be returned as-is."""
+        self.assertEqual(normalize_start_step(100), 100)
+
+    def test_valid_zero(self):
+        """Zero is valid and should be returned as-is."""
+        self.assertEqual(normalize_start_step(0), 0)
+
+    def test_clamps_negative_to_zero(self):
+        """Negative values should be clamped to 0."""
+        self.assertEqual(normalize_start_step(-10), 0)
+
+    def test_returns_0_for_none(self):
+        """None should return default of 0."""
+        self.assertEqual(normalize_start_step(None), 0)
+
+    def test_returns_0_for_invalid_string(self):
+        """Invalid string should return default of 0."""
+        self.assertEqual(normalize_start_step("invalid"), 0)
+
+
+class TestNormalizeEndEpoch(unittest.TestCase):
+    """Tests for normalize_end_epoch function."""
+
+    @classmethod
+    def setUpClass(cls):
+        if IMPORT_ERROR is not None:
+            raise unittest.SkipTest(f"Import failed: {IMPORT_ERROR}")
+
+    def test_valid_int(self):
+        """Valid integer >= 1 should be returned as-is."""
+        self.assertEqual(normalize_end_epoch(5), 5)
+
+    def test_valid_string_int(self):
+        """Valid string integer should be converted."""
+        self.assertEqual(normalize_end_epoch("10"), 10)
+
+    def test_none_returns_none(self):
+        """None should return None (no end limit)."""
+        self.assertIsNone(normalize_end_epoch(None))
+
+    def test_empty_string_returns_none(self):
+        """Empty string should return None."""
+        self.assertIsNone(normalize_end_epoch(""))
+
+    def test_zero_returns_none(self):
+        """Zero should return None (no end limit)."""
+        self.assertIsNone(normalize_end_epoch(0))
+
+    def test_negative_returns_none(self):
+        """Negative values should return None."""
+        self.assertIsNone(normalize_end_epoch(-5))
+
+    def test_invalid_string_returns_none(self):
+        """Invalid string should return None."""
+        self.assertIsNone(normalize_end_epoch("invalid"))
+
+    def test_float_is_truncated(self):
+        """Float values should be truncated to int."""
+        self.assertEqual(normalize_end_epoch(3.7), 3)
+
+
+class TestNormalizeEndStep(unittest.TestCase):
+    """Tests for normalize_end_step function."""
+
+    @classmethod
+    def setUpClass(cls):
+        if IMPORT_ERROR is not None:
+            raise unittest.SkipTest(f"Import failed: {IMPORT_ERROR}")
+
+    def test_valid_int(self):
+        """Valid integer >= 1 should be returned as-is."""
+        self.assertEqual(normalize_end_step(300), 300)
+
+    def test_valid_string_int(self):
+        """Valid string integer should be converted."""
+        self.assertEqual(normalize_end_step("500"), 500)
+
+    def test_none_returns_none(self):
+        """None should return None (no end limit)."""
+        self.assertIsNone(normalize_end_step(None))
+
+    def test_empty_string_returns_none(self):
+        """Empty string should return None."""
+        self.assertIsNone(normalize_end_step(""))
+
+    def test_zero_returns_none(self):
+        """Zero should return None (no end limit)."""
+        self.assertIsNone(normalize_end_step(0))
+
+    def test_negative_returns_none(self):
+        """Negative values should return None."""
+        self.assertIsNone(normalize_end_step(-100))
+
+    def test_invalid_string_returns_none(self):
+        """Invalid string should return None."""
+        self.assertIsNone(normalize_end_step("invalid"))
+
+
+class TestDatasetIsActive(unittest.TestCase):
+    """Tests for dataset_is_active function with start and end conditions."""
+
+    @classmethod
+    def setUpClass(cls):
+        if IMPORT_ERROR is not None:
+            raise unittest.SkipTest(f"Import failed: {IMPORT_ERROR}")
+
+    def setUp(self):
+        """Reset StateTracker before each test."""
+        StateTracker.global_step = 0
+        StateTracker.epoch = 1
+        StateTracker.dataset_schedule = {}
+
+    def _make_backend(self, backend_id, **config):
+        """Create a mock backend with the given config.
+
+        The backend is a dict where config fields are at the top level,
+        matching how _extract_backend_config works.
+        """
+        result = {"id": backend_id}
+        result.update(config)
+        return result
+
+    def _is_active(self, backend_id, backend, **kwargs):
+        """Call dataset_is_active with the correct signature."""
+        return dataset_is_active(backend_id, backend, **kwargs)
+
+    def test_immediate_dataset_is_active(self):
+        """Dataset with no scheduling should be active from the start."""
+        backend = self._make_backend("test")
+        is_active, _ = self._is_active("test", backend, epoch_hint=1, step_hint=1, update_state=False)
+        self.assertTrue(is_active)
+
+    def test_delayed_by_epoch_not_active_before_start(self):
+        """Dataset with start_epoch=3 should not be active in epoch 1."""
+        backend = self._make_backend("test", start_epoch=3)
+        is_active, _ = self._is_active("test", backend, epoch_hint=1, step_hint=1, update_state=False)
+        self.assertFalse(is_active)
+
+    def test_delayed_by_epoch_active_at_start(self):
+        """Dataset with start_epoch=3 should be active in epoch 3."""
+        backend = self._make_backend("test", start_epoch=3)
+        is_active, _ = self._is_active("test", backend, epoch_hint=3, step_hint=1, update_state=False)
+        self.assertTrue(is_active)
+
+    def test_delayed_by_step_not_active_before_start(self):
+        """Dataset with start_step=100 should not be active at step 50."""
+        backend = self._make_backend("test", start_step=100)
+        is_active, _ = self._is_active("test", backend, epoch_hint=1, step_hint=49, update_state=False)
+        self.assertFalse(is_active)
+
+    def test_delayed_by_step_active_at_start(self):
+        """Dataset with start_step=100 should be active at step 100."""
+        backend = self._make_backend("test", start_step=100)
+        is_active, _ = self._is_active("test", backend, epoch_hint=1, step_hint=99, update_state=False)
+        self.assertTrue(is_active)
+
+    # End condition tests
+    def test_end_epoch_not_active_after_end(self):
+        """Dataset with end_epoch=3 should not be active in epoch 4."""
+        backend = self._make_backend("test", end_epoch=3)
+        is_active, _ = self._is_active("test", backend, epoch_hint=4, step_hint=1, update_state=False)
+        self.assertFalse(is_active)
+
+    def test_end_epoch_active_at_end(self):
+        """Dataset with end_epoch=3 should be active in epoch 3."""
+        backend = self._make_backend("test", end_epoch=3)
+        is_active, _ = self._is_active("test", backend, epoch_hint=3, step_hint=1, update_state=False)
+        self.assertTrue(is_active)
+
+    def test_end_step_not_active_after_end(self):
+        """Dataset with end_step=300 should not be active at step 301."""
+        backend = self._make_backend("test", end_step=300)
+        is_active, _ = self._is_active("test", backend, epoch_hint=1, step_hint=300, update_state=False)
+        self.assertFalse(is_active)
+
+    def test_end_step_active_at_end(self):
+        """Dataset with end_step=300 should be active at step 300."""
+        backend = self._make_backend("test", end_step=300)
+        is_active, _ = self._is_active("test", backend, epoch_hint=1, step_hint=299, update_state=False)
+        self.assertTrue(is_active)
+
+    def test_no_end_means_infinite(self):
+        """Dataset with no end conditions should always be active after start."""
+        backend = self._make_backend("test")
+        is_active, _ = self._is_active("test", backend, epoch_hint=100, step_hint=10000, update_state=False)
+        self.assertTrue(is_active)
+
+    # Combined start and end tests
+    def test_bounded_range_active_within(self):
+        """Dataset with start_epoch=2 and end_epoch=5 should be active in epoch 3."""
+        backend = self._make_backend("test", start_epoch=2, end_epoch=5)
+        is_active, _ = self._is_active("test", backend, epoch_hint=3, step_hint=1, update_state=False)
+        self.assertTrue(is_active)
+
+    def test_bounded_range_not_active_before(self):
+        """Dataset with start_epoch=2 and end_epoch=5 should not be active in epoch 1."""
+        backend = self._make_backend("test", start_epoch=2, end_epoch=5)
+        is_active, _ = self._is_active("test", backend, epoch_hint=1, step_hint=1, update_state=False)
+        self.assertFalse(is_active)
+
+    def test_bounded_range_not_active_after(self):
+        """Dataset with start_epoch=2 and end_epoch=5 should not be active in epoch 6."""
+        backend = self._make_backend("test", start_epoch=2, end_epoch=5)
+        is_active, _ = self._is_active("test", backend, epoch_hint=6, step_hint=1, update_state=False)
+        self.assertFalse(is_active)
+
+    def test_step_bounded_range_active_within(self):
+        """Dataset with start_step=100 and end_step=300 should be active at step 200."""
+        backend = self._make_backend("test", start_step=100, end_step=300)
+        is_active, _ = self._is_active("test", backend, epoch_hint=1, step_hint=199, update_state=False)
+        self.assertTrue(is_active)
+
+    def test_step_bounded_range_not_active_before(self):
+        """Dataset with start_step=100 and end_step=300 should not be active at step 50."""
+        backend = self._make_backend("test", start_step=100, end_step=300)
+        is_active, _ = self._is_active("test", backend, epoch_hint=1, step_hint=49, update_state=False)
+        self.assertFalse(is_active)
+
+    def test_step_bounded_range_not_active_after(self):
+        """Dataset with start_step=100 and end_step=300 should not be active at step 350."""
+        backend = self._make_backend("test", start_step=100, end_step=300)
+        is_active, _ = self._is_active("test", backend, epoch_hint=1, step_hint=349, update_state=False)
+        self.assertFalse(is_active)
+
+
+class TestCurriculumLearningScenarios(unittest.TestCase):
+    """Integration tests for curriculum learning use cases."""
+
+    @classmethod
+    def setUpClass(cls):
+        if IMPORT_ERROR is not None:
+            raise unittest.SkipTest(f"Import failed: {IMPORT_ERROR}")
+
+    def setUp(self):
+        """Reset StateTracker before each test."""
+        StateTracker.global_step = 0
+        StateTracker.epoch = 1
+        StateTracker.dataset_schedule = {}
+
+    def _make_backend(self, backend_id, **config):
+        """Create a mock backend with the given config.
+
+        The backend is a dict where config fields are at the top level,
+        matching how _extract_backend_config works.
+        """
+        result = {"id": backend_id}
+        result.update(config)
+        return result
+
+    def _is_active(self, backend_id, backend, **kwargs):
+        """Call dataset_is_active with the correct signature."""
+        return dataset_is_active(backend_id, backend, **kwargs)
+
+    def test_step_based_curriculum_handoff(self):
+        """
+        Curriculum learning scenario: low-res until step 300, then high-res.
+
+        - lowres-512: immediate start, ends at step 300
+        - highres-1024: starts at step 300
+        """
+        lowres = self._make_backend("lowres-512", end_step=300)
+        highres = self._make_backend("highres-1024", start_step=300)
+
+        # At step 100: only lowres should be active
+        lowres_active, _ = self._is_active("lowres-512", lowres, epoch_hint=1, step_hint=99, update_state=False)
+        highres_active, _ = self._is_active("highres-1024", highres, epoch_hint=1, step_hint=99, update_state=False)
+        self.assertTrue(lowres_active, "Low-res should be active at step 100")
+        self.assertFalse(highres_active, "High-res should not be active at step 100")
+
+        # At step 300: both active (handoff point)
+        lowres_active, _ = self._is_active("lowres-512", lowres, epoch_hint=1, step_hint=299, update_state=False)
+        highres_active, _ = self._is_active("highres-1024", highres, epoch_hint=1, step_hint=299, update_state=False)
+        self.assertTrue(lowres_active, "Low-res should be active at step 300")
+        self.assertTrue(highres_active, "High-res should be active at step 300")
+
+        # At step 400: only highres should be active
+        lowres_active, _ = self._is_active("lowres-512", lowres, epoch_hint=1, step_hint=399, update_state=False)
+        highres_active, _ = self._is_active("highres-1024", highres, epoch_hint=1, step_hint=399, update_state=False)
+        self.assertFalse(lowres_active, "Low-res should not be active at step 400")
+        self.assertTrue(highres_active, "High-res should be active at step 400")
+
+    def test_epoch_based_curriculum_three_stages(self):
+        """
+        Three-stage curriculum based on epochs.
+
+        - stage1: epochs 1-3
+        - stage2: epochs 3-6
+        - stage3: epochs 6+
+        """
+        stage1 = self._make_backend("stage1", end_epoch=3)
+        stage2 = self._make_backend("stage2", start_epoch=3, end_epoch=6)
+        stage3 = self._make_backend("stage3", start_epoch=6)
+
+        # Epoch 1: only stage1
+        self.assertTrue(self._is_active("stage1", stage1, epoch_hint=1, step_hint=1, update_state=False)[0])
+        self.assertFalse(self._is_active("stage2", stage2, epoch_hint=1, step_hint=1, update_state=False)[0])
+        self.assertFalse(self._is_active("stage3", stage3, epoch_hint=1, step_hint=1, update_state=False)[0])
+
+        # Epoch 3: stage1 and stage2 overlap
+        self.assertTrue(self._is_active("stage1", stage1, epoch_hint=3, step_hint=1, update_state=False)[0])
+        self.assertTrue(self._is_active("stage2", stage2, epoch_hint=3, step_hint=1, update_state=False)[0])
+        self.assertFalse(self._is_active("stage3", stage3, epoch_hint=3, step_hint=1, update_state=False)[0])
+
+        # Epoch 5: only stage2
+        self.assertFalse(self._is_active("stage1", stage1, epoch_hint=5, step_hint=1, update_state=False)[0])
+        self.assertTrue(self._is_active("stage2", stage2, epoch_hint=5, step_hint=1, update_state=False)[0])
+        self.assertFalse(self._is_active("stage3", stage3, epoch_hint=5, step_hint=1, update_state=False)[0])
+
+        # Epoch 6: stage2 and stage3 overlap
+        self.assertFalse(self._is_active("stage1", stage1, epoch_hint=6, step_hint=1, update_state=False)[0])
+        self.assertTrue(self._is_active("stage2", stage2, epoch_hint=6, step_hint=1, update_state=False)[0])
+        self.assertTrue(self._is_active("stage3", stage3, epoch_hint=6, step_hint=1, update_state=False)[0])
+
+        # Epoch 8: only stage3
+        self.assertFalse(self._is_active("stage1", stage1, epoch_hint=8, step_hint=1, update_state=False)[0])
+        self.assertFalse(self._is_active("stage2", stage2, epoch_hint=8, step_hint=1, update_state=False)[0])
+        self.assertTrue(self._is_active("stage3", stage3, epoch_hint=8, step_hint=1, update_state=False)[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2274

This pull request introduces support for scheduling when a dataset should stop sampling using new `end_epoch` and `end_step` parameters, complementing the existing `start_epoch` and `start_step` scheduling. This enables more flexible workflows such as curriculum learning and multi-stage training. The changes affect backend logic, validation, and documentation in multiple languages, and update the UI to reflect the new scheduling options.

**Backend logic and scheduling enhancements:**

* Added `end_epoch` and `end_step` support to dataset scheduling, including normalization functions, propagation through backend configuration, and logic in `dataset_is_active` to check both start and end conditions. [[1]](diffhunk://#diff-57615ebb58fa92a702515b29c5d3dcee1e1ac481ee2f71564229f128a28894feL88-R94) [[2]](diffhunk://#diff-57615ebb58fa92a702515b29c5d3dcee1e1ac481ee2f71564229f128a28894feR276-R281) [[3]](diffhunk://#diff-57615ebb58fa92a702515b29c5d3dcee1e1ac481ee2f71564229f128a28894feR1614-R1627) [[4]](diffhunk://#diff-57615ebb58fa92a702515b29c5d3dcee1e1ac481ee2f71564229f128a28894feR4046-R4047) [[5]](diffhunk://#diff-33f68dab6874ee4d3086dc767975cb708701091d3bcebbc5dfce5f12d82feae2R28-R51) [[6]](diffhunk://#diff-33f68dab6874ee4d3086dc767975cb708701091d3bcebbc5dfce5f12d82feae2L38-R68) [[7]](diffhunk://#diff-33f68dab6874ee4d3086dc767975cb708701091d3bcebbc5dfce5f12d82feae2L58-R125) [[8]](diffhunk://#diff-bd04a7fecf08df61ca41aa8560ad7fd31d9022ff72355d4ca525fc51cf4269a9L374-R381) [[9]](diffhunk://#diff-bd04a7fecf08df61ca41aa8560ad7fd31d9022ff72355d4ca525fc51cf4269a9R393-R407)

* Updated `StateTracker` and related scheduling state to store and handle `end_epoch` and `end_step` values. [[1]](diffhunk://#diff-bd04a7fecf08df61ca41aa8560ad7fd31d9022ff72355d4ca525fc51cf4269a9L374-R381) [[2]](diffhunk://#diff-bd04a7fecf08df61ca41aa8560ad7fd31d9022ff72355d4ca525fc51cf4269a9R393-R407)

* Added validation logic to ensure `end_epoch` is not before `start_epoch` and `end_step` is not before `start_step` in both backend and server-side validation. [[1]](diffhunk://#diff-57615ebb58fa92a702515b29c5d3dcee1e1ac481ee2f71564229f128a28894feR1614-R1627) [[2]](diffhunk://#diff-32fc72b11bd8d546159a7e68d28a9044b03eaa5f414cf099f5b0f5df0625ce64R385-R424)

**Documentation updates:**

* Updated `DATALOADER.md` and its translations (Spanish, Hindi, Japanese, Portuguese, Chinese) to document the new `end_epoch`/`end_step` options, including examples for curriculum learning workflows. [[1]](diffhunk://#diff-832fa306c74a75dd82d3f3ea4991ef8ae01d9e5fe676fa48064ad900650fbedbR614-R645) [[2]](diffhunk://#diff-53020b5b852ec497768f106a35a23f9643d17154aede1a376f3d0ea2823a1c77R580-R611) [[3]](diffhunk://#diff-40cc304678d5de3b894191892493b735faf57669a9639eb6f263b6743cbb2017R580-R611) [[4]](diffhunk://#diff-1ed4a7dac98fba8d8bccea736baf8b209b326025ae3755421b7ffaa7badf1bc1R581-R612) [[5]](diffhunk://#diff-91821919af7cefc854d5b74caff07f8a098fbb95d543840e88be1699d6ad86f4R580-R611) [[6]](diffhunk://#diff-0f61518874320948c7f36ca9c2070b7d11b5cd55df24a4ed6586a864b8fb96cbR581-R612)

**Frontend/UI improvements:**

* Updated the dataloader section component to recognize and initialize the new end scheduling fields (`end_epoch`, `end_step`) and their modes for datasets in the UI.