### PR TITLE
SDXL single file loader should pull text enc from ckpt

### DIFF
--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -485,6 +485,7 @@ class ModelFoundation(ABC):
         self.accelerator = accelerator
         self.noise_schedule = None
         self.pipelines = {}
+        self._single_file_component_cache = None
         self._qkv_projections_fused = False
         self._validation_preview_decoder = None
         self._validation_preview_decoder_failed = False
@@ -1613,6 +1614,59 @@ class ModelFoundation(ABC):
             model_path=self.config.pretrained_model_name_or_path,
         )
 
+    def _single_file_checkpoint_path(self) -> Optional[str]:
+        model_path = getattr(self.config, "pretrained_model_name_or_path", None)
+        if isinstance(model_path, str) and model_path.endswith(".safetensors"):
+            return model_path
+        return None
+
+    def _load_single_file_pipeline_component_cache(self) -> Optional[dict]:
+        if self._single_file_component_cache is not None:
+            return self._single_file_component_cache
+
+        checkpoint_path = self._single_file_checkpoint_path()
+        if checkpoint_path is None:
+            return None
+
+        pipeline_class = getattr(self, "PIPELINE_CLASSES", {}).get(PipelineTypes.TEXT2IMG)
+        if pipeline_class is None or not hasattr(pipeline_class, "from_single_file"):
+            return None
+
+        logger.info(
+            "Loading preprocessing components from single-file checkpoint %s using %s.",
+            checkpoint_path,
+            pipeline_class.__name__,
+        )
+        pipeline_kwargs = {
+            "config": self._model_config_path(),
+            "torch_dtype": self.config.weight_dtype,
+        }
+        pipeline_init_signature = inspect.signature(pipeline_class.__init__)
+        if "add_watermarker" in pipeline_init_signature.parameters:
+            pipeline_kwargs["add_watermarker"] = False
+        if getattr(self.config, "revision", None) is not None:
+            pipeline_kwargs["revision"] = self.config.revision
+        if getattr(self.config, "local_files_only", None) is not None:
+            pipeline_kwargs["local_files_only"] = self.config.local_files_only
+
+        pipeline = pipeline_class.from_single_file(checkpoint_path, **pipeline_kwargs)
+
+        text_encoders = []
+        tokenizers = []
+        text_encoder_configuration = getattr(self, "TEXT_ENCODER_CONFIGURATION", {}) or {}
+        for text_encoder_attr in text_encoder_configuration.keys():
+            text_encoders.append(getattr(pipeline, text_encoder_attr, None))
+            tokenizer_attr = text_encoder_attr.replace("text_encoder", "tokenizer")
+            tokenizers.append(getattr(pipeline, tokenizer_attr, None))
+
+        self._single_file_component_cache = {
+            "vae": getattr(pipeline, "vae", None),
+            "text_encoders": text_encoders,
+            "tokenizers": tokenizers,
+        }
+
+        return self._single_file_component_cache
+
     def unwrap_model(self, model=None):
         if self.config.controlnet and model is None:
             if self.controlnet is None:
@@ -1922,19 +1976,25 @@ class ModelFoundation(ABC):
                 logger.info(f"load_vae: registered VAE cache path: {cache_repo_path}")
 
         self.vae = None
-        self.config.vae_kwargs = {
-            "pretrained_model_name_or_path": get_model_config_path(self.config.model_family, self.config.vae_path),
-            "subfolder": "vae",
-            "revision": self.config.revision,
-            "force_upcast": False,
-            "variant": self.config.variant,
-        }
-        with ContextManagers(deepspeed_zero_init_disabled_context_manager()):
-            try:
-                self.vae = self.AUTOENCODER_CLASS.from_pretrained(**self.config.vae_kwargs)
-            except Exception as e:
-                self.config.vae_kwargs["subfolder"] = None
-                self.vae = self.AUTOENCODER_CLASS.from_pretrained(**self.config.vae_kwargs)
+        checkpoint_path = self._single_file_checkpoint_path()
+        use_single_file_vae = checkpoint_path is not None and self.config.vae_path == checkpoint_path
+        if use_single_file_vae:
+            cached_components = self._load_single_file_pipeline_component_cache() or {}
+            self.vae = cached_components.get("vae")
+        else:
+            self.config.vae_kwargs = {
+                "pretrained_model_name_or_path": get_model_config_path(self.config.model_family, self.config.vae_path),
+                "subfolder": "vae",
+                "revision": self.config.revision,
+                "force_upcast": False,
+                "variant": self.config.variant,
+            }
+            with ContextManagers(deepspeed_zero_init_disabled_context_manager()):
+                try:
+                    self.vae = self.AUTOENCODER_CLASS.from_pretrained(**self.config.vae_kwargs)
+                except Exception as e:
+                    self.config.vae_kwargs["subfolder"] = None
+                    self.vae = self.AUTOENCODER_CLASS.from_pretrained(**self.config.vae_kwargs)
         if self.vae is None:
             raise ValueError("Could not load VAE. Please check the model path and ensure the VAE is compatible.")
         if self.config.vae_enable_tiling:
