### PR TITLE
torchao: fix int8 weight only quant via pipeline

### DIFF
--- a/simpletuner/helpers/training/quantisation/__init__.py
+++ b/simpletuner/helpers/training/quantisation/__init__.py
@@ -198,9 +198,9 @@ def _build_quanto_fp8uz_config(
 
 
 TORCHAO_PIPELINE_PRESET_MAP = {
-    "int4-torchao": "int4wo",
-    "int8-torchao": "int8wo",
-    "fp8-torchao": "float8wo_e4m3",
+    "int4-torchao": "int4_weight_only",
+    "int8-torchao": "int8_weight_only",
+    "fp8-torchao": "float8_weight_only",
 }
 QUANTO_PIPELINE_PRESET_MAP = {
     "int8-quanto": "int8",


### PR DESCRIPTION
This pull request updates the preset mapping names for the TorchAO quantization pipelines in the `simpletuner/helpers/training/quantisation/__init__.py` file. The new names are more descriptive and consistent with naming conventions.

Quantization pipeline preset mapping updates:

* Updated `TORCHAO_PIPELINE_PRESET_MAP` to use more explicit preset names: `"int4_weight_only"`, `"int8_weight_only"`, and `"float8_weight_only"` instead of their previous shorter forms.