### PR TITLE
(#2583) remove low_cpu_mem_usage from qwen init, it does not do anything anymore; use dtype instead of torch_dtype

### DIFF
--- a/simpletuner/helpers/models/flux2/model.py
+++ b/simpletuner/helpers/models/flux2/model.py
@@ -398,10 +398,10 @@ class Flux2(ImageModelFoundation):
             tokenizer_kwargs["revision"] = revision
         self._qwen_tokenizer = Qwen2TokenizerFast.from_pretrained(text_encoder_path, **tokenizer_kwargs)
 
-        # Load model
+        # Load model to CPU first, then move to the per-rank accelerator device.
+        # This avoids all ranks contending on a single GPU during from_pretrained.
         model_kwargs = {
-            "torch_dtype": dtype,
-            "low_cpu_mem_usage": True,
+            "dtype": dtype,
         }
         if text_encoder_subfolder:
             model_kwargs["subfolder"] = text_encoder_subfolder
@@ -412,6 +412,13 @@ class Flux2(ImageModelFoundation):
         if move_to_device and not self._ramtorch_text_encoders_requested():
             target_device = (
                 torch.device("cpu") if quantize_via_cpu and should_quantize_text_encoder else self.accelerator.device
+            )
+            logger.info(
+                "Moving Qwen3 text encoder to %s (accelerator.device=%s, local_rank=%s, process_index=%s)",
+                target_device,
+                self.accelerator.device,
+                os.environ.get("LOCAL_RANK", "unset"),
+                self.accelerator.local_process_index,
             )
             self._qwen_model.to(target_device, dtype=dtype)
         if self._ramtorch_text_encoders_requested():
@@ -449,10 +456,9 @@ class Flux2(ImageModelFoundation):
             processor_kwargs["revision"] = mistral_revision
         self._mistral_processor = AutoProcessor.from_pretrained(mistral_path, **processor_kwargs)
 
-        # Load model
+        # Load model to CPU first, then move to the per-rank accelerator device.
         model_kwargs = {
-            "torch_dtype": dtype,
-            "low_cpu_mem_usage": True,
+            "dtype": dtype,
         }
         if mistral_revision is not None:
             model_kwargs["revision"] = mistral_revision
@@ -463,6 +469,13 @@ class Flux2(ImageModelFoundation):
         if move_to_device and not self._ramtorch_text_encoders_requested():
             target_device = (
                 torch.device("cpu") if quantize_via_cpu and should_quantize_text_encoder else self.accelerator.device
+            )
+            logger.info(
+                "Moving Mistral-3 text encoder to %s (accelerator.device=%s, local_rank=%s, process_index=%s)",
+                target_device,
+                self.accelerator.device,
+                os.environ.get("LOCAL_RANK", "unset"),
+                self.accelerator.local_process_index,
             )
             self._mistral_model.to(target_device, dtype=dtype)
         if self._ramtorch_text_encoders_requested():


### PR DESCRIPTION
This pull request improves the loading process for text encoder models in `simpletuner/helpers/models/flux2/model.py`. The changes optimize device placement during model initialization and add informative logging to help debug device allocation in distributed setups.

Device placement improvements:

* Changed model loading for both Qwen3 and Mistral-3 text encoders to load models onto CPU first, then move them to the per-rank accelerator device, preventing GPU contention during initialization. (`_load_text_encoder_qwen3`, `_load_text_encoder_mistral`) [[1]](diffhunk://#diff-2390d666883fb499d80e71fbe6b05b21e5141f934149c7fc66937368b6ae0c02L401-R404) [[2]](diffhunk://#diff-2390d666883fb499d80e71fbe6b05b21e5141f934149c7fc66937368b6ae0c02L452-R461)
* Updated model loading parameters by replacing `torch_dtype` with `dtype` and removing `low_cpu_mem_usage` for consistency and clarity. (`_load_text_encoder_qwen3`, `_load_text_encoder_mistral`) [[1]](diffhunk://#diff-2390d666883fb499d80e71fbe6b05b21e5141f934149c7fc66937368b6ae0c02L401-R404) [[2]](diffhunk://#diff-2390d666883fb499d80e71fbe6b05b21e5141f934149c7fc66937368b6ae0c02L452-R461)

Logging enhancements:

* Added detailed logging statements when moving Qwen3 and Mistral-3 text encoders to their target devices, including device information and process rank, to aid in debugging distributed training setups. (`_load_text_encoder_qwen3`, `_load_text_encoder_mistral`) [[1]](diffhunk://#diff-2390d666883fb499d80e71fbe6b05b21e5141f934149c7fc66937368b6ae0c02R416-R422) [[2]](diffhunk://#diff-2390d666883fb499d80e71fbe6b05b21e5141f934149c7fc66937368b6ae0c02R473-R479)