### PR TITLE
[UI] add dataset configuration missing options; allow configuring audio duration for standalone sets

### DIFF
--- a/simpletuner/static/css/dataloader-builder.css
+++ b/simpletuner/static/css/dataloader-builder.css
@@ -1760,6 +1760,12 @@
     padding: var(--spacing-md);
 }
 
+#dataloaderSection .dataset-list-item-expanded .list-item-expanded-footer {
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(0, 0, 0, 0.1);
+}
+
 /* Section body - sections flow horizontally when room, wrap when not */
 #dataloaderSection .dataset-list-item-expanded .modal-section-body {
     display: flex;

--- a/simpletuner/static/js/dataloader-section-component.js
+++ b/simpletuner/static/js/dataloader-section-component.js
@@ -370,7 +370,7 @@ function dataloaderSectionComponent() {
     getListTab(dataset) {
         if (dataset._listTab) return dataset._listTab;
         // Default to 'storage' for types without a Basic tab
-        const noBasicTypes = ['text_embeds', 'image_embeds', 'audio'];
+        const noBasicTypes = ['text_embeds', 'image_embeds'];
         return noBasicTypes.includes(dataset.dataset_type) ? 'storage' : 'basic';
     },
 

--- a/simpletuner/templates/components/dataloader/dataset_list_item.html
+++ b/simpletuner/templates/components/dataloader/dataset_list_item.html
@@ -149,7 +149,7 @@
         <button type="button"
                 :class="{'active': getListTab(dataset) === 'basic'}"
                 @click="setListTab(dataset, 'basic')"
-                x-show="dataset.dataset_type !== 'text_embeds' && dataset.dataset_type !== 'image_embeds' && dataset.dataset_type !== 'audio'">
+                x-show="dataset.dataset_type !== 'text_embeds' && dataset.dataset_type !== 'image_embeds'">
             <i class="fas fa-sliders-h"></i>
             <span>Basic</span>
         </button>
@@ -243,6 +243,20 @@
         <!-- Scheduling Tab -->
         <div x-show="getListTab(dataset) === 'scheduling'" x-cloak>
             {% include 'components/dataloader/sections/scheduling_body.html' %}
+        </div>
+    </div>
+
+    <!-- Expanded Footer -->
+    <div class="list-item-expanded-footer">
+        <div class="form-check form-check-inline mb-0">
+            <input type="checkbox"
+                   class="form-check-input"
+                   :id="'list-dataset-disabled-' + dataset.id"
+                   x-model="dataset.disabled"
+                   @change="markAsUnsaved()">
+            <label class="form-check-label small" :for="'list-dataset-disabled-' + dataset.id">
+                Disable dataset
+            </label>
         </div>
     </div>
 </div>

--- a/simpletuner/templates/components/dataloader/dataset_modal.html
+++ b/simpletuner/templates/components/dataloader/dataset_modal.html
@@ -45,7 +45,7 @@
                 <button type="button"
                         :class="{'active': modalTab === 'basic'}"
                         @click="modalTab = 'basic'"
-                        x-show="editingDataset.dataset_type !== 'text_embeds' && editingDataset.dataset_type !== 'image_embeds' && editingDataset.dataset_type !== 'audio'">
+                        x-show="editingDataset.dataset_type !== 'text_embeds' && editingDataset.dataset_type !== 'image_embeds'">
                     <i class="fas fa-sliders-h"></i>
                     <span>Basic</span>
                 </button>

--- a/simpletuner/templates/components/dataloader/sections/advanced_body.html
+++ b/simpletuner/templates/components/dataloader/sections/advanced_body.html
@@ -72,6 +72,24 @@
         </div>
     </div>
 
+    <!-- Metadata Refresh -->
+    <div class="section-group" x-show="!['text_embeds','image_embeds'].includes(editingDataset.dataset_type) && matchesParamFilter('metadata', 'update', 'interval', 'refresh')">
+        <h6 class="modal-section-title">Metadata Refresh</h6>
+        <div class="row g-2">
+            <div class="col-md-6">
+                <label class="form-label small">Update Interval (seconds) <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#metadata_update_interval') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                <input type="number"
+                       class="form-control form-control-sm"
+                       min="0"
+                       step="1"
+                       x-model.number.lazy="editingDataset.metadata_update_interval"
+                       @input="markAsUnsaved()"
+                       placeholder="Use global setting">
+                <div class="form-text small">How often to refresh dataset metadata during training</div>
+            </div>
+        </div>
+    </div>
+
     <!-- VAE Cache Behavior -->
     <div class="section-group" x-show="!['text_embeds','image_embeds','audio'].includes(editingDataset.dataset_type) && matchesParamFilter('vae', 'cache', 'epoch', 'clear', 'random', 'crop')">
         <h6 class="modal-section-title">VAE Cache Behavior</h6>
@@ -108,6 +126,37 @@
                     <div class="form-text small text-muted ps-4" x-text="option.hint"></div>
                 </div>
             </template>
+        </div>
+    </div>
+
+    <!-- Destructive Options -->
+    <div class="section-group" x-show="!['text_embeds','image_embeds','audio'].includes(editingDataset.dataset_type) && matchesParamFilter('delete', 'unwanted', 'problematic', 'remove', 'cleanup')">
+        <h6 class="modal-section-title text-danger"><i class="fas fa-exclamation-triangle me-1"></i>Destructive Options</h6>
+        <div class="form-check mb-2">
+            <input class="form-check-input"
+                   type="checkbox"
+                   :id="'delete-unwanted-' + editingDataset.id"
+                   x-model="editingDataset.delete_unwanted_images"
+                   @change="markAsUnsaved()">
+            <label class="form-check-label small" :for="'delete-unwanted-' + editingDataset.id">
+                Delete unwanted images <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#delete_unwanted_images') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a>
+            </label>
+        </div>
+        <div class="form-text small text-warning ps-4 mb-2">
+            <i class="fas fa-exclamation-triangle me-1"></i>Permanently deletes images that fail size or aspect ratio filters
+        </div>
+        <div class="form-check">
+            <input class="form-check-input"
+                   type="checkbox"
+                   :id="'delete-problematic-' + editingDataset.id"
+                   x-model="editingDataset.delete_problematic_images"
+                   @change="markAsUnsaved()">
+            <label class="form-check-label small" :for="'delete-problematic-' + editingDataset.id">
+                Delete problematic images <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#delete_problematic_images') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a>
+            </label>
+        </div>
+        <div class="form-text small text-warning ps-4">
+            <i class="fas fa-exclamation-triangle me-1"></i>Permanently deletes images that fail VAE encoding (corrupted files)
         </div>
     </div>
 </div>

--- a/simpletuner/templates/components/dataloader/sections/audio_body.html
+++ b/simpletuner/templates/components/dataloader/sections/audio_body.html
@@ -1,39 +1,49 @@
 <!-- Audio Settings Body (for modal) -->
-<div class="modal-section-body">
+<div class="modal-section-body" x-init="editingDataset.audio = editingDataset.audio || {}">
     <!-- Duration Settings -->
-    <div class="section-group" x-show="matchesParamFilter('duration', 'min', 'max', 'interval', 'seconds', 'truncate')">
-        <h6 class="modal-section-title">Duration</h6>
+    <div class="section-group" x-show="matchesParamFilter('duration', 'min', 'max', 'interval', 'seconds', 'truncate', 'bucket')">
+        <h6 class="modal-section-title">Duration & Bucketing</h6>
         <div class="row g-2">
-            <div class="col-md-4">
-                <label class="form-label small">Min (seconds)</label>
+            <div class="col-md-3">
+                <label class="form-label small">Min (seconds) <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-dataset-configuration-dataset_typeaudio') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
                 <input type="number"
                        class="form-control form-control-sm"
-                       x-model.number.lazy="editingDataset.audio_min_duration_seconds"
+                       x-model.number.lazy="editingDataset.audio.min_duration_seconds"
                        @input="markAsUnsaved()"
                        step="0.1"
                        min="0"
                        placeholder="0">
             </div>
-            <div class="col-md-4">
-                <label class="form-label small">Max (seconds)</label>
+            <div class="col-md-3">
+                <label class="form-label small">Max (seconds) <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-dataset-configuration-dataset_typeaudio') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
                 <input type="number"
                        class="form-control form-control-sm"
-                       x-model.number.lazy="editingDataset.audio_max_duration_seconds"
+                       x-model.number.lazy="editingDataset.audio.max_duration_seconds"
                        @input="markAsUnsaved()"
                        step="0.1"
                        min="0"
-                       placeholder="30">
+                       placeholder="No limit">
+                <div class="form-text small">Clips longer than this are skipped</div>
             </div>
-            <div class="col-md-4">
-                <label class="form-label small">Interval</label>
+            <div class="col-md-3">
+                <label class="form-label small">Duration Interval <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-dataset-configuration-dataset_typeaudio') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
                 <input type="number"
                        class="form-control form-control-sm"
-                       x-model.number.lazy="editingDataset.audio_duration_interval"
+                       x-model.number.lazy="editingDataset.audio.duration_interval"
                        @input="markAsUnsaved()"
                        step="0.1"
                        min="0.1"
                        placeholder="3.0">
-                <div class="form-text small">Truncate to nearest multiple</div>
+                <div class="form-text small">Bucket rounding (seconds)</div>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label small">Bucket Strategy <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-dataset-configuration-dataset_typeaudio') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                <select class="form-select form-select-sm"
+                        x-model="editingDataset.audio.bucket_strategy"
+                        @change="markAsUnsaved()">
+                    <option value="">Duration (default)</option>
+                    <option value="duration">Duration</option>
+                </select>
             </div>
         </div>
     </div>
@@ -43,23 +53,25 @@
         <h6 class="modal-section-title">Format</h6>
         <div class="row g-2">
             <div class="col-md-6">
-                <label class="form-label small">Channels</label>
+                <label class="form-label small">Channels <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-dataset-configuration-dataset_typeaudio') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
                 <select class="form-select form-select-sm"
-                        x-model.number.lazy="editingDataset.audio_channels"
+                        x-model.number.lazy="editingDataset.audio.channels"
                         @change="markAsUnsaved()">
                     <option value="1">1 (Mono)</option>
                     <option value="2">2 (Stereo)</option>
                 </select>
             </div>
             <div class="col-md-6">
-                <label class="form-label small">Truncation Mode</label>
+                <label class="form-label small">Truncation Mode <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-dataset-configuration-dataset_typeaudio') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
                 <select class="form-select form-select-sm"
-                        x-model="editingDataset.audio_truncation_mode"
+                        x-model="editingDataset.audio.truncation_mode"
                         @change="markAsUnsaved()">
+                    <option value="">Beginning (default)</option>
                     <option value="beginning">Beginning</option>
                     <option value="end">End</option>
                     <option value="random">Random</option>
                 </select>
+                <div class="form-text small">Which part of clip to keep when truncating</div>
             </div>
         </div>
     </div>

--- a/simpletuner/templates/components/dataloader/sections/basic_body.html
+++ b/simpletuner/templates/components/dataloader/sections/basic_body.html
@@ -179,6 +179,17 @@
                        placeholder="0">
                 <div class="form-text small">0 = single pass, 1+ = extra sweeps</div>
             </div>
+            <div class="col-md-4">
+                <label class="form-label small">Max Samples <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#max_num_samples') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                <input type="number"
+                       class="form-control form-control-sm"
+                       min="0"
+                       step="1"
+                       x-model.number.lazy="editingDataset.max_num_samples"
+                       @input="markAsUnsaved()"
+                       placeholder="No limit">
+                <div class="form-text small">Limit dataset size</div>
+            </div>
             <div class="col-md-4" :class="{'opacity-50': !dangerModeEnabled()}">
                 <label class="form-label small">Probability</label>
                 <input type="number"

--- a/simpletuner/templates/components/dataloader/sections/captions_body.html
+++ b/simpletuner/templates/components/dataloader/sections/captions_body.html
@@ -37,6 +37,24 @@
         </div>
     </div>
 
+    <!-- Text File Options -->
+    <div class="section-group" x-show="editingDataset.caption_strategy === 'textfile' && matchesParamFilter('textfile', 'multiline', 'split', 'newline')" x-cloak>
+        <h6 class="modal-section-title">Text File Options</h6>
+        <div class="form-check">
+            <input class="form-check-input"
+                   type="checkbox"
+                   :id="'disable-multiline-' + editingDataset.id"
+                   x-model="editingDataset.disable_multiline_split"
+                   @change="markAsUnsaved()">
+            <label class="form-check-label small" :for="'disable-multiline-' + editingDataset.id">
+                Disable multiline split <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#disable_multiline_split') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a>
+            </label>
+        </div>
+        <div class="form-text small text-muted ps-4">
+            Preserve line breaks in captions instead of treating each line as a variant
+        </div>
+    </div>
+
     <!-- Trigger Words -->
     <div class="section-group" x-show="editingDataset.dataset_type !== 'text_embeds' && editingDataset.dataset_type !== 'image_embeds' && matchesParamFilter('trigger', 'word', 'instance', 'prompt', 'prepend')">
         <h6 class="modal-section-title">Trigger Words</h6>

--- a/simpletuner/templates/components/dataloader/sections/storage_body.html
+++ b/simpletuner/templates/components/dataloader/sections/storage_body.html
@@ -267,6 +267,27 @@
                        placeholder="hf_...">
             </div>
         </div>
+        <!-- Audio-specific HuggingFace options -->
+        <div class="row g-2 mt-2" x-show="editingDataset.dataset_type === 'audio'" x-cloak>
+            <div class="col-md-6">
+                <label class="form-label small">Audio Caption Fields <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-captions-hugging-face') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                <input type="text"
+                       class="form-control form-control-sm"
+                       x-model="editingDataset._audioCaptionFieldsText"
+                       @input="markAsUnsaved()"
+                       placeholder="prompt, tags">
+                <div class="form-text small">Comma-separated columns joined for caption</div>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label small">Lyrics Column <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-captions-hugging-face') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                <input type="text"
+                       class="form-control form-control-sm"
+                       x-model="editingDataset.lyrics_column"
+                       @input="markAsUnsaved()"
+                       placeholder="lyrics">
+                <div class="form-text small">Column for lyrics (used by lyric encoder)</div>
+            </div>
+        </div>
     </div>
 
     <!-- VAE Cache Directory (for non-local backends) -->

--- a/simpletuner/templates/components/dataloader/sections/video_body.html
+++ b/simpletuner/templates/components/dataloader/sections/video_body.html
@@ -37,6 +37,34 @@
         </div>
     </div>
 
+    <!-- Bucketing -->
+    <div class="section-group" x-show="matchesParamFilter('bucket', 'strategy', 'frame', 'interval', 'resolution')">
+        <h6 class="modal-section-title">Bucketing</h6>
+        <div class="row g-2">
+            <div class="col-md-6">
+                <label class="form-label small">Bucket Strategy <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#video-dataset') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                <select class="form-select form-select-sm"
+                        x-model="editingDataset.video.bucket_strategy"
+                        @change="markAsUnsaved()">
+                    <option value="">Aspect ratio (default)</option>
+                    <option value="aspect_ratio">Aspect ratio</option>
+                    <option value="resolution_frames">Resolution + frames</option>
+                </select>
+                <div class="form-text small">Group videos by aspect or resolution+frames</div>
+            </div>
+            <div class="col-md-6" x-show="editingDataset.video.bucket_strategy === 'resolution_frames'" x-cloak>
+                <label class="form-label small">Frame Interval <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#video-dataset') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                <input type="number"
+                       class="form-control form-control-sm"
+                       min="1"
+                       x-model.number.lazy="editingDataset.video.frame_interval"
+                       @input="markAsUnsaved()"
+                       placeholder="25">
+                <div class="form-text small">Round frames to this interval</div>
+            </div>
+        </div>
+    </div>
+
     <!-- Video Processing -->
     <div class="section-group" x-show="matchesParamFilter('video', 'processing', 'i2v', 'augmentation', 'image')">
         <h6 class="modal-section-title">Video Processing</h6>

--- a/simpletuner/templates/trainer_htmx.html
+++ b/simpletuner/templates/trainer_htmx.html
@@ -1729,6 +1729,12 @@ function trainerComponent() {
                 dataset.video = this.normalizeVideoOptions(dataset.video);
             }
 
+            if (dataset.dataset_type === 'audio') {
+                dataset.audio = this.normalizeAudioOptions(dataset.audio);
+            } else if (dataset.audio && typeof dataset.audio === 'object') {
+                dataset.audio = this.normalizeAudioOptions(dataset.audio);
+            }
+
             if (dataset.dataset_type === 'conditioning') {
                 // Default to 'controlnet' if ControlNet training is enabled, otherwise 'reference_strict'
                 const defaultConditioningType = this.modelContext?.controlnetEnabled ? 'controlnet' : 'reference_strict';
@@ -1813,6 +1819,15 @@ function trainerComponent() {
             );
             dataset.crop_aspect_buckets = buckets;
             dataset._cropAspectBucketsText = buckets.length ? buckets.join(', ') : '';
+
+            // Handle audio_caption_fields array <-> text conversion
+            const audioCaptionFields = this.parseCommaSeparatedText(
+                typeof dataset._audioCaptionFieldsText === 'string' && dataset._audioCaptionFieldsText.trim() !== ''
+                    ? dataset._audioCaptionFieldsText
+                    : dataset.audio_caption_fields,
+            );
+            dataset.audio_caption_fields = audioCaptionFields;
+            dataset._audioCaptionFieldsText = audioCaptionFields.length ? audioCaptionFields.join(', ') : '';
 
             if (Array.isArray(dataset.skip_file_discovery)) {
                 dataset.skip_file_discovery = dataset.skip_file_discovery.join(' ');
@@ -1946,6 +1961,41 @@ function trainerComponent() {
                 } else if (typeof value.is_i2v === 'string' && value.is_i2v.trim() !== '') {
                     result.is_i2v = value.is_i2v.trim().toLowerCase() === 'true';
                 }
+                if (value.bucket_strategy && typeof value.bucket_strategy === 'string') {
+                    result.bucket_strategy = value.bucket_strategy;
+                }
+                const frameInterval = this._coerceInt(value.frame_interval);
+                if (Number.isFinite(frameInterval) && frameInterval > 0) {
+                    result.frame_interval = frameInterval;
+                }
+            }
+            return result;
+        },
+        normalizeAudioOptions(value) {
+            const result = {};
+            if (value && typeof value === 'object') {
+                const minDuration = this._coerceFloat(value.min_duration_seconds);
+                const maxDuration = this._coerceFloat(value.max_duration_seconds);
+                const durationInterval = this._coerceFloat(value.duration_interval);
+                const channels = this._coerceInt(value.channels);
+                if (Number.isFinite(minDuration) && minDuration > 0) {
+                    result.min_duration_seconds = minDuration;
+                }
+                if (Number.isFinite(maxDuration) && maxDuration > 0) {
+                    result.max_duration_seconds = maxDuration;
+                }
+                if (Number.isFinite(durationInterval) && durationInterval > 0) {
+                    result.duration_interval = durationInterval;
+                }
+                if (Number.isFinite(channels) && channels > 0) {
+                    result.channels = channels;
+                }
+                if (value.bucket_strategy && typeof value.bucket_strategy === 'string') {
+                    result.bucket_strategy = value.bucket_strategy;
+                }
+                if (value.truncation_mode && typeof value.truncation_mode === 'string') {
+                    result.truncation_mode = value.truncation_mode;
+                }
             }
             return result;
         },
@@ -2016,6 +2066,20 @@ function trainerComponent() {
                     }
                 });
             return buckets;
