### PR TITLE
fix: replace bare except with explicit exception type in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def run_command(cmd):
     try:
         result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
         return result.returncode == 0
-    except:
+    except Exception:
         return False
 
 
@@ -54,7 +54,7 @@ def get_version():
             for line in f:
                 if line.startswith("__version__"):
                     return line.split("=")[1].strip().strip('"').strip("'")
-    except:
+    except Exception:
         pass
     return "3.0.0"
 
@@ -379,7 +379,7 @@ if not _is_building_dist:
 try:
     with open("README.md", "r", encoding="utf-8") as fh:
         long_description = fh.read()
-except:
+except Exception:
     long_description = "Stable Diffusion 2.x and XL tuner."
 
 setup(


### PR DESCRIPTION
## Summary

Replaces bare `except:` clauses with explicit exception types. Bare `except:` catches `SystemExit` and `KeyboardInterrupt`, which can mask test interruptions and swallow critical signals. This PR follows PEP 8 / E722 recommendations.

**Change:**
```python
# Before
try:
    ...
except:
    ...

# After
try:
    ...
except Exception:
    ...
```

For `except:` blocks that re-raise, `except BaseException:` is used instead so `SystemExit`/`KeyboardInterrupt` still propagate correctly.

## Testing

No behavior change for expected code paths. The change only affects how non-`Exception` signals (e.g. `SystemExit`, `KeyboardInterrupt`) propagate — making shutdown and Ctrl+C behave correctly.

## References

- [PEP 8 — bare except](https://peps.python.org/pep-0008/#programming-recommendations)
- [pycodestyle E722](https://www.flake8rules.com/rules/E722.html)
