### PR TITLE
Security: Webhook URL accepted without SSRF protections

### DIFF
--- a/simpletuner/helpers/webhooks/config.py
+++ b/simpletuner/helpers/webhooks/config.py
@@ -1,6 +1,35 @@
+from ipaddress import ip_address
 from json import load
+from socket import IPPROTO_TCP, gaierror, getaddrinfo
+from urllib.parse import urlparse
 
 supported_webhooks = ["discord", "raw"]
+
+
+def validate_webhook_url(url: str, field_name: str):
+    parsed_url = urlparse(url)
+    if parsed_url.scheme != "https":
+        raise ValueError(f"Webhook config '{field_name}' must use https.")
+    if not parsed_url.hostname:
+        raise ValueError(f"Webhook config '{field_name}' must include a valid hostname.")
+    try:
+        resolved_addresses = {
+            address_info[4][0]
+            for address_info in getaddrinfo(parsed_url.hostname, parsed_url.port or 443, proto=IPPROTO_TCP)
+        }
+    except gaierror as e:
+        raise ValueError(f"Unable to resolve webhook hostname for '{field_name}': {e}")
+    for resolved_address in resolved_addresses:
+        parsed_ip = ip_address(resolved_address)
+        if (
+            parsed_ip.is_private
+            or parsed_ip.is_loopback
+            or parsed_ip.is_link_local
+            or parsed_ip.is_multicast
+            or parsed_ip.is_reserved
+            or parsed_ip.is_unspecified
+        ):
+            raise ValueError(f"Webhook config '{field_name}' resolves to a disallowed address.")
 
 
 def check_discord_webhook_config(config: dict) -> bool:
@@ -8,6 +37,7 @@ def check_discord_webhook_config(config: dict) -> bool:
         return False
     if "webhook_url" not in config:
         raise ValueError("Discord webhook config is missing 'webhook_url' value.")
+    validate_webhook_url(config["webhook_url"], "webhook_url")
     return True
 
 
@@ -21,6 +51,7 @@ def check_raw_webhook_config(config: dict) -> bool:
             missing_fields.append(config_field)
     if missing_fields:
         raise ValueError(f"Missing fields on webhook config: {missing_fields}")
+    validate_webhook_url(config["callback_url"], "callback_url")
     return True
 
 


### PR DESCRIPTION
## Summary

Security: Webhook URL accepted without SSRF protections

## Problem

**Severity**: `Medium` | **File**: `simpletuner/helpers/webhooks/config.py:L6`

Webhook configuration only checks for field presence and allows arbitrary `webhook_url`/`callback_url` values. If non-admin or untrusted users can set webhook config, outbound requests could be abused for SSRF (accessing internal network endpoints, metadata services, or localhost).

## Solution

Enforce URL validation and SSRF controls: allow only `https`, block private/link-local/loopback IP ranges after DNS resolution, optionally enforce a hostname allowlist, and disable redirects to disallowed targets.

## Changes

- `simpletuner/helpers/webhooks/config.py` (modified)