### PR TITLE
ui: add audio options for video datasets on models which support a+v

### DIFF
--- a/simpletuner/static/js/dataloader-section-component.js
+++ b/simpletuner/static/js/dataloader-section-component.js
@@ -220,6 +220,20 @@ function dataloaderSectionComponent() {
         ).toString().toLowerCase();
         return family === 'ace_step';
     },
+    get supportsAudioInputs() {
+        // Check if the model supports audio inputs (for video models that can use audio conditioning)
+        const context = this.modelContext || {};
+        const capabilities = context.capabilities || {};
+        return this.normalizeBoolean(capabilities.supports_audio_inputs) ||
+               this.normalizeBoolean(context.supportsAudioInputs);
+    },
+    get requiresS2VDatasets() {
+        // Check if the model requires S2V (sound-to-video) datasets
+        const context = this.modelContext || {};
+        const capabilities = context.capabilities || {};
+        return this.normalizeBoolean(capabilities.requires_s2v_datasets) ||
+               this.normalizeBoolean(context.requiresS2VDatasets);
+    },
     get requiresStrictI2VDatasets() {
         const context = this.modelContext || {};
         const active = this.normalizeBoolean(context.strictI2VActive);

--- a/simpletuner/static/js/dataset-wizard.js
+++ b/simpletuner/static/js/dataset-wizard.js
@@ -198,6 +198,15 @@
                 return family === 'ace_step';
             },
 
