### PR TITLE
qwen image and qwen edit do not need attn masking when no padding

### DIFF
--- a/simpletuner/helpers/models/qwen_image/pipeline.py
+++ b/simpletuner/helpers/models/qwen_image/pipeline.py
@@ -303,6 +303,9 @@ class QwenImageEditPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
         prompt_embeds_mask = prompt_embeds_mask.repeat(1, num_images_per_prompt, 1)
         prompt_embeds_mask = prompt_embeds_mask.view(batch_size * num_images_per_prompt, seq_len)
 
+        if prompt_embeds_mask is not None and prompt_embeds_mask.all():
+            prompt_embeds_mask = None
+
         return prompt_embeds, prompt_embeds_mask
 
     def check_inputs(

--- a/simpletuner/helpers/models/qwen_image/pipeline_edit_plus.py
+++ b/simpletuner/helpers/models/qwen_image/pipeline_edit_plus.py
@@ -317,6 +317,9 @@ class QwenImageEditPlusPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
         prompt_embeds_mask = prompt_embeds_mask.repeat(1, num_images_per_prompt, 1)
         prompt_embeds_mask = prompt_embeds_mask.view(batch_size * num_images_per_prompt, seq_len)
 
+        if prompt_embeds_mask is not None and prompt_embeds_mask.all():
+            prompt_embeds_mask = None
+
         return prompt_embeds, prompt_embeds_mask
 
     # Copied from diffusers.pipelines.qwenimage.pipeline_qwenimage_edit.QwenImageEditPipeline.check_inputs


### PR DESCRIPTION
This pull request introduces a small but important improvement to the prompt encoding logic in both the `qwen_image` and `qwen_image_edit_plus` pipelines. The change ensures that if the `prompt_embeds_mask` tensor contains only `True` values (i.e., all positions are valid), it is set to `None` before being returned. This helps downstream components distinguish between an explicit mask and the absence of masking, potentially simplifying logic and improving efficiency.

Key change:

* In both `simpletuner/helpers/models/qwen_image/pipeline.py` and `simpletuner/helpers/models/qwen_image/pipeline_edit_plus.py`, updated the `encode_prompt` method to set `prompt_embeds_mask` to `None` if it contains only `True` values. [[1]](diffhunk://#diff-9e7797a4a527e9f8867c9f05e0fab69710127fe7bee261be109be89b2584019bR306-R308) [[2]](diffhunk://#diff-cb1d5da694d224d40d454eee36b1b42b895e6321b4fe410491493dbd7d3a341fR320-R322)