### PR TITLE
Upgrade `transformers` to v5.x (CVE PVE-2026-85102)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -274,7 +274,7 @@ def _collect_package_files(*directories: str):
 # Base dependencies (minimal, works on all platforms)
 base_deps = [
     "diffusers>=0.36.0",
-    "transformers>=4.55.0",
+    "transformers>=5.0.0",
     "hf_transfer>=0.1.0",
     "datasets>=3.0.1",
     "wandb>=0.21.0",
@@ -283,8 +283,6 @@ base_deps = [
     "trainingsample>=0.2.10",
     "accelerate>=1.5.2",
     "safetensors>=0.5.3",
-    "compel>=2.1.1",
-    "clip-interrogator>=0.6.0",
     "open-clip-torch>=2.26.1",
     "iterutils>=0.1.6",
     "scipy>=1.11.1",

--- a/simpletuner/helpers/data_backend/huggingface.py
+++ b/simpletuner/helpers/data_backend/huggingface.py
@@ -1017,7 +1017,7 @@ def test_huggingface_dataset(
     split: Optional[str] = None,
     revision: Optional[str] = None,
     streaming: bool = False,
-    use_auth_token: Optional[str] = None,
+    token: Optional[str] = None,
     sample_count: int = 1,
 ) -> Dict[str, Any]:
     """Load lightweight dataset metadata and sample rows for validation."""
@@ -1037,8 +1037,7 @@ def test_huggingface_dataset(
             dataset_name,
             name=dataset_config,
             revision=revision,
-            token=use_auth_token,
-            use_auth_token=use_auth_token,
+            token=token,
         )
     except Exception as exc:
         raise ValueError(f"Failed to load dataset metadata: {exc}") from exc
@@ -1056,7 +1055,7 @@ def test_huggingface_dataset(
                 split=split,
                 revision=revision,
                 streaming=True,
-                use_auth_token=use_auth_token,
+                token=token,
             )
             iterator = iter(dataset_stream)
             try:
@@ -1080,7 +1079,7 @@ def test_huggingface_dataset(
                     split=limited_split,
                     revision=revision,
                     streaming=False,
-                    use_auth_token=use_auth_token,
+                    token=token,
                 )
                 if sample_count == 1:
                     sample = dataset_slice[0] if len(dataset_slice) else None

--- a/simpletuner/helpers/data_generation/bbox_generator.py
+++ b/simpletuner/helpers/data_generation/bbox_generator.py
@@ -147,7 +147,7 @@ class BboxGenerator:
                 do_sample=False,
                 num_beams=3,
             )
-        generated_text = self._processor.batch_decode(generated_ids, skip_special_tokens=False)[0]
+        generated_text = self._processor.decode(generated_ids, skip_special_tokens=False)[0]
         return self._processor.post_process_generation(generated_text, task=task, image_size=(image.width, image.height))
 
     def _detect_batch(self, batch_paths: list[Path]) -> list[list[dict]]:

--- a/simpletuner/helpers/legacy/pipeline.py
+++ b/simpletuner/helpers/legacy/pipeline.py
@@ -357,7 +357,7 @@ class StableDiffusionPipeline(
             untruncated_ids = self.tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
 
             if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-                removed_text = self.tokenizer.batch_decode(untruncated_ids[:, self.tokenizer.model_max_length - 1 : -1])
+                removed_text = self.tokenizer.decode(untruncated_ids[:, self.tokenizer.model_max_length - 1 : -1])
                 logger.warning(
                     "The following part of your input was truncated because CLIP can only handle sequences up to"
                     f" {self.tokenizer.model_max_length} tokens: {removed_text}"

--- a/simpletuner/helpers/models/auraflow/pipeline.py
+++ b/simpletuner/helpers/models/auraflow/pipeline.py
@@ -698,7 +698,7 @@ class AuraFlowPipeline(DiffusionPipeline, AuraFlowLoraLoaderMixin):
             untruncated_ids = self.tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
 
             if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-                removed_text = self.tokenizer.batch_decode(untruncated_ids[:, max_length - 1 : -1])
+                removed_text = self.tokenizer.decode(untruncated_ids[:, max_length - 1 : -1])
                 logger.warning(
                     "The following part of your input was truncated because T5 can only handle sequences up to"
                     f" {max_length} tokens: {removed_text}"

--- a/simpletuner/helpers/models/auraflow/pipeline_controlnet.py
+++ b/simpletuner/helpers/models/auraflow/pipeline_controlnet.py
@@ -339,7 +339,7 @@ class AuraFlowControlNetPipeline(
             untruncated_ids = tokenizers(prompt, padding="longest", return_tensors="pt").input_ids
 
             if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-                removed_text = tokenizers.batch_decode(untruncated_ids[:, max_sequence_length - 1 : -1])
+                removed_text = tokenizers.decode(untruncated_ids[:, max_sequence_length - 1 : -1])
                 logger.warning(
                     "The following part of your input was truncated because T5 can only handle sequences up to"
                     f" {max_sequence_length} tokens: {removed_text}"

--- a/simpletuner/helpers/models/cosmos/pipeline.py
+++ b/simpletuner/helpers/models/cosmos/pipeline.py
@@ -223,7 +223,7 @@ class Cosmos2TextToImagePipeline(DiffusionPipeline, FluxLoraLoaderMixin):
 
         untruncated_ids = self.tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = self.tokenizer.batch_decode(untruncated_ids[:, max_sequence_length - 1 : -1])
+            removed_text = self.tokenizer.decode(untruncated_ids[:, max_sequence_length - 1 : -1])
             logger.warning(
                 "The following part of your input was truncated because `max_sequence_length` is set to "
                 f" {max_sequence_length} tokens: {removed_text}"

--- a/simpletuner/helpers/models/flux/pipeline.py
+++ b/simpletuner/helpers/models/flux/pipeline.py
@@ -1076,7 +1076,7 @@ class FluxPipeline(DiffusionPipeline, FluxLoraLoaderMixin):
         untruncated_ids = self.tokenizer_2(prompt, padding="longest", return_tensors="pt").input_ids
 
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = self.tokenizer_2.batch_decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
+            removed_text = self.tokenizer_2.decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
             # logger.warning(
             #     "The following part of your input was truncated because `max_sequence_length` is set to "
             #     f" {max_sequence_length} tokens: {removed_text}"
@@ -1119,7 +1119,7 @@ class FluxPipeline(DiffusionPipeline, FluxLoraLoaderMixin):
         text_input_ids = text_inputs.input_ids
         untruncated_ids = self.tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = self.tokenizer.batch_decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
+            removed_text = self.tokenizer.decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
             # logger.warning(
             #     "The following part of your input was truncated because CLIP can only handle sequences up to"
             #     f" {self.tokenizer_max_length} tokens: {removed_text}"
@@ -1820,7 +1820,7 @@ class FluxKontextPipeline(DiffusionPipeline, FluxLoraLoaderMixin):
         untruncated_ids = self.tokenizer_2(prompt, padding="longest", return_tensors="pt").input_ids
 
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = self.tokenizer_2.batch_decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
+            removed_text = self.tokenizer_2.decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
             # logger.warning(
             #     "The following part of your input was truncated because `max_sequence_length` is set to "
             #     f" {max_sequence_length} tokens: {removed_text}"
@@ -1863,7 +1863,7 @@ class FluxKontextPipeline(DiffusionPipeline, FluxLoraLoaderMixin):
         text_input_ids = text_inputs.input_ids
         untruncated_ids = self.tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = self.tokenizer.batch_decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
+            removed_text = self.tokenizer.decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
             # logger.warning(
             #     "The following part of your input was truncated because CLIP can only handle sequences up to"
             #     f" {self.tokenizer_max_length} tokens: {removed_text}"

--- a/simpletuner/helpers/models/flux/pipeline_controlnet.py
+++ b/simpletuner/helpers/models/flux/pipeline_controlnet.py
@@ -234,7 +234,7 @@ class FluxControlNetPipeline(DiffusionPipeline, FluxLoraLoaderMixin, FromSingleF
         untruncated_ids = self.tokenizer_2(prompt, padding="longest", return_tensors="pt").input_ids
 
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = self.tokenizer_2.batch_decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
+            removed_text = self.tokenizer_2.decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
             logger.warning(
                 "The following part of your input was truncated because `max_sequence_length` is set to "
                 f" {max_sequence_length} tokens: {removed_text}"
@@ -280,7 +280,7 @@ class FluxControlNetPipeline(DiffusionPipeline, FluxLoraLoaderMixin, FromSingleF
         text_input_ids = text_inputs.input_ids
         untruncated_ids = self.tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = self.tokenizer.batch_decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
+            removed_text = self.tokenizer.decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
             logger.warning(
                 "The following part of your input was truncated because CLIP can only handle sequences up to"
                 f" {self.tokenizer_max_length} tokens: {removed_text}"
@@ -1259,7 +1259,7 @@ class FluxControlPipeline(
         untruncated_ids = self.tokenizer_2(prompt, padding="longest", return_tensors="pt").input_ids
 
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = self.tokenizer_2.batch_decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
+            removed_text = self.tokenizer_2.decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
             logger.warning(
                 "The following part of your input was truncated because `max_sequence_length` is set to "
                 f" {max_sequence_length} tokens: {removed_text}"
@@ -1306,7 +1306,7 @@ class FluxControlPipeline(
         text_input_ids = text_inputs.input_ids
         untruncated_ids = self.tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = self.tokenizer.batch_decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
+            removed_text = self.tokenizer.decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
             logger.warning(
                 "The following part of your input was truncated because CLIP can only handle sequences up to"
                 f" {self.tokenizer_max_length} tokens: {removed_text}"

--- a/simpletuner/helpers/models/hidream/controlnet.py
+++ b/simpletuner/helpers/models/hidream/controlnet.py
@@ -486,7 +486,7 @@ class HiDreamControlNetPipeline(DiffusionPipeline, FromSingleFileMixin, HiDreamI
         untruncated_ids = self.tokenizer_3(prompt, padding="longest", return_tensors="pt").input_ids
 
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = self.tokenizer_3.batch_decode(
+            removed_text = self.tokenizer_3.decode(
                 untruncated_ids[
                     :,
                     min(max_sequence_length, self.tokenizer_3.model_max_length) - 1 : -1,
@@ -535,7 +535,7 @@ class HiDreamControlNetPipeline(DiffusionPipeline, FromSingleFileMixin, HiDreamI
         untruncated_ids = tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
 
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = tokenizer.batch_decode(untruncated_ids[:, 128 - 1 : -1])
+            removed_text = tokenizer.decode(untruncated_ids[:, 128 - 1 : -1])
             logger.warning(
                 "The following part of your input was truncated because CLIP can only handle sequences up to"
                 f" {128} tokens: {removed_text}"
@@ -581,7 +581,7 @@ class HiDreamControlNetPipeline(DiffusionPipeline, FromSingleFileMixin, HiDreamI
         untruncated_ids = self.tokenizer_4(prompt, padding="longest", return_tensors="pt").input_ids
 
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = self.tokenizer_4.batch_decode(
+            removed_text = self.tokenizer_4.decode(
                 untruncated_ids[
                     :,
                     min(max_sequence_length, self.tokenizer_4.model_max_length) - 1 : -1,

--- a/simpletuner/helpers/models/hidream/pipeline.py
+++ b/simpletuner/helpers/models/hidream/pipeline.py
@@ -967,7 +967,7 @@ class HiDreamImagePipeline(DiffusionPipeline, FromSingleFileMixin, HiDreamImageL
         untruncated_ids = self.tokenizer_3(prompt, padding="longest", return_tensors="pt").input_ids
 
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = self.tokenizer_3.batch_decode(
+            removed_text = self.tokenizer_3.decode(
                 untruncated_ids[
                     :,
                     min(max_sequence_length, self.tokenizer_3.model_max_length) - 1 : -1,
@@ -1029,7 +1029,7 @@ class HiDreamImagePipeline(DiffusionPipeline, FromSingleFileMixin, HiDreamImageL
         text_input_ids = text_inputs.input_ids
         untruncated_ids = tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = tokenizer.batch_decode(untruncated_ids[:, 128 - 1 : -1])
+            removed_text = tokenizer.decode(untruncated_ids[:, 128 - 1 : -1])
             logger.warning(
                 "The following part of your input was truncated because CLIP can only handle sequences up to"
                 f" {128} tokens: {removed_text}"
@@ -1086,7 +1086,7 @@ class HiDreamImagePipeline(DiffusionPipeline, FromSingleFileMixin, HiDreamImageL
         untruncated_ids = self.tokenizer_4(prompt, padding="longest", return_tensors="pt").input_ids
 
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = self.tokenizer_4.batch_decode(
+            removed_text = self.tokenizer_4.decode(
                 untruncated_ids[
                     :,
                     min(max_sequence_length, self.tokenizer_4.model_max_length) - 1 : -1,

--- a/simpletuner/helpers/models/kolors/model.py
+++ b/simpletuner/helpers/models/kolors/model.py
@@ -152,7 +152,7 @@ class Kolors(ImageModelFoundation):
                 if untruncated_ids.shape[-1] > tokenizer.model_max_length and not torch.equal(
                     text_inputs.input_ids, untruncated_ids
                 ):
-                    removed_text = tokenizer.batch_decode(untruncated_ids[:, tokenizer.model_max_length - 1 : -1])
+                    removed_text = tokenizer.decode(untruncated_ids[:, tokenizer.model_max_length - 1 : -1])
                     if not emitted_warning:
                         # Only print this once. It's a bit spammy otherwise.
                         emitted_warning = True

--- a/simpletuner/helpers/models/longcat_image/pipeline.py
+++ b/simpletuner/helpers/models/longcat_image/pipeline.py
@@ -161,7 +161,7 @@ class LongCatImagePipeline(
 
         generated_ids = self.text_encoder.generate(**inputs, max_new_tokens=self.max_tokenizer_len)
         generated_ids_trimmed = [out_ids[len(in_ids) :] for in_ids, out_ids in zip(inputs.input_ids, generated_ids)]
-        output_text = self.text_processor.batch_decode(
+        output_text = self.text_processor.decode(
             generated_ids_trimmed, skip_special_tokens=True, clean_up_tokenization_spaces=False
         )[0]
         return output_text

--- a/simpletuner/helpers/models/pixart/pipeline.py
+++ b/simpletuner/helpers/models/pixart/pipeline.py
@@ -535,7 +535,7 @@ class PixArtSigmaPipeline(DiffusionPipeline, PixArtSigmaControlNetLoraLoaderMixi
             untruncated_ids = self.tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
 
             if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-                removed_text = self.tokenizer.batch_decode(untruncated_ids[:, max_length - 1 : -1])
+                removed_text = self.tokenizer.decode(untruncated_ids[:, max_length - 1 : -1])
                 logger.warning(
                     "The following part of your input was truncated because T5 can only handle sequences up to"
                     f" {max_length} tokens: {removed_text}"
@@ -1443,7 +1443,7 @@ class PixArtSigmaControlPipeline(DiffusionPipeline):
             untruncated_ids = self.tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
 
             if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-                removed_text = self.tokenizer.batch_decode(untruncated_ids[:, max_length - 1 : -1])
+                removed_text = self.tokenizer.decode(untruncated_ids[:, max_length - 1 : -1])
                 logger.warning(
                     "The following part of your input was truncated because T5 can only handle sequences up to"
                     f" {max_length} tokens: {removed_text}"
@@ -2223,7 +2223,7 @@ class PixArtSigmaControlNetPipeline(DiffusionPipeline, PixArtSigmaControlNetLora
             untruncated_ids = self.tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
 
             if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-                removed_text = self.tokenizer.batch_decode(untruncated_ids[:, max_length - 1 : -1])
+                removed_text = self.tokenizer.decode(untruncated_ids[:, max_length - 1 : -1])
                 logger.warning(
                     "The following part of your input was truncated because T5 can only handle sequences up to"
                     f" {max_length} tokens: {removed_text}"

--- a/simpletuner/helpers/models/sd1x/pipeline.py
+++ b/simpletuner/helpers/models/sd1x/pipeline.py
@@ -411,7 +411,7 @@ class StableDiffusionPipeline(
             untruncated_ids = self.tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
 
             if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-                removed_text = self.tokenizer.batch_decode(untruncated_ids[:, self.tokenizer.model_max_length - 1 : -1])
+                removed_text = self.tokenizer.decode(untruncated_ids[:, self.tokenizer.model_max_length - 1 : -1])
                 logger.warning(
                     "The following part of your input was truncated because CLIP can only handle sequences up to"
                     f" {self.tokenizer.model_max_length} tokens: {removed_text}"
@@ -1570,7 +1570,7 @@ class StableDiffusionImg2ImgPipeline(
             untruncated_ids = self.tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
 
             if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-                removed_text = self.tokenizer.batch_decode(untruncated_ids[:, self.tokenizer.model_max_length - 1 : -1])
+                removed_text = self.tokenizer.decode(untruncated_ids[:, self.tokenizer.model_max_length - 1 : -1])
                 logger.warning(
                     "The following part of your input was truncated because CLIP can only handle sequences up to"
                     f" {self.tokenizer.model_max_length} tokens: {removed_text}"
@@ -2708,7 +2708,7 @@ class StableDiffusionControlNetPipeline(
             untruncated_ids = self.tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
 
             if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-                removed_text = self.tokenizer.batch_decode(untruncated_ids[:, self.tokenizer.model_max_length - 1 : -1])
+                removed_text = self.tokenizer.decode(untruncated_ids[:, self.tokenizer.model_max_length - 1 : -1])
                 logger.warning(
                     "The following part of your input was truncated because CLIP can only handle sequences up to"
                     f" {self.tokenizer.model_max_length} tokens: {removed_text}"

--- a/simpletuner/helpers/models/sd3/controlnet.py
+++ b/simpletuner/helpers/models/sd3/controlnet.py
@@ -286,7 +286,7 @@ class StableDiffusion3ControlNetPipeline(DiffusionPipeline, SD3LoraLoaderMixin, 
         untruncated_ids = self.tokenizer_3(prompt, padding="longest", return_tensors="pt").input_ids
 
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = self.tokenizer_3.batch_decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
+            removed_text = self.tokenizer_3.decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
             logger.warning(
                 "The following part of your input was truncated because `max_sequence_length` is set to "
                 f" {max_sequence_length} tokens: {removed_text}"
@@ -336,7 +336,7 @@ class StableDiffusion3ControlNetPipeline(DiffusionPipeline, SD3LoraLoaderMixin, 
         text_input_ids = text_inputs.input_ids
         untruncated_ids = tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = tokenizer.batch_decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
+            removed_text = tokenizer.decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
             logger.warning(
                 "The following part of your input was truncated because CLIP can only handle sequences up to"
                 f" {self.tokenizer_max_length} tokens: {removed_text}"

--- a/simpletuner/helpers/models/sd3/pipeline.py
+++ b/simpletuner/helpers/models/sd3/pipeline.py
@@ -1051,7 +1051,7 @@ class StableDiffusion3Pipeline(DiffusionPipeline, SD3LoraLoaderMixin, FromSingle
         untruncated_ids = self.tokenizer_3(prompt, padding="longest", return_tensors="pt").input_ids
 
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = self.tokenizer_3.batch_decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
+            removed_text = self.tokenizer_3.decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
             logger.warning(
                 "The following part of your input was truncated because `max_sequence_length` is set to "
                 f" {max_sequence_length} tokens: {removed_text}"
@@ -1100,7 +1100,7 @@ class StableDiffusion3Pipeline(DiffusionPipeline, SD3LoraLoaderMixin, FromSingle
         text_input_ids = text_inputs.input_ids
         untruncated_ids = tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = tokenizer.batch_decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
+            removed_text = tokenizer.decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
             logger.warning(
                 "The following part of your input was truncated because CLIP can only handle sequences up to"
                 f" {self.tokenizer_max_length} tokens: {removed_text}"
@@ -1995,7 +1995,7 @@ class StableDiffusion3Img2ImgPipeline(DiffusionPipeline, SD3LoraLoaderMixin, Fro
         untruncated_ids = self.tokenizer_3(prompt, padding="longest", return_tensors="pt").input_ids
 
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = self.tokenizer_3.batch_decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
+            removed_text = self.tokenizer_3.decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
             logger.warning(
                 "The following part of your input was truncated because `max_sequence_length` is set to "
                 f" {max_sequence_length} tokens: {removed_text}"
@@ -2045,7 +2045,7 @@ class StableDiffusion3Img2ImgPipeline(DiffusionPipeline, SD3LoraLoaderMixin, Fro
         text_input_ids = text_inputs.input_ids
         untruncated_ids = tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
         if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = tokenizer.batch_decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
+            removed_text = tokenizer.decode(untruncated_ids[:, self.tokenizer_max_length - 1 : -1])
             logger.warning(
                 "The following part of your input was truncated because CLIP can only handle sequences up to"
                 f" {self.tokenizer_max_length} tokens: {removed_text}"

--- a/simpletuner/helpers/models/sdxl/model.py
+++ b/simpletuner/helpers/models/sdxl/model.py
@@ -172,7 +172,7 @@ class SDXL(ImageModelFoundation):
                 if untruncated_ids.shape[-1] > tokenizer.model_max_length and not torch.equal(
                     text_inputs.input_ids, untruncated_ids
                 ):
-                    removed_text = tokenizer.batch_decode(untruncated_ids[:, tokenizer.model_max_length - 1 : -1])
+                    removed_text = tokenizer.decode(untruncated_ids[:, tokenizer.model_max_length - 1 : -1])
                     if not emitted_warning:
                         # Only print this once. It's a bit spammy otherwise.
                         emitted_warning = True

--- a/simpletuner/helpers/models/sdxl/pipeline.py
+++ b/simpletuner/helpers/models/sdxl/pipeline.py
@@ -820,7 +820,7 @@ class StableDiffusionXLPipeline(
                 if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(
                     text_input_ids, untruncated_ids
                 ):
-                    removed_text = tokenizer.batch_decode(untruncated_ids[:, tokenizer.model_max_length - 1 : -1])
+                    removed_text = tokenizer.decode(untruncated_ids[:, tokenizer.model_max_length - 1 : -1])
                     logger.warning(
                         "The following part of your input was truncated because CLIP can only handle sequences up to"
                         f" {tokenizer.model_max_length} tokens: {removed_text}"
@@ -2003,7 +2003,7 @@ class StableDiffusionXLImg2ImgPipeline(
                 if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(
                     text_input_ids, untruncated_ids
                 ):
-                    removed_text = tokenizer.batch_decode(untruncated_ids[:, tokenizer.model_max_length - 1 : -1])
+                    removed_text = tokenizer.decode(untruncated_ids[:, tokenizer.model_max_length - 1 : -1])
                     logger.warning(
                         "The following part of your input was truncated because CLIP can only handle sequences up to"
                         f" {tokenizer.model_max_length} tokens: {removed_text}"
@@ -3354,7 +3354,7 @@ class StableDiffusionXLControlNetPipeline(
                 if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(
                     text_input_ids, untruncated_ids
                 ):
-                    removed_text = tokenizer.batch_decode(untruncated_ids[:, tokenizer.model_max_length - 1 : -1])
+                    removed_text = tokenizer.decode(untruncated_ids[:, tokenizer.model_max_length - 1 : -1])
                     logger.warning(
                         "The following part of your input was truncated because CLIP can only handle sequences up to"
                         f" {tokenizer.model_max_length} tokens: {removed_text}"

--- a/simpletuner/helpers/models/stable_cascade/pipeline_decoder.py
+++ b/simpletuner/helpers/models/stable_cascade/pipeline_decoder.py
@@ -176,7 +176,7 @@ class StableCascadeDecoderPipeline(DiffusionPipeline):
             untruncated_ids = self.tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
 
             if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-                removed_text = self.tokenizer.batch_decode(untruncated_ids[:, self.tokenizer.model_max_length - 1 : -1])
+                removed_text = self.tokenizer.decode(untruncated_ids[:, self.tokenizer.model_max_length - 1 : -1])
                 logger.warning(
                     "The following part of your input was truncated because CLIP can only handle sequences up to"
                     f" {self.tokenizer.model_max_length} tokens: {removed_text}"

--- a/simpletuner/helpers/models/stable_cascade/pipeline_prior.py
+++ b/simpletuner/helpers/models/stable_cascade/pipeline_prior.py
@@ -197,7 +197,7 @@ class StableCascadePriorPipeline(DiffusionPipeline):
             untruncated_ids = self.tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
 
             if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-                removed_text = self.tokenizer.batch_decode(untruncated_ids[:, self.tokenizer.model_max_length - 1 : -1])
+                removed_text = self.tokenizer.decode(untruncated_ids[:, self.tokenizer.model_max_length - 1 : -1])
                 logger.warning(
                     "The following part of your input was truncated because CLIP can only handle sequences up to"
                     f" {self.tokenizer.model_max_length} tokens: {removed_text}"

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -6468,9 +6468,9 @@ def run_trainer_job(config):
             if token:
                 return token
         try:
-            from huggingface_hub import HfFolder
+            from huggingface_hub import get_token as hf_get_token
 
-            token = HfFolder.get_token()
+            token = hf_get_token()
             if token:
                 return token
         except Exception:

--- a/simpletuner/simpletuner_sdk/server/routes/cloud/helpers.py
+++ b/simpletuner/simpletuner_sdk/server/routes/cloud/helpers.py
@@ -204,9 +204,9 @@ def get_local_upload_dir() -> Path:
 def get_hf_token() -> Optional[str]:
     """Read HF token from local cache."""
     try:
-        from huggingface_hub import HfFolder
+        from huggingface_hub import get_token as hf_get_token
 
-        token = HfFolder.get_token()
+        token = hf_get_token()
         if token:
             return token
     except ImportError:

--- a/simpletuner/simpletuner_sdk/server/services/cloud/job_submission.py
+++ b/simpletuner/simpletuner_sdk/server/services/cloud/job_submission.py
@@ -521,9 +521,9 @@ class JobSubmissionService:
             if token:
                 return token
 
-        from huggingface_hub import HfFolder
+        from huggingface_hub import get_token as hf_get_token
 
-        token = HfFolder.get_token()
+        token = hf_get_token()
         if token:
             return token
 

--- a/simpletuner/simpletuner_sdk/server/services/dataset_connection_service.py
+++ b/simpletuner/simpletuner_sdk/server/services/dataset_connection_service.py
@@ -114,7 +114,7 @@ class DatasetConnectionService:
         split = dataset.get("split")
         revision = dataset.get("revision")
         streaming = bool(dataset.get("streaming"))
-        auth_token = dataset.get("auth_token") or dataset.get("use_auth_token")
+        auth_token = dataset.get("auth_token") or dataset.get("token")
 
         try:
             details = test_huggingface_dataset(
@@ -123,7 +123,7 @@ class DatasetConnectionService:
                 split=split,
                 revision=revision,
                 streaming=streaming,
-                use_auth_token=auth_token,
+                token=auth_token,
                 sample_count=1,
             )
         except ImportError as exc:

--- a/simpletuner/simpletuner_sdk/server/services/publishing_service.py
+++ b/simpletuner/simpletuner_sdk/server/services/publishing_service.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from fastapi import status
-from huggingface_hub import HfApi, HfFolder
+from huggingface_hub import HfApi, get_token as hf_get_token, login as hf_login, logout as hf_logout
 
 
 class PublishingServiceError(Exception):
@@ -56,8 +56,8 @@ class PublishingService:
             Dictionary with validation status and user information.
         """
         try:
-            # Try to get token from HfFolder (standard location)
-            token = HfFolder.get_token()
+            # Try to get token from huggingface_hub
+            token = hf_get_token()
 
             # If not found, try direct file read
             if not token:
@@ -115,8 +115,8 @@ class PublishingService:
             token_path.write_text(token.strip())
             token_path.chmod(0o600)  # Secure permissions
 
-            # Also save via HfFolder for compatibility
-            HfFolder.save_token(token.strip())
+            # Also save via huggingface_hub login for compatibility
+            hf_login(token=token.strip(), add_to_git_credential=False)
 
             return {
                 "valid": True,
@@ -145,9 +145,9 @@ class PublishingService:
             if token_path.exists():
                 token_path.unlink()
 
-            # Also delete via HfFolder for compatibility
+            # Also delete via huggingface_hub logout for compatibility
             try:
-                HfFolder.delete_token()
+                hf_logout()
             except Exception:
                 pass  # May not exist, that's ok
 
@@ -176,7 +176,7 @@ class PublishingService:
             )
 
         try:
-            token = HfFolder.get_token()
+            token = hf_get_token()
             if not token:
                 token_path = Path.home() / ".cache" / "huggingface" / "token"
                 if token_path.exists():
@@ -227,7 +227,7 @@ class PublishingService:
             return self._orgs_cache
 
         try:
-            token = HfFolder.get_token()
+            token = hf_get_token()
             if not token:
                 token_path = Path.home() / ".cache" / "huggingface" / "token"
                 if token_path.exists():

--- a/tests/test_publishing_service.py
+++ b/tests/test_publishing_service.py
@@ -45,7 +45,7 @@ class PublishingServiceTestCase(unittest.TestCase):
         self.assertEqual(self.service.get_license_for_model(""), "apache-2.0")
         self.assertEqual(self.service.get_license_for_model(None), "apache-2.0")
 
-    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfFolder.get_token")
+    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.hf_get_token")
     @patch("pathlib.Path.exists")
     def test_validate_token_no_token_found(self, mock_exists, mock_get_token) -> None:
         """Test token validation when no token is found."""
@@ -56,7 +56,7 @@ class PublishingServiceTestCase(unittest.TestCase):
         self.assertFalse(result["valid"])
         self.assertIn("No HuggingFace token found", result["message"])
 
-    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfFolder.get_token")
+    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.hf_get_token")
     @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfApi")
     def test_validate_token_valid(self, mock_api_class, mock_get_token) -> None:
         """Test token validation with a valid token."""
@@ -70,7 +70,7 @@ class PublishingServiceTestCase(unittest.TestCase):
         self.assertTrue(result["valid"])
         self.assertEqual(result["username"], "testuser")
 
-    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfFolder.get_token")
+    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.hf_get_token")
     @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfApi")
     def test_check_repository_exists(self, mock_api_class, mock_get_token) -> None:
         """Test checking a repository that exists."""
@@ -87,7 +87,7 @@ class PublishingServiceTestCase(unittest.TestCase):
         self.assertTrue(result["exists"])
         self.assertFalse(result["available"])
 
-    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfFolder.get_token")
+    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.hf_get_token")
     @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfApi")
     def test_check_repository_available(self, mock_api_class, mock_get_token) -> None:
         """Test checking a repository that doesn't exist (available)."""
@@ -107,7 +107,7 @@ class PublishingServiceTestCase(unittest.TestCase):
             self.service.check_repository("invalid-repo-id")
         self.assertEqual(ctx.exception.status_code, 400)
 
-    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfFolder.get_token")
+    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.hf_get_token")
     @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfApi")
     def test_get_user_organizations(self, mock_api_class, mock_get_token) -> None:
         """Test getting user organizations."""
@@ -125,7 +125,7 @@ class PublishingServiceTestCase(unittest.TestCase):
         self.assertEqual(result["organizations"], ["org1", "org2"])
         self.assertEqual(result["namespaces"], ["testuser", "org1", "org2"])
 
-    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfFolder.get_token")
+    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.hf_get_token")
     @patch("pathlib.Path.exists")
     def test_get_organizations_no_token(self, mock_exists, mock_get_token) -> None:
         """Test getting organizations when no token exists."""
@@ -138,7 +138,7 @@ class PublishingServiceTestCase(unittest.TestCase):
         self.assertEqual(ctx.exception.status_code, 401)
         self.assertIn("No HuggingFace token found", ctx.exception.message)
 
-    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfFolder.get_token")
+    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.hf_get_token")
     @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfApi")
     def test_get_organizations_no_orgs(self, mock_api_class, mock_get_token) -> None:
         """Test getting organizations when user has no organizations."""
@@ -153,7 +153,7 @@ class PublishingServiceTestCase(unittest.TestCase):
         self.assertEqual(result["organizations"], [])
         self.assertEqual(result["namespaces"], ["solouser"])
 
-    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfFolder.get_token")
+    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.hf_get_token")
     @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfApi")
     def test_get_organizations_missing_orgs_key(self, mock_api_class, mock_get_token) -> None:
         """Test getting organizations when orgs key is missing from API response."""
@@ -168,7 +168,7 @@ class PublishingServiceTestCase(unittest.TestCase):
         self.assertEqual(result["organizations"], [])
         self.assertEqual(result["namespaces"], ["testuser"])
 
-    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfFolder.get_token")
+    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.hf_get_token")
     @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfApi")
     def test_validate_token_invalid(self, mock_api_class, mock_get_token) -> None:
         """Test token validation with an invalid token."""
@@ -182,7 +182,7 @@ class PublishingServiceTestCase(unittest.TestCase):
         self.assertFalse(result["valid"])
         self.assertIn("Token is invalid or expired", result["message"])
 
-    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfFolder.get_token")
+    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.hf_get_token")
     @patch("pathlib.Path.exists")
     @patch("builtins.open", new_callable=unittest.mock.mock_open, read_data="hf_file_token\n")
     @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfApi")
@@ -208,7 +208,7 @@ class PublishingServiceTestCase(unittest.TestCase):
         self.assertEqual(ctx.exception.status_code, 400)
         self.assertIn("Invalid repository ID", ctx.exception.message)
 
-    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfFolder.get_token")
+    @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.hf_get_token")
     @patch("pathlib.Path.exists")
     @patch("builtins.open", new_callable=unittest.mock.mock_open, read_data="hf_file_token")
     @patch("simpletuner.simpletuner_sdk.server.services.publishing_service.HfApi")


### PR DESCRIPTION
## Motivation

`transformers <5.0.0` is affected by **PVE-2026-85102**. This PR upgrades the project to `transformers>=5.0.0` (tested with 5.5.1) and addresses all breaking changes introduced in the 4.x → 5.x transition.

## Changes

Changes are made according to the transformers [migration guide](https://raw.githubusercontent.com/huggingface/transformers/main/MIGRATION_GUIDE_V5.md).

**Dependency updates** (setup.py)
- `transformers>=4.55.0` → `transformers>=5.0.0`
- Removed `compel>=2.1.1` and `clip-interrogator>=0.6.0` — both pin `transformers<5` and are unused in the codebase (no imports found anywhere in simpletuner)

**`batch_decode` → `decode`** (20 files)
Transformers v5 unified `batch_decode` into `decode`, which now handles both single and batched inputs. All tokenizer `.batch_decode()` calls were migrated across every pipeline and model module: sd1x, sdxl, sd3, flux, hidream, auraflow, cosmos, pixart, kolors, longcat_image, stable_cascade, legacy, and bbox_generator. The custom `ace_step/lyrics_utils/lyric_tokenizer.py` was excluded as it defines its own `batch_decode` method.

**`use_auth_token` → `token`** (2 files)
The deprecated `use_auth_token` parameter was replaced with `token` in:
- huggingface.py
- dataset_connection_service.py

**`HfFolder` removed** (6 files + 1 test file)
`huggingface_hub>=1.0.0` (required by transformers v5) removed the `HfFolder` class. All usages were replaced with the modern top-level API:
- `HfFolder.get_token()` → `huggingface_hub.get_token()`
- `HfFolder.save_token()` → `huggingface_hub.login()`
- `HfFolder.delete_token()` → `huggingface_hub.logout()`

Affected files:
- publishing_service.py
- trainer.py
- job_submission.py
- helpers.py
- test_publishing_service.py (patch targets updated)

## Testing

- All critical transformers imports verified (CLIPTextModel, T5EncoderModel, AutoTokenizer, BitsAndBytesConfig, PreTrainedTokenizerFast, ContextManagers, HfDeepSpeedConfig, etc.)
- Full project smoke test passes
- **614 unit tests pass** (1 skipped, 1 pre-existing failure in `test_forbidden_system_paths` unrelated to this change)

_Disclaimer: this PR was co-authored by Claude Opus 4.6_