### PR TITLE
(#2645) reduce discord spam by limiting structured messages

### DIFF
--- a/simpletuner/helpers/logging.py
+++ b/simpletuner/helpers/logging.py
@@ -80,7 +80,9 @@ def _webhook_worker_loop():
                             "Failed to forward structured log message to webhook.", exc_info=True
                         )
 
-                if hasattr(task.handler, "send"):
+                # Typed payloads should remain on raw backends. Discord delivery should
+                # come from explicit webhook sends, not mirrored structured events.
+                if task.structured_payload is None and hasattr(task.handler, "send"):
                     try:
                         task.handler.send(
                             message=task.text_message,

--- a/tests/test_logging_helper.py
+++ b/tests/test_logging_helper.py
@@ -45,10 +45,7 @@ class WebhookLoggerTests(unittest.TestCase):
         logger.error("boom %s", "value")
         flush_webhook_queue(timeout=1.0)
 
-        handler_mock.send.assert_called_once()
-        send_kwargs = handler_mock.send.call_args.kwargs
-        self.assertEqual(send_kwargs["message"], "[tests.logging.existing] boom value")
-        self.assertEqual(send_kwargs["message_level"], "error")
+        handler_mock.send.assert_not_called()
 
         handler_mock.send_raw.assert_called_once()
         raw_kwargs = handler_mock.send_raw.call_args.kwargs
@@ -79,7 +76,7 @@ class WebhookLoggerTests(unittest.TestCase):
 
         webhook_handler_cls.assert_called_once()
         mock_state_tracker.set_webhook_handler.assert_called_once_with(handler_instance)
-        handler_instance.send.assert_called_once()
+        handler_instance.send.assert_not_called()
         handler_instance.send_raw.assert_called_once()
 
     @patch(
@@ -119,7 +116,7 @@ class WebhookLoggerTests(unittest.TestCase):
         self.assertIn("webhook_config", kwargs)
         config = kwargs["webhook_config"]
         self.assertTrue(config, "Expected fallback webhook config to be provided")
-        handler_instance.send.assert_called_once()
+        handler_instance.send.assert_not_called()
         handler_instance.send_raw.assert_called_once()
 
     def test_fallback_returns_none_without_env_config(self):


### PR DESCRIPTION
Closes #2645

This pull request updates the logic for dispatching log messages to webhook handlers, ensuring that only unstructured log messages are sent via the `send` method, while structured payloads use the `send_raw` method. The associated tests have been updated to reflect this new behavior.

**Logging behavior changes:**

* Modified `_webhook_worker_loop` in `simpletuner/helpers/logging.py` so that only log messages without a structured payload call the handler's `send` method; structured payloads are now excluded from this path.

**Test updates:**

* Updated `test_existing_handler_receives_messages` in `tests/test_logging_helper.py` to assert that `send` is not called and only `send_raw` is used for structured payloads.
* Updated `test_handler_created_when_missing` and `test_env_config_used_when_args_missing` in `tests/test_logging_helper.py` to assert that `send` is not called and `send_raw` is called for structured payloads. [[1]](diffhunk://#diff-f3012e3c187b019747cc830f5135146d6e844d0b40294feb8af8a15143a12722L82-R79) [[2]](diffhunk://#diff-f3012e3c187b019747cc830f5135146d6e844d0b40294feb8af8a15143a12722L122-R119)