### PR TITLE
feat: log prodigy_d and prodigy_effective_lr in training metrics

### DIFF
--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -5706,6 +5706,12 @@ class Trainer:
                         if "prodigy" in self.config.optimizer:
                             self.lr_scheduler.step(**self.extra_lr_scheduler_kwargs)
                             self.lr = self.optimizer.param_groups[0]["d"]
+                            # Log Prodigy's adaptive step-size for diagnostics
+                            _pg = self.optimizer.param_groups[0]
+                            _prodigy_d = float(_pg.get("d", 0.0))
+                            _prodigy_elr = float(_prodigy_d * _pg.get("lr", 1.0))
+                            wandb_logs["prodigy_d"] = _prodigy_d
+                            wandb_logs["prodigy_effective_lr"] = _prodigy_elr
                         elif self.config.is_lr_scheduler_disabled:
                             # Alternative method for retrieving LR from accelerated optimizers
                             self.lr = StateTracker.get_last_lr()
@@ -5941,6 +5947,14 @@ class Trainer:
                     "lr": float(self.lr),
                 }
                 progress_logs = dict(logs)
+                if "prodigy" in self.config.optimizer:
+                    _pg = self.optimizer.param_groups[0]
+                    _d_val = float(_pg.get("d", 0.0))
+                    _elr_val = round(float(_d_val * _pg.get("lr", 1.0)), 8)
+                    logs["prodigy_d"] = round(_d_val, 6)
+                    logs["prodigy_effective_lr"] = _elr_val
+                    progress_logs["prodigy_d"] = round(_d_val, 6)
+                    progress_logs["prodigy_effective_lr"] = _elr_val
                 if loss_logs is not None:
                     logs.update(loss_logs)
                     if "video_loss" in loss_logs:


### PR DESCRIPTION
## Summary

Adds Prodigy optimizer diagnostic metrics to training output:

- **`prodigy_d`**: The adaptive step-size multiplier (monotonically non-decreasing). This is Prodigy's core diagnostic — it shows how aggressively the optimizer is scaling updates.
- **`prodigy_effective_lr`**: `d * lr` — the actual applied learning rate after Prodigy's adaptation.

Both values are logged to:
1. **wandb_logs** — for WandB/offline logging and dashboard visualization
2. **tqdm progress bar** — for real-time terminal monitoring
3. **logs dict** — for any downstream consumers

## Motivation

Prodigy's `d` value is critical for the probe-then-AdamW workflow: run a short Prodigy training to discover the optimal learning rate via `d` trajectory, then switch to AdamW with that fixed LR for the full run. Currently `d` is invisible — you have to manually inspect `optimizer.param_groups` to see it. This makes the diagnostic value immediately visible during training.

Guarded by `"prodigy" in self.config.optimizer` — zero impact on non-Prodigy training runs.

## Validated

- ST 4.1.2, PRO 6000, Qwen Image v2.0, LoRA r32, Prodigy optimizer
- `prodigy_d` and `prodigy_effective_lr` visible in tqdm output across 75 steps
- d trajectory: 1e-6 → 3.9e-5 (expected climb for 35-image dataset)