### PR TITLE
Allow negative --validation_adapter_strength

### DIFF
--- a/simpletuner/helpers/configuration/cmd_args.py
+++ b/simpletuner/helpers/configuration/cmd_args.py
@@ -1233,8 +1233,8 @@ def parse_cmdline_args(input_args=None, exit_on_error: bool = False):
             strength = float(strength_value)
         except (TypeError, ValueError):
             raise ValueError(f"Invalid --validation_adapter_strength value: {strength_value}") from None
-        if strength <= 0:
-            raise ValueError("--validation_adapter_strength must be greater than 0.")
+        if strength == 0:
+            raise ValueError("--validation_adapter_strength must not be 0.")
         args.validation_adapter_strength = strength
 
     mode_value = getattr(args, "validation_adapter_mode", None)


### PR DESCRIPTION
This allows an assistant LoRA to be used with a negative weight after it has been merged with the base model. The config would look something like this:

```
    "--pretrained_model_name_or_path": "/path/to/merged/model",
    "--validation_adapter_path": "mikaelh/qwen_image_2512_training_adapter:pytorch_lora_weights.safetensors",
    "--validation_adapter_name": "ta",
    "--validation_adapter_strength": -1.0,
    "--validation_adapter_mode": "adapter_only",
```