### PR TITLE
fix(z_image): exclude refiner layers from LoRA targets

### DIFF
--- a/simpletuner/helpers/models/z_image/model.py
+++ b/simpletuner/helpers/models/z_image/model.py
@@ -35,6 +35,7 @@ class ZImage(ImageModelFoundation):
     LATENT_CHANNEL_COUNT = 16
     VALIDATION_PREVIEW_SPEC = ImageTAESpec(repo_id="madebyollin/taef1")
     SLIDER_LORA_TARGET = ["to_k", "to_q", "to_v", "to_out.0"]
+    DEFAULT_LORA_EXCLUDE_TARGETS = "noise_refiner|context_refiner"
 
     MODEL_CLASS = ZImageTransformer2DModel
     MODEL_SUBFOLDER = "transformer"


### PR DESCRIPTION
## Problem

Z-Image LoRAs trained with SimpleTuner include `noise_refiner` (2 blocks) and `context_refiner` (2 blocks) in the default LoRA target set. No known inference loader can apply these layers:

- **ComfyUI**: drops keys silently (PR #12717 pending but doesn't address refiners)
- **A1111/Forge**: same — unknown keys discarded
- **Generic safetensors loaders**: no refiner support

This wastes ~12% of trained parameters (32/272 keys) on every Z-Image LoRA.

## Evidence

Audited 7 production Z-Image LoRAs (base + turbo variants). **100% hit rate** — all contain `context_refiner.*/noise_refiner.*` keys that are silently discarded at inference.

Example from a typical LoRA:
```
# Keys present but dropped by every loader:
lora_A.weight context_refiner.0.attention.to_q  (and to_k, to_v, to_out.0)
lora_A.weight context_refiner.1.attention.to_q  (...)
lora_A.weight noise_refiner.0.attention.to_q    (...)
lora_A.weight noise_refiner.1.attention.to_q    (...)
# = 32 keys out of 272 total, all silently dropped
```

## Fix

One-liner: set `DEFAULT_LORA_EXCLUDE_TARGETS` on the `ZImage` class to exclude refiner blocks via PEFT's `exclude_modules` regex.

```python
DEFAULT_LORA_EXCLUDE_TARGETS = "noise_refiner|context_refiner"
```

This flows through the existing `add_lora_adapter()` → `LoraConfig(exclude_modules=...)` path. No new config flags needed.

## Impact

- Future Z-Image LoRAs train only the 30 main transformer blocks (240 keys) — all loadable
- No breaking change: existing LoRAs unaffected (they already work minus the dropped keys)
- Slight training speedup from fewer parameters
- No config changes required for users

## Test plan

- [ ] Train a Z-Image LoRA with this change, verify output safetensors has 0 refiner keys
- [ ] Load resulting LoRA in ComfyUI, confirm no dropped keys in log
- [ ] Verify no regression on LoRA quality (same architecture, just fewer wasted params)