### PR TITLE
flux2: add hint about Flux2 single stream block

### DIFF
--- a/documentation/LYCORIS.es.md
+++ b/documentation/LYCORIS.es.md
@@ -59,6 +59,46 @@ Campos obligatorios:
 
 Para más información sobre LyCORIS, consulta la [documentación en la librería](https://github.com/KohakuBlueleaf/LyCORIS/tree/main/docs).
 
+### Módulos objetivo de Flux 2 (Klein)
+
+Los modelos Flux 2 usan clases de módulo personalizadas en lugar de los nombres genéricos `Attention` y `FeedForward`. Una configuración LoKR de Flux 2 debe apuntar a:
+
+- `Flux2Attention` — bloques de atención de doble flujo
+- `Flux2FeedForward` — bloques feedforward de doble flujo
+- `Flux2ParallelSelfAttention` — bloques paralelos de atención+feedforward de flujo único (proyecciones QKV y MLP fusionadas)
+
+Incluir `Flux2ParallelSelfAttention` entrena los bloques de flujo único, lo que puede mejorar la convergencia a costa de un mayor riesgo de sobreajuste. Si tienes dificultades para que LyCORIS LoKR converja en Flux 2, se recomienda agregar este objetivo.
+
+Ejemplo de configuración LoKR para Flux 2:
+
+```json
+{
+    "bypass_mode": true,
+    "algo": "lokr",
+    "multiplier": 1.0,
+    "full_matrix": true,
+    "linear_dim": 10000,
+    "linear_alpha": 1,
+    "factor": 4,
+    "apply_preset": {
+        "target_module": [
+            "Flux2Attention", "Flux2FeedForward", "Flux2ParallelSelfAttention"
+        ],
+        "module_algo_map": {
+            "Flux2FeedForward": {
+                "factor": 4
+            },
+            "Flux2Attention": {
+                "factor": 2
+            },
+            "Flux2ParallelSelfAttention": {
+                "factor": 2
+            }
+        }
+    }
+}
+```
+
 ## Problemas potenciales
 
 Al usar Lycoris en SDXL, se ha observado que entrenar los módulos FeedForward puede romper el modelo y llevar la pérdida a valores `NaN` (Not-a-Number).

--- a/documentation/LYCORIS.hi.md
+++ b/documentation/LYCORIS.hi.md
@@ -59,6 +59,46 @@ LyCORIS कॉन्फ़िगरेशन फ़ाइल का फ़ॉर
 
 LyCORIS के बारे में अधिक जानकारी के लिए, [लाइब्रेरी के दस्तावेज़](https://github.com/KohakuBlueleaf/LyCORIS/tree/main/docs) देखें।
 
+### Flux 2 (Klein) मॉड्यूल टारगेट
+
+Flux 2 मॉडल generic `Attention` और `FeedForward` नामों के बजाय कस्टम मॉड्यूल क्लासेस का उपयोग करते हैं। Flux 2 LoKR config में निम्नलिखित को टारगेट करें:
+
+- `Flux2Attention` — डबल-स्ट्रीम अटेंशन ब्लॉक
+- `Flux2FeedForward` — डबल-स्ट्रीम फीडफॉरवर्ड ब्लॉक
+- `Flux2ParallelSelfAttention` — सिंगल-स्ट्रीम पैरेलल अटेंशन+फीडफॉरवर्ड ब्लॉक (फ्यूज्ड QKV और MLP प्रोजेक्शन)
+
+`Flux2ParallelSelfAttention` को शामिल करने से सिंगल-स्ट्रीम ब्लॉक भी ट्रेन होते हैं, जो convergence में सुधार कर सकता है लेकिन overfitting का जोखिम बढ़ सकता है। यदि Flux 2 पर LyCORIS LoKR को converge करने में कठिनाई हो रही है, तो इस टारगेट को जोड़ने की सिफारिश की जाती है।
+
+Flux 2 LoKR config का उदाहरण:
+
+```json
+{
+    "bypass_mode": true,
+    "algo": "lokr",
+    "multiplier": 1.0,
+    "full_matrix": true,
+    "linear_dim": 10000,
+    "linear_alpha": 1,
+    "factor": 4,
+    "apply_preset": {
+        "target_module": [
+            "Flux2Attention", "Flux2FeedForward", "Flux2ParallelSelfAttention"
+        ],
+        "module_algo_map": {
+            "Flux2FeedForward": {
+                "factor": 4
+            },
+            "Flux2Attention": {
+                "factor": 2
+            },
+            "Flux2ParallelSelfAttention": {
+                "factor": 2
+            }
+        }
+    }
+}
+```
+
 ## संभावित समस्याएँ
 
 SDXL पर Lycoris उपयोग करते समय यह नोट किया गया है कि FeedForward मॉड्यूल्स को ट्रेन करने से मॉडल टूट सकता है और loss `NaN` (Not‑a‑Number) हो सकता है।

--- a/documentation/LYCORIS.ja.md
+++ b/documentation/LYCORIS.ja.md
@@ -59,6 +59,46 @@ LyCORIS 設定ファイルの形式は次のとおりです:
 
 LyCORIS の詳細は、[ライブラリのドキュメント](https://github.com/KohakuBlueleaf/LyCORIS/tree/main/docs) を参照してください。
 
+### Flux 2 (Klein) モジュールターゲット
+
+Flux 2 モデルは、汎用の `Attention` や `FeedForward` ではなく、カスタムモジュールクラスを使用します。Flux 2 の LoKR 設定では以下をターゲットに設定してください：
+
+- `Flux2Attention` — ダブルストリームアテンションブロック
+- `Flux2FeedForward` — ダブルストリームフィードフォワードブロック
+- `Flux2ParallelSelfAttention` — シングルストリーム並列アテンション+フィードフォワードブロック（QKV と MLP 投影が融合）
+
+`Flux2ParallelSelfAttention` を含めるとシングルストリームブロックも学習対象となり、収束が改善する可能性がありますが、過学習のリスクが増加します。Flux 2 で LyCORIS LoKR の収束が困難な場合、このターゲットの追加を推奨します。
+
+Flux 2 LoKR 設定例：
+
+```json
+{
+    "bypass_mode": true,
+    "algo": "lokr",
+    "multiplier": 1.0,
+    "full_matrix": true,
+    "linear_dim": 10000,
+    "linear_alpha": 1,
+    "factor": 4,
+    "apply_preset": {
+        "target_module": [
+            "Flux2Attention", "Flux2FeedForward", "Flux2ParallelSelfAttention"
+        ],
+        "module_algo_map": {
+            "Flux2FeedForward": {
+                "factor": 4
+            },
+            "Flux2Attention": {
+                "factor": 2
+            },
+            "Flux2ParallelSelfAttention": {
+                "factor": 2
+            }
+        }
+    }
+}
+```
+
 ## 予想される問題
 
 SDXL に Lycoris を使用すると、FeedForward モジュールの学習でモデルが壊れ、損失が `NaN`（Not-a-Number）に飛ぶことがあります。

--- a/documentation/LYCORIS.md
+++ b/documentation/LYCORIS.md
@@ -59,6 +59,46 @@ Mandatory fields:
 
 For more information on LyCORIS, please refer to the [documentation in the library](https://github.com/KohakuBlueleaf/LyCORIS/tree/main/docs).
 
+### Flux 2 (Klein) module targets
+
+Flux 2 models use custom module classes instead of the generic `Attention` and `FeedForward` names. A Flux 2 LoKR config should target:
+
+- `Flux2Attention` — double-stream attention blocks
+- `Flux2FeedForward` — double-stream feedforward blocks
+- `Flux2ParallelSelfAttention` — single-stream parallel attention+feedforward blocks (fused QKV and MLP projections)
+
+Including `Flux2ParallelSelfAttention` trains the single-stream blocks, which may improve convergence at the cost of increased risk of overfitting. If you are having difficulty getting LyCORIS LoKR to converge on Flux 2, adding this target is recommended.
+
+Example Flux 2 LoKR config:
+
+```json
+{
+    "bypass_mode": true,
+    "algo": "lokr",
+    "multiplier": 1.0,
+    "full_matrix": true,
+    "linear_dim": 10000,
+    "linear_alpha": 1,
+    "factor": 4,
+    "apply_preset": {
+        "target_module": [
+            "Flux2Attention", "Flux2FeedForward", "Flux2ParallelSelfAttention"
+        ],
+        "module_algo_map": {
+            "Flux2FeedForward": {
+                "factor": 4
+            },
+            "Flux2Attention": {
+                "factor": 2
+            },
+            "Flux2ParallelSelfAttention": {
+                "factor": 2
+            }
+        }
+    }
+}
+```
+
 ## Potential problems
 
 When using Lycoris on SDXL, it's noted that training the FeedForward modules may break the model and send loss into `NaN` (Not-a-Number) territory.

--- a/documentation/LYCORIS.pt-BR.md
+++ b/documentation/LYCORIS.pt-BR.md
@@ -59,6 +59,46 @@ Campos obrigatorios:
 
 Para mais informacoes sobre LyCORIS, consulte a [documentacao na biblioteca](https://github.com/KohakuBlueleaf/LyCORIS/tree/main/docs).
 
+### Modulos alvo do Flux 2 (Klein)
+
+Os modelos Flux 2 usam classes de modulo personalizadas em vez dos nomes genericos `Attention` e `FeedForward`. Uma configuracao LoKR para Flux 2 deve ter como alvo:
+
+- `Flux2Attention` — blocos de atencao de fluxo duplo
+- `Flux2FeedForward` — blocos feedforward de fluxo duplo
+- `Flux2ParallelSelfAttention` — blocos paralelos de atencao+feedforward de fluxo unico (projecoes QKV e MLP fundidas)
+
+Incluir `Flux2ParallelSelfAttention` treina os blocos de fluxo unico, o que pode melhorar a convergencia ao custo de maior risco de overfitting. Se voce esta tendo dificuldade para convergir LyCORIS LoKR no Flux 2, e recomendado adicionar este alvo.
+
+Exemplo de configuracao LoKR para Flux 2:
+
+```json
+{
+    "bypass_mode": true,
+    "algo": "lokr",
+    "multiplier": 1.0,
+    "full_matrix": true,
+    "linear_dim": 10000,
+    "linear_alpha": 1,
+    "factor": 4,
+    "apply_preset": {
+        "target_module": [
+            "Flux2Attention", "Flux2FeedForward", "Flux2ParallelSelfAttention"
+        ],
+        "module_algo_map": {
+            "Flux2FeedForward": {
+                "factor": 4
+            },
+            "Flux2Attention": {
+                "factor": 2
+            },
+            "Flux2ParallelSelfAttention": {
+                "factor": 2
+            }
+        }
+    }
+}
+```
+
 ## Problemas potenciais
 
 Ao usar Lycoris no SDXL, foi observado que treinar os modulos FeedForward pode quebrar o modelo e levar a loss para valores `NaN` (Not-a-Number).

--- a/documentation/LYCORIS.zh.md
+++ b/documentation/LYCORIS.zh.md
@@ -59,6 +59,46 @@ LyCORIS 配置文件格式如下：
 
 更多信息请参考 [库文档](https://github.com/KohakuBlueleaf/LyCORIS/tree/main/docs)。
 
+### Flux 2 (Klein) 模块目标
+
+Flux 2 模型使用自定义模块类，而非通用的 `Attention` 和 `FeedForward` 名称。Flux 2 的 LoKR 配置应以下列模块为目标：
+
+- `Flux2Attention` — 双流注意力块
+- `Flux2FeedForward` — 双流前馈块
+- `Flux2ParallelSelfAttention` — 单流并行注意力+前馈块（融合的 QKV 和 MLP 投影）
+
+包含 `Flux2ParallelSelfAttention` 会训练单流块，可能改善收敛性，但会增加过拟合的风险。如果在 Flux 2 上使用 LyCORIS LoKR 难以收敛，建议添加此目标。
+
+Flux 2 LoKR 配置示例：
+
+```json
+{
+    "bypass_mode": true,
+    "algo": "lokr",
+    "multiplier": 1.0,
+    "full_matrix": true,
+    "linear_dim": 10000,
+    "linear_alpha": 1,
+    "factor": 4,
+    "apply_preset": {
+        "target_module": [
+            "Flux2Attention", "Flux2FeedForward", "Flux2ParallelSelfAttention"
+        ],
+        "module_algo_map": {
+            "Flux2FeedForward": {
+                "factor": 4
+            },
+            "Flux2Attention": {
+                "factor": 2
+            },
+            "Flux2ParallelSelfAttention": {
+                "factor": 2
+            }
+        }
+    }
+}
+```
+
 ## 潜在问题
 
 在 SDXL 上使用 Lycoris 时，训练 FeedForward 模块可能会破坏模型并使损失变为 `NaN`。

--- a/simpletuner/examples/flux2-klein-9b-i2i.lycoris-lokr/lycoris_config.json
+++ b/simpletuner/examples/flux2-klein-9b-i2i.lycoris-lokr/lycoris_config.json
@@ -8,13 +8,16 @@
     "factor": 4,
     "apply_preset": {
         "target_module": [
-            "Flux2Attention", "Flux2FeedForward"
+            "Flux2Attention", "Flux2FeedForward", "Flux2ParallelSelfAttention"
         ],
         "module_algo_map": {
             "Flux2FeedForward": {
                 "factor": 4
             },
             "Flux2Attention": {
+                "factor": 2
+            },
+            "Flux2ParallelSelfAttention": {
                 "factor": 2
             }
         }


### PR DESCRIPTION
This pull request updates the documentation and example configuration to clarify how to target Flux 2 (Klein) model modules when using LyCORIS LoKR. The main focus is on adding guidance for including the new `Flux2ParallelSelfAttention` module, which may help with convergence but could increase the risk of overfitting. These updates are made consistently across all supported languages and in the example config.

**Documentation updates for Flux 2 LoKR targeting:**

* Added new sections in all language variants of the LyCORIS documentation (`LYCORIS.md`, `LYCORIS.es.md`, `LYCORIS.pt-BR.md`, `LYCORIS.ja.md`, `LYCORIS.zh.md`, `LYCORIS.hi.md`) to explain the use of custom module class names in Flux 2 models, specifically `Flux2Attention`, `Flux2FeedForward`, and `Flux2ParallelSelfAttention`, and how to configure them for LoKR training. [[1]](diffhunk://#diff-6d9ca7e1cf507a415b3210622404332e4ee66bb01b6192d386ef1092e8f1f7fcR62-R101) [[2]](diffhunk://#diff-c8391c1dc087c13186e606541fd557aa01b4b9d7f4dc17c5e6ea234094797d9aR62-R101) [[3]](diffhunk://#diff-d14f8f257ad8ee779ad0cb38651cf582d9806c7a8e159ec8f9388431b7c9cc25R62-R101) [[4]](diffhunk://#diff-7aa86c69f138207c09b624d2f488c84014bdbb2544d80aa723182b44411bb5aaR62-R101) [[5]](diffhunk://#diff-77242be2792028680ea01c3325b2761810c9e4e7f7ed3a15fb6d905571240f73R62-R101) [[6]](diffhunk://#diff-580f8be6b36a0f694f546e617f0b1a0537f4521626f37a1122bea080ef09ef26R62-R101)
* Provided example configuration JSON in each documentation file to demonstrate correct targeting of all relevant Flux 2 modules, including the new module and its recommended usage. [[1]](diffhunk://#diff-6d9ca7e1cf507a415b3210622404332e4ee66bb01b6192d386ef1092e8f1f7fcR62-R101) [[2]](diffhunk://#diff-c8391c1dc087c13186e606541fd557aa01b4b9d7f4dc17c5e6ea234094797d9aR62-R101) [[3]](diffhunk://#diff-d14f8f257ad8ee779ad0cb38651cf582d9806c7a8e159ec8f9388431b7c9cc25R62-R101) [[4]](diffhunk://#diff-7aa86c69f138207c09b624d2f488c84014bdbb2544d80aa723182b44411bb5aaR62-R101) [[5]](diffhunk://#diff-77242be2792028680ea01c3325b2761810c9e4e7f7ed3a15fb6d905571240f73R62-R101) [[6]](diffhunk://#diff-580f8be6b36a0f694f546e617f0b1a0537f4521626f37a1122bea080ef09ef26R62-R101)

**Example configuration update:**

* Updated the example `lycoris_config.json` in `simpletuner/examples/flux2-klein-9b-i2i.lycoris-lokr` to include `Flux2ParallelSelfAttention` as a targeted module, with its own factor setting, matching the new documentation guidance.