+            get supportsAudioInputs() {
+                // Check if the model supports audio inputs (for video models that can use audio conditioning)
+                const trainer = Alpine.store('trainer');
+                if (!trainer) return false;
+                const context = trainer.modelContext || {};
+                const capabilities = context.capabilities || {};
+                return Boolean(capabilities.supports_audio_inputs || context.supportsAudioInputs);
+            },
+
             get hasPrimaryDatasetAvailable() {
                 const excludeId = this.editingQueuedDataset ? this.currentDataset.id : null;
                 const queueHas = this.datasetQueue.some(dataset => this.isPrimaryDataset(dataset, excludeId));

--- a/simpletuner/templates/components/dataloader/dataset_modal.html
+++ b/simpletuner/templates/components/dataloader/dataset_modal.html
@@ -71,7 +71,7 @@
                 </button>
                 <button type="button"
                         :class="{'active': modalTab === 'audio'}"
-                        x-show="editingDataset.dataset_type === 'audio'"
+                        x-show="editingDataset.dataset_type === 'audio' || (editingDataset.dataset_type === 'video' && supportsAudioInputs)"
                         @click="modalTab = 'audio'">
                     <i class="fas fa-music"></i>
                     <span>Audio</span>

--- a/simpletuner/templates/components/dataloader/sections/audio_body.html
+++ b/simpletuner/templates/components/dataloader/sections/audio_body.html
@@ -1,78 +1,187 @@
 <!-- Audio Settings Body (for modal) -->
 <div class="modal-section-body" x-init="editingDataset.audio = editingDataset.audio || {}">
-    <!-- Duration Settings -->
-    <div class="section-group" x-show="matchesParamFilter('duration', 'min', 'max', 'interval', 'seconds', 'truncate', 'bucket')">
-        <h6 class="modal-section-title">Duration & Bucketing</h6>
-        <div class="row g-2">
-            <div class="col-md-3">
-                <label class="form-label small">Min (seconds) <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-dataset-configuration-dataset_typeaudio') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
-                <input type="number"
-                       class="form-control form-control-sm"
-                       x-model.number.lazy="editingDataset.audio.min_duration_seconds"
-                       @input="markAsUnsaved()"
-                       step="0.1"
-                       min="0"
-                       placeholder="0">
+    <!-- Video Audio Auto-Split Settings (shown for video datasets) -->
+    <template x-if="editingDataset.dataset_type === 'video'">
+        <div>
+            <!-- Auto-Split Toggle -->
+            <div class="section-group" x-show="matchesParamFilter('auto', 'split', 'extract', 'audio')">
+                <h6 class="modal-section-title">Audio Extraction</h6>
+                <div class="row g-2">
+                    <div class="col-12">
+                        <div class="form-check form-switch">
+                            <input type="checkbox"
+                                   class="form-check-input"
+                                   id="audio-auto-split"
+                                   x-model="editingDataset.audio.auto_split"
+                                   @change="markAsUnsaved()">
+                            <label class="form-check-label" for="audio-auto-split">
+                                Auto-extract audio from videos
+                                <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#s2vsound-to-video-audio-configuration') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a>
+                            </label>
+                        </div>
+                        <div class="form-text small">
+                            When enabled, audio will be automatically extracted from video files and used for audio conditioning.
+                            A separate audio dataset will be created automatically.
+                        </div>
+                    </div>
+                </div>
             </div>
-            <div class="col-md-3">
-                <label class="form-label small">Max (seconds) <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-dataset-configuration-dataset_typeaudio') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
-                <input type="number"
-                       class="form-control form-control-sm"
-                       x-model.number.lazy="editingDataset.audio.max_duration_seconds"
-                       @input="markAsUnsaved()"
-                       step="0.1"
-                       min="0"
-                       placeholder="No limit">
-                <div class="form-text small">Clips longer than this are skipped</div>
-            </div>
-            <div class="col-md-3">
-                <label class="form-label small">Duration Interval <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-dataset-configuration-dataset_typeaudio') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
-                <input type="number"
-                       class="form-control form-control-sm"
-                       x-model.number.lazy="editingDataset.audio.duration_interval"
-                       @input="markAsUnsaved()"
-                       step="0.1"
-                       min="0.1"
-                       placeholder="3.0">
-                <div class="form-text small">Bucket rounding (seconds)</div>
-            </div>
-            <div class="col-md-3">
-                <label class="form-label small">Bucket Strategy <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-dataset-configuration-dataset_typeaudio') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
-                <select class="form-select form-select-sm"
-                        x-model="editingDataset.audio.bucket_strategy"
-                        @change="markAsUnsaved()">
-                    <option value="">Duration (default)</option>
-                    <option value="duration">Duration</option>
-                </select>
-            </div>
-        </div>
-    </div>
 
-    <!-- Audio Format -->
-    <div class="section-group" x-show="matchesParamFilter('format', 'channel', 'mono', 'stereo', 'truncation', 'mode')">
-        <h6 class="modal-section-title">Format</h6>
-        <div class="row g-2">
-            <div class="col-md-6">
-                <label class="form-label small">Channels <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-dataset-configuration-dataset_typeaudio') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
-                <select class="form-select form-select-sm"
-                        x-model.number.lazy="editingDataset.audio.channels"
-                        @change="markAsUnsaved()">
-                    <option value="1">1 (Mono)</option>
-                    <option value="2">2 (Stereo)</option>
-                </select>
+            <!-- Audio Format Settings (shown when auto_split is enabled or has value) -->
+            <template x-if="editingDataset.audio.auto_split !== false">
+                <div>
+                    <div class="section-group" x-show="matchesParamFilter('sample', 'rate', 'channel', 'format')">
+                        <h6 class="modal-section-title">Audio Format</h6>
+                        <div class="row g-2">
+                            <div class="col-md-4">
+                                <label class="form-label small">Sample Rate (Hz) <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#s2vsound-to-video-audio-configuration') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                                <input type="number"
+                                       class="form-control form-control-sm"
+                                       x-model.number.lazy="editingDataset.audio.sample_rate"
+                                       @input="markAsUnsaved()"
+                                       step="1000"
+                                       min="8000"
+                                       placeholder="16000">
+                                <div class="form-text small">16000 Hz recommended for Wav2Vec2</div>
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label small">Channels <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#s2vsound-to-video-audio-configuration') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                                <select class="form-select form-select-sm"
+                                        x-model.number.lazy="editingDataset.audio.channels"
+                                        @change="markAsUnsaved()">
+                                    <option value="">Default</option>
+                                    <option value="1">1 (Mono)</option>
+                                    <option value="2">2 (Stereo)</option>
+                                </select>
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label small">Duration Interval <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#s2vsound-to-video-audio-configuration') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                                <input type="number"
+                                       class="form-control form-control-sm"
+                                       x-model.number.lazy="editingDataset.audio.duration_interval"
+                                       @input="markAsUnsaved()"
+                                       step="0.1"
+                                       min="0.1"
+                                       placeholder="3.0">
+                                <div class="form-text small">Bucket rounding (seconds)</div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="section-group" x-show="matchesParamFilter('truncation', 'zero', 'silent', 'mode')">
+                        <h6 class="modal-section-title">Handling Options</h6>
+                        <div class="row g-2">
+                            <div class="col-md-6">
+                                <label class="form-label small">Truncation Mode <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#s2vsound-to-video-audio-configuration') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                                <select class="form-select form-select-sm"
+                                        x-model="editingDataset.audio.truncation_mode"
+                                        @change="markAsUnsaved()">
+                                    <option value="">Beginning (default)</option>
+                                    <option value="beginning">Beginning</option>
+                                    <option value="end">End</option>
+                                    <option value="random">Random</option>
+                                </select>
+                                <div class="form-text small">Which part of audio to keep when truncating</div>
+                            </div>
+                            <div class="col-md-6">
+                                <div class="form-check mt-4">
+                                    <input type="checkbox"
+                                           class="form-check-input"
+                                           id="audio-allow-zero"
+                                           x-model="editingDataset.audio.allow_zero_audio"
+                                           @change="markAsUnsaved()">
+                                    <label class="form-check-label" for="audio-allow-zero">
+                                        Allow zero audio
+                                        <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#s2vsound-to-video-audio-configuration') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a>
+                                    </label>
+                                    <div class="form-text small">Generate zero-filled audio for videos without audio tracks</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </template>
+        </div>
+    </template>
+
+    <!-- Audio Dataset Settings (shown for audio datasets) -->
+    <template x-if="editingDataset.dataset_type === 'audio'">
+        <div>
+            <!-- Duration Settings -->
+            <div class="section-group" x-show="matchesParamFilter('duration', 'min', 'max', 'interval', 'seconds', 'truncate', 'bucket')">
+                <h6 class="modal-section-title">Duration & Bucketing</h6>
+                <div class="row g-2">
+                    <div class="col-md-3">
+                        <label class="form-label small">Min (seconds) <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-dataset-configuration-dataset_typeaudio') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                        <input type="number"
+                               class="form-control form-control-sm"
+                               x-model.number.lazy="editingDataset.audio.min_duration_seconds"
+                               @input="markAsUnsaved()"
+                               step="0.1"
+                               min="0"
+                               placeholder="0">
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label small">Max (seconds) <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-dataset-configuration-dataset_typeaudio') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                        <input type="number"
+                               class="form-control form-control-sm"
+                               x-model.number.lazy="editingDataset.audio.max_duration_seconds"
+                               @input="markAsUnsaved()"
+                               step="0.1"
+                               min="0"
+                               placeholder="No limit">
+                        <div class="form-text small">Clips longer than this are skipped</div>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label small">Duration Interval <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-dataset-configuration-dataset_typeaudio') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                        <input type="number"
+                               class="form-control form-control-sm"
+                               x-model.number.lazy="editingDataset.audio.duration_interval"
+                               @input="markAsUnsaved()"
+                               step="0.1"
+                               min="0.1"
+                               placeholder="3.0">
+                        <div class="form-text small">Bucket rounding (seconds)</div>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label small">Bucket Strategy <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-dataset-configuration-dataset_typeaudio') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                        <select class="form-select form-select-sm"
+                                x-model="editingDataset.audio.bucket_strategy"
+                                @change="markAsUnsaved()">
+                            <option value="">Duration (default)</option>
+                            <option value="duration">Duration</option>
+                        </select>
+                    </div>
+                </div>
             </div>
-            <div class="col-md-6">
-                <label class="form-label small">Truncation Mode <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-dataset-configuration-dataset_typeaudio') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
-                <select class="form-select form-select-sm"
-                        x-model="editingDataset.audio.truncation_mode"
-                        @change="markAsUnsaved()">
-                    <option value="">Beginning (default)</option>
-                    <option value="beginning">Beginning</option>
-                    <option value="end">End</option>
-                    <option value="random">Random</option>
-                </select>
-                <div class="form-text small">Which part of clip to keep when truncating</div>
+
+            <!-- Audio Format -->
+            <div class="section-group" x-show="matchesParamFilter('format', 'channel', 'mono', 'stereo', 'truncation', 'mode')">
+                <h6 class="modal-section-title">Format</h6>
+                <div class="row g-2">
+                    <div class="col-md-6">
+                        <label class="form-label small">Channels <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-dataset-configuration-dataset_typeaudio') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                        <select class="form-select form-select-sm"
+                                x-model.number.lazy="editingDataset.audio.channels"
+                                @change="markAsUnsaved()">
+                            <option value="1">1 (Mono)</option>
+                            <option value="2">2 (Stereo)</option>
+                        </select>
+                    </div>
+                    <div class="col-md-6">
+                        <label class="form-label small">Truncation Mode <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#audio-dataset-configuration-dataset_typeaudio') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
+                        <select class="form-select form-select-sm"
+                                x-model="editingDataset.audio.truncation_mode"
+                                @change="markAsUnsaved()">
+                            <option value="">Beginning (default)</option>
+                            <option value="beginning">Beginning</option>
+                            <option value="end">End</option>
+                            <option value="random">Random</option>
+                        </select>
+                        <div class="form-text small">Which part of clip to keep when truncating</div>
+                    </div>
+                </div>
             </div>
         </div>
-    </div>
+    </template>
 </div>

--- a/tests/js/dataloader_audio_capabilities.test.js
+++ b/tests/js/dataloader_audio_capabilities.test.js
@@ -1,0 +1,231 @@
+/**
+ * Tests for dataloader section component audio capabilities.
+ *
+ * Covers the supportsAudioInputs and requiresS2VDatasets getters
+ * which determine whether audio settings should be shown for video datasets.
+ */
+
+// Mock localStorage
+const localStorageMock = (() => {
+    let store = {};
+    return {
+        getItem: jest.fn((key) => store[key] || null),
+        setItem: jest.fn((key, value) => {
+            store[key] = value;
+        }),
+        removeItem: jest.fn((key) => {
+            delete store[key];
+        }),
+        clear: jest.fn(() => {
+            store = {};
+        }),
+    };
+})();
+Object.defineProperty(global, 'localStorage', { value: localStorageMock });
+
+// Default mock trainer store
+const createMockTrainerStore = (overrides = {}) => ({
+    modelContext: {
+        capabilities: {},
+        ...overrides.modelContext
+    },
+    configValues: {},
+    ...overrides
+});
+
+// Setup Alpine mock
+global.Alpine = {
+    data: jest.fn((name, factory) => {
+        global.Alpine._components = global.Alpine._components || {};
+        global.Alpine._components[name] = factory;
+    }),
+    store: jest.fn(() => createMockTrainerStore()),
+    start: jest.fn(),
+    _components: {},
+};
+
+// Mock window utilities
+global.window = global.window || {};
+window.showToast = jest.fn();
+window.ToastType = { SUCCESS: 'success', ERROR: 'error', WARNING: 'warning' };
+
+// Load the dataloader section component module
+require('../../simpletuner/static/js/dataloader-section-component.js');
+
+// Helper to create component with specific model context
+const createComponentWithContext = (modelContext) => {
+    global.Alpine.store = jest.fn((storeName) => {
+        if (storeName === 'trainer') {
+            return {
+                modelContext: modelContext,
+                configValues: {}
+            };
+        }
+        return null;
+    });
+
+    const factory = window.dataloaderSectionComponent;
+    return factory();
+};
+
+describe('Dataloader Section Audio Capabilities', () => {
+    describe('supportsAudioInputs getter', () => {
+        test('returns false when trainer store is unavailable', () => {
+            global.Alpine.store = jest.fn(() => null);
+            const factory = window.dataloaderSectionComponent;
+            const component = factory();
+            expect(component.supportsAudioInputs).toBe(false);
+        });
+
+        test('returns false when modelContext has no audio capabilities', () => {
+            const component = createComponentWithContext({
+                capabilities: {}
+            });
+            expect(component.supportsAudioInputs).toBe(false);
+        });
+
+        test('returns true when capabilities.supports_audio_inputs is true', () => {
+            const component = createComponentWithContext({
+                capabilities: {
+                    supports_audio_inputs: true
+                }
+            });
+            expect(component.supportsAudioInputs).toBe(true);
+        });
+
+        test('returns true when modelContext.supportsAudioInputs is true', () => {
+            const component = createComponentWithContext({
+                supportsAudioInputs: true,
+                capabilities: {}
+            });
+            expect(component.supportsAudioInputs).toBe(true);
+        });
+
+        test('returns false when supports_audio_inputs is explicitly false', () => {
+            const component = createComponentWithContext({
+                capabilities: {
+                    supports_audio_inputs: false
+                }
+            });
+            expect(component.supportsAudioInputs).toBe(false);
+        });
+
+        test('handles string "true" value correctly', () => {
+            const component = createComponentWithContext({
+                capabilities: {
+                    supports_audio_inputs: 'true'
+                }
+            });
+            expect(component.supportsAudioInputs).toBe(true);
+        });
+
+        test('handles numeric 1 value correctly', () => {
+            const component = createComponentWithContext({
+                capabilities: {
+                    supports_audio_inputs: 1
+                }
+            });
+            expect(component.supportsAudioInputs).toBe(true);
+        });
+    });
+
+    describe('requiresS2VDatasets getter', () => {
+        test('returns false when trainer store is unavailable', () => {
+            global.Alpine.store = jest.fn(() => null);
+            const factory = window.dataloaderSectionComponent;
+            const component = factory();
+            expect(component.requiresS2VDatasets).toBe(false);
+        });
+
+        test('returns false when modelContext has no S2V requirement', () => {
+            const component = createComponentWithContext({
+                capabilities: {}
+            });
+            expect(component.requiresS2VDatasets).toBe(false);
+        });
+
+        test('returns true when capabilities.requires_s2v_datasets is true', () => {
+            const component = createComponentWithContext({
+                capabilities: {
+                    requires_s2v_datasets: true
+                }
+            });
+            expect(component.requiresS2VDatasets).toBe(true);
+        });
+
+        test('returns true when modelContext.requiresS2VDatasets is true', () => {
+            const component = createComponentWithContext({
+                requiresS2VDatasets: true,
+                capabilities: {}
+            });
+            expect(component.requiresS2VDatasets).toBe(true);
+        });
+
+        test('returns false when requires_s2v_datasets is explicitly false', () => {
+            const component = createComponentWithContext({
+                capabilities: {
+                    requires_s2v_datasets: false
+                }
+            });
+            expect(component.requiresS2VDatasets).toBe(false);
+        });
+    });
+
+    describe('Audio capabilities combinations', () => {
+        test('model with audio inputs and no S2V requirement (like LTX-2)', () => {
+            const component = createComponentWithContext({
+                capabilities: {
+                    supports_audio_inputs: true,
+                    requires_s2v_datasets: false
+                }
+            });
+
+            expect(component.supportsAudioInputs).toBe(true);
+            expect(component.requiresS2VDatasets).toBe(false);
+        });
+
+        test('S2V model requires audio datasets (like WanS2V)', () => {
+            const component = createComponentWithContext({
+                capabilities: {
+                    supports_audio_inputs: true,
+                    requires_s2v_datasets: true
+                }
+            });
+
+            expect(component.supportsAudioInputs).toBe(true);
+            expect(component.requiresS2VDatasets).toBe(true);
+        });
+
+        test('model without audio support (like SDXL)', () => {
+            const component = createComponentWithContext({
+                capabilities: {
+                    supports_audio_inputs: false,
+                    requires_s2v_datasets: false
+                }
+            });
+
+            expect(component.supportsAudioInputs).toBe(false);
+            expect(component.requiresS2VDatasets).toBe(false);
+        });
+    });
+
+    describe('normalizeBoolean helper', () => {
+        test('normalizes various truthy values', () => {
+            const component = createComponentWithContext({});
+            expect(component.normalizeBoolean(true)).toBe(true);
+            expect(component.normalizeBoolean('true')).toBe(true);
+            expect(component.normalizeBoolean(1)).toBe(true);
+            expect(component.normalizeBoolean('1')).toBe(true);
+        });
+
+        test('normalizes various falsy values', () => {
+            const component = createComponentWithContext({});
+            expect(component.normalizeBoolean(false)).toBe(false);
+            expect(component.normalizeBoolean('false')).toBe(false);
+            expect(component.normalizeBoolean(0)).toBe(false);
+            expect(component.normalizeBoolean('0')).toBe(false);
+            expect(component.normalizeBoolean(null)).toBe(false);
+            expect(component.normalizeBoolean(undefined)).toBe(false);
+        });
+    });
+});

--- a/tests/js/dataset_wizard.test.js
+++ b/tests/js/dataset_wizard.test.js
@@ -501,3 +501,134 @@ describe('HintMixin Integration', () => {
         expect(component.showHeroCTA()).toBe(false);
     });
 });
