### PR TITLE
(#2575) fix dataset wizard for video type

### DIFF
--- a/simpletuner/simpletuner_sdk/server/data/dataset_blueprints.py
+++ b/simpletuner/simpletuner_sdk/server/data/dataset_blueprints.py
@@ -51,7 +51,7 @@ _BLUEPRINTS: List[BackendBlueprint] = [
         {
             "id": "local-image",
             "backendType": "local",
-            "datasetTypes": ["image", "conditioning", "eval"],
+            "datasetTypes": ["image", "video", "conditioning", "eval"],
             "label": "local media backend",
             "description": "use filesystem folders or network mounts for primary training data",
             "defaults": {
@@ -673,7 +673,7 @@ _BLUEPRINTS: List[BackendBlueprint] = [
         {
             "id": "huggingface-image",
             "backendType": "huggingface",
-            "datasetTypes": ["image"],
+            "datasetTypes": ["image", "video"],
             "label": "hugging face dataset",
             "description": "stream images from the hugging face hub",
             "defaults": {
@@ -785,7 +785,7 @@ _BLUEPRINTS: List[BackendBlueprint] = [
         {
             "id": "csv-image",
             "backendType": "csv",
-            "datasetTypes": ["image"],
+            "datasetTypes": ["image", "video"],
             "label": "csv manifest",
             "description": "drive image datasets via url/caption csv manifests",
             "defaults": {
@@ -861,7 +861,7 @@ _BLUEPRINTS: List[BackendBlueprint] = [
         {
             "id": "aws-image",
             "backendType": "aws",
-            "datasetTypes": ["image"],
+            "datasetTypes": ["image", "video"],
             "label": "aws s3 bucket",
             "description": "pull media from an s3 bucket using botocore",
             "defaults": {

--- a/simpletuner/static/js/dataset-wizard.js
+++ b/simpletuner/static/js/dataset-wizard.js
@@ -462,7 +462,7 @@
 
                 // Find the blueprint for this backend type
                 this.selectedBlueprint = this.blueprints.find(b =>
-                    b.backendType === backendType && b.datasetTypes.includes('image')
+                    b.backendType === backendType && b.datasetTypes.includes(this.currentDataset.dataset_type)
                 );
 
                 // Apply blueprint defaults


### PR DESCRIPTION
Closes #2575 

This pull request expands support for video datasets across multiple backend types and updates the frontend logic to correctly handle the new dataset types. The main changes ensure that "video" is now a recognized dataset type for local, HuggingFace, CSV, and AWS backends, and that the dataset wizard frontend selects blueprints based on the actual dataset type, not just "image".

**Backend support for video datasets:**

* Added "video" to the `datasetTypes` for the `local-image` backend in `dataset_blueprints.py`, allowing local backends to support video datasets.
* Added "video" to the `datasetTypes` for the `huggingface-image` backend, enabling HuggingFace datasets to include videos.
* Added "video" to the `datasetTypes` for the `csv-image` backend, so CSV manifest-driven datasets can now include videos.
* Added "video" to the `datasetTypes` for the `aws-image` backend, allowing AWS S3 buckets to serve video datasets.

**Frontend logic update:**

* Updated the dataset wizard in `dataset-wizard.js` to select the blueprint based on the current dataset's type (e.g., "image" or "video") instead of always defaulting to "image".