### PR TITLE
prevent double-encoding of captions for audio auto-split dataset

### DIFF
--- a/simpletuner/helpers/data_backend/factory.py
+++ b/simpletuner/helpers/data_backend/factory.py
@@ -3268,6 +3268,13 @@ class FactoryRegistry:
         """Process text embeddings for captions."""
         if not self._uses_text_embeddings_cache():
             return
+        # Skip text embed processing for audio datasets that source from video.
+        # These datasets inherit captions from their parent dataset during training
+        # (see MultiAspectSampler.__getitem__ where source_dataset_id triggers caption lookup from parent).
+        audio_config = backend.get("audio", {})
+        if audio_config.get("source_from_video", False):
+            info_log(f"(id={init_backend['id']}) Skipping text embedding processing for source_from_video audio dataset.")
+            return
         # We get captions from the IMAGE dataset. Not the text embeds dataset.
         # caption_strategy is stored in init_backend["config"], not directly in backend
         caption_strategy = init_backend["config"].get("caption_strategy")


### PR DESCRIPTION
This pull request introduces a safeguard to the text embeddings processing logic for audio datasets that source their data from video. Specifically, it ensures that text embedding processing is skipped for these datasets, as they inherit captions from their parent video dataset during training.

Text embedding processing logic:

* In `simpletuner/helpers/data_backend/factory.py`, the `_process_text_embeddings` function now checks if the audio dataset is configured with `source_from_video=True` and skips text embedding processing in that case, logging an informational message. This prevents redundant processing since captions are inherited from the parent dataset.