+
+describe('Model Audio Capabilities', () => {
+    let component;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        const factory = window.datasetWizardComponent;
+        component = factory();
+        component.$nextTick = jest.fn((cb) => cb());
+    });
+
+    describe('supportsAudioInputs getter', () => {
+        test('supportsAudioInputs is a reactive getter', () => {
+            const descriptor = Object.getOwnPropertyDescriptor(component, 'supportsAudioInputs');
+            expect(descriptor).toBeDefined();
+            expect(typeof descriptor.get).toBe('function');
+        });
+
+        test('returns false when trainer store is unavailable', () => {
+            global.Alpine.store = jest.fn(() => null);
+            expect(component.supportsAudioInputs).toBe(false);
+        });
+
+        test('returns false when modelContext has no audio capabilities', () => {
+            global.Alpine.store = jest.fn(() => ({
+                modelContext: {
+                    capabilities: {}
+                },
+                configValues: {}
+            }));
+            expect(component.supportsAudioInputs).toBe(false);
+        });
+
+        test('returns true when capabilities.supports_audio_inputs is true', () => {
+            global.Alpine.store = jest.fn(() => ({
+                modelContext: {
+                    capabilities: {
+                        supports_audio_inputs: true
+                    }
+                },
+                configValues: {}
+            }));
+            expect(component.supportsAudioInputs).toBe(true);
+        });
+
+        test('returns true when modelContext.supportsAudioInputs is true', () => {
+            global.Alpine.store = jest.fn(() => ({
+                modelContext: {
+                    supportsAudioInputs: true,
+                    capabilities: {}
+                },
+                configValues: {}
+            }));
+            expect(component.supportsAudioInputs).toBe(true);
+        });
+
+        test('returns false when supports_audio_inputs is explicitly false', () => {
+            global.Alpine.store = jest.fn(() => ({
+                modelContext: {
+                    capabilities: {
+                        supports_audio_inputs: false
+                    }
+                },
+                configValues: {}
+            }));
+            expect(component.supportsAudioInputs).toBe(false);
+        });
+    });
+
+    describe('isVideoModel getter', () => {
+        test('returns true when modelContext.isVideoModel is true', () => {
+            global.Alpine.store = jest.fn(() => ({
+                modelContext: {
+                    isVideoModel: true
+                },
+                configValues: {}
+            }));
+            expect(component.isVideoModel).toBe(true);
+        });
+
+        test('returns true when modelContext.supportsVideo is true', () => {
+            global.Alpine.store = jest.fn(() => ({
+                modelContext: {
+                    supportsVideo: true
+                },
+                configValues: {}
+            }));
+            expect(component.isVideoModel).toBe(true);
+        });
+
+        test('returns false when neither flag is set', () => {
+            global.Alpine.store = jest.fn(() => ({
+                modelContext: {},
+                configValues: {}
+            }));
+            expect(component.isVideoModel).toBe(false);
+        });
+    });
+
+    describe('isAudioModel getter', () => {
+        test('returns true when modelContext.isAudioModel is true', () => {
+            global.Alpine.store = jest.fn(() => ({
+                modelContext: {
+                    isAudioModel: true
+                },
+                configValues: {}
+            }));
+            expect(component.isAudioModel).toBe(true);
+        });
+
+        test('returns true for ace_step model family', () => {
+            global.Alpine.store = jest.fn(() => ({
+                modelContext: {},
+                configValues: {
+                    model_family: 'ace_step'
+                }
+            }));
+            expect(component.isAudioModel).toBe(true);
+        });
+
+        test('returns false for non-audio model family', () => {
+            global.Alpine.store = jest.fn(() => ({
+                modelContext: {},
+                configValues: {
+                    model_family: 'flux'
+                }
+            }));
+            expect(component.isAudioModel).toBe(false);
+        });
+    });
+});

