### PR TITLE
qwen image: tested new fix for batched training

### DIFF
--- a/simpletuner/helpers/models/qwen_image/transformer.py
+++ b/simpletuner/helpers/models/qwen_image/transformer.py
@@ -603,12 +603,12 @@ class QwenDoubleStreamAttnProcessor2_0:
                 true_txt_len = max(true_txt_len, 1)  # at least 1 to avoid empty attn
 
                 # Slice text QKV to actual length (no padding tokens)
-                s_txt_q = txt_query[s:s+1, :true_txt_len, :]
-                s_txt_k = txt_key[s:s+1, :true_txt_len, :]
-                s_txt_v = txt_value[s:s+1, :true_txt_len, :]
-                s_img_q = img_query[s:s+1]
-                s_img_k = img_key[s:s+1]
-                s_img_v = img_value[s:s+1]
+                s_txt_q = txt_query[s : s + 1, :true_txt_len, :]
+                s_txt_k = txt_key[s : s + 1, :true_txt_len, :]
+                s_txt_v = txt_value[s : s + 1, :true_txt_len, :]
+                s_img_q = img_query[s : s + 1]
+                s_img_k = img_key[s : s + 1]
+                s_img_v = img_value[s : s + 1]
 
                 # Joint concat for this sample only
                 s_joint_q = torch.cat([s_txt_q, s_img_q], dim=1)
@@ -634,8 +634,7 @@ class QwenDoubleStreamAttnProcessor2_0:
                 # Zero-pad text output back to seq_txt (the padded batch width)
                 if true_txt_len < seq_txt:
                     pad = torch.zeros(
-                        1, seq_txt - true_txt_len, s_txt_out.shape[-1],
-                        dtype=s_txt_out.dtype, device=s_txt_out.device
+                        1, seq_txt - true_txt_len, s_txt_out.shape[-1], dtype=s_txt_out.dtype, device=s_txt_out.device
                     )
                     s_txt_out = torch.cat([s_txt_out, pad], dim=1)
 
@@ -819,7 +818,11 @@ class QwenImageTransformerBlock(PatchableModule):
         # 2. Applies QK normalization and RoPE
         # 3. Concatenates and runs joint attention
         # 4. Splits results back to separate streams
