### PR TITLE
add --ramtorch_disable_extensions and --ramtorch_disable_sync_hooks to disable custom features

### DIFF
--- a/documentation/OPTIONS.es.md
+++ b/documentation/OPTIONS.es.md
@@ -170,6 +170,20 @@ Donde `foo` es tu entorno de configuración; o simplemente usa `config/config.js
 - **Por qué**: Permite la descarga parcial de codificadores de texto cuando `--ramtorch_text_encoder` está habilitado.
 - **Notas**: Solo aplica cuando `--ramtorch_text_encoder` está habilitado.
 
+### `--ramtorch_disable_sync_hooks`
+
+- **Qué**: Desactiva los hooks de sincronización CUDA que se añaden después de las capas RamTorch.
+- **Predeterminado**: `False` (hooks de sincronización habilitados)
+- **Por qué**: Los hooks de sincronización corrigen condiciones de carrera en el sistema de buffering ping-pong de RamTorch que pueden causar salidas no deterministas. Desactivarlos puede mejorar el rendimiento pero arriesga resultados incorrectos.
+- **Notas**: Solo desactivar si experimentas problemas con los hooks de sincronización o quieres probar sin ellos.
+
+### `--ramtorch_disable_extensions`
+
+- **Qué**: Solo aplica RamTorch a capas Linear, omite Embedding/RMSNorm/LayerNorm/Conv.
+- **Predeterminado**: `False` (extensiones habilitadas)
+- **Por qué**: SimpleTuner extiende RamTorch más allá de las capas Linear para incluir capas Embedding, RMSNorm, LayerNorm y Conv. Usa esto para desactivar esas extensiones y solo descargar capas Linear.
+- **Notas**: Puede reducir el ahorro de VRAM pero puede ayudar a depurar problemas con los tipos de capas extendidas.
+
 ### `--pretrained_model_name_or_path`
 
 - **Qué**: Ruta al modelo preentrenado o su identificador en <https://huggingface.co/models>.

--- a/documentation/OPTIONS.hi.md
+++ b/documentation/OPTIONS.hi.md
@@ -170,6 +170,20 @@ simpletuner configure config/foo/config.json
 - **Why**: जब `--ramtorch_text_encoder` enabled हो तब text encoders की partial offloading की अनुमति देता है।
 - **Notes**: केवल तब लागू होता है जब `--ramtorch_text_encoder` enabled हो।
 
+### `--ramtorch_disable_sync_hooks`
+
+- **What**: RamTorch layers के बाद add किए गए CUDA synchronization hooks को disable करता है।
+- **Default**: `False` (sync hooks enabled)
+- **Why**: Sync hooks RamTorch के ping-pong buffering system में race conditions को fix करते हैं जो non-deterministic outputs का कारण बन सकते हैं। Disable करने से performance बेहतर हो सकता है लेकिन incorrect results का risk है।
+- **Notes**: केवल तब disable करें जब sync hooks में समस्या हो या उनके बिना test करना हो।
+
+### `--ramtorch_disable_extensions`
+
+- **What**: केवल Linear layers पर RamTorch apply करता है, Embedding/RMSNorm/LayerNorm/Conv को skip करता है।
+- **Default**: `False` (extensions enabled)
+- **Why**: SimpleTuner RamTorch को Linear layers से आगे बढ़ाकर Embedding, RMSNorm, LayerNorm, और Conv layers को include करता है। इन extensions को disable करके केवल Linear layers offload करने के लिए इसका उपयोग करें।
+- **Notes**: VRAM savings कम हो सकती है लेकिन extended layer types की समस्याओं को debug करने में मदद कर सकता है।
+
 ### `--pretrained_model_name_or_path`
 
 - **What**: pretrained model का path या <https://huggingface.co/models> से उसका identifier.

--- a/documentation/OPTIONS.ja.md
+++ b/documentation/OPTIONS.ja.md
@@ -171,6 +171,20 @@ simpletuner configure config/foo/config.json
 - **理由**: `--ramtorch_text_encoder` 有効時にテキストエンコーダーの部分的なオフロードを可能にします。
 - **注記**: `--ramtorch_text_encoder` が有効な場合のみ適用。
 
+### `--ramtorch_disable_sync_hooks`
+
+- **内容**: RamTorch レイヤーの後に追加される CUDA 同期フックを無効にします。
+- **既定**: `False`（同期フック有効）
+- **理由**: 同期フックは RamTorch のピンポンバッファリングシステムにおける競合状態を修正し、非決定的な出力を防ぎます。無効にするとパフォーマンスが向上する可能性がありますが、不正確な結果のリスクがあります。
+- **注記**: 同期フックに問題がある場合やテストする場合にのみ無効にしてください。
+
+### `--ramtorch_disable_extensions`
+
+- **内容**: Linear レイヤーのみに RamTorch を適用し、Embedding/RMSNorm/LayerNorm/Conv をスキップします。
+- **既定**: `False`（拡張機能有効）
+- **理由**: SimpleTuner は RamTorch を Linear レイヤー以外に拡張し、Embedding、RMSNorm、LayerNorm、Conv レイヤーを含めます。この拡張機能を無効にして Linear レイヤーのみをオフロードするにはこのオプションを使用します。
+- **注記**: VRAM 節約が減少する可能性がありますが、拡張レイヤータイプの問題をデバッグするのに役立ちます。
+
 ### `--pretrained_model_name_or_path`
 
 - **内容**: 事前学習済みモデルのパス、または <https://huggingface.co/models> の識別子。

--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -170,6 +170,20 @@ Where `foo` is your config environment - or just use `config/config.json` if you
 - **Why**: Allows partial offloading of text encoders when `--ramtorch_text_encoder` is enabled.
 - **Notes**: Only applies when `--ramtorch_text_encoder` is enabled.
 
+### `--ramtorch_disable_sync_hooks`
+
+- **What**: Disable CUDA synchronization hooks that are added after RamTorch layers.
+- **Default**: `False` (sync hooks enabled)
+- **Why**: Sync hooks fix race conditions in RamTorch's ping-pong buffering system that can cause non-deterministic outputs. Disabling may improve performance but risks incorrect results.
+- **Notes**: Only disable if you experience issues with sync hooks or want to test without them.
+
+### `--ramtorch_disable_extensions`
+
+- **What**: Only apply RamTorch to Linear layers, skip Embedding/RMSNorm/LayerNorm/Conv.
+- **Default**: `False` (extensions enabled)
+- **Why**: SimpleTuner extends RamTorch beyond Linear layers to include Embedding, RMSNorm, LayerNorm, and Conv layers. Use this to disable those extensions and only offload Linear layers.
+- **Notes**: May reduce VRAM savings but can help debug issues with the extended layer types.
+
 ### `--pretrained_model_name_or_path`
 
 - **What**: Path to the pretrained model or its identifier from <https://huggingface.co/models>.

--- a/documentation/OPTIONS.pt-BR.md
+++ b/documentation/OPTIONS.pt-BR.md
@@ -170,6 +170,20 @@ Onde `foo` e seu ambiente de config — ou use `config/config.json` se nao estiv
 - **Por que**: Permite descarregamento parcial de codificadores de texto quando `--ramtorch_text_encoder` esta habilitado.
 - **Notas**: Aplica-se apenas quando `--ramtorch_text_encoder` esta habilitado.
 
+### `--ramtorch_disable_sync_hooks`
+
+- **O que**: Desativa os hooks de sincronizacao CUDA adicionados apos as camadas RamTorch.
+- **Padrao**: `False` (hooks de sincronizacao habilitados)
+- **Por que**: Os hooks de sincronizacao corrigem condicoes de corrida no sistema de buffering ping-pong do RamTorch que podem causar saidas nao deterministicas. Desativar pode melhorar o desempenho, mas arrisca resultados incorretos.
+- **Notas**: Desative apenas se tiver problemas com os hooks de sincronizacao ou quiser testar sem eles.
+
+### `--ramtorch_disable_extensions`
+
+- **O que**: Aplica RamTorch apenas a camadas Linear, pula Embedding/RMSNorm/LayerNorm/Conv.
+- **Padrao**: `False` (extensoes habilitadas)
+- **Por que**: O SimpleTuner estende o RamTorch alem das camadas Linear para incluir camadas Embedding, RMSNorm, LayerNorm e Conv. Use isso para desativar essas extensoes e descarregar apenas camadas Linear.
+- **Notas**: Pode reduzir a economia de VRAM, mas pode ajudar a depurar problemas com os tipos de camadas estendidas.
+
 ### `--pretrained_model_name_or_path`
 
 - **O que**: Caminho para o modelo pre-treinado ou seu identificador em <https://huggingface.co/models>.

--- a/documentation/OPTIONS.zh.md
+++ b/documentation/OPTIONS.zh.md
@@ -171,6 +171,20 @@ simpletuner configure config/foo/config.json
 - **原因**：当启用 `--ramtorch_text_encoder` 时，允许部分卸载文本编码器。
 - **说明**：仅在启用 `--ramtorch_text_encoder` 时适用。
 
+### `--ramtorch_disable_sync_hooks`
+
+- **内容**：禁用 RamTorch 层后添加的 CUDA 同步钩子。
+- **默认**：`False`（同步钩子已启用）
+- **原因**：同步钩子修复了 RamTorch 乒乓缓冲系统中可能导致非确定性输出的竞争条件。禁用可能提高性能，但有结果不正确的风险。
+- **说明**：仅在同步钩子出现问题或想要测试时才禁用。
+
+### `--ramtorch_disable_extensions`
+
+- **内容**：仅对 Linear 层应用 RamTorch，跳过 Embedding/RMSNorm/LayerNorm/Conv。
+- **默认**：`False`（扩展已启用）
+- **原因**：SimpleTuner 将 RamTorch 扩展到 Linear 层之外，包括 Embedding、RMSNorm、LayerNorm 和 Conv 层。使用此选项禁用这些扩展，仅卸载 Linear 层。
+- **说明**：可能减少显存节省，但有助于调试扩展层类型的问题。
+
 ### `--pretrained_model_name_or_path`
 
 - **内容**：预训练模型路径或 <https://huggingface.co/models> 上的标识符。

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/training.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/training.py
@@ -416,6 +416,42 @@ def register_training_fields(registry: "FieldRegistry") -> None:
 
     registry._add_field(
         ConfigField(
+            name="ramtorch_disable_sync_hooks",
+            arg_name="--ramtorch_disable_sync_hooks",
+            ui_label="Disable RamTorch Sync Hooks",
+            field_type=FieldType.CHECKBOX,
+            tab="model",
+            section="memory_optimization",
+            default_value=False,
+            help_text="Disable CUDA synchronization hooks added after RamTorch layers.",
+            tooltip="Sync hooks fix race conditions in RamTorch but add overhead. Only disable if you experience issues.",
+            importance=ImportanceLevel.EXPERIMENTAL,
+            order=12,
+            dependencies=[FieldDependency(field="ramtorch", operator="equals", value=True, action="show")],
+            documentation="OPTIONS.md#--ramtorch_disable_sync_hooks",
+        )
+    )
+
+    registry._add_field(
+        ConfigField(
+            name="ramtorch_disable_extensions",
+            arg_name="--ramtorch_disable_extensions",
+            ui_label="Disable RamTorch Extensions",
+            field_type=FieldType.CHECKBOX,
+            tab="model",
+            section="memory_optimization",
+            default_value=False,
+            help_text="Only apply RamTorch to Linear layers, skip Embedding/RMSNorm/LayerNorm/Conv.",
+            tooltip="Use this to disable SimpleTuner's RamTorch extensions for Embedding, RMSNorm, LayerNorm, and Conv layers.",
+            importance=ImportanceLevel.EXPERIMENTAL,
+            order=13,
+            dependencies=[FieldDependency(field="ramtorch", operator="equals", value=True, action="show")],
+            documentation="OPTIONS.md#--ramtorch_disable_extensions",
+        )
+    )
+
+    registry._add_field(
+        ConfigField(
             name="group_offload_type",
             arg_name="--group_offload_type",
             ui_label="Group Offload Granularity",


### PR DESCRIPTION
The Embedding/RMSNorm and others may not be needed on medium-to-large GPUs, and can cause problems.

The sync hooks are added to ensure deterministic operations for RamTorch since it has drift between executions. Disabling them can speed it up a little bit, at the risk of having random differences during training.

note: ramtorch uses stochastic rounding internally anyway during training, accuracy isn't guaranteed.