### PR TITLE
U-REPA: SDXL, SD1x, Kolors

### DIFF
--- a/simpletuner/helpers/models/kolors/model.py
+++ b/simpletuner/helpers/models/kolors/model.py
@@ -188,8 +188,36 @@ class Kolors(ImageModelFoundation):
         return prompt_embeds, pooled_prompt_embeds
 
     def model_predict(self, prepared_batch):
-        return {
-            "model_prediction": self.model(
+        # Check if U-REPA is enabled and we need to capture mid-block hidden states
+        urepa = getattr(self, "urepa_regularizer", None)
+        capture_mid_block = urepa is not None and urepa.enabled
+
+        urepa_hidden = None
+        if capture_mid_block:
+            from simpletuner.helpers.utils.hidden_state_buffer import UNetMidBlockCapture
+
+            unwrapped_model = self.unwrap_model(self.model)
+            with UNetMidBlockCapture(unwrapped_model) as capture:
+                model_pred = self.model(
+                    prepared_batch["noisy_latents"].to(
+                        device=self.accelerator.device,
+                        dtype=self.config.base_weight_dtype,
+                    ),
+                    prepared_batch["timesteps"],
+                    prepared_batch["encoder_hidden_states"].to(
+                        device=self.accelerator.device,
+                        dtype=self.config.base_weight_dtype,
+                    ),
+                    prepared_batch["add_text_embeds"].to(
+                        device=self.accelerator.device,
+                        dtype=self.config.weight_dtype,
+                    ),
+                    added_cond_kwargs=prepared_batch["added_cond_kwargs"],
+                    return_dict=False,
+                )[0]
+                urepa_hidden = capture.get_captured()
+        else:
+            model_pred = self.model(
                 prepared_batch["noisy_latents"].to(
                     device=self.accelerator.device,
                     dtype=self.config.base_weight_dtype,
@@ -206,6 +234,11 @@ class Kolors(ImageModelFoundation):
                 added_cond_kwargs=prepared_batch["added_cond_kwargs"],
                 return_dict=False,
             )[0]
+
+        return {
+            "model_prediction": model_pred,
+            "hidden_states_buffer": None,
+            "urepa_hidden_states": urepa_hidden,
         }
 
     def post_model_load_setup(self):

--- a/simpletuner/helpers/models/sdxl/model.py
+++ b/simpletuner/helpers/models/sdxl/model.py
@@ -264,10 +264,37 @@ class SDXL(ImageModelFoundation):
             f"\n{prepared_batch['add_text_embeds'].shape}"
             f"\n{prepared_batch['added_cond_kwargs']['text_embeds'].shape}"
         )
-        # Note: UNet2DConditionModel does not support hidden_states_buffer parameter
-        # unlike custom transformers (Flux, AuraFlow, etc.)
-        return {
-            "model_prediction": self.model(
+
+        # Check if U-REPA is enabled and we need to capture mid-block hidden states
+        urepa = getattr(self, "urepa_regularizer", None)
+        capture_mid_block = urepa is not None and urepa.enabled
+
+        urepa_hidden = None
+        if capture_mid_block:
+            from simpletuner.helpers.utils.hidden_state_buffer import UNetMidBlockCapture
+
+            unwrapped_model = self.unwrap_model(self.model)
+            with UNetMidBlockCapture(unwrapped_model) as capture:
+                model_pred = self.model(
+                    prepared_batch["noisy_latents"].to(
+                        device=self.accelerator.device,
+                        dtype=self.config.base_weight_dtype,
+                    ),
+                    prepared_batch["timesteps"],
+                    prepared_batch["encoder_hidden_states"].to(
+                        device=self.accelerator.device,
+                        dtype=self.config.base_weight_dtype,
+                    ),
+                    prepared_batch["add_text_embeds"].to(
+                        device=self.accelerator.device,
+                        dtype=self.config.weight_dtype,
+                    ),
+                    added_cond_kwargs=prepared_batch["added_cond_kwargs"],
+                    return_dict=False,
+                )[0]
+                urepa_hidden = capture.get_captured()
+        else:
+            model_pred = self.model(
                 prepared_batch["noisy_latents"].to(
                     device=self.accelerator.device,
                     dtype=self.config.base_weight_dtype,
@@ -283,8 +310,12 @@ class SDXL(ImageModelFoundation):
                 ),
                 added_cond_kwargs=prepared_batch["added_cond_kwargs"],
                 return_dict=False,
-            )[0],
+            )[0]
+
+        return {
+            "model_prediction": model_pred,
             "hidden_states_buffer": None,
+            "urepa_hidden_states": urepa_hidden,
         }
 
     def post_model_load_setup(self):

--- a/simpletuner/helpers/utils/hidden_state_buffer.py
+++ b/simpletuner/helpers/utils/hidden_state_buffer.py
@@ -1,3 +1,8 @@
+from typing import Optional
+
+import torch
+
+
 class HiddenStateBuffer(dict):
     """
     Lightweight per-forward buffer for capturing intermediate hidden states.
@@ -18,3 +23,57 @@ class HiddenStateBuffer(dict):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.clear()
+
+
+class UNetMidBlockCapture:
+    """
+    Utility for capturing mid-block hidden states from UNet2DConditionModel.
+
+    UNet models produce convolutional features (B, C, H, W) at the mid-block,
+    which is the natural alignment point for U-REPA.
+
+    Usage:
+        capture = UNetMidBlockCapture(unet)
+        capture.enable()
+        output = unet(...)
+        mid_features = capture.get_captured()  # (B, C, H, W)
+        capture.disable()
+    """
+
+    def __init__(self, unet: torch.nn.Module):
+        self.unet = unet
+        self._hook_handle: Optional[torch.utils.hooks.RemovableHandle] = None
+        self._captured: Optional[torch.Tensor] = None
+
+    def enable(self):
+        """Register forward hook on mid_block to capture its output."""
+        if self._hook_handle is not None:
+            return  # Already enabled
+
+        if not hasattr(self.unet, "mid_block") or self.unet.mid_block is None:
+            raise ValueError("UNet does not have a mid_block to capture from")
+
+        def hook_fn(module, input, output):
+            self._captured = output.detach()
+
+        self._hook_handle = self.unet.mid_block.register_forward_hook(hook_fn)
+
+    def disable(self):
+        """Remove the forward hook."""
+        if self._hook_handle is not None:
+            self._hook_handle.remove()
+            self._hook_handle = None
+        self._captured = None
+
+    def get_captured(self) -> Optional[torch.Tensor]:
+        """Get the captured mid-block features and clear the buffer."""
+        captured = self._captured
+        self._captured = None
+        return captured
+
+    def __enter__(self):
+        self.enable()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.disable()


### PR DESCRIPTION
https://arxiv.org/pdf/2503.08250 (https://softrepa.github.io/)
https://arxiv.org/abs/2503.18414 (https://github.com/YuchuanTian/U-REPA, based on SiT, but still applicable)

This pull request introduces support for the new U-REPA (Universal Representation Alignment) regularizer to UNet-based diffusion models across the codebase. U-REPA enables training-free representation alignment by extracting and aligning mid-block hidden states with vision encoder features, facilitating improved model regularization. The main changes include adding the `UrepaRegularizer` implementation, updating model prediction methods to capture and return U-REPA hidden states, and supporting the new regularizer in training workflows.

**U-REPA Regularizer Implementation:**

* Added the `UrepaRegularizer` class to `crepa.py`, implementing feature extraction from the UNet mid-block, manifold loss computation, and integration with vision encoders (e.g., DINOv2). This includes methods for projection, spatial alignment, loss calculation, and encoder loading.

**Model Prediction Updates:**

* Updated `model_predict` methods in `kolors/model.py`, `sd1x/model.py`, and `sdxl/model.py` to check for U-REPA activation, capture mid-block hidden states using `UNetMidBlockCapture`, and return these states in the model output dictionary. [[1]](diffhunk://#diff-cc63a213fb94c7942037e1111f05b8aeafffed71c65b3f67f07e1961937da9a2L191-R220) [[2]](diffhunk://#diff-cc63a213fb94c7942037e1111f05b8aeafffed71c65b3f67f07e1961937da9a2R237-R241) [[3]](diffhunk://#diff-b6ac93ebeef3bfa9b6473b42d91c62acacaf37f26789c1897f6cb168696607e3R191-R201) [[4]](diffhunk://#diff-b6ac93ebeef3bfa9b6473b42d91c62acacaf37f26789c1897f6cb168696607e3R213-R231) [[5]](diffhunk://#diff-56cc2cfb7ef5a68e1abf9d68640ea5eb89d0b0aaf28dc4c62ae6833644cc457aL267-R278) [[6]](diffhunk://#diff-56cc2cfb7ef5a68e1abf9d68640ea5eb89d0b0aaf28dc4c62ae6833644cc457aL286-R318)

**Utility Improvements:**

* Added missing import for `Optional` in `hidden_state_buffer.py` to support type annotations.

These changes collectively enable U-REPA regularization for UNet-based diffusion models, paving the way for improved representation learning and alignment with vision encoders.