### PR TITLE
(#2680) resolve error when using external validation script with benchmark

### DIFF
--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -1689,7 +1689,7 @@ class Validation:
 
         return build_script_command(script_template, _resolver)
 
-    def _run_external_validation(self, validation_type: str | None, step: int):
+    def _run_external_validation(self, validation_type: str | None, step: int) -> bool:
         try:
             command = self._build_external_validation_command()
         except ValidationCheckpointUnavailableError as exc:
@@ -2124,7 +2124,10 @@ class Validation:
         )
         validation_method = configured_validation_method
         if validation_method == "external-script" and is_base_model_benchmark:
-            logger.info("Using built-in validation pipeline for base model benchmark; external-script needs a checkpoint.")
+            logger.info(
+                "Using built-in validation pipeline for base model benchmark; external-script is not used at step 0 "
+                "because the benchmark runs before checkpoints are available."
+            )
             validation_method = "simpletuner-local"
         logger.debug(
             f"Should evaluate: {current_validation_will_execute}, force evaluation: {force_evaluation}, skip execution: {skip_execution}"
@@ -2165,7 +2168,16 @@ class Validation:
                 self.validation_video_paths.clear()
                 self.eval_scores = {}
                 self.evaluation_result = None
-                self._run_external_validation(validation_type=validation_type, step=step)
+                external_validation_ran = self._run_external_validation(validation_type=validation_type, step=step)
+                if not external_validation_ran:
+                    if should_notify:
+                        webhook_handler.send_lifecycle_stage(
+                            stage_key="validation",
+                            stage_label="Running Validation",
+                            stage_status="skipped",
+                            message="Validation skipped because no checkpoint is available yet.",
+                        )
+                    return self
                 if should_notify:
                     webhook_handler.send_lifecycle_stage(
                         stage_key="validation",

--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -1527,6 +1527,12 @@ class ValidationAbortedException(Exception):
     pass
 
 
+class ValidationCheckpointUnavailableError(ValueError):
+    """Raised when external validation requires a checkpoint before one exists."""
+
+    pass
+
+
 class Validation:
     def __init__(
         self,
@@ -1639,7 +1645,7 @@ class Validation:
         checkpoint_manager = CheckpointManager(self.config.output_dir)
         latest_checkpoint = checkpoint_manager.get_latest_checkpoint()
         if latest_checkpoint is None:
-            raise ValueError(
+            raise ValidationCheckpointUnavailableError(
                 "validation_external_script requires {local_checkpoint_path}, but no checkpoints exist in output_dir."
             )
         checkpoint_path = os.path.join(self.config.output_dir, latest_checkpoint)
@@ -1684,7 +1690,16 @@ class Validation:
         return build_script_command(script_template, _resolver)
 
     def _run_external_validation(self, validation_type: str | None, step: int):
-        command = self._build_external_validation_command()
+        try:
+            command = self._build_external_validation_command()
+        except ValidationCheckpointUnavailableError as exc:
+            logger.warning(
+                "Skipping external validation for %s at step %s: %s",
+                validation_type or "validation",
+                step,
+                exc,
+            )
+            return False
         background = bool(getattr(self.config, "validation_external_background", False))
         logger.info(
             "Running external validation command for %s (step=%s, background=%s): %s",
@@ -1695,8 +1710,9 @@ class Validation:
         )
         if background:
             subprocess.Popen(command)
-            return
+            return True
         subprocess.run(command, check=True)
+        return True
 
     def _validation_multigpu_mode(self) -> str:
         """
@@ -2088,7 +2104,7 @@ class Validation:
         skip_execution: bool = False,
     ):
         self._update_state()
-        validation_method = self._validation_method()
+        configured_validation_method = self._validation_method()
         if self.validation_prompt_metadata is None:
             return self
         content = self.validation_prompt_metadata.get("validation_prompts", None)
@@ -2106,6 +2122,10 @@ class Validation:
         current_validation_will_execute = has_validation_prompts and (
             current_step_aligns_with_interval or is_base_model_benchmark
         )
+        validation_method = configured_validation_method
+        if validation_method == "external-script" and is_base_model_benchmark:
+            logger.info("Using built-in validation pipeline for base model benchmark; external-script needs a checkpoint.")
+            validation_method = "simpletuner-local"
         logger.debug(
             f"Should evaluate: {current_validation_will_execute}, force evaluation: {force_evaluation}, skip execution: {skip_execution}"
         )

--- a/tests/test_validation_external.py
+++ b/tests/test_validation_external.py
@@ -259,13 +259,14 @@ class ValidationExternalScriptTests(unittest.TestCase):
                     return_value=None,
                 ),
                 patch("subprocess.run") as mock_run,
-                self.assertLogs("Validation", level="WARNING") as logs,
+                patch("simpletuner.helpers.training.validation.logger.warning") as mock_warning,
             ):
                 result = validation._run_external_validation(validation_type="intermediary", step=100)
 
         self.assertFalse(result)
         mock_run.assert_not_called()
-        self.assertIn("Skipping external validation for intermediary at step 100", "\n".join(logs.output))
+        mock_warning.assert_called_once()
+        self.assertEqual(mock_warning.call_args.args[1:3], ("intermediary", 100))
 
     def test_run_external_validation_background_uses_popen(self):
         validation = Validation.__new__(Validation)

--- a/tests/test_validation_external.py
+++ b/tests/test_validation_external.py
@@ -159,6 +159,44 @@ class ValidationExternalScriptTests(unittest.TestCase):
         validation._run_external_validation.assert_called_once_with(validation_type="intermediary", step=1)
         self.assertEqual(validation.validation_images, {})
 
+    def test_run_validations_reports_skipped_when_external_validation_does_not_run(self):
+        webhook_handler = MagicMock()
+        validation = Validation.__new__(Validation)
+        validation.config = SimpleNamespace(
+            validation_method="external-script",
+            validation_multigpu="single-gpu",
+            gradient_accumulation_steps=1,
+        )
+        validation.accelerator = SimpleNamespace(is_main_process=True, num_processes=1)
+        validation.deepspeed = False
+        validation._pending_epoch_validation = None
+        validation._epoch_validations_completed = set()
+        validation.validation_prompt_metadata = {"validation_prompts": ["prompt-1"]}
+        validation.validation_prompt_dict = {}
+        validation.validation_video_paths = {}
+        validation.eval_scores = {}
+        validation.validation_images = None
+        validation.evaluation_result = None
+        validation.global_step = 1
+        validation.global_resume_step = 0
+        validation.current_epoch = 0
+        validation.current_epoch_step = 0
+        validation._run_external_validation = MagicMock(return_value=False)
+        validation._use_distributed_validation = MagicMock(return_value=False)
+        validation.should_perform_intermediary_validation = MagicMock(return_value=True)
+        validation._update_state = MagicMock()
+
+        with patch(
+            "simpletuner.helpers.training.validation.StateTracker.get_webhook_handler",
+            return_value=webhook_handler,
+        ):
+            validation.run_validations(step=1, validation_type="intermediary")
+
+        lifecycle_statuses = [call.kwargs["stage_status"] for call in webhook_handler.send_lifecycle_stage.call_args_list]
+        self.assertIn("running", lifecycle_statuses)
+        self.assertIn("skipped", lifecycle_statuses)
+        self.assertNotIn("completed", lifecycle_statuses)
+
     @patch("simpletuner.helpers.training.validation.StateTracker.get_webhook_handler", return_value=None)
     @patch("simpletuner.helpers.training.validation.reclaim_memory")
     def test_base_model_benchmark_uses_builtin_validation_when_external_script_configured(

--- a/tests/test_validation_external.py
+++ b/tests/test_validation_external.py
@@ -159,6 +159,76 @@ class ValidationExternalScriptTests(unittest.TestCase):
         validation._run_external_validation.assert_called_once_with(validation_type="intermediary", step=1)
         self.assertEqual(validation.validation_images, {})
 
+    @patch("simpletuner.helpers.training.validation.StateTracker.get_webhook_handler", return_value=None)
+    @patch("simpletuner.helpers.training.validation.reclaim_memory")
+    def test_base_model_benchmark_uses_builtin_validation_when_external_script_configured(
+        self, _mock_reclaim_memory, _mock_webhook
+    ):
+        validation = Validation.__new__(Validation)
+        validation.config = SimpleNamespace(
+            validation_method="external-script",
+            validation_multigpu="single-gpu",
+            gradient_accumulation_steps=1,
+        )
+        validation.accelerator = SimpleNamespace(is_main_process=True, num_processes=1)
+        validation.deepspeed = False
+        validation._pending_epoch_validation = None
+        validation._epoch_validations_completed = set()
+        validation.validation_prompt_metadata = {"validation_prompts": ["prompt-1"]}
+        validation.validation_prompt_dict = {}
+        validation.validation_video_paths = {}
+        validation.eval_scores = {}
+        validation.validation_images = None
+        validation.validation_audios = None
+        validation.evaluation_result = None
+        validation.global_step = 0
+        validation.global_resume_step = 0
+        validation.current_epoch = 0
+        validation.current_epoch_step = 0
+        validation.validation_adapter_runs = []
+        validation.model = SimpleNamespace(pipeline=object())
+        validation._run_external_validation = MagicMock()
+        validation._use_distributed_validation = MagicMock(return_value=False)
+        validation.should_perform_intermediary_validation = MagicMock(return_value=False)
+        validation._update_state = MagicMock()
+        validation._check_abort = MagicMock()
+        validation.setup_pipeline = MagicMock()
+        validation.setup_scheduler = MagicMock()
+        validation.finalize_validation = MagicMock()
+        validation._publish_validation_artifacts = MagicMock()
+        validation.clean_pipeline = MagicMock()
+
+        validation.run_validations(step=0, validation_type="base_model")
+
+        validation._run_external_validation.assert_not_called()
+        validation.setup_pipeline.assert_called_once_with("base_model")
+        validation.setup_scheduler.assert_called_once()
+        validation.finalize_validation.assert_called_once_with("base_model")
+        validation.clean_pipeline.assert_called_once()
+
+    def test_run_external_validation_skips_when_checkpoint_placeholder_has_no_checkpoint(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            validation = Validation.__new__(Validation)
+            validation.config = SimpleNamespace(
+                validation_external_script="echo {local_checkpoint_path}",
+                validation_external_background=False,
+                output_dir=tmp_dir,
+            )
+
+            with (
+                patch(
+                    "simpletuner.helpers.training.validation.CheckpointManager.get_latest_checkpoint",
+                    return_value=None,
+                ),
+                patch("subprocess.run") as mock_run,
+                self.assertLogs("Validation", level="WARNING") as logs,
+            ):
+                result = validation._run_external_validation(validation_type="intermediary", step=100)
+
+        self.assertFalse(result)
+        mock_run.assert_not_called()
+        self.assertIn("Skipping external validation for intermediary at step 100", "\n".join(logs.output))
+
     def test_run_external_validation_background_uses_popen(self):
         validation = Validation.__new__(Validation)
         validation.config = SimpleNamespace(validation_external_background=True)


### PR DESCRIPTION
Closes #2680 
This pull request improves the robustness and clarity of the external validation process in the `Validation` class, particularly around handling missing checkpoints and the use of external validation scripts. It introduces a custom exception for missing checkpoints, ensures the built-in validation pipeline is used for base model benchmarks even if external validation is configured, and adds comprehensive tests for these scenarios.

**Error Handling Improvements:**
* Added a new exception `ValidationCheckpointUnavailableError` to clearly signal when an external validation script requires a checkpoint but none exist. (`simpletuner/helpers/training/validation.py`)
* Updated the checkpoint resolution logic to raise `ValidationCheckpointUnavailableError` instead of a generic `ValueError` when no checkpoint is found. (`simpletuner/helpers/training/validation.py`)
* Modified `_run_external_validation` to catch `ValidationCheckpointUnavailableError`, log a warning, and skip external validation gracefully when no checkpoint is available. Now returns `False` when skipped, and `True` on successful execution. (`simpletuner/helpers/training/validation.py`) [[1]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09R1693-R1702) [[2]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09L1698-R1715)

**Validation Method Selection Logic:**
* Ensured that for base model benchmarks, the built-in validation pipeline is used even if the configuration specifies `external-script`, with an informative log message. (`simpletuner/helpers/training/validation.py`) [[1]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09L2091-R2107) [[2]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09R2125-R2128)

**Testing Enhancements:**
* Added tests to verify that base model benchmarks use the built-in validation pipeline and that external validation is skipped (with a warning) if no checkpoint exists. (`tests/test_validation_external.py`)

These changes make the validation process more predictable, user-friendly, and easier to debug.