### PR TITLE
unsloth checkpointing: flux2, hv, kv5, ltx2, wan, zim

### DIFF
--- a/simpletuner/helpers/models/ltxvideo2/transformer.py
+++ b/simpletuner/helpers/models/ltxvideo2/transformer.py
@@ -1129,6 +1129,7 @@ class LTX2VideoTransformer3DModel(
         self.audio_proj_out = nn.Linear(audio_inner_dim, audio_out_channels)
 
         self.gradient_checkpointing = False
+        self.gradient_checkpointing_backend = "torch"
         self.time_sign_embed: Optional[nn.Embedding] = None
         self.audio_time_sign_embed: Optional[nn.Embedding] = None
         if enable_time_sign_embed:
@@ -1146,6 +1147,9 @@ class LTX2VideoTransformer3DModel(
             swap_device=musubi_block_swap_device,
             logger=logger,
         )
+
+    def set_gradient_checkpointing_backend(self, backend: str):
+        self.gradient_checkpointing_backend = backend
 
     def set_router(self, router: TREADRouter, routes: Optional[List[Dict[str, Any]]] = None):
         """Attach a TREAD router and route definitions."""
@@ -1423,7 +1427,14 @@ class LTX2VideoTransformer3DModel(
                 musubi_manager.stream_in(block, hidden_states.device)
 
             if torch.is_grad_enabled() and self.gradient_checkpointing:
-                hidden_states, audio_hidden_states = self._gradient_checkpointing_func(
+                if self.gradient_checkpointing_backend == "unsloth":
+                    from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
+
+                    checkpoint_fn = offloaded_checkpoint
+                else:
+                    checkpoint_fn = torch.utils.checkpoint.checkpoint
+
+                hidden_states, audio_hidden_states = checkpoint_fn(
                     block,
                     hidden_states,
                     audio_hidden_states,
@@ -1441,6 +1452,7 @@ class LTX2VideoTransformer3DModel(
                     audio_cross_attn_rotary_emb,
                     encoder_attention_mask,
                     audio_encoder_attention_mask,
+                    use_reentrant=False,
                 )
             else:
                 hidden_states, audio_hidden_states = block(
@@ -1513,7 +1525,9 @@ class LTX2VideoTransformer3DModel(
         hidden_states = hidden_states * (1 + scale) + shift
         output = self.proj_out(hidden_states)
 
-        audio_scale_shift_values = self.audio_scale_shift_table[None, None].to(audio_embedded_timestep.device) + audio_embedded_timestep[:, :, None]
+        audio_scale_shift_values = (
+            self.audio_scale_shift_table[None, None].to(audio_embedded_timestep.device) + audio_embedded_timestep[:, :, None]
+        )
         audio_shift, audio_scale = audio_scale_shift_values[:, :, 0], audio_scale_shift_values[:, :, 1]
 
         audio_hidden_states = self.audio_norm_out(audio_hidden_states)


### PR DESCRIPTION
This pull request adds support for selecting the backend used for gradient checkpointing in several transformer model classes. It introduces a new attribute and setter method to specify the backend, allowing users to choose between the default PyTorch checkpointing and a custom "unsloth" offloaded checkpointing implementation. The forward methods are updated to use the selected backend dynamically.

### Gradient checkpointing backend selection

* Added a new attribute `gradient_checkpointing_backend` (defaulting to `"torch"`) and a corresponding `set_gradient_checkpointing_backend` method to all relevant transformer model classes, enabling runtime selection of the checkpointing backend. [[1]](diffhunk://#diff-dc724b7872bbf8da3e20198895e6b013646442113c5cbaaced6028c23aaabc78R837) [[2]](diffhunk://#diff-11e3602fb2ffa5f8a976887e93337fb72a30783152bd32fa317fbde1dd418370R678) [[3]](diffhunk://#diff-86a056789af901f8bbf232bf7e04f6f6f236c3e3f74cb3f35193deda9632af63R706-R716) [[4]](diffhunk://#diff-74bb16505072fd326a32489c14b3f8656c7108552ed74e0a26002f86a41bbc1eR968) [[5]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3R1132) [[6]](diffhunk://#diff-41de8cc2788649a626338119dfe8ed7c7a9ebaeee88132abc387bf645115921eR684) [[7]](diffhunk://#diff-8a4adb9e6956a827ded3b9935466f2f2d4459ac3be5c6e7c5db05fc21644d0bdR431)

### Forward method updates for backend support

* Updated all affected model `forward` methods to use the selected checkpointing backend (`torch.utils.checkpoint.checkpoint` or the custom `offloaded_checkpoint` from "unsloth") when gradient checkpointing is enabled. This includes replacing calls to `_gradient_checkpointing_func` with the chosen backend and passing `use_reentrant=False` for compatibility. [[1]](diffhunk://#diff-dc724b7872bbf8da3e20198895e6b013646442113c5cbaaced6028c23aaabc78L1056-R1082) [[2]](diffhunk://#diff-dc724b7872bbf8da3e20198895e6b013646442113c5cbaaced6028c23aaabc78L1148-R1188) [[3]](diffhunk://#diff-11e3602fb2ffa5f8a976887e93337fb72a30783152bd32fa317fbde1dd418370R838-R855) [[4]](diffhunk://#diff-86a056789af901f8bbf232bf7e04f6f6f236c3e3f74cb3f35193deda9632af63L790-R801) [[5]](diffhunk://#diff-86a056789af901f8bbf232bf7e04f6f6f236c3e3f74cb3f35193deda9632af63L866-R891) [[6]](diffhunk://#diff-74bb16505072fd326a32489c14b3f8656c7108552ed74e0a26002f86a41bbc1eL1075-R1086) [[7]](diffhunk://#diff-74bb16505072fd326a32489c14b3f8656c7108552ed74e0a26002f86a41bbc1eR1097) [[8]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3L1426-R1437) [[9]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3R1455) [[10]](diffhunk://#diff-41de8cc2788649a626338119dfe8ed7c7a9ebaeee88132abc387bf645115921eL871-R888) [[11]](diffhunk://#diff-8a4adb9e6956a827ded3b9935466f2f2d4459ac3be5c6e7c5db05fc21644d0bdR688-R696)

### API consistency improvements

* Ensured all transformer classes expose a consistent API for setting the gradient checkpointing backend by adding the `set_gradient_checkpointing_backend` method where missing. [[1]](diffhunk://#diff-dc724b7872bbf8da3e20198895e6b013646442113c5cbaaced6028c23aaabc78R850-R852) [[2]](diffhunk://#diff-11e3602fb2ffa5f8a976887e93337fb72a30783152bd32fa317fbde1dd418370R905-R907) [[3]](diffhunk://#diff-86a056789af901f8bbf232bf7e04f6f6f236c3e3f74cb3f35193deda9632af63R706-R716) [[4]](diffhunk://#diff-74bb16505072fd326a32489c14b3f8656c7108552ed74e0a26002f86a41bbc1eR977-R979) [[5]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3R1151-R1153) [[6]](diffhunk://#diff-41de8cc2788649a626338119dfe8ed7c7a9ebaeee88132abc387bf645115921eR704-R706) [[7]](diffhunk://#diff-8a4adb9e6956a827ded3b9935466f2f2d4459ac3be5c6e7c5db05fc21644d0bdR504-R506)

### Minor code cleanup

* Minor formatting and assignment improvements, such as parenthesizing a long assignment in `ltxvideo2/transformer.py`.