### PR TITLE
(#2470) multi-aspect input conditioning for kontext, flux2 and qwen edit

### DIFF
--- a/simpletuner/helpers/models/flux2/model.py
+++ b/simpletuner/helpers/models/flux2/model.py
@@ -742,6 +742,17 @@ class Flux2(ImageModelFoundation):
             # Random mode should have selected just one conditioning set
             cond = cond[0]
 
+        # Flatten nested lists that may result from check_latent_shapes returning
+        # per-sample lists when conditioning images have different aspect ratios
+        if isinstance(cond, list):
+            flat_cond = []
+            for item in cond:
+                if isinstance(item, list):
+                    flat_cond.extend(item)
+                else:
+                    flat_cond.append(item)
+            cond = flat_cond if flat_cond else cond
+
         if isinstance(cond, list):
             logger.debug(f"FLUX.2 conditioning inputs shapes: {[d.shape for d in cond]} {cond[0].dtype}")
         else:

--- a/simpletuner/helpers/training/collate.py
+++ b/simpletuner/helpers/training/collate.py
@@ -865,6 +865,7 @@ def collate_fn(batch):
                         _filepaths,
                         backend_id,
                         _examples,
+                        is_conditioning=(conditioning_type == "reference_loose"),
                     )
                     conditioning_latents.append(_latents)
             else:

--- a/tests/test_collate.py
+++ b/tests/test_collate.py
@@ -131,7 +131,7 @@ class CollateFunctionTests(unittest.TestCase):
             patch("simpletuner.helpers.training.collate.compute_latents", return_value=[torch.zeros(1, 4, 4, 4)]),
             patch(
                 "simpletuner.helpers.training.collate.check_latent_shapes",
-                side_effect=lambda latents, *_: latents,
+                side_effect=lambda latents, *_, **__: latents,
             ),
             patch(
                 "simpletuner.helpers.training.collate.compute_prompt_embeddings",


### PR DESCRIPTION
Closes #2470 

This pull request addresses issues with handling conditioning data in the batch preparation process, particularly when dealing with nested lists that can arise from varying image aspect ratios. It also makes minor adjustments to training example handling and test mocks for improved robustness.

**Batch conditioning robustness:**

* Added logic to flatten nested lists in the `prepare_batch_conditions` method of `model.py`, ensuring consistent handling of conditioning data even when input images have different aspect ratios.

**Training example handling:**

* Modified the `_pop_training_example_for_path` function in `collate.py` to pass an explicit `is_conditioning` flag when the conditioning type is `"reference_loose"`, improving clarity and correctness in downstream processing.

**Test improvements:**

* Updated the mock for `check_latent_shapes` in `test_collate.py` to accept arbitrary keyword arguments, preventing potential errors during testing.