### PR TITLE
ramtorch: update docs to mention required suffix

### DIFF
--- a/documentation/OPTIONS.es.md
+++ b/documentation/OPTIONS.es.md
@@ -138,7 +138,10 @@ Donde `foo` es tu entorno de configuración; o simplemente usa `config/config.js
 
 - **Qué**: Patrones glob separados por comas que limitan qué módulos Linear se convierten a RamTorch.
 - **Predeterminado**: Todas las capas Linear se convierten cuando no se proporciona un patrón.
-- **Notas**: Coincide con nombres de módulos completamente calificados o nombres de clase (se permiten comodines).
+- **Notas**:
+  - Coincide con nombres de módulos completamente calificados o nombres de clase usando la sintaxis glob de `fnmatch`.
+  - Los patrones deben incluir un comodín `.*` al final para coincidir con las capas dentro de un bloque. Por ejemplo, `transformer_blocks.0.*` coincide con todas las capas dentro del bloque 0, mientras que `transformer_blocks.*` coincide con todos los bloques transformer. Un nombre simple como `transformer_blocks.0` sin `.*` también funciona (se expande automáticamente), pero se recomienda la forma explícita con comodín para mayor claridad.
+  - Ejemplo: `"transformer_blocks.*,single_transformer_blocks.0.*,single_transformer_blocks.1.*"`
 
 ### `--ramtorch_text_encoder`
 

--- a/documentation/OPTIONS.hi.md
+++ b/documentation/OPTIONS.hi.md
@@ -138,7 +138,10 @@ simpletuner configure config/foo/config.json
 
 - **What**: Comma‑separated glob patterns जो यह सीमित करते हैं कि कौन‑से Linear modules को RamTorch में बदला जाए।
 - **Default**: यदि कोई pattern नहीं दिया गया, तो सभी Linear layers convert होती हैं।
-- **Notes**: fully qualified module names या class names को match करता है (wildcards allowed)।
+- **Notes**:
+  - `fnmatch` glob syntax का उपयोग करके fully qualified module names या class names को match करता है।
+  - किसी block के अंदर की layers को match करने के लिए patterns में trailing `.*` wildcard शामिल होना चाहिए। उदाहरण के लिए, `transformer_blocks.0.*` block 0 के अंदर सभी layers को match करता है, जबकि `transformer_blocks.*` सभी transformer blocks को match करता है। `transformer_blocks.0` जैसा bare name बिना `.*` के भी काम करेगा (यह automatically expand होता है), लेकिन clarity के लिए explicit wildcard form recommended है।
+  - उदाहरण: `"transformer_blocks.*,single_transformer_blocks.0.*,single_transformer_blocks.1.*"`
 
 ### `--ramtorch_text_encoder`
 

--- a/documentation/OPTIONS.ja.md
+++ b/documentation/OPTIONS.ja.md
@@ -139,7 +139,10 @@ simpletuner configure config/foo/config.json
 
 - **内容**: RamTorch に変換する Linear モジュールを制限するカンマ区切りの glob パターン。
 - **既定**: パターン未指定の場合、すべての Linear レイヤーを変換。
-- **注記**: 完全修飾モジュール名またはクラス名にマッチ（ワイルドカード可）。
+- **注記**:
+  - `fnmatch` glob 構文を使用して完全修飾モジュール名またはクラス名にマッチ。
+  - ブロック内のレイヤーにマッチさせるには、末尾に `.*` ワイルドカードを含める必要があります。例えば、`transformer_blocks.0.*` はブロック 0 内のすべてのレイヤーにマッチし、`transformer_blocks.*` はすべての transformer ブロックにマッチします。`transformer_blocks.0` のような `.*` なしの名前も動作します（自動的に展開されます）が、明確さのために明示的なワイルドカード形式を推奨します。
+  - 例: `"transformer_blocks.*,single_transformer_blocks.0.*,single_transformer_blocks.1.*"`
 
 ### `--ramtorch_text_encoder`
 

--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -138,7 +138,10 @@ Where `foo` is your config environment - or just use `config/config.json` if you
 
 - **What**: Comma-separated glob patterns limiting which Linear modules are converted to RamTorch.
 - **Default**: All Linear layers are converted when no pattern is provided.
-- **Notes**: Matches fully qualified module names or class names (wildcards allowed).
+- **Notes**:
+  - Matches fully qualified module names or class names using `fnmatch` glob syntax.
+  - Patterns must include a trailing `.*` wildcard to match layers inside a block. For example, `transformer_blocks.0.*` matches all layers inside block 0, while `transformer_blocks.*` matches all transformer blocks. A bare name like `transformer_blocks.0` without `.*` will also work (it is expanded automatically), but the explicit wildcard form is recommended for clarity.
+  - Example: `"transformer_blocks.*,single_transformer_blocks.0.*,single_transformer_blocks.1.*"`
 
 ### `--ramtorch_text_encoder`
 

--- a/documentation/OPTIONS.pt-BR.md
+++ b/documentation/OPTIONS.pt-BR.md
@@ -138,7 +138,10 @@ Onde `foo` e seu ambiente de config — ou use `config/config.json` se nao estiv
 
 - **O que**: Padroes glob separados por virgula limitando quais modulos Linear sao convertidos para RamTorch.
 - **Padrao**: Todas as camadas Linear sao convertidas quando nenhum padrao e fornecido.
-- **Notas**: Casa nomes de modulo totalmente qualificados ou nomes de classe (wildcards permitidos).
+- **Notas**:
+  - Casa nomes de modulo totalmente qualificados ou nomes de classe usando sintaxe glob `fnmatch`.
+  - Os padroes devem incluir um wildcard `.*` no final para corresponder as camadas dentro de um bloco. Por exemplo, `transformer_blocks.0.*` corresponde a todas as camadas dentro do bloco 0, enquanto `transformer_blocks.*` corresponde a todos os blocos transformer. Um nome simples como `transformer_blocks.0` sem `.*` tambem funciona (e expandido automaticamente), mas a forma explicita com wildcard e recomendada para clareza.
+  - Exemplo: `"transformer_blocks.*,single_transformer_blocks.0.*,single_transformer_blocks.1.*"`
 
 ### `--ramtorch_text_encoder`
 

--- a/documentation/OPTIONS.zh.md
+++ b/documentation/OPTIONS.zh.md
@@ -139,7 +139,10 @@ simpletuner configure config/foo/config.json
 
 - **内容**：逗号分隔的 glob 模式，用于限制哪些 Linear 模块转换为 RamTorch。
 - **默认**：未提供模式时转换所有 Linear 层。
-- **说明**：匹配完整模块名或类名（支持通配符）。
+- **说明**：
+  - 使用 `fnmatch` glob 语法匹配完整模块名或类名。
+  - 模式必须包含末尾的 `.*` 通配符才能匹配块内的层。例如，`transformer_blocks.0.*` 匹配块 0 内的所有层，而 `transformer_blocks.*` 匹配所有 transformer 块。不带 `.*` 的裸名称如 `transformer_blocks.0` 也可以工作（会自动展开），但建议使用明确的通配符形式以提高清晰度。
+  - 示例：`"transformer_blocks.*,single_transformer_blocks.0.*,single_transformer_blocks.1.*"`
 
 ### `--ramtorch_text_encoder`
 


### PR DESCRIPTION
This pull request improves the documentation for the `--ramtorch_linear_layers` option across all supported languages. The updates clarify how to use glob patterns for selecting Linear modules to convert, provide guidance on the recommended use of trailing wildcards, and include explicit examples for better user understanding.

**Documentation improvements for glob pattern usage:**

* Clarified that patterns use `fnmatch` glob syntax and explained the importance of a trailing `.*` wildcard to match layers within blocks, with examples provided for each language. [[1]](diffhunk://#diff-45e063db3ebcffb55dde68f083e92399a74f4cefbb464e8cd36911971c50933fL141-R144) [[2]](diffhunk://#diff-3f0cd39e3a7f176d81408ae40dc4f8c6271347f75b1cee5cf71c4e701d7db561L141-R144) [[3]](diffhunk://#diff-2c007ae9176f9f69b3ae16558be55b46d524f460a626f4e5c31e1e9a1d1b14b8L141-R144) [[4]](diffhunk://#diff-39b5789a705b2e70400106934436b619d10413ca5e37bd7a2b5fa7aa0c0fb8cfL141-R144) [[5]](diffhunk://#diff-fd629904ab3e1ecdd5b568c3ef6ac61e71e3d7741700e360820849938158a1d9L142-R145) [[6]](diffhunk://#diff-cddcc50c252e719be92644d65ea8542cc51d08f15e67d918bfae737904142b1fL142-R145)
* Added recommendations to use explicit wildcard forms for clarity and noted that bare names without `.*` are also supported via automatic expansion. [[1]](diffhunk://#diff-45e063db3ebcffb55dde68f083e92399a74f4cefbb464e8cd36911971c50933fL141-R144) [[2]](diffhunk://#diff-3f0cd39e3a7f176d81408ae40dc4f8c6271347f75b1cee5cf71c4e701d7db561L141-R144) [[3]](diffhunk://#diff-2c007ae9176f9f69b3ae16558be55b46d524f460a626f4e5c31e1e9a1d1b14b8L141-R144) [[4]](diffhunk://#diff-39b5789a705b2e70400106934436b619d10413ca5e37bd7a2b5fa7aa0c0fb8cfL141-R144) [[5]](diffhunk://#diff-fd629904ab3e1ecdd5b568c3ef6ac61e71e3d7741700e360820849938158a1d9L142-R145) [[6]](diffhunk://#diff-cddcc50c252e719be92644d65ea8542cc51d08f15e67d918bfae737904142b1fL142-R145)
* Provided language-specific example patterns to illustrate correct usage. [[1]](diffhunk://#diff-45e063db3ebcffb55dde68f083e92399a74f4cefbb464e8cd36911971c50933fL141-R144) [[2]](diffhunk://#diff-3f0cd39e3a7f176d81408ae40dc4f8c6271347f75b1cee5cf71c4e701d7db561L141-R144) [[3]](diffhunk://#diff-2c007ae9176f9f69b3ae16558be55b46d524f460a626f4e5c31e1e9a1d1b14b8L141-R144) [[4]](diffhunk://#diff-39b5789a705b2e70400106934436b619d10413ca5e37bd7a2b5fa7aa0c0fb8cfL141-R144) [[5]](diffhunk://#diff-fd629904ab3e1ecdd5b568c3ef6ac61e71e3d7741700e360820849938158a1d9L142-R145) [[6]](diffhunk://#diff-cddcc50c252e719be92644d65ea8542cc51d08f15e67d918bfae737904142b1fL142-R145)