### PR TITLE
ramtorch should disable quantisation and device moving

### DIFF
--- a/simpletuner/helpers/training/quantisation/__init__.py
+++ b/simpletuner/helpers/training/quantisation/__init__.py
@@ -328,6 +328,16 @@ def _quanto_model(
         logger.info(f"...No quantisation applied to {model.__class__.__name__}.")
         return model
 
+    # Check if model has ramtorch modules - skip quantization entirely if so
+    # RamTorch keeps weights on CPU and streams to GPU, which is incompatible with quantization
+    has_ramtorch = any(getattr(p, "is_ramtorch", False) for p in model.parameters())
+    if has_ramtorch:
+        logger.info(
+            f"Skipping quanto quantization for {model.__class__.__name__} - model uses RamTorch for CPU offloading. "
+            "RamTorch and quantization are incompatible approaches to memory management."
+        )
+        return model
+
     logger.info(f"Quantising {model.__class__.__name__}. Using {model_precision}.")
     weight_quant = _quanto_type_map(model_precision)
     extra_quanto_args = {}
@@ -427,6 +437,16 @@ def _torchao_model(
         return model
     if model_precision == "no_change" or model_precision is None:
         logger.info(f"...No quantisation applied to {model.__class__.__name__}.")
+        return model
+
+    # Check if model has ramtorch modules - skip quantization entirely if so
+    # RamTorch keeps weights on CPU and streams to GPU, which is incompatible with quantization
+    has_ramtorch = any(getattr(p, "is_ramtorch", False) for p in model.parameters())
+    if has_ramtorch:
+        logger.info(
+            f"Skipping torchao quantization for {model.__class__.__name__} - model uses RamTorch for CPU offloading. "
+            "RamTorch and quantization are incompatible approaches to memory management."
+        )
         return model
 
     try:


### PR DESCRIPTION
This pull request introduces important compatibility checks and logic updates to ensure that quantization is not applied to models using RamTorch for CPU offloading, as these two approaches are incompatible. Additionally, it refines how model device placement and dtype conversion are handled when RamTorch is enabled, preventing device moves and ensuring only dtype conversion occurs.

**Quantization compatibility and device handling improvements:**

* Added a check in `_quanto_model` and `_torchao_model` in `simpletuner/helpers/training/quantisation/__init__.py` to skip quantization entirely if any model parameter uses RamTorch (detected via the `is_ramtorch` attribute), with clear logging explaining the incompatibility between RamTorch and quantization. [[1]](diffhunk://#diff-b1e7c0be21b43a43948fe6f04ff01641e8890b137f8cd8c3d2300fe420411198R331-R340) [[2]](diffhunk://#diff-b1e7c0be21b43a43948fe6f04ff01641e8890b137f8cd8c3d2300fe420411198R442-R451)

* Updated `init_precision` in `simpletuner/helpers/training/trainer.py` to skip device movement and only perform dtype conversion when RamTorch is enabled, since RamTorch manages device placement itself. This logic applies to both the main model and ControlNet, with improved logging for clarity.