### PR TITLE
(#2524) ui: reduce severity of non-fatal errors

### DIFF
--- a/simpletuner/static/js/event-handler.js
+++ b/simpletuner/static/js/event-handler.js
@@ -149,9 +149,13 @@ class EventHandler {
                     }
 
                     const severity = String(payload.severity || '').toLowerCase();
+                    const statusValue = String(payload.status || payload.state || payload.data?.status || '').toLowerCase();
+                    const isFailureStatus = ['failed', 'error', 'fatal', 'crashed'].includes(statusValue);
                     let messageType = 'info';
-                    if (severity === 'error' || severity === 'critical' || severity === 'fatal') {
+                    if (severity === 'critical' || severity === 'fatal' || (severity === 'error' && isFailureStatus)) {
                         messageType = 'fatal_error';
+                    } else if (severity === 'error') {
+                        messageType = 'error';
                     } else if (severity === 'warning') {
                         messageType = 'warning';
                     } else if (severity === 'success') {
@@ -1762,9 +1766,13 @@ class EventHandler {
                 }
             } else if (event.type === 'notification') {
                 const severity = String(event.severity || '').toLowerCase();
-                if (severity === 'error' || severity === 'fatal') {
+                const statusValue = String(event.data?.status || event.data?.state || event.status || '').toLowerCase();
+                const isFailureStatus = ['failed', 'error', 'fatal', 'crashed'].includes(statusValue);
+                if (severity === 'critical' || severity === 'fatal' || (severity === 'error' && isFailureStatus)) {
                     baseEvent.message_type = 'fatal_error';
                     this.notifyTrainingState('error', { ...event.data, job_id: jobId, message: event.message || event.title }, { resetProgress: true });
+                } else if (severity === 'error') {
+                    baseEvent.message_type = 'error';
                 } else if (severity === 'warning') {
                     baseEvent.message_type = 'warning';
                 } else if (severity === 'success') {

--- a/tests/test_webui_e2e.py
+++ b/tests/test_webui_e2e.py
@@ -805,6 +805,46 @@ class TrainingWorkflowTestCase(_TrainerPageMixin, WebUITestCase):
                     )
                 )
 
+            with self.subTest("notification_error_does_not_stop_training"):
+                driver.execute_script(
+                    """
+                    if (window.eventHandler && typeof window.eventHandler.processProcessKeeperEvents === 'function') {
+                        window.eventHandler.processProcessKeeperEvents([{
+                            id: 'notif-err-1',
+                            type: 'notification',
+                            severity: 'error',
+                            message: 'Upload failed due to quota',
+                            job_id: 'harness-job',
+                            data: { status: 'uploading_model' }
+                        }]);
+                    }
+                    """
+                )
+
+                WebDriverWait(driver, 5).until(
+                    lambda d: d.execute_script("return document.body && document.body.dataset.trainingActive === 'true';")
+                )
+
+            with self.subTest("notification_error_with_failure_status_stops_training"):
+                driver.execute_script(
+                    """
+                    if (window.eventHandler && typeof window.eventHandler.processProcessKeeperEvents === 'function') {
+                        window.eventHandler.processProcessKeeperEvents([{
+                            id: 'notif-err-2',
+                            type: 'notification',
+                            severity: 'error',
+                            message: 'Training failed',
+                            job_id: 'harness-job',
+                            data: { status: 'failed' }
+                        }]);
+                    }
+                    """
+                )
+
+                WebDriverWait(driver, 5).until(
+                    lambda d: d.execute_script("return document.body && document.body.dataset.trainingActive === 'false';")
+                )
+
             driver.execute_script(
                 dispatch_script,
                 {


### PR DESCRIPTION
Closes #2524 

This pull request refines how error events are handled and displayed in both backend and frontend, making the distinction between recoverable and fatal errors more precise. Now, only errors with explicit failure statuses (like `"failed"`, `"fatal"`, etc.) will trigger job failure logic, while other errors will not halt training. The changes also add comprehensive tests to ensure this behavior is correct.

**Backend: Improved Error Handling Logic**

* Added a private method `_extract_event_status` in `callback_service.py` to consistently extract and normalize status/state from event payloads.
* Updated `_update_training_state` to only mark jobs as failed if the severity is `error` *and* the extracted status is one of the fatal values (`"failed"`, `"error"`, `"fatal"`, `"crashed"`), instead of marking all errors as fatal.

**Frontend: More Accurate Error Display**

* Updated `event-handler.js` to use the new logic: only treat errors as fatal if their status indicates a failure, otherwise display them as non-fatal errors. This affects both payload and notification handling. [[1]](diffhunk://#diff-23bda0617e67adff2c5b206547c041c3f0fa8cd49d5ae27a88b4326f22d607a9R152-R158) [[2]](diffhunk://#diff-23bda0617e67adff2c5b206547c041c3f0fa8cd49d5ae27a88b4326f22d607a9L1765-R1775)

**Testing: Ensuring Correct Behavior**

* Added backend tests to verify that errors without a fatal status do not mark training as failed, while errors with a fatal status do.
* Added end-to-end tests to confirm that the UI does not stop training for non-fatal errors, but does stop for fatal errors.