--- a/tests/test_models_service_validation_preview.py
+++ b/tests/test_models_service_validation_preview.py
@@ -38,6 +38,35 @@ class TestModelsServiceValidationPreview(unittest.TestCase):
         self.assertFalse(capabilities.get("supports_lyrics"))
         self.assertFalse(capabilities.get("is_audio_model"))
 
+    def test_ltxvideo2_supports_audio_inputs(self):
+        """LTX-Video 2 should support audio inputs for audio conditioning."""
+        details = self.service.get_model_details("ltxvideo2")
+        capabilities = details["capabilities"]
+        self.assertTrue(capabilities.get("supports_audio_inputs"))
+        # LTX-2 supports audio but doesn't require S2V datasets
+        self.assertFalse(capabilities.get("requires_s2v_datasets"))
+
+    def test_wan_s2v_requires_s2v_datasets(self):
+        """Wan S2V should require S2V datasets and support audio inputs."""
+        details = self.service.get_model_details("wan_s2v")
+        capabilities = details["capabilities"]
+        self.assertTrue(capabilities.get("supports_audio_inputs"))
+        self.assertTrue(capabilities.get("requires_s2v_datasets"))
+
+    def test_sdxl_does_not_support_audio_inputs(self):
+        """SDXL should not support audio inputs."""
+        details = self.service.get_model_details("sdxl")
+        capabilities = details["capabilities"]
+        self.assertFalse(capabilities.get("supports_audio_inputs"))
+        self.assertFalse(capabilities.get("requires_s2v_datasets"))
+
+    def test_flux_does_not_support_audio_inputs(self):
+        """Flux should not support audio inputs."""
+        details = self.service.get_model_details("flux")
+        capabilities = details["capabilities"]
+        self.assertFalse(capabilities.get("supports_audio_inputs"))
+        self.assertFalse(capabilities.get("requires_s2v_datasets"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request adds support for video models that use audio conditioning by introducing new capabilities for handling audio inputs and S2V (sound-to-video) requirements. It updates both backend and frontend logic to detect and expose these capabilities, enhances the dataset wizard UI to allow audio settings for video datasets, and adds comprehensive frontend tests to ensure correct behavior.

**Backend: Model capability detection**
- Added logic in `models_service.py` to detect if a model supports audio inputs (`supports_audio_inputs`) and if it requires S2V datasets (`requires_s2v_datasets`). These are now included in the model's reported capabilities.

**Frontend: Capability exposure and UI logic**
- Updated `dataloader-section-component.js` and `dataset-wizard.js` to expose `supportsAudioInputs` and `requiresS2VDatasets` getters, making these capabilities available for Alpine.js components and UI logic. [[1]](diffhunk://#diff-6911b85e59d4dd6d3e841f2fcfe01eaec290eb8f10a3816640b9f9a216a6e730R223-R236) [[2]](diffhunk://#diff-0686ced55e44778d6e58196ffd127349b6a648cd15a7da1748a0a055f275bbadR201-R209)

**UI: Audio settings for video datasets**
- Modified the dataset modal in `dataset_modal.html` so that the Audio tab is shown for video datasets if the selected model supports audio inputs.
- Enhanced the audio settings section in `audio_body.html` to display auto-split and audio format options for video datasets, including toggles and advanced configuration for audio extraction from videos. [[1]](diffhunk://#diff-afef37130b669cd094d745371bcaa8d0ab4bfee6a7e8795f8420903f518507aaR3-R109) [[2]](diffhunk://#diff-afef37130b669cd094d745371bcaa8d0ab4bfee6a7e8795f8420903f518507aaR186-R187)

**Testing: Frontend logic**
- Added a new test suite `dataloader_audio_capabilities.test.js` covering the new getters and their combinations, ensuring that audio-related UI logic behaves correctly for various model capabilities.