### PR TITLE
enable full ramtorch mode by default for the transformer so flux2 RMSNorm gets offloaded

### DIFF
--- a/simpletuner/helpers/utils/ramtorch.py
+++ b/simpletuner/helpers/utils/ramtorch.py
@@ -171,13 +171,11 @@ def replace_linear_layers_with_ramtorch(
         return 0
 
     # Calculate how many to replace based on percentage
-    remaining = []
     if use_percent:
         total_eligible = len(eligible)
         num_to_replace = math.ceil(total_eligible * percent / 100)
         if num_to_replace == 0 and percent > 0:
             num_to_replace = 1  # At least one if percent > 0
-        remaining = eligible[num_to_replace:]
         eligible = eligible[:num_to_replace]
         logger.info(
             "RamTorch percentage mode: replacing %d of %d eligible Linear layers (%.1f%%).",
@@ -215,15 +213,6 @@ def replace_linear_layers_with_ramtorch(
 
         setattr(parent, child_name, new_layer)
         replaced += 1
-
-    if remaining or patterns is not None:
-        for _, child in module.named_modules():
-            if not isinstance(child, nn.Linear) or isinstance(child, ramtorch_linear):
-                continue
-            for param in child.parameters(recurse=False):
-                if param.device.type == "cpu":
-                    child.to(resolved_device)
-                    break
 
     return replaced
 


### PR DESCRIPTION
This pull request improves the integration and diagnostics of RamTorch layer conversion in the model loading process. The main focus is on enhancing logging for RamTorch conversions, ensuring correct device placement, and simplifying related utility logic.

**RamTorch conversion and diagnostics:**

* Added detailed logging in `_apply_ramtorch_layers` to report the number and size (in GB) of parameters converted to RamTorch and those remaining as standard parameters, including device information for up to 10 non-converted parameters.
* Changed the logging level from `debug` to `info` when reporting the movement of non-RamTorch parameters to the target device, and included the total size in GB.

**Model loading and device management:**

* Updated `_load_model` to always use `full_ramtorch=True` when applying RamTorch layers, ensuring all eligible layer types (including RMSNorm) are converted. Also, device movement is now skipped if RamTorch is enabled, since RamTorch keeps weights on CPU.

**Utility function simplification:**

* Removed unused `remaining` logic and related code from `replace_linear_layers_with_ramtorch`, simplifying the function and eliminating unnecessary device moves for non-converted layers. [[1]](diffhunk://#diff-35085c1320aeab677e8f229708eb17ff88af3495d0da5f1c1162af961acefd08L174-L180) [[2]](diffhunk://#diff-35085c1320aeab677e8f229708eb17ff88af3495d0da5f1c1162af961acefd08L219-L227)