### PR TITLE
UI event system should rely on SSE manager

### DIFF
--- a/simpletuner/static/js/event-handler.js
+++ b/simpletuner/static/js/event-handler.js
@@ -1523,19 +1523,6 @@ class EventHandler {
             eventStatus.innerHTML = statusContent;
         }
 
-        // Determine the status string
-        let status = 'disconnected';
-        if (connected) {
-            status = 'connected';
-        } else if (message && message.toLowerCase().includes('reconnect')) {
-            status = 'reconnecting';
-        }
-
-        // Update via centralized function (updates Alpine store + dispatches event)
-        if (typeof window.updateConnectionStatus === 'function') {
-            window.updateConnectionStatus(status, connected ? '' : (message || 'Disconnected'));
-        }
-
         // Only show message in event list if requested
         if (showMessage) {
             this.updateEventList([{

--- a/simpletuner/templates/components/training_events_sse.html
+++ b/simpletuner/templates/components/training_events_sse.html
@@ -1485,11 +1485,6 @@
             var status = info.status;
             var message = info.message || '';
 
-            // Update connection status via centralized function (updates Alpine store + dispatches event)
-            if (typeof window.updateConnectionStatus === 'function') {
-                window.updateConnectionStatus(status, message);
-            }
-
             // Handle status-specific side effects
             if (status === 'connected') {
                 // Restore training state after reconnection


### PR DESCRIPTION
This pull request removes duplicate logic for updating the connection status in both the JavaScript event handler and the training events SSE component. By eliminating these redundant calls, the codebase is simplified and the risk of inconsistent status updates is reduced.

**Codebase simplification:**

* Removed the logic for determining and updating the connection status from the `EventHandler` class in `event-handler.js`, centralizing status updates elsewhere.
* Removed the call to `window.updateConnectionStatus` from the SSE handler in `training_events_sse.html`, further consolidating status update responsibilities.