@@ -2068,6 +2128,17 @@ class ModelFoundation(ABC):
         if self.TEXT_ENCODER_CONFIGURATION is None or len(self.TEXT_ENCODER_CONFIGURATION) == 0:
             return
         self.tokenizers = []
+        cached_components = self._load_single_file_pipeline_component_cache()
+        expected_count = len(self.TEXT_ENCODER_CONFIGURATION)
+        cached_tokenizers = (cached_components or {}).get("tokenizers", [])
+        if len(cached_tokenizers) >= expected_count and all(
+            tokenizer is not None for tokenizer in cached_tokenizers[:expected_count]
+        ):
+            for tokenizer_idx, tokenizer in enumerate(cached_tokenizers[:expected_count], start=1):
+                self.tokenizers.append(tokenizer)
+                setattr(self, f"tokenizer_{tokenizer_idx}", tokenizer)
+            return
+
         tokenizer_kwargs = {
             "subfolder": "tokenizer",
             "revision": self.config.revision,
@@ -2092,6 +2163,31 @@ class ModelFoundation(ABC):
         if self.TEXT_ENCODER_CONFIGURATION is None or len(self.TEXT_ENCODER_CONFIGURATION) == 0:
             return
         self.load_text_tokenizer()
+
+        cached_components = self._load_single_file_pipeline_component_cache()
+        expected_count = len(self.TEXT_ENCODER_CONFIGURATION)
+        cached_text_encoders = (cached_components or {}).get("text_encoders", [])
+        if len(cached_text_encoders) >= expected_count and all(
+            text_encoder is not None for text_encoder in cached_text_encoders[:expected_count]
+        ):
+            for text_encoder_idx, (attr_name, _text_encoder_config) in enumerate(
+                self.TEXT_ENCODER_CONFIGURATION.items(),
+                start=1,
+            ):
+                text_encoder = cached_text_encoders[text_encoder_idx - 1]
+                if move_to_device and not self._ramtorch_text_encoders_requested():
+                    precision_attr = f"text_encoder_{text_encoder_idx}_precision"
+                    text_encoder_precision = getattr(
+                        self.config, precision_attr, getattr(self.config, f"{attr_name}_precision", None)
+                    )
+                    if text_encoder_precision in ["no_change", None]:
+                        text_encoder.to(
+                            self.accelerator.device,
+                            dtype=self.config.weight_dtype,
+                        )
+                self.text_encoders.append(text_encoder)
+                setattr(self, attr_name, text_encoder)
+            return
 
         # Track if we should store cache paths for text encoder deletion
         should_track_for_deletion = getattr(self.config, "delete_model_after_load", False)

--- a/tests/test_sdxl_single_file_loading.py
+++ b/tests/test_sdxl_single_file_loading.py
@@ -1,0 +1,123 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from simpletuner.helpers.models.common import PipelineTypes
+from simpletuner.helpers.models.sdxl.model import SDXL
+
+
+class DummyModule:
+    def __init__(self, name, *, scaling_factor=None):
+        self.name = name
+        self.device = "cpu"
+        self.dtype = torch.float32
+        self.to_calls = []
+        self.config = SimpleNamespace(scaling_factor=scaling_factor)
+
+    def to(self, device, dtype=None):
+        self.device = device
+        if dtype is not None:
+            self.dtype = dtype
+        self.to_calls.append((device, dtype))
+        return self
+
+
+class DummyPipeline:
+    calls = []
+    pipeline = None
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    @classmethod
+    def from_single_file(cls, checkpoint_path, **kwargs):
+        cls.calls.append((checkpoint_path, kwargs))
+        return cls.pipeline
+
+
+class TestSDXLSingleFileLoading(unittest.TestCase):
+    def _make_model(self, *, vae_path=None):
+        model = SDXL.__new__(SDXL)
+        checkpoint_path = "/tmp/illustrious-xl-v2.safetensors"
+        model.config = SimpleNamespace(
+            model_family="sdxl",
+            pretrained_model_name_or_path=checkpoint_path,
+            pretrained_vae_model_name_or_path=vae_path or checkpoint_path,
+            vae_path=vae_path or checkpoint_path,
+            revision=None,
+            variant=None,
+            weight_dtype=torch.bfloat16,
+            controlnet=False,
+            delete_model_after_load=False,
+            vae_enable_tiling=False,
+            vae_enable_slicing=False,
+            crepa_drop_vae_encoder=False,
+            vae_dtype="bf16",
+            local_files_only=True,
+        )
+        model.accelerator = SimpleNamespace(device="cpu")
+        model.pipelines = {}
+        model._single_file_component_cache = None
+        model._validation_preview_decoder = None
+        model._validation_preview_decoder_failed = False
+        model._ramtorch_vae_requested = lambda: False
+        model._ramtorch_text_encoders_requested = lambda: False
+        model.post_vae_load_setup = lambda: None
+        model.PIPELINE_CLASSES = {PipelineTypes.TEXT2IMG: DummyPipeline}
+        return model
+
+    def setUp(self):
+        DummyPipeline.calls = []
+        DummyPipeline.pipeline = SimpleNamespace(
+            vae=DummyModule("pipeline_vae", scaling_factor=0.13025),
+            text_encoder=DummyModule("text_encoder"),
+            text_encoder_2=DummyModule("text_encoder_2"),
+            tokenizer=object(),
+            tokenizer_2=object(),
+        )
+
+    def test_single_file_loads_vae_and_text_components_from_pipeline(self):
+        model = self._make_model()
+
+        with (
+            patch("simpletuner.helpers.models.sdxl.model.AutoencoderKL.from_pretrained") as mock_vae_loader,
+            patch("simpletuner.helpers.models.sdxl.model.CLIPTokenizer.from_pretrained") as mock_tokenizer_loader,
+            patch("simpletuner.helpers.models.sdxl.model.CLIPTextModel.from_pretrained") as mock_te1_loader,
+            patch("simpletuner.helpers.models.sdxl.model.CLIPTextModelWithProjection.from_pretrained") as mock_te2_loader,
+        ):
+            model.load_vae(move_to_device=False)
+            model.load_text_encoder(move_to_device=False)
+
+        self.assertIs(model.vae, DummyPipeline.pipeline.vae)
+        self.assertEqual(model.AUTOENCODER_SCALING_FACTOR, 0.13025)
+        self.assertEqual(model.text_encoders, [DummyPipeline.pipeline.text_encoder, DummyPipeline.pipeline.text_encoder_2])
+        self.assertEqual(model.tokenizers, [DummyPipeline.pipeline.tokenizer, DummyPipeline.pipeline.tokenizer_2])
+        self.assertEqual(len(DummyPipeline.calls), 1)
+        self.assertEqual(DummyPipeline.calls[0][0], "/tmp/illustrious-xl-v2.safetensors")
+        self.assertEqual(DummyPipeline.calls[0][1]["config"], "stabilityai/stable-diffusion-xl-base-1.0")
+        self.assertTrue(DummyPipeline.calls[0][1]["local_files_only"])
+        mock_vae_loader.assert_not_called()
+        mock_tokenizer_loader.assert_not_called()
+        mock_te1_loader.assert_not_called()
+        mock_te2_loader.assert_not_called()
+
+    def test_explicit_external_vae_override_skips_single_file_pipeline_vae(self):
+        model = self._make_model(vae_path="madebyollin/sdxl-vae-fp16-fix")
+        external_vae = DummyModule("external_vae", scaling_factor=0.5)
+
+        with patch(
+            "simpletuner.helpers.models.sdxl.model.AutoencoderKL.from_pretrained",
+            return_value=external_vae,
+        ) as mock_vae_loader:
+            model.load_vae(move_to_device=False)
+
+        self.assertIs(model.vae, external_vae)
+        self.assertEqual(model.AUTOENCODER_SCALING_FACTOR, 0.5)
+        self.assertEqual(DummyPipeline.calls, [])
+        mock_vae_loader.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2624

This pull request introduces support for loading VAE, text encoders, and tokenizers directly from a single-file `.safetensors` checkpoint when available, optimizing component loading and reducing redundant model initialization. It also adds comprehensive tests to ensure correct behavior when loading components from both single-file checkpoints and explicit external sources.

**Single-file checkpoint loading enhancements:**

* Added a cache (`_single_file_component_cache`) and helper methods (`_single_file_checkpoint_path`, `_load_single_file_pipeline_component_cache`) to efficiently load and reuse VAE, text encoders, and tokenizers from a `.safetensors` checkpoint if specified in the configuration. [[1]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR488) [[2]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR1617-R1669)
* Updated `load_vae`, `load_text_tokenizer`, and `load_text_encoder` to check for and utilize cached components from a single-file checkpoint, falling back to standard loading only when necessary. [[1]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR1979-R1984) [[2]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR2131-R2141) [[3]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR2167-R2191)

**Testing improvements:**

* Added `tests/test_sdxl_single_file_loading.py` with unit tests to verify that VAE and text components are correctly loaded from a single-file pipeline, and that explicit external VAE overrides bypass the single-file logic as expected.