### PR TITLE
limit torchao to less than 0.16.0 for diffusers bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -269,7 +269,7 @@ def get_cuda13_dependencies():
         build_cuda13_wheel_url("torchaudio", torchaudio_version),
         "triton>=3.3.0",
         "deepspeed>=0.17.2",
-        "torchao>=0.14.1",
+        "torchao>=0.14.0,<0.16.0",
         "bitsandbytes>=0.45.0",
         "nvidia-cudnn-cu13",
         "nvidia-nccl-cu13",
@@ -294,7 +294,7 @@ def get_cuda_nightly_dependencies():
         build_triton_wheel_url(triton_version, "https://download.pytorch.org/whl/nightly"),
         "bitsandbytes>=0.45.0",
         "deepspeed>=0.17.2",
-        "torchao>=0.14.1",
+        "torchao>=0.14.0,<0.16.0",
         "nvidia-cudnn-cu12",
         "nvidia-nccl-cu12",
         "nvidia-ml-py>=12.555",
@@ -317,7 +317,7 @@ def get_cuda13_nightly_dependencies():
         build_cuda13_nightly_wheel_url("torchaudio", torchaudio_version),
         build_triton_wheel_url(triton_version, "https://download.pytorch.org/whl/nightly"),
         "deepspeed>=0.17.2",
-        "torchao>=0.14.1",
+        "torchao>=0.14.0,<0.16.0",
         "bitsandbytes>=0.45.0",
         "nvidia-cudnn-cu13",
         "nvidia-nccl-cu13",
@@ -336,7 +336,7 @@ def get_cuda_dependencies():
         "triton>=3.3.0",
         "bitsandbytes>=0.45.0",
         "deepspeed>=0.17.2",
-        "torchao>=0.14.1",
+        "torchao>=0.14.0,<0.16.0",
         "nvidia-cudnn-cu12",
         "nvidia-nccl-cu12",
         "nvidia-ml-py>=12.555",
@@ -365,7 +365,7 @@ def get_rocm_dependencies():
             build_rocm_wheel_url("torchvision", torchvision_version, vision_tag, rocm_base_url),
             build_rocm_wheel_url("torchaudio", torchaudio_version, audio_tag, rocm_base_url),
             build_rocm_triton_wheel_url(triton_version, triton_tag, rocm_base_url),
-            "torchao>=0.14.1",
+            "torchao>=0.14.0,<0.16.0",
             ramtorch_dep,
         ]
     except Exception as exc:
@@ -374,7 +374,7 @@ def get_rocm_dependencies():
             "torch>=2.10.0",
             "torchvision>=0.25.0",
             "torchaudio>=2.10.0",
-            "torchao>=0.14.1",
+            "torchao>=0.14.0,<0.16.0",
             ramtorch_dep,
         ]
 
@@ -384,7 +384,7 @@ def get_apple_dependencies():
         "torch>=2.10.0",
         "torchvision>=0.25.0",
         "torchaudio>=2.10.0",
-        "torchao>=0.14.1",
+        "torchao>=0.14.0,<0.16.0",
     ]
 
 
@@ -393,7 +393,7 @@ def get_cpu_dependencies():
         "torch>=2.10.0",
         "torchvision>=0.25.0",
         "torchaudio>=2.10.0",
-        "torchao>=0.14.1",
+        "torchao>=0.14.0,<0.16.0",
     ]
 
 


### PR DESCRIPTION
This pull request updates the dependency specification for `torchao` across all platform-specific dependency groups in `setup.py`. The minimum version requirement (`>=0.14.1`) has been replaced with an upper bound, restricting `torchao` to versions less than `0.16.0`. This change likely addresses compatibility or stability concerns with newer versions of `torchao`.

Dependency version pinning:

* Updated all platform-specific dependency lists in `setup.py` (`get_cuda13_dependencies`, `get_cuda_nightly_dependencies`, `get_cuda13_nightly_dependencies`, `get_cuda_dependencies`, `get_rocm_dependencies`, `get_apple_dependencies`, `get_cpu_dependencies`) to require `torchao<0.16.0` instead of `torchao>=0.14.1`. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L272-R272) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L297-R297) [[3]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L320-R320) [[4]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L339-R339) [[5]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L368-R368) [[6]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L377-R377) [[7]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L387-R387) [[8]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L396-R396)