+        },
+        parseCommaSeparatedText(text) {
+            if (Array.isArray(text)) {
+                return text
+                    .map((entry) => this._coerceString(entry))
+                    .filter((entry) => entry !== '');
+            }
+            if (typeof text !== 'string' || !text.trim()) {
+                return [];
+            }
+            return text
+                .split(',')
+                .map((entry) => entry.trim())
+                .filter((entry) => entry !== '');
         },
         normalizeSkipList(value) {
             if (Array.isArray(value)) {
@@ -2268,6 +2332,43 @@ function trainerComponent() {
                 } else if (typeof options.is_i2v === 'string' && options.is_i2v.trim() !== '') {
                     cleaned.is_i2v = options.is_i2v.trim().toLowerCase() === 'true';
                 }
+                if (options.bucket_strategy && typeof options.bucket_strategy === 'string' && options.bucket_strategy.trim()) {
+                    cleaned.bucket_strategy = options.bucket_strategy.trim();
+                }
+                const frameInterval = this._coerceInt(options.frame_interval);
+                if (Number.isFinite(frameInterval) && frameInterval > 0) {
+                    cleaned.frame_interval = frameInterval;
+                }
+                return Object.keys(cleaned).length ? cleaned : undefined;
+            };
+
+            const sanitizeAudioOptions = (options) => {
+                if (!options || typeof options !== 'object') {
+                    return undefined;
+                }
+                const cleaned = {};
+                const minDuration = this._coerceFloat(options.min_duration_seconds);
+                const maxDuration = this._coerceFloat(options.max_duration_seconds);
+                const durationInterval = this._coerceFloat(options.duration_interval);
+                const channels = this._coerceInt(options.channels);
+                if (Number.isFinite(minDuration) && minDuration > 0) {
+                    cleaned.min_duration_seconds = minDuration;
+                }
+                if (Number.isFinite(maxDuration) && maxDuration > 0) {
+                    cleaned.max_duration_seconds = maxDuration;
+                }
+                if (Number.isFinite(durationInterval) && durationInterval > 0) {
+                    cleaned.duration_interval = durationInterval;
+                }
+                if (Number.isFinite(channels) && channels > 0) {
+                    cleaned.channels = channels;
+                }
+                if (options.bucket_strategy && typeof options.bucket_strategy === 'string' && options.bucket_strategy.trim()) {
+                    cleaned.bucket_strategy = options.bucket_strategy.trim();
+                }
+                if (options.truncation_mode && typeof options.truncation_mode === 'string' && options.truncation_mode.trim()) {
+                    cleaned.truncation_mode = options.truncation_mode.trim();
+                }
                 return Object.keys(cleaned).length ? cleaned : undefined;
             };
 
@@ -2350,6 +2451,13 @@ function trainerComponent() {
                     }
                 }
 
