### PR TITLE
face detection fixes for TrainingSample with PIL fallback

### DIFF
--- a/tests/test_cropping.py
+++ b/tests/test_cropping.py
@@ -1,5 +1,7 @@
+import inspect
 import unittest
 
+import numpy as np
 from PIL import Image
 
 from simpletuner.helpers.multiaspect.image import MultiaspectImage  # Adjust import according to your project structure
@@ -9,6 +11,10 @@ class TestCropping(unittest.TestCase):
     def setUp(self):
         # Creating a sample image for testing
         self.sample_image = Image.new("RGB", (500, 300), "white")
+        # Create numpy array version
+        self.sample_array = np.ones((300, 500, 3), dtype=np.uint8) * 255
+        # Create video (4D array) version - 10 frames
+        self.sample_video = np.ones((10, 300, 500, 3), dtype=np.uint8) * 255
 
     def test_crop_corner(self):
         target_width, target_height = 300, 200
@@ -58,7 +64,93 @@ class TestCropping(unittest.TestCase):
         self.assertTrue(top + target_height <= self.sample_image.height)
         self.assertEqual(cropped_image.size, (target_width, target_height))
 
-    # Add additional tests for other methods as necessary
+
+class TestFaceCropping(unittest.TestCase):
+    def setUp(self):
+        # Creating sample images for testing (no faces)
+        self.sample_image = Image.new("RGB", (500, 300), "white")
+        self.sample_array = np.ones((300, 500, 3), dtype=np.uint8) * 255
+        self.sample_video = np.ones((10, 300, 500, 3), dtype=np.uint8) * 255
+        self.target_width = 300
+        self.target_height = 200
+
+    def test_face_cropping_signature_matches_parent(self):
+        """FaceCropping.crop() should have the same signature as RandomCropping.crop()"""
+        from simpletuner.helpers.image_manipulation.cropping import FaceCropping, RandomCropping
+
+        fc_params = list(inspect.signature(FaceCropping.crop).parameters.keys())
+        rc_params = list(inspect.signature(RandomCropping.crop).parameters.keys())
+        self.assertEqual(fc_params, rc_params)
+
+    def test_face_cropping_pil_no_faces_fallback(self):
+        """FaceCropping with PIL image and no faces should fall back to random cropping"""
+        from simpletuner.helpers.image_manipulation.cropping import FaceCropping
+
+        cropper = FaceCropping(self.sample_image)
+        cropper.set_intermediary_size(500, 300)
+        cropped_image, (top, left) = cropper.crop(self.target_width, self.target_height)
+
+        # Should return a valid cropped image
+        self.assertIsNotNone(cropped_image)
+        self.assertIsInstance(cropped_image, Image.Image)
+        self.assertEqual(cropped_image.size, (self.target_width, self.target_height))
+
+        # Coordinates should be within bounds
+        self.assertTrue(0 <= left < self.sample_image.width)
+        self.assertTrue(0 <= top < self.sample_image.height)
+
+    def test_face_cropping_numpy_no_faces_fallback(self):
+        """FaceCropping with numpy array and no faces should fall back to random cropping"""
+        from simpletuner.helpers.image_manipulation.cropping import FaceCropping
+
+        cropper = FaceCropping(self.sample_array)
+        cropper.set_intermediary_size(500, 300)
+        cropped_array, (top, left) = cropper.crop(self.target_width, self.target_height)
+
+        # Should return a valid cropped array
+        self.assertIsNotNone(cropped_array)
+        self.assertIsInstance(cropped_array, np.ndarray)
+        self.assertEqual(cropped_array.shape, (self.target_height, self.target_width, 3))
+
+        # Coordinates should be within bounds
+        self.assertTrue(0 <= left < self.sample_array.shape[1])
+        self.assertTrue(0 <= top < self.sample_array.shape[0])
+
+    def test_face_cropping_video_no_faces_fallback(self):
+        """FaceCropping with video (4D array) and no faces should fall back to random cropping"""
+        from simpletuner.helpers.image_manipulation.cropping import FaceCropping
+
+        cropper = FaceCropping(self.sample_video)
+        cropper.set_intermediary_size(500, 300)
+        cropped_video, (top, left) = cropper.crop(self.target_width, self.target_height)
+
+        # Should return a valid cropped video
+        self.assertIsNotNone(cropped_video)
+        self.assertIsInstance(cropped_video, np.ndarray)
+        # Video shape: (num_frames, height, width, channels)
+        self.assertEqual(cropped_video.shape, (10, self.target_height, self.target_width, 3))
+
+        # Coordinates should be within bounds
+        self.assertTrue(0 <= left < self.sample_video.shape[2])
+        self.assertTrue(0 <= top < self.sample_video.shape[1])
+
+    def test_face_cropping_uses_correct_api(self):
+        """FaceCropping should use detect_multi_scale (snake_case), not detectMultiScale"""
+        import os
+
+        cropping_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "simpletuner",
+            "helpers",
+            "image_manipulation",
+            "cropping.py",
+        )
+        with open(cropping_path) as f:
+            content = f.read()
+
+        self.assertNotIn("detectMultiScale", content, "Should not use camelCase detectMultiScale")
+        self.assertIn("detect_multi_scale", content, "Should use snake_case detect_multi_scale")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request refactors the `FaceCropping` class in `cropping.py` to consistently use the instance variable `self.image` instead of a method parameter, and updates the face detection API to use the correct `detect_multi_scale` method. It also adds comprehensive unit tests for the `FaceCropping` class to ensure correct behavior and API usage.

### Refactoring and API Consistency

* Refactored the `FaceCropping.crop` method to use `self.image` throughout, removing the `image` parameter and updating all references accordingly for consistency with the class design. [[1]](diffhunk://#diff-dae0fdced1727ba126b68762ed25254c4eee98d752363437b682b80e1ee15bd6L182-R200) [[2]](diffhunk://#diff-dae0fdced1727ba126b68762ed25254c4eee98d752363437b682b80e1ee15bd6L220-R218) [[3]](diffhunk://#diff-dae0fdced1727ba126b68762ed25254c4eee98d752363437b682b80e1ee15bd6L237-R249) [[4]](diffhunk://#diff-dae0fdced1727ba126b68762ed25254c4eee98d752363437b682b80e1ee15bd6L276-R271)
* Updated all face detection calls from the camelCase `detectMultiScale` to the correct snake_case `detect_multi_scale` method to match the API and coding standards. [[1]](diffhunk://#diff-dae0fdced1727ba126b68762ed25254c4eee98d752363437b682b80e1ee15bd6L182-R200) [[2]](diffhunk://#diff-dae0fdced1727ba126b68762ed25254c4eee98d752363437b682b80e1ee15bd6L237-R249)

### Testing Improvements

* Added a new `TestFaceCropping` test case in `tests/test_cropping.py` with tests for:
  - Signature compatibility between `FaceCropping.crop` and its parent `RandomCropping.crop`
  - Fallback to random cropping when no faces are detected for PIL images, numpy arrays, and videos
  - Correct usage of the `detect_multi_scale` API
* Created sample image, numpy array, and video data in test setup for thorough test coverage. [[1]](diffhunk://#diff-37efb91f98f813df8b12351e6efdb65d85d08d67dfc18f641acc9a667e2136ceR1-R4) [[2]](diffhunk://#diff-37efb91f98f813df8b12351e6efdb65d85d08d67dfc18f641acc9a667e2136ceR14-R17)