-        joint_attention_kwargs = joint_attention_kwargs or {}
+        joint_attention_kwargs = dict(joint_attention_kwargs or {})
+        if encoder_hidden_states_mask is None:
+            encoder_hidden_states_mask = joint_attention_kwargs.pop("encoder_hidden_states_mask", None)
+        else:
+            joint_attention_kwargs.pop("encoder_hidden_states_mask", None)
         attn_output = self.attn(
             hidden_states=img_modulated,  # Image stream (will be processed as "sample")
             encoder_hidden_states=txt_modulated,  # Text stream (will be processed as "context")
@@ -1188,9 +1191,9 @@ class QwenImageTransformer2DModel(
         # Construct attention mask for blocks.
         # For batch_size==1: build a joint bool mask [text_mask, all_ones_for_image] once
         # to avoid reconstructing per-block (eliminates 60 GPU syncs, torch.compile safe).
-        # For batch_size>1 with variable text lengths: pass the raw encoder_hidden_states_mask
-        # so the processor can run per-sample attention, slicing each sample to its true
-        # text length and avoiding contamination from padding tokens.
+        # For batch_size>1 with variable text lengths: the block forwards
+        # encoder_hidden_states_mask explicitly to Attention.forward, so only
+        # the single-sample joint attention_mask belongs in joint_attention_kwargs.
         block_attention_kwargs = attention_kwargs.copy() if attention_kwargs is not None else {}
         if encoder_hidden_states_mask is not None:
             batch_size, image_seq_len = hidden_states.shape[:2]
@@ -1199,9 +1202,6 @@ class QwenImageTransformer2DModel(
                 image_mask = torch.ones((batch_size, image_seq_len), dtype=torch.bool, device=hidden_states.device)
                 joint_attention_mask = torch.cat([encoder_hidden_states_mask, image_mask], dim=1)
                 block_attention_kwargs["attention_mask"] = joint_attention_mask
-            else:
-                # Multi-sample: pass raw mask; processor handles per-sample split attention
-                block_attention_kwargs["encoder_hidden_states_mask"] = encoder_hidden_states_mask
 
         capture_idx = 0
         for index_block, block in enumerate(self.transformer_blocks):

--- a/tests/test_transformers/test_qwen_image_transformer.py
+++ b/tests/test_transformers/test_qwen_image_transformer.py
@@ -941,6 +941,30 @@ class TestQwenImageTransformerBlock(TransformerBaseTest, TransformerBlockTestMix
         # Verify kwargs were passed to attention
         self.assertIn("scale", patched_attn.last_kwargs)
 
+    def test_joint_attention_kwargs_do_not_duplicate_encoder_mask(self):
+        """Duplicate encoder_hidden_states_mask must be stripped before calling attention."""
+        block = QwenImageTransformerBlock(512, 8, 64)
+
+        hidden_states = torch.randn(2, 128, 512)
+        encoder_hidden_states = torch.randn(2, 77, 512)
+        encoder_hidden_states_mask = torch.ones(2, 77)
+        temb = torch.randn(2, 512)
+
+        patched_attn = MockAttention(return_tuple=True, hidden_dim=512)
+        with patch.object(block, "attn", patched_attn):
+            with torch.no_grad():
+                block(
+                    hidden_states=hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    encoder_hidden_states_mask=encoder_hidden_states_mask,
+                    temb=temb,
+                    joint_attention_kwargs={"encoder_hidden_states_mask": encoder_hidden_states_mask, "scale": 1.0},
+                )
+
+        self.assertIn("encoder_hidden_states_mask", patched_attn.last_kwargs)
+        self.assertIn("scale", patched_attn.last_kwargs)
+        self.assertIs(patched_attn.last_kwargs["encoder_hidden_states_mask"], encoder_hidden_states_mask)
+
     def test_different_qk_norm_options(self):
         """Test different QK normalization options."""
         qk_norm_options = ["rms_norm", "layer_norm", None]
@@ -1197,6 +1221,32 @@ class TestQwenImageTransformer2DModel(TransformerBaseTest):
         )
 
         self.assertIsNotNone(output)
+
+    def test_batch_size_gt_one_does_not_forward_encoder_mask_twice(self):
+        """Batch>1 should keep encoder_hidden_states_mask out of joint_attention_kwargs."""
+        model = self._create_model_or_skip(**self.config)
+
+        for i, _block in enumerate(model.transformer_blocks):
+            model.transformer_blocks[i] = Mock(return_value=(torch.randn(2, 77, 512), torch.randn(2, 256, 512)))
+
+        hidden_states, img_shapes = self._generate_packed_hidden_states(2, 32, 32)
+        encoder_hidden_states = torch.randn(2, 77, 512)
+        encoder_hidden_states_mask = torch.ones(2, 77)
+        timestep = torch.randint(0, 1000, (2,))
+
+        model(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_hidden_states_mask=encoder_hidden_states_mask,
+            timestep=timestep,
+            img_shapes=img_shapes,
+        )
+
+        first_block_kwargs = model.transformer_blocks[0].call_args.kwargs
+        self.assertTrue(
+            torch.equal(first_block_kwargs["encoder_hidden_states_mask"], encoder_hidden_states_mask.to(torch.bool))
+        )
+        self.assertNotIn("encoder_hidden_states_mask", first_block_kwargs["joint_attention_kwargs"])
 
     def test_controlnet_integration(self):
         """Test ControlNet residual integration."""


### PR DESCRIPTION
This pull request improves how attention masks are handled and passed through the Qwen Image Transformer model, particularly when dealing with batches larger than one and joint attention. The changes ensure that the `encoder_hidden_states_mask` is not duplicated or incorrectly forwarded, which prevents potential bugs and inefficiencies. Additional tests have been added to verify this behavior.

**Attention mask handling improvements:**

* Updated the logic in `transformer.py` to ensure that for batch sizes greater than one, the `encoder_hidden_states_mask` is only passed where appropriate and is not duplicated in `joint_attention_kwargs`. This prevents redundant or conflicting mask arguments during attention computation. [[1]](diffhunk://#diff-83ee739b6267cdf0f846cae468a07a56b066d03b0b7e0199414245b2043c2ea0L822-R825) [[2]](diffhunk://#diff-83ee739b6267cdf0f846cae468a07a56b066d03b0b7e0199414245b2043c2ea0L1191-R1196) [[3]](diffhunk://#diff-83ee739b6267cdf0f846cae468a07a56b066d03b0b7e0199414245b2043c2ea0L1202-L1204)

**Testing enhancements:**

* Added `test_joint_attention_kwargs_do_not_duplicate_encoder_mask` to verify that `encoder_hidden_states_mask` is stripped from `joint_attention_kwargs` before calling attention, ensuring no duplication occurs.
* Added `test_batch_size_gt_one_does_not_forward_encoder_mask_twice` to confirm that, for batch sizes greater than one, the mask is not forwarded twice and is handled correctly in the model's blocks.

**Minor code formatting:**

* Minor formatting update to a `torch.zeros` call for consistency and readability.