### PR TITLE
ss_tag_frequency should contain only terms in more than 50% of all captions

### DIFF
--- a/simpletuner/helpers/training/save_hooks.py
+++ b/simpletuner/helpers/training/save_hooks.py
@@ -202,14 +202,17 @@ class SaveHookManager:
 
     def _build_tag_frequency_from_captions(self) -> dict[str, dict[str, int]]:
         """
-        Scan all training captions, split into tags, and build frequency dict.
+        Scan all training captions and build frequency dict of trigger words.
+        Only includes tags that appear in more than 50% of all captions.
         Returns dict of dataset_id -> {tag: count}.
         """
         import re
 
         from simpletuner.helpers.prompts import PromptHandler
 
-        ss_tag_frequency = {}
+        # First pass: collect all captions and count tag presence across all backends
+        all_captions = []
+        backend_captions = {}
 
         for backend_id, backend in StateTracker.get_data_backends().items():
             if backend.get("data_backend") is None:
@@ -220,7 +223,6 @@ class SaveHookManager:
             if not caption_strategy:
                 continue
 
-            # Get caption config parameters
             prepend_instance_prompt = config.get(
                 "prepend_instance_prompt", getattr(self.args, "prepend_instance_prompt", False)
             )
@@ -246,17 +248,40 @@ class SaveHookManager:
                 logger.debug(f"Could not get captions for backend {backend_id}: {e}")
                 continue
 
+            valid_captions = [c for c in captions if c and c != "__caption_dropout__"]
+            backend_captions[backend_id] = valid_captions
+            all_captions.extend(valid_captions)
+
+        if not all_captions:
+            return {}
+
+        # Count how many captions each tag appears in (presence-based)
+        tag_caption_count = {}
+        for caption in all_captions:
+            tags = re.split(r"[,\n]+", str(caption))
+            seen_in_caption = set()
+            for tag in tags:
+                tag = tag.strip()
+                if tag and tag not in seen_in_caption:
+                    seen_in_caption.add(tag)
+                    tag_caption_count[tag] = tag_caption_count.get(tag, 0) + 1
+
+        # Filter to tags appearing in more than 50% of all captions
+        threshold = len(all_captions) / 2
+        frequent_tags = {tag for tag, count in tag_caption_count.items() if count > threshold}
+
+        if not frequent_tags:
+            return {}
+
+        # Build per-backend frequency dict with only frequent tags
+        ss_tag_frequency = {}
+        for backend_id, captions in backend_captions.items():
             tag_counts = {}
             for caption in captions:
-                if not caption or caption == "__caption_dropout__":
-                    continue
-
-                # Split by comma for booru-style tags, or keep as single trigger word
-                # Also handle newlines and other common separators
                 tags = re.split(r"[,\n]+", str(caption))
                 for tag in tags:
                     tag = tag.strip()
-                    if tag:
+                    if tag and tag in frequent_tags:
                         tag_counts[tag] = tag_counts.get(tag, 0) + 1
 
             if tag_counts:


### PR DESCRIPTION
This pull request updates the logic for building the tag frequency dictionary from training captions to focus on identifying "trigger words" (tags) that are common across the majority of captions. The new implementation ensures that only tags appearing in more than 50% of all captions are included, improving the relevance of the trigger words used in training.

**Enhancements to tag frequency calculation:**

* The `_build_tag_frequency_from_captions` method now collects all captions from all backends, filters out invalid entries, and computes tag frequencies based on tag presence across captions rather than raw counts. [[1]](diffhunk://#diff-ac3fd13d7c7aec8ae0ac09890a4abf96651b04a8b6f2f85a0559ed18889a1b7eL205-R215) [[2]](diffhunk://#diff-ac3fd13d7c7aec8ae0ac09890a4abf96651b04a8b6f2f85a0559ed18889a1b7eR251-R284)
* Only tags that appear in more than 50% of all captions are considered "frequent" and included in the resulting frequency dictionary.

**Code clarity improvements:**

* Removed unnecessary inline comments and improved the logic for filtering and processing captions.