### PR TITLE
(#2578) ramtorch should match on wildcard like PEFT targets do

### DIFF
--- a/simpletuner/helpers/models/ace_step/model.py
+++ b/simpletuner/helpers/models/ace_step/model.py
@@ -129,7 +129,7 @@ class ACEStep(AudioModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "transformer_blocks.14,transformer_blocks.15,transformer_blocks.16,transformer_blocks.17,transformer_blocks.18,transformer_blocks.19,transformer_blocks.20,transformer_blocks.21,transformer_blocks.22,transformer_blocks.23,transformer_blocks.24,transformer_blocks.25,transformer_blocks.26,transformer_blocks.27",
+                    "ramtorch_target_modules": "transformer_blocks.14.*,transformer_blocks.15.*,transformer_blocks.16.*,transformer_blocks.17.*,transformer_blocks.18.*,transformer_blocks.19.*,transformer_blocks.20.*,transformer_blocks.21.*,transformer_blocks.22.*,transformer_blocks.23.*,transformer_blocks.24.*,transformer_blocks.25.*,transformer_blocks.26.*,transformer_blocks.27.*",
                 },
             ),
             AccelerationPreset(
@@ -145,7 +145,7 @@ class ACEStep(AudioModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "transformer_blocks.7,transformer_blocks.8,transformer_blocks.9,transformer_blocks.10,transformer_blocks.11,transformer_blocks.12,transformer_blocks.13,transformer_blocks.14,transformer_blocks.15,transformer_blocks.16,transformer_blocks.17,transformer_blocks.18,transformer_blocks.19,transformer_blocks.20,transformer_blocks.21,transformer_blocks.22,transformer_blocks.23,transformer_blocks.24,transformer_blocks.25,transformer_blocks.26,transformer_blocks.27",
+                    "ramtorch_target_modules": "transformer_blocks.7.*,transformer_blocks.8.*,transformer_blocks.9.*,transformer_blocks.10.*,transformer_blocks.11.*,transformer_blocks.12.*,transformer_blocks.13.*,transformer_blocks.14.*,transformer_blocks.15.*,transformer_blocks.16.*,transformer_blocks.17.*,transformer_blocks.18.*,transformer_blocks.19.*,transformer_blocks.20.*,transformer_blocks.21.*,transformer_blocks.22.*,transformer_blocks.23.*,transformer_blocks.24.*,transformer_blocks.25.*,transformer_blocks.26.*,transformer_blocks.27.*",
                 },
             ),
             AccelerationPreset(

--- a/simpletuner/helpers/models/auraflow/model.py
+++ b/simpletuner/helpers/models/auraflow/model.py
@@ -119,7 +119,7 @@ class Auraflow(ImageModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "joint_transformer_blocks.*,single_transformer_blocks.0,single_transformer_blocks.1,single_transformer_blocks.2,single_transformer_blocks.3,single_transformer_blocks.4,single_transformer_blocks.5,single_transformer_blocks.6,single_transformer_blocks.7",
+                    "ramtorch_target_modules": "joint_transformer_blocks.*,single_transformer_blocks.0.*,single_transformer_blocks.1.*,single_transformer_blocks.2.*,single_transformer_blocks.3.*,single_transformer_blocks.4.*,single_transformer_blocks.5.*,single_transformer_blocks.6.*,single_transformer_blocks.7.*",
                 },
             ),
             AccelerationPreset(
@@ -135,7 +135,7 @@ class Auraflow(ImageModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "joint_transformer_blocks.*,single_transformer_blocks.0,single_transformer_blocks.1,single_transformer_blocks.2,single_transformer_blocks.3,single_transformer_blocks.4,single_transformer_blocks.5,single_transformer_blocks.6,single_transformer_blocks.7,single_transformer_blocks.8,single_transformer_blocks.9,single_transformer_blocks.10,single_transformer_blocks.11,single_transformer_blocks.12,single_transformer_blocks.13,single_transformer_blocks.14,single_transformer_blocks.15",
+                    "ramtorch_target_modules": "joint_transformer_blocks.*,single_transformer_blocks.0.*,single_transformer_blocks.1.*,single_transformer_blocks.2.*,single_transformer_blocks.3.*,single_transformer_blocks.4.*,single_transformer_blocks.5.*,single_transformer_blocks.6.*,single_transformer_blocks.7.*,single_transformer_blocks.8.*,single_transformer_blocks.9.*,single_transformer_blocks.10.*,single_transformer_blocks.11.*,single_transformer_blocks.12.*,single_transformer_blocks.13.*,single_transformer_blocks.14.*,single_transformer_blocks.15.*",
                 },
             ),
             AccelerationPreset(

--- a/simpletuner/helpers/models/chroma/model.py
+++ b/simpletuner/helpers/models/chroma/model.py
@@ -124,7 +124,7 @@ class Chroma(ImageModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "transformer_blocks.*,single_transformer_blocks.0,single_transformer_blocks.1,single_transformer_blocks.2,single_transformer_blocks.3,single_transformer_blocks.4,single_transformer_blocks.5,single_transformer_blocks.6,single_transformer_blocks.7,single_transformer_blocks.8,single_transformer_blocks.9,single_transformer_blocks.10,single_transformer_blocks.11,single_transformer_blocks.12,single_transformer_blocks.13,single_transformer_blocks.14,single_transformer_blocks.15,single_transformer_blocks.16,single_transformer_blocks.17,single_transformer_blocks.18",
+                    "ramtorch_target_modules": "transformer_blocks.*,single_transformer_blocks.0.*,single_transformer_blocks.1.*,single_transformer_blocks.2.*,single_transformer_blocks.3.*,single_transformer_blocks.4.*,single_transformer_blocks.5.*,single_transformer_blocks.6.*,single_transformer_blocks.7.*,single_transformer_blocks.8.*,single_transformer_blocks.9.*,single_transformer_blocks.10.*,single_transformer_blocks.11.*,single_transformer_blocks.12.*,single_transformer_blocks.13.*,single_transformer_blocks.14.*,single_transformer_blocks.15.*,single_transformer_blocks.16.*,single_transformer_blocks.17.*,single_transformer_blocks.18.*",
                 },
             ),
             AccelerationPreset(

--- a/simpletuner/helpers/models/cosmos/model.py
+++ b/simpletuner/helpers/models/cosmos/model.py
@@ -108,7 +108,7 @@ class Cosmos2Image(VideoModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "transformer_blocks.0,transformer_blocks.1,transformer_blocks.2,transformer_blocks.3,transformer_blocks.4,transformer_blocks.5,transformer_blocks.6",
+                    "ramtorch_target_modules": "transformer_blocks.0.*,transformer_blocks.1.*,transformer_blocks.2.*,transformer_blocks.3.*,transformer_blocks.4.*,transformer_blocks.5.*,transformer_blocks.6.*",
                 },
             ),
             AccelerationPreset(
@@ -124,7 +124,7 @@ class Cosmos2Image(VideoModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "transformer_blocks.0,transformer_blocks.1,transformer_blocks.2,transformer_blocks.3,transformer_blocks.4,transformer_blocks.5,transformer_blocks.6,transformer_blocks.7,transformer_blocks.8,transformer_blocks.9,transformer_blocks.10,transformer_blocks.11,transformer_blocks.12,transformer_blocks.13",
+                    "ramtorch_target_modules": "transformer_blocks.0.*,transformer_blocks.1.*,transformer_blocks.2.*,transformer_blocks.3.*,transformer_blocks.4.*,transformer_blocks.5.*,transformer_blocks.6.*,transformer_blocks.7.*,transformer_blocks.8.*,transformer_blocks.9.*,transformer_blocks.10.*,transformer_blocks.11.*,transformer_blocks.12.*,transformer_blocks.13.*",
                 },
             ),
             AccelerationPreset(

--- a/simpletuner/helpers/models/flux2/model.py
+++ b/simpletuner/helpers/models/flux2/model.py
@@ -204,7 +204,7 @@ class Flux2(ImageModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "transformer_blocks.*,single_transformer_blocks.0,single_transformer_blocks.1,single_transformer_blocks.2,single_transformer_blocks.3,single_transformer_blocks.4,single_transformer_blocks.5,single_transformer_blocks.6,single_transformer_blocks.7,single_transformer_blocks.8,single_transformer_blocks.9,single_transformer_blocks.10,single_transformer_blocks.11,single_transformer_blocks.12,single_transformer_blocks.13,single_transformer_blocks.14,single_transformer_blocks.15,single_transformer_blocks.16,single_transformer_blocks.17,single_transformer_blocks.18,single_transformer_blocks.19,single_transformer_blocks.20,single_transformer_blocks.21,single_transformer_blocks.22,single_transformer_blocks.23",
+                    "ramtorch_target_modules": "transformer_blocks.*,single_transformer_blocks.0.*,single_transformer_blocks.1.*,single_transformer_blocks.2.*,single_transformer_blocks.3.*,single_transformer_blocks.4.*,single_transformer_blocks.5.*,single_transformer_blocks.6.*,single_transformer_blocks.7.*,single_transformer_blocks.8.*,single_transformer_blocks.9.*,single_transformer_blocks.10.*,single_transformer_blocks.11.*,single_transformer_blocks.12.*,single_transformer_blocks.13.*,single_transformer_blocks.14.*,single_transformer_blocks.15.*,single_transformer_blocks.16.*,single_transformer_blocks.17.*,single_transformer_blocks.18.*,single_transformer_blocks.19.*,single_transformer_blocks.20.*,single_transformer_blocks.21.*,single_transformer_blocks.22.*,single_transformer_blocks.23.*",
                 },
             ),
             AccelerationPreset(

--- a/simpletuner/helpers/models/hidream/model.py
+++ b/simpletuner/helpers/models/hidream/model.py
@@ -160,7 +160,7 @@ class HiDream(ImageModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "double_stream_blocks.*,single_stream_blocks.0,single_stream_blocks.1,single_stream_blocks.2,single_stream_blocks.3,single_stream_blocks.4,single_stream_blocks.5,single_stream_blocks.6,single_stream_blocks.7,single_stream_blocks.8,single_stream_blocks.9,single_stream_blocks.10,single_stream_blocks.11,single_stream_blocks.12,single_stream_blocks.13,single_stream_blocks.14,single_stream_blocks.15",
+                    "ramtorch_target_modules": "double_stream_blocks.*,single_stream_blocks.0.*,single_stream_blocks.1.*,single_stream_blocks.2.*,single_stream_blocks.3.*,single_stream_blocks.4.*,single_stream_blocks.5.*,single_stream_blocks.6.*,single_stream_blocks.7.*,single_stream_blocks.8.*,single_stream_blocks.9.*,single_stream_blocks.10.*,single_stream_blocks.11.*,single_stream_blocks.12.*,single_stream_blocks.13.*,single_stream_blocks.14.*,single_stream_blocks.15.*",
                 },
             ),
             AccelerationPreset(

--- a/simpletuner/helpers/models/kandinsky5_image/model.py
+++ b/simpletuner/helpers/models/kandinsky5_image/model.py
@@ -115,7 +115,7 @@ class Kandinsky5Image(ImageModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "visual_transformer_blocks.0,visual_transformer_blocks.1,visual_transformer_blocks.2,visual_transformer_blocks.3,visual_transformer_blocks.4,visual_transformer_blocks.5,visual_transformer_blocks.6,visual_transformer_blocks.7",
+                    "ramtorch_target_modules": "visual_transformer_blocks.0.*,visual_transformer_blocks.1.*,visual_transformer_blocks.2.*,visual_transformer_blocks.3.*,visual_transformer_blocks.4.*,visual_transformer_blocks.5.*,visual_transformer_blocks.6.*,visual_transformer_blocks.7.*",
                 },
             ),
             AccelerationPreset(
@@ -131,7 +131,7 @@ class Kandinsky5Image(ImageModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "visual_transformer_blocks.0,visual_transformer_blocks.1,visual_transformer_blocks.2,visual_transformer_blocks.3,visual_transformer_blocks.4,visual_transformer_blocks.5,visual_transformer_blocks.6,visual_transformer_blocks.7,visual_transformer_blocks.8,visual_transformer_blocks.9,visual_transformer_blocks.10,visual_transformer_blocks.11,visual_transformer_blocks.12,visual_transformer_blocks.13,visual_transformer_blocks.14,visual_transformer_blocks.15,visual_transformer_blocks.16",
+                    "ramtorch_target_modules": "visual_transformer_blocks.0.*,visual_transformer_blocks.1.*,visual_transformer_blocks.2.*,visual_transformer_blocks.3.*,visual_transformer_blocks.4.*,visual_transformer_blocks.5.*,visual_transformer_blocks.6.*,visual_transformer_blocks.7.*,visual_transformer_blocks.8.*,visual_transformer_blocks.9.*,visual_transformer_blocks.10.*,visual_transformer_blocks.11.*,visual_transformer_blocks.12.*,visual_transformer_blocks.13.*,visual_transformer_blocks.14.*,visual_transformer_blocks.15.*,visual_transformer_blocks.16.*",
                 },
             ),
             AccelerationPreset(

--- a/simpletuner/helpers/models/kandinsky5_video/model.py
+++ b/simpletuner/helpers/models/kandinsky5_video/model.py
@@ -129,7 +129,7 @@ class Kandinsky5Video(VideoModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "text_transformer_blocks.*,visual_transformer_blocks.0,visual_transformer_blocks.1,visual_transformer_blocks.2,visual_transformer_blocks.3,visual_transformer_blocks.4,visual_transformer_blocks.5,visual_transformer_blocks.6,visual_transformer_blocks.7,visual_transformer_blocks.8,visual_transformer_blocks.9,visual_transformer_blocks.10,visual_transformer_blocks.11,visual_transformer_blocks.12,visual_transformer_blocks.13,visual_transformer_blocks.14,visual_transformer_blocks.15",
+                    "ramtorch_target_modules": "text_transformer_blocks.*,visual_transformer_blocks.0.*,visual_transformer_blocks.1.*,visual_transformer_blocks.2.*,visual_transformer_blocks.3.*,visual_transformer_blocks.4.*,visual_transformer_blocks.5.*,visual_transformer_blocks.6.*,visual_transformer_blocks.7.*,visual_transformer_blocks.8.*,visual_transformer_blocks.9.*,visual_transformer_blocks.10.*,visual_transformer_blocks.11.*,visual_transformer_blocks.12.*,visual_transformer_blocks.13.*,visual_transformer_blocks.14.*,visual_transformer_blocks.15.*",
                 },
             ),
             AccelerationPreset(

--- a/simpletuner/helpers/models/longcat_image/model.py
+++ b/simpletuner/helpers/models/longcat_image/model.py
@@ -109,7 +109,7 @@ class LongCatImage(ImageModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "single_transformer_blocks.*,transformer_blocks.10,transformer_blocks.11,transformer_blocks.12,transformer_blocks.13,transformer_blocks.14,transformer_blocks.15,transformer_blocks.16,transformer_blocks.17,transformer_blocks.18",
+                    "ramtorch_target_modules": "single_transformer_blocks.*,transformer_blocks.10.*,transformer_blocks.11.*,transformer_blocks.12.*,transformer_blocks.13.*,transformer_blocks.14.*,transformer_blocks.15.*,transformer_blocks.16.*,transformer_blocks.17.*,transformer_blocks.18.*",
                 },
             ),
             AccelerationPreset(

--- a/simpletuner/helpers/models/longcat_video/model.py
+++ b/simpletuner/helpers/models/longcat_video/model.py
@@ -110,7 +110,7 @@ class LongCatVideo(VideoModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "blocks.0,blocks.1,blocks.2,blocks.3,blocks.4,blocks.5,blocks.6,blocks.7,blocks.8,blocks.9,blocks.10,blocks.11,blocks.12,blocks.13,blocks.14,blocks.15,blocks.16,blocks.17,blocks.18,blocks.19,blocks.20,blocks.21,blocks.22,blocks.23",
+                    "ramtorch_target_modules": "blocks.0.*,blocks.1.*,blocks.2.*,blocks.3.*,blocks.4.*,blocks.5.*,blocks.6.*,blocks.7.*,blocks.8.*,blocks.9.*,blocks.10.*,blocks.11.*,blocks.12.*,blocks.13.*,blocks.14.*,blocks.15.*,blocks.16.*,blocks.17.*,blocks.18.*,blocks.19.*,blocks.20.*,blocks.21.*,blocks.22.*,blocks.23.*",
                 },
             ),
             AccelerationPreset(

--- a/simpletuner/helpers/models/ltxvideo/model.py
+++ b/simpletuner/helpers/models/ltxvideo/model.py
@@ -115,7 +115,7 @@ class LTXVideo(VideoModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "transformer_blocks.0,transformer_blocks.1,transformer_blocks.2,transformer_blocks.3,transformer_blocks.4,transformer_blocks.5,transformer_blocks.6,transformer_blocks.7,transformer_blocks.8,transformer_blocks.9,transformer_blocks.10,transformer_blocks.11,transformer_blocks.12,transformer_blocks.13",
+                    "ramtorch_target_modules": "transformer_blocks.0.*,transformer_blocks.1.*,transformer_blocks.2.*,transformer_blocks.3.*,transformer_blocks.4.*,transformer_blocks.5.*,transformer_blocks.6.*,transformer_blocks.7.*,transformer_blocks.8.*,transformer_blocks.9.*,transformer_blocks.10.*,transformer_blocks.11.*,transformer_blocks.12.*,transformer_blocks.13.*",
                 },
             ),
             AccelerationPreset(

--- a/simpletuner/helpers/models/omnigen/model.py
+++ b/simpletuner/helpers/models/omnigen/model.py
@@ -68,7 +68,7 @@ class OmniGen(ImageModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "layers.12,layers.13,layers.14,layers.15,layers.16,layers.17,layers.18,layers.19,layers.20,layers.21,layers.22,layers.23",
+                    "ramtorch_target_modules": "layers.12.*,layers.13.*,layers.14.*,layers.15.*,layers.16.*,layers.17.*,layers.18.*,layers.19.*,layers.20.*,layers.21.*,layers.22.*,layers.23.*",
                 },
             ),
             AccelerationPreset(
@@ -84,7 +84,7 @@ class OmniGen(ImageModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "layers.6,layers.7,layers.8,layers.9,layers.10,layers.11,layers.12,layers.13,layers.14,layers.15,layers.16,layers.17,layers.18,layers.19,layers.20,layers.21,layers.22,layers.23",
+                    "ramtorch_target_modules": "layers.6.*,layers.7.*,layers.8.*,layers.9.*,layers.10.*,layers.11.*,layers.12.*,layers.13.*,layers.14.*,layers.15.*,layers.16.*,layers.17.*,layers.18.*,layers.19.*,layers.20.*,layers.21.*,layers.22.*,layers.23.*",
                 },
             ),
             AccelerationPreset(

--- a/simpletuner/helpers/models/qwen_image/model.py
+++ b/simpletuner/helpers/models/qwen_image/model.py
@@ -135,7 +135,7 @@ class QwenImage(ImageModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "transformer_blocks.0,transformer_blocks.1,transformer_blocks.2,transformer_blocks.3,transformer_blocks.4,transformer_blocks.5,transformer_blocks.6,transformer_blocks.7,transformer_blocks.8,transformer_blocks.9,transformer_blocks.10,transformer_blocks.11,transformer_blocks.12,transformer_blocks.13,transformer_blocks.14",
+                    "ramtorch_target_modules": "transformer_blocks.0.*,transformer_blocks.1.*,transformer_blocks.2.*,transformer_blocks.3.*,transformer_blocks.4.*,transformer_blocks.5.*,transformer_blocks.6.*,transformer_blocks.7.*,transformer_blocks.8.*,transformer_blocks.9.*,transformer_blocks.10.*,transformer_blocks.11.*,transformer_blocks.12.*,transformer_blocks.13.*,transformer_blocks.14.*",
                 },
             ),
             AccelerationPreset(
@@ -151,7 +151,7 @@ class QwenImage(ImageModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "transformer_blocks.0,transformer_blocks.1,transformer_blocks.2,transformer_blocks.3,transformer_blocks.4,transformer_blocks.5,transformer_blocks.6,transformer_blocks.7,transformer_blocks.8,transformer_blocks.9,transformer_blocks.10,transformer_blocks.11,transformer_blocks.12,transformer_blocks.13,transformer_blocks.14,transformer_blocks.15,transformer_blocks.16,transformer_blocks.17,transformer_blocks.18,transformer_blocks.19,transformer_blocks.20,transformer_blocks.21,transformer_blocks.22,transformer_blocks.23,transformer_blocks.24,transformer_blocks.25,transformer_blocks.26,transformer_blocks.27,transformer_blocks.28,transformer_blocks.29",
+                    "ramtorch_target_modules": "transformer_blocks.0.*,transformer_blocks.1.*,transformer_blocks.2.*,transformer_blocks.3.*,transformer_blocks.4.*,transformer_blocks.5.*,transformer_blocks.6.*,transformer_blocks.7.*,transformer_blocks.8.*,transformer_blocks.9.*,transformer_blocks.10.*,transformer_blocks.11.*,transformer_blocks.12.*,transformer_blocks.13.*,transformer_blocks.14.*,transformer_blocks.15.*,transformer_blocks.16.*,transformer_blocks.17.*,transformer_blocks.18.*,transformer_blocks.19.*,transformer_blocks.20.*,transformer_blocks.21.*,transformer_blocks.22.*,transformer_blocks.23.*,transformer_blocks.24.*,transformer_blocks.25.*,transformer_blocks.26.*,transformer_blocks.27.*,transformer_blocks.28.*,transformer_blocks.29.*",
                 },
             ),
             AccelerationPreset(

--- a/simpletuner/helpers/models/sanavideo/model.py
+++ b/simpletuner/helpers/models/sanavideo/model.py
@@ -117,7 +117,7 @@ class SanaVideo(VideoModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "transformer_blocks.0,transformer_blocks.1,transformer_blocks.2,transformer_blocks.3,transformer_blocks.4,transformer_blocks.5,transformer_blocks.6,transformer_blocks.7,transformer_blocks.8,transformer_blocks.9",
+                    "ramtorch_target_modules": "transformer_blocks.0.*,transformer_blocks.1.*,transformer_blocks.2.*,transformer_blocks.3.*,transformer_blocks.4.*,transformer_blocks.5.*,transformer_blocks.6.*,transformer_blocks.7.*,transformer_blocks.8.*,transformer_blocks.9.*",
                 },
             ),
             AccelerationPreset(

--- a/simpletuner/helpers/models/sd3/model.py
+++ b/simpletuner/helpers/models/sd3/model.py
@@ -186,7 +186,7 @@ class SD3(ImageModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "transformer_blocks.0,transformer_blocks.1,transformer_blocks.2,transformer_blocks.3,transformer_blocks.4,transformer_blocks.5",
+                    "ramtorch_target_modules": "transformer_blocks.0.*,transformer_blocks.1.*,transformer_blocks.2.*,transformer_blocks.3.*,transformer_blocks.4.*,transformer_blocks.5.*",
                 },
             ),
             AccelerationPreset(
@@ -202,7 +202,7 @@ class SD3(ImageModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "transformer_blocks.0,transformer_blocks.1,transformer_blocks.2,transformer_blocks.3,transformer_blocks.4,transformer_blocks.5,transformer_blocks.6,transformer_blocks.7,transformer_blocks.8,transformer_blocks.9,transformer_blocks.10,transformer_blocks.11",
+                    "ramtorch_target_modules": "transformer_blocks.0.*,transformer_blocks.1.*,transformer_blocks.2.*,transformer_blocks.3.*,transformer_blocks.4.*,transformer_blocks.5.*,transformer_blocks.6.*,transformer_blocks.7.*,transformer_blocks.8.*,transformer_blocks.9.*,transformer_blocks.10.*,transformer_blocks.11.*",
                 },
             ),
             AccelerationPreset(

--- a/simpletuner/helpers/models/wan/model.py
+++ b/simpletuner/helpers/models/wan/model.py
@@ -341,7 +341,7 @@ class Wan(VideoModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "blocks.0,blocks.1,blocks.2,blocks.3,blocks.4,blocks.5,blocks.6,blocks.7,blocks.8,blocks.9,blocks.10,blocks.11,blocks.12,blocks.13,blocks.14,blocks.15,blocks.16,blocks.17,blocks.18,blocks.19",
+                    "ramtorch_target_modules": "blocks.0.*,blocks.1.*,blocks.2.*,blocks.3.*,blocks.4.*,blocks.5.*,blocks.6.*,blocks.7.*,blocks.8.*,blocks.9.*,blocks.10.*,blocks.11.*,blocks.12.*,blocks.13.*,blocks.14.*,blocks.15.*,blocks.16.*,blocks.17.*,blocks.18.*,blocks.19.*",
                 },
             ),
             AccelerationPreset(

--- a/simpletuner/helpers/models/z_image/model.py
+++ b/simpletuner/helpers/models/z_image/model.py
@@ -90,7 +90,7 @@ class ZImage(ImageModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "layers.15,layers.16,layers.17,layers.18,layers.19,layers.20,layers.21,layers.22,layers.23,layers.24,layers.25,layers.26,layers.27,layers.28,layers.29",
+                    "ramtorch_target_modules": "layers.15.*,layers.16.*,layers.17.*,layers.18.*,layers.19.*,layers.20.*,layers.21.*,layers.22.*,layers.23.*,layers.24.*,layers.25.*,layers.26.*,layers.27.*,layers.28.*,layers.29.*",
                 },
             ),
             AccelerationPreset(
@@ -106,7 +106,7 @@ class ZImage(ImageModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "layers.8,layers.9,layers.10,layers.11,layers.12,layers.13,layers.14,layers.15,layers.16,layers.17,layers.18,layers.19,layers.20,layers.21,layers.22,layers.23,layers.24,layers.25,layers.26,layers.27,layers.28,layers.29",
+                    "ramtorch_target_modules": "layers.8.*,layers.9.*,layers.10.*,layers.11.*,layers.12.*,layers.13.*,layers.14.*,layers.15.*,layers.16.*,layers.17.*,layers.18.*,layers.19.*,layers.20.*,layers.21.*,layers.22.*,layers.23.*,layers.24.*,layers.25.*,layers.26.*,layers.27.*,layers.28.*,layers.29.*",
                 },
             ),
             AccelerationPreset(

--- a/simpletuner/helpers/models/z_image_omni/model.py
+++ b/simpletuner/helpers/models/z_image_omni/model.py
@@ -74,7 +74,7 @@ class ZImageOmni(ImageModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "layers.15,layers.16,layers.17,layers.18,layers.19,layers.20,layers.21,layers.22,layers.23,layers.24,layers.25,layers.26,layers.27,layers.28,layers.29",
+                    "ramtorch_target_modules": "layers.15.*,layers.16.*,layers.17.*,layers.18.*,layers.19.*,layers.20.*,layers.21.*,layers.22.*,layers.23.*,layers.24.*,layers.25.*,layers.26.*,layers.27.*,layers.28.*,layers.29.*",
                 },
             ),
             AccelerationPreset(
@@ -90,7 +90,7 @@ class ZImageOmni(ImageModelFoundation):
                 config={
                     **_base_memory_config,
                     "ramtorch": True,
-                    "ramtorch_target_modules": "layers.8,layers.9,layers.10,layers.11,layers.12,layers.13,layers.14,layers.15,layers.16,layers.17,layers.18,layers.19,layers.20,layers.21,layers.22,layers.23,layers.24,layers.25,layers.26,layers.27,layers.28,layers.29",
+                    "ramtorch_target_modules": "layers.8.*,layers.9.*,layers.10.*,layers.11.*,layers.12.*,layers.13.*,layers.14.*,layers.15.*,layers.16.*,layers.17.*,layers.18.*,layers.19.*,layers.20.*,layers.21.*,layers.22.*,layers.23.*,layers.24.*,layers.25.*,layers.26.*,layers.27.*,layers.28.*,layers.29.*",
                 },
             ),
             AccelerationPreset(

--- a/simpletuner/helpers/utils/ramtorch.py
+++ b/simpletuner/helpers/utils/ramtorch.py
@@ -83,6 +83,7 @@ def _normalize_device(device: object) -> object:
 
 
 def _matches_pattern(name: str, module: nn.Module, patterns: Iterable[str]) -> bool:
+    glob_chars = {"*", "?", "["}
     class_name = module.__class__.__name__
     for pattern in patterns:
         candidates = [name]
@@ -90,6 +91,11 @@ def _matches_pattern(name: str, module: nn.Module, patterns: Iterable[str]) -> b
             candidates.append(name.split(".", 1)[1])
         if any(fnmatch(candidate, pattern) for candidate in candidates) or fnmatch(class_name, pattern):
             return True
+        # Bare block names like "transformer_blocks.0" should also match
+        # children such as "transformer_blocks.0.attn.to_q".
+        if not any(ch in pattern for ch in glob_chars):
+            if any(fnmatch(candidate, pattern + ".*") for candidate in candidates):
+                return True
     return False
 
 


### PR DESCRIPTION
This pull request updates the `ramtorch_target_modules` configuration in the acceleration presets for multiple model helper files. The main change is to make the module targeting more flexible and comprehensive by appending `.*` to each module name, which ensures that all submodules within the specified modules are included in the acceleration process. This should improve compatibility and coverage for model acceleration.

**Updates to ramtorch target module patterns:**

* All relevant `ramtorch_target_modules` strings now use the `.*` wildcard to match all submodules, instead of targeting only the parent module (e.g., `transformer_blocks.14` → `transformer_blocks.14.*`). This change is applied across all model helper files. [[1]](diffhunk://#diff-e34e7b7e69a677399426b34f91fd1a10bb8e9f9f5a9eea54c8de088c103acebbL132-R132) [[2]](diffhunk://#diff-e34e7b7e69a677399426b34f91fd1a10bb8e9f9f5a9eea54c8de088c103acebbL148-R148) [[3]](diffhunk://#diff-bb687de4a71d62f31bb7b892a22f0a94108d93d0323112a0bc221680a2890b5fL122-R122) [[4]](diffhunk://#diff-bb687de4a71d62f31bb7b892a22f0a94108d93d0323112a0bc221680a2890b5fL138-R138) [[5]](diffhunk://#diff-571111f5431ee4a79012ae61ee50c3b6dffca3fbe3ccbdeba0a3132ca48343e7L127-R127) [[6]](diffhunk://#diff-01ff9e59af344fe6857ccb05e1e335ed6c7029d571dfae4d6014dea582b36cfeL111-R111) [[7]](diffhunk://#diff-01ff9e59af344fe6857ccb05e1e335ed6c7029d571dfae4d6014dea582b36cfeL127-R127) [[8]](diffhunk://#diff-2390d666883fb499d80e71fbe6b05b21e5141f934149c7fc66937368b6ae0c02L207-R207) [[9]](diffhunk://#diff-df6046a31196ac9ebae68e69c519f1db8029fb3d44f975605572c7d42401211dL163-R163) [[10]](diffhunk://#diff-0e4e8215bf58377859f3a1fdcdc6830fc78a66180571a8644da1d0fc68214e25L118-R118) [[11]](diffhunk://#diff-0e4e8215bf58377859f3a1fdcdc6830fc78a66180571a8644da1d0fc68214e25L134-R134) [[12]](diffhunk://#diff-555e034e93759554c225e9431fea3e2f0142064207a2137c357006586161e252L132-R132) [[13]](diffhunk://#diff-3c31404afbc2794ab1cade7c5646a388854e745fb3a5df70800b65737dc035daL112-R112) [[14]](diffhunk://#diff-035c3b65c204f1bfbde1b88ca07e0d537e119d009ba012a6c430ac360e4ff07dL113-R113) [[15]](diffhunk://#diff-d7441e8a834b13258f78e0abaf1c9d0974251cb17c3fdd3dec47d0e54a179f08L118-R118) [[16]](diffhunk://#diff-24974277a89edb0c93bfcea9a8ee5c20b0124235875022b717ee2ca4f08f12e5L71-R71) [[17]](diffhunk://#diff-24974277a89edb0c93bfcea9a8ee5c20b0124235875022b717ee2ca4f08f12e5L87-R87) [[18]](diffhunk://#diff-868c258faf0823a94ef01c5caeb668c0f1596af5b0e9707bf8b15864b5347e6cL138-R138)

**Files and models affected:**

* `ace_step`, `auraflow`, `chroma`, `cosmos`, `flux2`, `hidream`, `kandinsky5_image`, `kandinsky5_video`, `longcat_image`, `longcat_video`, `ltxvideo`, `omnigen`, `qwen_image` model helpers now all use the updated targeting pattern for their acceleration presets. (see references above)

This change should make the acceleration presets more robust to changes in module structure and ensure all relevant submodules are included in memory optimization routines.