### PR TITLE
set timestep index to 0 to avoid lookup in scheduler.step

### DIFF
--- a/simpletuner/helpers/models/auraflow/pipeline.py
+++ b/simpletuner/helpers/models/auraflow/pipeline.py
@@ -1172,7 +1172,8 @@ class AuraFlowPipeline(DiffusionPipeline, AuraFlowLoraLoaderMixin):
         self._num_timesteps = len(timesteps)
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/auraflow/pipeline_controlnet.py
+++ b/simpletuner/helpers/models/auraflow/pipeline_controlnet.py
@@ -785,7 +785,8 @@ class AuraFlowControlNetPipeline(
 
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/chroma/pipeline.py
+++ b/simpletuner/helpers/models/chroma/pipeline.py
@@ -1379,7 +1379,8 @@ class ChromaPipeline(
 
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/cosmos/pipeline.py
+++ b/simpletuner/helpers/models/cosmos/pipeline.py
@@ -561,7 +561,8 @@ class Cosmos2TextToImagePipeline(DiffusionPipeline, FluxLoraLoaderMixin):
         # 6. Denoising loop
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
         self._num_timesteps = len(timesteps)
 

--- a/simpletuner/helpers/models/flux/pipeline.py
+++ b/simpletuner/helpers/models/flux/pipeline.py
@@ -1571,7 +1571,8 @@ class FluxPipeline(DiffusionPipeline, FluxLoraLoaderMixin):
         # 6. Denoising loop
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:
@@ -2363,7 +2364,8 @@ class FluxKontextPipeline(DiffusionPipeline, FluxLoraLoaderMixin):
         # 6. Denoising loop
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/flux/pipeline_controlnet.py
+++ b/simpletuner/helpers/models/flux/pipeline_controlnet.py
@@ -1004,7 +1004,8 @@ class FluxControlNetPipeline(DiffusionPipeline, FluxLoraLoaderMixin, FromSingleF
         # 7. Denoising loop
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:
@@ -1793,7 +1794,8 @@ class FluxControlPipeline(
         # 6. Denoising loop
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/flux2/pipeline.py
+++ b/simpletuner/helpers/models/flux2/pipeline.py
@@ -1476,7 +1476,8 @@ class Flux2Pipeline(DiffusionPipeline, Flux2LoraLoaderMixin):
         # 7. Denoising loop
         # We set the index here to remove DtoH sync, helpful especially during compilation.
         # Check out more details here: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/hidream/pipeline.py
+++ b/simpletuner/helpers/models/hidream/pipeline.py
@@ -1685,7 +1685,8 @@ class HiDreamImagePipeline(DiffusionPipeline, FromSingleFileMixin, HiDreamImageL
         # 9. Denoising loop
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/hunyuanvideo/pipeline.py
+++ b/simpletuner/helpers/models/hunyuanvideo/pipeline.py
@@ -846,7 +846,8 @@ class HunyuanVideo15Pipeline(DiffusionPipeline, LoraLoaderMixin):
 
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/hunyuanvideo/pipeline_i2v.py
+++ b/simpletuner/helpers/models/hunyuanvideo/pipeline_i2v.py
@@ -841,7 +841,8 @@ class HunyuanVideo15ImageToVideoPipeline(DiffusionPipeline, LoraLoaderMixin):
 
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/kandinsky5_image/pipeline_kandinsky5_t2i.py
+++ b/simpletuner/helpers/models/kandinsky5_image/pipeline_kandinsky5_t2i.py
@@ -434,7 +434,8 @@ class Kandinsky5T2IPipeline(DiffusionPipeline, KandinskyLoraLoaderMixin):
 
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/kandinsky5_video/pipeline_kandinsky5_t2v.py
+++ b/simpletuner/helpers/models/kandinsky5_video/pipeline_kandinsky5_t2v.py
@@ -801,7 +801,8 @@ class Kandinsky5T2VPipeline(DiffusionPipeline, KandinskyLoraLoaderMixin):
 
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/longcat_image/pipeline.py
+++ b/simpletuner/helpers/models/longcat_image/pipeline.py
@@ -454,7 +454,8 @@ class LongCatImagePipeline(
 
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/longcat_image/pipeline_edit.py
+++ b/simpletuner/helpers/models/longcat_image/pipeline_edit.py
@@ -458,7 +458,8 @@ class LongCatImageEditPipeline(
 
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/longcat_video/pipeline.py
+++ b/simpletuner/helpers/models/longcat_video/pipeline.py
@@ -646,7 +646,8 @@ class LongCatVideoPipeline(DiffusionPipeline, LongCatLoraLoaderMixin):
 
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/ltxvideo2/pipeline_ltx2.py
+++ b/simpletuner/helpers/models/ltxvideo2/pipeline_ltx2.py
@@ -1229,7 +1229,8 @@ class LTX2Pipeline(DiffusionPipeline, FromSingleFileMixin, LTXVideoLoraLoaderMix
 
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/ltxvideo2/pipeline_ltx2_image2video.py
+++ b/simpletuner/helpers/models/ltxvideo2/pipeline_ltx2_image2video.py
@@ -1263,7 +1263,8 @@ class LTX2ImageToVideoPipeline(DiffusionPipeline, FromSingleFileMixin, LTXVideoL
         # 7. Denoising loop
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/qwen_image/pipeline.py
+++ b/simpletuner/helpers/models/qwen_image/pipeline.py
@@ -804,7 +804,8 @@ class QwenImageEditPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
             self._attention_kwargs = {}
 
         # 6. Denoising loop
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/qwen_image/pipeline_edit_plus.py
+++ b/simpletuner/helpers/models/qwen_image/pipeline_edit_plus.py
@@ -779,7 +779,8 @@ class QwenImageEditPlusPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
         )
 
         # 6. Denoising loop
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/wan/pipeline.py
+++ b/simpletuner/helpers/models/wan/pipeline.py
@@ -629,7 +629,8 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
 
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:
@@ -842,7 +843,8 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
 
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/wan_s2v/pipeline.py
+++ b/simpletuner/helpers/models/wan_s2v/pipeline.py
@@ -405,7 +405,8 @@ class WanS2VPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         # Denoising loop
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         for i, t in enumerate(timesteps):
             latent_model_input = latents
 

--- a/simpletuner/helpers/models/z_image/pipeline.py
+++ b/simpletuner/helpers/models/z_image/pipeline.py
@@ -893,7 +893,8 @@ class ZImagePipeline(DiffusionPipeline, ZImageLoraLoaderMixin, FromSingleFileMix
         # 6. Denoising loop
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/simpletuner/helpers/models/z_image_omni/pipeline.py
+++ b/simpletuner/helpers/models/z_image_omni/pipeline.py
@@ -553,7 +553,8 @@ class ZImageOmniPipeline(DiffusionPipeline, ZImageLoraLoaderMixin, FromSingleFil
 
         # Set begin index to avoid timestep lookup in scheduler.step() which can fail due to
         # floating-point precision issues. See: https://github.com/huggingface/diffusers/pull/11696
-        self.scheduler.set_begin_index(0)
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:


### PR DESCRIPTION
This pull request addresses a potential issue with floating-point precision in the scheduler's timestep lookup across multiple model pipelines. The main change is the addition of a call to `self.scheduler.set_begin_index(0)` before entering the denoising loop in each pipeline. This ensures robust and consistent behavior during inference by preventing failures in `scheduler.step()` due to precision errors, as referenced in a related HuggingFace diffusers pull request.

Key changes by theme:

**Scheduler Robustness and Consistency:**

* Added `self.scheduler.set_begin_index(0)` before the denoising loop in the `__call__` or equivalent method of the following pipelines to avoid floating-point precision issues in timestep lookup (see: https://github.com/huggingface/diffusers/pull/11696):
  - `auraflow/pipeline.py`
  - `auraflow/pipeline_controlnet.py`
  - `chroma/pipeline.py`
  - `cosmos/pipeline.py`
  - `flux/pipeline.py` [[1]](diffhunk://#diff-a729936306f863c0ea5ad72c60c8dc1ee33a209221bf7d3acf319e559534fefcR1572-R1574) [[2]](diffhunk://#diff-a729936306f863c0ea5ad72c60c8dc1ee33a209221bf7d3acf319e559534fefcR2364-R2366)
  - `flux/pipeline_controlnet.py` [[1]](diffhunk://#diff-46a62b409462b4329b25822a6ecdb62cc1bb0149480d68a928fa3827f3406e2dR1005-R1007) [[2]](diffhunk://#diff-46a62b409462b4329b25822a6ecdb62cc1bb0149480d68a928fa3827f3406e2dR1794-R1796)
  - `hidream/pipeline.py`
  - `hunyuanvideo/pipeline.py`
  - `hunyuanvideo/pipeline_i2v.py`
  - `kandinsky5_image/pipeline_kandinsky5_t2i.py`
  - `kandinsky5_video/pipeline_kandinsky5_t2v.py`
  - `longcat_image/pipeline.py`
  - `longcat_image/pipeline_edit.py`
  - `longcat_video/pipeline.py`
  - `ltxvideo2/pipeline_ltx2.py`
  - `ltxvideo2/pipeline_ltx2_image2video.py`
  - `wan/pipeline.py` [[1]](diffhunk://#diff-3a7b0df93ae20e9cf053fc16c32107e296c47d2bcf857a28518e50e4c5de9e69R630-R632) [[2]](diffhunk://#diff-3a7b0df93ae20e9cf053fc16c32107e296c47d2bcf857a28518e50e4c5de9e69R843-R845)
  - `wan_s2v/pipeline.py`
  - `z_image/pipeline.py`
  - `z_image_omni/pipeline.py`