### PR TITLE
(#2628) remove spam during validation, downgrade to debug message

### DIFF
--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -3458,7 +3458,7 @@ class Validation:
                     pipeline_kwargs = {k: v for k, v in pipeline_kwargs.items() if k in call_kwargs}
                     logger.debug(f"Running validations with inputs: {pipeline_kwargs.keys()}")
                     if removed_kwargs:
-                        logger.warning(f"Removed the following kwargs from validation pipeline: {removed_kwargs}")
+                        logger.debug(f"Removed the following kwargs from validation pipeline: {removed_kwargs}")
                     # run in autocast ctx
                     preview_ctx = nullcontext()
                     if self.preview and current_validation_type == "checkpoint":


### PR DESCRIPTION
Closes #2628

This pull request makes a minor adjustment to the logging behavior in the `abort_check_callback` function. Specifically, it changes the log level for a message about removed keyword arguments from a warning to a debug message.

* Logging adjustment:
  * Changed the log level from warning to debug for messages about removed keyword arguments in `abort_check_callback` in `validation.py`.