### PR TITLE
(#2573) step number consistency in async upload

### DIFF
--- a/simpletuner/helpers/publishing/metadata.py
+++ b/simpletuner/helpers/publishing/metadata.py
@@ -566,6 +566,8 @@ def save_model_card(
     validation_prompts: list = None,
     validation_shortnames: list = None,
     repo_folder: str = None,
+    global_step: int = None,
+    epoch: int = None,
 ):
     if repo_folder is None:
         raise ValueError("The repo_folder must be specified and not be None.")
@@ -693,8 +695,8 @@ The text encoder {'**was**' if train_text_encoder else '**was not**'} trained.
 
 ## Training settings
 
-- Training epochs: {StateTracker.get_epoch() - 1}
-- Training steps: {StateTracker.get_global_step()}
+- Training epochs: {(epoch - 1) if epoch is not None else (StateTracker.get_epoch() - 1)}
+- Training steps: {global_step if global_step is not None else StateTracker.get_global_step()}
 - Learning rate: {StateTracker.get_args().learning_rate}
   - Learning rate schedule: {StateTracker.get_args().lr_scheduler}
   - Warmup steps: {StateTracker.get_args().lr_warmup_steps}

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -197,43 +197,37 @@ class TestMetadataFunctions(unittest.TestCase):
                 return_value={},
             ):
                 with patch(
-                    "simpletuner.helpers.publishing.metadata.StateTracker.get_epoch",
-                    return_value=1,
+                    "simpletuner.helpers.publishing.metadata.StateTracker.get_weight_dtype",
+                    return_value=torch.bfloat16,
                 ):
                     with patch(
-                        "simpletuner.helpers.publishing.metadata.StateTracker.get_global_step",
-                        return_value=1000,
+                        "simpletuner.helpers.publishing.metadata.StateTracker.get_accelerator",
+                        return_value=MagicMock(num_processes=1),
                     ):
                         with patch(
-                            "simpletuner.helpers.publishing.metadata.StateTracker.get_weight_dtype",
-                            return_value=torch.bfloat16,
+                            "simpletuner.helpers.training.state_tracker.StateTracker.get_args",
+                            return_value=self.args,
                         ):
-                            with patch(
-                                "simpletuner.helpers.publishing.metadata.StateTracker.get_accelerator",
-                                return_value=MagicMock(num_processes=1),
-                            ):
-                                with patch(
-                                    "simpletuner.helpers.training.state_tracker.StateTracker.get_args",
-                                    return_value=self.args,
-                                ):
-                                    with patch("builtins.open", unittest.mock.mock_open()) as mock_file:
-                                        save_model_card(
-                                            repo_id="test-repo",
-                                            images=None,
-                                            base_model="test-base-model",
-                                            train_text_encoder=True,
-                                            prompt="Test prompt",
-                                            validation_prompts=["Test prompt"],
-                                            validation_shortnames=["shortname"],
-                                            repo_folder="test-folder",
-                                            model=MagicMock(),
-                                        )
-                                        # Ensure the README.md was written
-                                        mock_file.assert_called_with(
-                                            os.path.join("test-folder", "README.md"),
-                                            "w",
-                                            encoding="utf-8",
-                                        )
+                            with patch("builtins.open", unittest.mock.mock_open()) as mock_file:
+                                save_model_card(
+                                    repo_id="test-repo",
+                                    images=None,
+                                    base_model="test-base-model",
+                                    train_text_encoder=True,
+                                    prompt="Test prompt",
+                                    validation_prompts=["Test prompt"],
+                                    validation_shortnames=["shortname"],
+                                    repo_folder="test-folder",
+                                    model=MagicMock(),
+                                    global_step=1000,
+                                    epoch=1,
+                                )
+                                # Ensure the README.md was written
+                                mock_file.assert_called_with(
+                                    os.path.join("test-folder", "README.md"),
+                                    "w",
+                                    encoding="utf-8",
+                                )
 
     def test_adapter_download_fn(self):
         with patch("huggingface_hub.hf_hub_download", return_value="path/to/adapter"):


### PR DESCRIPTION
This pull request enhances the model upload and metadata publishing workflow to ensure that the correct training epoch and step information are consistently passed and recorded during model and checkpoint uploads to Hugging Face Hub. The main improvements involve propagating explicit `global_step` and `epoch` values throughout the upload process, leading to more accurate commit messages and model cards.

**Accurate Propagation of Training State:**

* The `upload_model`, `upload_full_model`, `upload_lora_model`, and `upload_latest_checkpoint` methods in `huggingface.py` now accept `global_step` and `epoch` arguments, ensuring that the correct training state is used for commit messages and metadata. [[1]](diffhunk://#diff-71d121897e9f0b56e665d94db94ea3ce8bd78761066af16cc1a972902db93e5cL135-R139) [[2]](diffhunk://#diff-71d121897e9f0b56e665d94db94ea3ce8bd78761066af16cc1a972902db93e5cL203-R223) [[3]](diffhunk://#diff-71d121897e9f0b56e665d94db94ea3ce8bd78761066af16cc1a972902db93e5cL230-R236) [[4]](diffhunk://#diff-71d121897e9f0b56e665d94db94ea3ce8bd78761066af16cc1a972902db93e5cL292-R300) [[5]](diffhunk://#diff-71d121897e9f0b56e665d94db94ea3ce8bd78761066af16cc1a972902db93e5cR354-R355)
* The `_commit_message` method now generates messages using the explicitly provided `global_step` and `epoch` if available, falling back to the current state otherwise.

**Consistent Metadata in Model Cards:**

* The `save_model_card` function and its consumers now accept and use `global_step` and `epoch` parameters, ensuring that the model card reflects the actual training state at the time of upload. [[1]](diffhunk://#diff-7e7621e1980ba1e0fb5c65b8dbf4491a028a6c471df661daf7019fadd3dd0b59R569-R570) [[2]](diffhunk://#diff-7e7621e1980ba1e0fb5c65b8dbf4491a028a6c471df661daf7019fadd3dd0b59L696-R699)

**Integration with Training Workflow:**

* In `trainer.py`, the current `global_step` and `current_epoch` are captured and passed during model and checkpoint uploads, guaranteeing that uploads correspond to the correct training state. [[1]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R4586-R4594) [[2]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R6142-R6151)

**Testing Adjustments:**

* Tests for model card saving have been updated to pass `global_step` and `epoch` explicitly, aligning with the new function signatures. [[1]](diffhunk://#diff-f3749f5c53ea2dc628ee9f0e6295d100144586bda2abd6853b69198d44b6434bL198-L205) [[2]](diffhunk://#diff-f3749f5c53ea2dc628ee9f0e6295d100144586bda2abd6853b69198d44b6434bR222-R223)