+                if (cleaned.dataset_type === 'audio') {
+                    const audioOptions = sanitizeAudioOptions(dataset.audio);
+                    if (audioOptions) {
+                        cleaned.audio = audioOptions;
+                    }
+                }
+
                 if (cleaned.type !== 'local') {
                     delete cleaned.instance_data_dir;
                 }
@@ -2422,6 +2530,25 @@ function trainerComponent() {
                         cleaned.crop_aspect_buckets = bucketValues;
                     } else {
                         delete cleaned.crop_aspect_buckets;
+                    }
+                }
+
+                // Handle audio_caption_fields for audio datasets
+                if (dataset.dataset_type === 'audio') {
+                    const audioCaptionSource = typeof dataset._audioCaptionFieldsText === 'string' && dataset._audioCaptionFieldsText.trim() !== ''
+                        ? dataset._audioCaptionFieldsText
+                        : dataset.audio_caption_fields;
+                    const audioCaptionValues = this.parseCommaSeparatedText(audioCaptionSource);
+                    if (audioCaptionValues.length) {
+                        cleaned.audio_caption_fields = audioCaptionValues;
+                    } else {
+                        delete cleaned.audio_caption_fields;
+                    }
+
+                    if (dataset.lyrics_column && dataset.lyrics_column.trim()) {
+                        cleaned.lyrics_column = dataset.lyrics_column.trim();
+                    } else {
+                        delete cleaned.lyrics_column;
                     }
                 }
 
