### PR TITLE
ramtorch: disable extensions by default for speedup on most systems

### DIFF
--- a/documentation/OPTIONS.es.md
+++ b/documentation/OPTIONS.es.md
@@ -180,7 +180,7 @@ Donde `foo` es tu entorno de configuración; o simplemente usa `config/config.js
 ### `--ramtorch_disable_extensions`
 
 - **Qué**: Solo aplica RamTorch a capas Linear, omite Embedding/RMSNorm/LayerNorm/Conv.
-- **Predeterminado**: `False` (extensiones habilitadas)
+- **Predeterminado**: `True` (extensiones deshabilitadas)
 - **Por qué**: SimpleTuner extiende RamTorch más allá de las capas Linear para incluir capas Embedding, RMSNorm, LayerNorm y Conv. Usa esto para desactivar esas extensiones y solo descargar capas Linear.
 - **Notas**: Puede reducir el ahorro de VRAM pero puede ayudar a depurar problemas con los tipos de capas extendidas.
 

--- a/documentation/OPTIONS.hi.md
+++ b/documentation/OPTIONS.hi.md
@@ -180,7 +180,7 @@ simpletuner configure config/foo/config.json
 ### `--ramtorch_disable_extensions`
 
 - **What**: केवल Linear layers पर RamTorch apply करता है, Embedding/RMSNorm/LayerNorm/Conv को skip करता है।
-- **Default**: `False` (extensions enabled)
+- **Default**: `True` (extensions disabled)
 - **Why**: SimpleTuner RamTorch को Linear layers से आगे बढ़ाकर Embedding, RMSNorm, LayerNorm, और Conv layers को include करता है। इन extensions को disable करके केवल Linear layers offload करने के लिए इसका उपयोग करें।
 - **Notes**: VRAM savings कम हो सकती है लेकिन extended layer types की समस्याओं को debug करने में मदद कर सकता है।
 

--- a/documentation/OPTIONS.ja.md
+++ b/documentation/OPTIONS.ja.md
@@ -181,7 +181,7 @@ simpletuner configure config/foo/config.json
 ### `--ramtorch_disable_extensions`
 
 - **内容**: Linear レイヤーのみに RamTorch を適用し、Embedding/RMSNorm/LayerNorm/Conv をスキップします。
-- **既定**: `False`（拡張機能有効）
+- **既定**: `True`（拡張機能無効）
 - **理由**: SimpleTuner は RamTorch を Linear レイヤー以外に拡張し、Embedding、RMSNorm、LayerNorm、Conv レイヤーを含めます。この拡張機能を無効にして Linear レイヤーのみをオフロードするにはこのオプションを使用します。
 - **注記**: VRAM 節約が減少する可能性がありますが、拡張レイヤータイプの問題をデバッグするのに役立ちます。
 

--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -180,7 +180,7 @@ Where `foo` is your config environment - or just use `config/config.json` if you
 ### `--ramtorch_disable_extensions`
 
 - **What**: Only apply RamTorch to Linear layers, skip Embedding/RMSNorm/LayerNorm/Conv.
-- **Default**: `False` (extensions enabled)
+- **Default**: `True` (extensions disabled)
 - **Why**: SimpleTuner extends RamTorch beyond Linear layers to include Embedding, RMSNorm, LayerNorm, and Conv layers. Use this to disable those extensions and only offload Linear layers.
 - **Notes**: May reduce VRAM savings but can help debug issues with the extended layer types.
 

--- a/documentation/OPTIONS.pt-BR.md
+++ b/documentation/OPTIONS.pt-BR.md
@@ -180,7 +180,7 @@ Onde `foo` e seu ambiente de config — ou use `config/config.json` se nao estiv
 ### `--ramtorch_disable_extensions`
 
 - **O que**: Aplica RamTorch apenas a camadas Linear, pula Embedding/RMSNorm/LayerNorm/Conv.
-- **Padrao**: `False` (extensoes habilitadas)
+- **Padrao**: `True` (extensoes desabilitadas)
 - **Por que**: O SimpleTuner estende o RamTorch alem das camadas Linear para incluir camadas Embedding, RMSNorm, LayerNorm e Conv. Use isso para desativar essas extensoes e descarregar apenas camadas Linear.
 - **Notas**: Pode reduzir a economia de VRAM, mas pode ajudar a depurar problemas com os tipos de camadas estendidas.
 

--- a/documentation/OPTIONS.zh.md
+++ b/documentation/OPTIONS.zh.md
@@ -181,7 +181,7 @@ simpletuner configure config/foo/config.json
 ### `--ramtorch_disable_extensions`
 
 - **内容**：仅对 Linear 层应用 RamTorch，跳过 Embedding/RMSNorm/LayerNorm/Conv。
-- **默认**：`False`（扩展已启用）
+- **默认**：`True`（扩展已禁用）
 - **原因**：SimpleTuner 将 RamTorch 扩展到 Linear 层之外，包括 Embedding、RMSNorm、LayerNorm 和 Conv 层。使用此选项禁用这些扩展，仅卸载 Linear 层。
 - **说明**：可能减少显存节省，但有助于调试扩展层类型的问题。
 

--- a/simpletuner/examples/ltxvideo2-19b-t2v.peft-lora+16G/config.json
+++ b/simpletuner/examples/ltxvideo2-19b-t2v.peft-lora+16G/config.json
@@ -24,6 +24,7 @@
     "optimizer": "adamw_bf16",
     "output_dir": "output/examples/ltxvideo2-19b-t2v.peft-lora",
     "ramtorch": true,
+    "ramtorch_disable_extensions": false,
     "ramtorch_text_encoder": true,
     "report_to": "none",
     "resolution": 480,

--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -3049,7 +3049,7 @@ class ModelFoundation(ABC):
 
     def _ramtorch_extensions_enabled(self) -> bool:
         """Check if ramtorch extensions (Embedding, RMSNorm, etc.) should be used."""
-        return not bool(getattr(self.config, "ramtorch_disable_extensions", False))
+        return not bool(getattr(self.config, "ramtorch_disable_extensions", True))
 
     def _apply_ramtorch_layers(
         self,

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/training.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/training.py
@@ -440,7 +440,7 @@ def register_training_fields(registry: "FieldRegistry") -> None:
             field_type=FieldType.CHECKBOX,
             tab="model",
             section="memory_optimization",
-            default_value=False,
+            default_value=True,
             help_text="Only apply RamTorch to Linear layers, skip Embedding/RMSNorm/LayerNorm/Conv.",
             tooltip="Use this to disable SimpleTuner's RamTorch extensions for Embedding, RMSNorm, LayerNorm, and Conv layers.",
             importance=ImportanceLevel.EXPERIMENTAL,


### PR DESCRIPTION
Ramtorch extensions for Embedding, RMSNorm, and other layers, for eg. Qwen Image, reduce the memory consumption from 25G to 12G, but on slower memory systems the speed drops by around 300% instead of 12%, from 14 seconds per step to 48 seconds per step.

On my 6000MHz DDR5 system, I don't observe such an extreme slowdown. But others have, and so, the option will be flipped by default so that the extensions are **disabled**.

This can be explicitly set to `false` in config, like the LTX-2 16G config example now does.