### PR TITLE
Update pip install commands in TUTORIAL.md

### DIFF
--- a/documentation/webui/TUTORIAL.md
+++ b/documentation/webui/TUTORIAL.md
@@ -47,9 +47,9 @@ python3.13 -m venv .venv
 NVIDIA users will have to use the CUDA extras to pull in all the right dependencies:
 
 ```bash
-pip install -e 'simpletuner[cuda]'
+pip install 'simpletuner[cuda]'
 # CUDA 13 / Blackwell users (NVIDIA B-series GPUs):
-# pip install -e 'simpletuner[cuda13]' --extra-index-url https://download.pytorch.org/whl/cu130
+# pip install 'simpletuner[cuda13]' --extra-index-url https://download.pytorch.org/whl/cu130
 # or, if you've cloned via git:
 # pip install -e '.[cuda]'
 ```


### PR DESCRIPTION
Removed the editable flag from pip install commands for clarity. Main Installation instructions list commands as edited

-e is only valid for local elements or git projects (not a valid editable requirement. It should either be a path to a local project or a VCS URL (beginning with bzr+http, bzr+https, bzr+ssh, bzr+sftp, bzr+ftp, bzr+lp, bzr+file, git+http, git+https, git+ssh, git+git, git+file, hg+file, hg+http, hg+https, hg+ssh, hg+static-http, svn+ssh, svn+http, svn+https, svn+svn, svn+file).