@@ -3518,6 +3645,9 @@ function trainerComponent() {
                     maximum_aspect_ratio: null,
                     crop_aspect_buckets: [],
                     _cropAspectBucketsText: '',
+                    audio_caption_fields: [],
+                    _audioCaptionFieldsText: '',
+                    lyrics_column: '',
                     skip_file_discovery: '',
                     hash_filenames: true,
                     preserve_data_backend_cache: false,
@@ -3531,6 +3661,8 @@ function trainerComponent() {
                     text_embeds: '',
                     image_embeds: '',
                     parquet: {},
+                    video: {},
+                    audio: {},
                     aws_bucket_name: '',
                     aws_data_prefix: '',
                     aws_region_name: '',


### PR DESCRIPTION
This pull request introduces several enhancements and improvements to the dataloader UI and configuration, with a particular focus on audio and video dataset support, advanced options, and user experience. The most important changes include the addition of new configuration options for audio and video datasets, improved advanced settings for destructive operations and metadata refresh, and UI consistency improvements for dataset type handling.

**Audio & Video Dataset Enhancements:**
- Added new audio configuration options, including duration bucketing, bucket strategy, and improved field structure for audio settings in `audio_body.html`. Also, added support for audio-specific HuggingFace dataset options and synchronization logic for caption fields. [[1]](diffhunk://#diff-afef37130b669cd094d745371bcaa8d0ab4bfee6a7e8795f8420903f518507aaL2-R46) [[2]](diffhunk://#diff-afef37130b669cd094d745371bcaa8d0ab4bfee6a7e8795f8420903f518507aaL46-R74) [[3]](diffhunk://#diff-3b2417488dd793fdc882f527a6575cdf1169cb2d6499efeaa79488dc70637f24R270-R290) [[4]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14R1732-R1737) [[5]](diffhunk://#diff-b6c4a44be6638bc81889c0aa13218d0a68fb5ff7692e04a031717490881f0a14R1823-R1831)
- Introduced video bucketing options, allowing users to select a bucket strategy and frame interval for video datasets in `video_body.html`.

**Advanced & Destructive Options:**
- Added a "Metadata Refresh" section to advanced settings, allowing users to set a metadata update interval for applicable dataset types.
- Introduced "Destructive Options" in advanced settings, providing checkboxes to delete unwanted or problematic images with clear warnings.

**UI & Usability Improvements:**
- Added a footer to expanded dataset list items with a "Disable dataset" toggle for quick enable/disable actions. [[1]](diffhunk://#diff-ade0168e7aadcc561ae25a10c4d97146bbf2fd10e7a77642aca84d7f216cf0efR1763-R1768) [[2]](diffhunk://#diff-b6b468193c5b6ec0444409caea4cfa9b5142fd9e9a0ab1ea84cabf447d9985f9R248-R261)
- Added a "Max Samples" field in the basic section to limit dataset size.
- Added "Text File Options" for caption strategy, allowing users to disable multiline split and preserve line breaks.

**Consistency & Restriction Updates:**
- Updated logic and UI to restrict the "Basic" tab for dataset types that do not support it (removing "audio" from the exclusion list so it now supports the basic tab). [[1]](diffhunk://#diff-6911b85e59d4dd6d3e841f2fcfe01eaec290eb8f10a3816640b9f9a216a6e730L373-R373) [[2]](diffhunk://#diff-b6b468193c5b6ec0444409caea4cfa9b5142fd9e9a0ab1ea84cabf447d9985f9L152-R152) [[3]](diffhunk://#diff-821be345a4e0879e1a10179c60214cf912a0979003ccb875758ddf9795fb94d8L48-R48)

These changes collectively improve the flexibility and safety of dataset configuration, especially for audio and video datasets, and provide users with more control and better feedback in the UI.