### PR TITLE
mkDocs: move to Zensical instead, and fix the theme

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,10 +38,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install mkdocs mkdocs-material pymdown-extensions mkdocs-static-i18n
+          pip install zensical
 
       - name: Build documentation
-        run: mkdocs build --strict
+        run: zensical build
 
       - name: Upload artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/documentation/TRANSLATING.es.md
+++ b/documentation/TRANSLATING.es.md
@@ -13,7 +13,7 @@
 
 ## Cómo funciona la traducción
 
-SimpleTuner usa **i18n basado en sufijos** con [mkdocs-static-i18n](https://github.com/ultrabug/mkdocs-static-i18n). Las traducciones se almacenan junto a los archivos originales con un sufijo de idioma:
+SimpleTuner usa **i18n basado en sufijos** con Zensical. Las traducciones se almacenan junto a los archivos originales con un sufijo de idioma:
 
 ```
 documentation/
@@ -98,10 +98,10 @@ Prueba tus traducciones localmente:
 
 ```bash
 # Instalar dependencias
-pip install mkdocs mkdocs-material mkdocs-static-i18n pymdown-extensions
+pip install zensical
 
 # Servir con hot reload
-mkdocs serve
+zensical serve
 
 # Abrir http://localhost:8000 y cambiar idiomas
 ```

--- a/documentation/TRANSLATING.hi.md
+++ b/documentation/TRANSLATING.hi.md
@@ -13,7 +13,7 @@ SimpleTuner दस्तावेज़ों के अनुवाद मे�
 
 ## अनुवाद कैसे काम करता है
 
-SimpleTuner [mkdocs-static-i18n](https://github.com/ultrabug/mkdocs-static-i18n) के साथ **suffix-based i18n** का उपयोग करता है। अनुवाद मूल फ़ाइलों के साथ भाषा suffix के रूप में संग्रहीत होते हैं:
+SimpleTuner Zensical के साथ **suffix-based i18n** का उपयोग करता है। अनुवाद मूल फ़ाइलों के साथ भाषा suffix के रूप में संग्रहीत होते हैं:
 
 ```
 documentation/
@@ -98,10 +98,10 @@ cp documentation/INSTALL.md documentation/INSTALL.zh.md
 
 ```bash
 # Install dependencies
-pip install mkdocs mkdocs-material mkdocs-static-i18n pymdown-extensions
+pip install zensical
 
 # Serve with hot reload
-mkdocs serve
+zensical serve
 
 # Open http://localhost:8000 and switch languages
 ```

--- a/documentation/TRANSLATING.ja.md
+++ b/documentation/TRANSLATING.ja.md
@@ -13,7 +13,7 @@ SimpleTuner ドキュメントの翻訳にご協力いただきありがとう�
 
 ## 翻訳の仕組み
 
-SimpleTuner は [mkdocs-static-i18n](https://github.com/ultrabug/mkdocs-static-i18n) を使った**接尾辞ベースの i18n**を採用しています。翻訳は元ファイルと同じ場所に、言語サフィックス付きで保存します。
+SimpleTuner は Zensical を使った**接尾辞ベースの i18n**を採用しています。翻訳は元ファイルと同じ場所に、言語サフィックス付きで保存します。
 
 ```
 documentation/
@@ -98,10 +98,10 @@ cp documentation/INSTALL.md documentation/INSTALL.zh.md
 
 ```bash
 # Install dependencies
-pip install mkdocs mkdocs-material mkdocs-static-i18n pymdown-extensions
+pip install zensical
 
 # Serve with hot reload
-mkdocs serve
+zensical serve
 
 # Open http://localhost:8000 and switch languages
 ```

--- a/documentation/TRANSLATING.md
+++ b/documentation/TRANSLATING.md
@@ -13,7 +13,7 @@ Thank you for helping translate SimpleTuner documentation! This guide explains h
 
 ## How Translation Works
 
-SimpleTuner uses **suffix-based i18n** with [mkdocs-static-i18n](https://github.com/ultrabug/mkdocs-static-i18n). Translations are stored alongside the original files with a language suffix:
+SimpleTuner uses **suffix-based i18n** with Zensical. Translations are stored alongside the original files with a language suffix:
 
 ```
 documentation/
@@ -98,10 +98,10 @@ Test your translations locally:
 
 ```bash
 # Install dependencies
-pip install mkdocs mkdocs-material mkdocs-static-i18n pymdown-extensions
+pip install zensical
 
 # Serve with hot reload
-mkdocs serve
+zensical serve
 
 # Open http://localhost:8000 and switch languages
 ```

--- a/documentation/TRANSLATING.pt-BR.md
+++ b/documentation/TRANSLATING.pt-BR.md
@@ -13,7 +13,7 @@ Obrigado por ajudar a traduzir a documentacao do SimpleTuner! Este guia explica 
 
 ## Como a traducao funciona
 
-O SimpleTuner usa **i18n baseado em sufixo** com [mkdocs-static-i18n](https://github.com/ultrabug/mkdocs-static-i18n). As traducoes sao armazenadas ao lado dos arquivos originais com um sufixo de idioma:
+O SimpleTuner usa **i18n baseado em sufixo** com Zensical. As traducoes sao armazenadas ao lado dos arquivos originais com um sufixo de idioma:
 
 ```
 documentation/
@@ -98,10 +98,10 @@ Teste suas traducoes localmente:
 
 ```bash
 # Instalar dependencias
-pip install mkdocs mkdocs-material mkdocs-static-i18n pymdown-extensions
+pip install zensical
 
 # Servir com hot reload
-mkdocs serve
+zensical serve
 
 # Abra http://localhost:8000 e alterne idiomas
 ```

--- a/documentation/TRANSLATING.zh.md
+++ b/documentation/TRANSLATING.zh.md
@@ -13,7 +13,7 @@
 
 ## 翻译机制
 
-SimpleTuner 使用 [mkdocs-static-i18n](https://github.com/ultrabug/mkdocs-static-i18n) 的**后缀式 i18n**。翻译与原文件并排存放，通过语言后缀区分：
+SimpleTuner 使用 Zensical 的**后缀式 i18n**。翻译与原文件并排存放，通过语言后缀区分：
 
 ```
 documentation/
@@ -98,10 +98,10 @@ cp documentation/INSTALL.md documentation/INSTALL.zh.md
 
 ```bash
 # Install dependencies
-pip install mkdocs mkdocs-material mkdocs-static-i18n pymdown-extensions
+pip install zensical
 
 # Serve with hot reload
-mkdocs serve
+zensical serve
 
 # Open http://localhost:8000 and switch languages
 ```

--- a/documentation/stylesheets/extra.css
+++ b/documentation/stylesheets/extra.css
@@ -26,3 +26,13 @@
 .md-nav__item .md-nav__link {
   font-size: 0.8rem;
 }
+
+/* Keep double-dash option names on one line in the TOC. */
+.md-nav--secondary .md-nav__link[href^="#-"] .md-ellipsis {
+  white-space: nowrap;
+}
+
+/* Expand layout width for wide screens. */
+.md-grid {
+  max-width: 90rem;
+}

--- a/setup.py
+++ b/setup.py
@@ -598,10 +598,7 @@ extras_require = {
     ],
     "test": ["selenium>=4.0.0", "coverage>=7.0.0"],
     "docs": [
-        "mkdocs>=1.6.0",
-        "mkdocs-material>=9.5.0",
-        "mkdocs-static-i18n>=1.2.0",
-        "pymdown-extensions>=10.0",
+        "zensical>=0.0.19",
     ],
     # Platform-specific extras - user must choose one
     "cuda": list(PLATFORM_DEPENDENCIES["cuda"]),


### PR DESCRIPTION
This pull request migrates the documentation build system from MkDocs (with mkdocs-material and mkdocs-static-i18n) to Zensical, updating all related instructions, dependencies, and workflow steps. It also introduces minor CSS improvements for the documentation site layout and navigation.

**Migration to Zensical for documentation:**

* Replaced MkDocs and its plugins with Zensical in the GitHub Actions workflow (`.github/workflows/docs.yml`), including updating the build and dependency installation steps.
* Updated all translation guides (`TRANSLATING.md`, `TRANSLATING.es.md`, `TRANSLATING.pt-BR.md`, `TRANSLATING.hi.md`, `TRANSLATING.ja.md`, `TRANSLATING.zh.md`) to reference Zensical instead of mkdocs-static-i18n, and changed local testing instructions to use `zensical serve` and `pip install zensical`. [[1]](diffhunk://#diff-84b1aaee9de0ac4a7c5799eed732f12ec2ee9974b91739c755a43494ef56ab9fL16-R16) [[2]](diffhunk://#diff-84b1aaee9de0ac4a7c5799eed732f12ec2ee9974b91739c755a43494ef56ab9fL101-R104) [[3]](diffhunk://#diff-cf9ee56375b98a2a8e59d27a561720af3c9b66fefadc6b05e43fc81c1a39f12bL16-R16) [[4]](diffhunk://#diff-cf9ee56375b98a2a8e59d27a561720af3c9b66fefadc6b05e43fc81c1a39f12bL101-R104) [[5]](diffhunk://#diff-63d91c004fbb4bceab12a6c45d42cb5891efe43564751e04ccfe82b763bf58baL16-R16) [[6]](diffhunk://#diff-63d91c004fbb4bceab12a6c45d42cb5891efe43564751e04ccfe82b763bf58baL101-R104) [[7]](diffhunk://#diff-fd3e69635f493b66b22bc034148959ed9102f862a27d34954be0a0a582fc7d48L16-R16) [[8]](diffhunk://#diff-fd3e69635f493b66b22bc034148959ed9102f862a27d34954be0a0a582fc7d48L101-R104) [[9]](diffhunk://#diff-02567c70e33b4b38e97a0098527ebf61e746493e68e23c7be59ad50dba5d07c8L16-R16) [[10]](diffhunk://#diff-02567c70e33b4b38e97a0098527ebf61e746493e68e23c7be59ad50dba5d07c8L101-R104) [[11]](diffhunk://#diff-3fc9fb5db35e863fd9dbb8c28645aa706fbbf18d0c4dc0a216a1e1645aec74d6L16-R16) [[12]](diffhunk://#diff-3fc9fb5db35e863fd9dbb8c28645aa706fbbf18d0c4dc0a216a1e1645aec74d6L101-R104)
* Updated the documentation dependencies in `setup.py` to use `zensical>=0.0.19` instead of MkDocs and related plugins.

**Documentation site styling improvements:**

* Added custom CSS in `documentation/stylesheets/extra.css` to:
  - Prevent line breaks in double-dash option names in the table of contents.
  - Expand the documentation layout width for wide screens.