### PR TITLE
bypass validation scheduler setup for special models

### DIFF
--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -1205,6 +1205,13 @@ class ModelFoundation(ABC):
         """
         return False
 
+    def requires_special_scheduler_setup(self) -> bool:
+        """
+        Returns True when validation should skip scheduler replacement and let
+        the model pipeline configure its own scheduler.
+        """
+        return False
+
     def conditioning_validation_dataset_type(self) -> str:
         """
         Returns the dataset type to use for conditioning during validation.

--- a/simpletuner/helpers/models/ltxvideo/model.py
+++ b/simpletuner/helpers/models/ltxvideo/model.py
@@ -218,6 +218,9 @@ class LTXVideo(VideoModelFoundation):
 
         return pipeline_kwargs
 
+    def requires_special_scheduler_setup(self) -> bool:
+        return True
+
     def _format_text_embedding(self, text_embedding: torch.Tensor):
         """
         Models can optionally format the stored text embedding, eg. in a dict, or

--- a/simpletuner/helpers/models/ltxvideo2/model.py
+++ b/simpletuner/helpers/models/ltxvideo2/model.py
@@ -144,6 +144,9 @@ class LTXVideo2(VideoModelFoundation):
             return list(self.AUDIO_LORA_TARGETS)
         return []
 
+    def requires_special_scheduler_setup(self) -> bool:
+        return True
+
     def get_lora_target_layers(self):
         manual_targets = self._get_peft_lora_target_modules()
         if manual_targets:

--- a/simpletuner/helpers/models/sana/model.py
+++ b/simpletuner/helpers/models/sana/model.py
@@ -76,6 +76,9 @@ class Sana(ImageModelFoundation):
         },
     }
 
+    def requires_special_scheduler_setup(self) -> bool:
+        return True
+
     def _format_text_embedding(self, text_embedding: torch.Tensor):
         """
         Models can optionally format the stored text embedding, eg. in a dict, or

--- a/simpletuner/helpers/models/sanavideo/model.py
+++ b/simpletuner/helpers/models/sanavideo/model.py
@@ -76,6 +76,9 @@ class SanaVideo(VideoModelFoundation):
         },
     }
 
+    def requires_special_scheduler_setup(self) -> bool:
+        return True
+
     @classmethod
     def adjust_video_frames(cls, num_frames: int) -> int:
         """Adjust frame count to satisfy frames % 8 == 1 constraint."""

--- a/simpletuner/helpers/models/wan/model.py
+++ b/simpletuner/helpers/models/wan/model.py
@@ -300,6 +300,9 @@ class Wan(VideoModelFoundation):
         },
     }
 
+    def requires_special_scheduler_setup(self) -> bool:
+        return True
+
     @classmethod
     def adjust_video_frames(cls, num_frames: int) -> int:
         """Adjust frame count to satisfy frames % 8 == 1 constraint."""

--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -1979,6 +1979,10 @@ class Validation:
             logger.info(f"TwinFlow validation using UCGM scheduler for {twinflow_steps}-step generation")
             return scheduler
 
+        if self.model.requires_special_scheduler_setup():
+            # allow the model's pipeline to initialise the scheduler itself
+            return
+
         scheduler_args = {
             "prediction_type": self.config.prediction_type,
         }


### PR DESCRIPTION
This pull request introduces a new mechanism for models to indicate if they require special handling when setting up schedulers during validation. Several model classes now override a new method to signal that scheduler setup should be delegated to the model pipeline, and the validation logic is updated to respect this flag.

**Scheduler setup improvements:**

* Added a new method `requires_special_scheduler_setup` to the base model class (`common.py`), allowing models to specify if they need custom scheduler initialization.
* Updated the validation logic in `validation.py` to check `requires_special_scheduler_setup` and skip default scheduler setup if the method returns `True`.

**Model-specific overrides:**

* Implemented `requires_special_scheduler_setup` to return `True` for the following models, indicating that they handle scheduler setup internally:
  * `ltxvideo` (`model.py`)
  * `ltxvideo2` (`model.py`)
  * `Sana` (`model.py`)
  * `SanaVideo` (`model.py`)
  * `Wan` (`model.py`)