### PR TITLE
clean up the cleanup loop to prevent test suite from staying open

### DIFF
--- a/simpletuner/simpletuner_sdk/process_keeper_multiprocessing.py
+++ b/simpletuner/simpletuner_sdk/process_keeper_multiprocessing.py
@@ -340,12 +340,14 @@ def cleanup_dead_processes():
 
 
 # Set up periodic cleanup
+_cleanup_stop = threading.Event()
+
+
 def start_cleanup_thread():
     """Start a background thread to clean up dead processes."""
 
     def cleanup_loop():
-        while True:
-            time.sleep(60)  # Check every minute
+        while not _cleanup_stop.wait(timeout=60):
             try:
                 cleanup_dead_processes()
             except Exception as e:
@@ -353,7 +355,17 @@ def start_cleanup_thread():
 
     thread = threading.Thread(target=cleanup_loop, daemon=True)
     thread.start()
+    return thread
 
+
+def stop_cleanup_thread():
+    """Signal the cleanup thread to stop."""
+    _cleanup_stop.set()
+
+
+# Use threading._register_atexit so the event is set before _thread_shutdown()
+# waits for non-daemon threads. The regular atexit module runs too late.
+threading._register_atexit(stop_cleanup_thread)
 
 # Start cleanup on import
 start_cleanup_thread()


### PR DESCRIPTION
This pull request addresses issues with lingering non-daemon threads (such as those from CUDA/PyTorch) that can cause the test suite to hang after completion. The changes ensure that background cleanup threads and the Python process itself exit cleanly and promptly after tests finish, using internal threading mechanisms to guarantee early exit.

Thread and process cleanup improvements:

* Both `simpletuner/simpletuner_sdk/process_keeper.py` and `simpletuner/simpletuner_sdk/process_keeper_multiprocessing.py` now use a `threading.Event` (`_cleanup_stop`) to allow the cleanup thread to be stopped gracefully. The cleanup loop checks this event and exits when signaled, and a new `stop_cleanup_thread()` function is registered with `threading._register_atexit` to ensure the thread stops before Python waits on non-daemon threads. [[1]](diffhunk://#diff-9189b7669099b8835588eb18e71254fe6877e815a04b148799bbe7edebea0ee7R1620-R1645) [[2]](diffhunk://#diff-44895f1d1fefcbead6e078817dd1341434f5668581e025de77851167110b77dfR343-R368)

Test suite exit handling:

* In `tests/__init__.py`, a workaround is added to force the Python process to exit immediately after tests complete. This is done by monkey-patching `sys.exit` to capture the exit code, and registering a function with `threading._register_atexit` that calls `os._exit` with the captured code, ensuring the process terminates before any non-daemon threads can block shutdown.