### PR TITLE
fix flux2 block swap validation performance

### DIFF
--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -2146,7 +2146,8 @@ class Validation:
 
         if not is_fsdp:
             base_precision = str(getattr(self.config, "base_model_precision", "") or "").lower()
-            musubi_active = (getattr(self.config, "musubi_blocks_to_swap", 0) or 0) > 0
+            _musubi_swap = getattr(self.config, "musubi_blocks_to_swap", None)
+            musubi_active = isinstance(_musubi_swap, int) and _musubi_swap > 0
             if "torchao" in base_precision:
                 logger.info(
                     "Skipping pipeline.to for TorchAO-quantized base model to avoid weight swap errors during validation."


### PR DESCRIPTION
This pull request introduces an improvement to the pipeline setup logic for model validation, specifically addressing scenarios where musubi block-swap models are used. The main change is the addition of a check for musubi block-swap activation, ensuring that device placement is handled appropriately and logging the behavior.

Validation pipeline handling:

* Added a check for musubi block-swap activation (`musubi_blocks_to_swap`), and updated the logic to skip device placement for musubi models, with a corresponding log message. This ensures block placement is managed by the forward pass and prevents potential errors.