### PR TITLE
add filename caption_strategy option to UI

### DIFF
--- a/simpletuner/templates/components/dataloader/sections/captions.html
+++ b/simpletuner/templates/components/dataloader/sections/captions.html
@@ -25,6 +25,7 @@
                                     @change="markAsUnsaved()"
                                     :class="{'border-danger': !dataset.caption_strategy}">
                                 <option value="">Select caption source...</option>
+                                <option value="filename">Filename</option>
                                 <option value="textfile">Text files (.txt)</option>
                                 <option value="csv">CSV</option>
                                 <option value="parquet">Parquet</option>

--- a/simpletuner/templates/components/dataloader/sections/captions_body.html
+++ b/simpletuner/templates/components/dataloader/sections/captions_body.html
@@ -1,7 +1,7 @@
 <!-- Captions & Metadata Body (for modal) -->
 <div class="modal-section-body" x-init="editingDataset.parquet = editingDataset.parquet || {}">
     <!-- Caption Strategy -->
-    <div class="section-group" x-show="matchesParamFilter('caption', 'strategy', 'metadata', 'backend', 'text', 'csv', 'parquet', 'jsonl', 'instance')">
+    <div class="section-group" x-show="matchesParamFilter('caption', 'strategy', 'metadata', 'backend', 'filename', 'text', 'csv', 'parquet', 'jsonl', 'instance')">
         <h6 class="modal-section-title">Caption Strategy</h6>
         <div class="row g-2">
             <div class="col-md-6">
@@ -11,6 +11,7 @@
                         @change="markAsUnsaved()"
                         :class="{'border-danger': !editingDataset.caption_strategy}">
                     <option value="">Select caption source...</option>
+                    <option value="filename">Filename</option>
                     <option value="textfile">Text files (.txt)</option>
                     <option value="csv">CSV</option>
                     <option value="parquet">Parquet</option>

--- a/tests/test_template_rendering.py
+++ b/tests/test_template_rendering.py
@@ -219,6 +219,18 @@ class TemplateRenderingTests(unittest.TestCase):
         self.assertIn("window.__promptLibraries =", rendered)
         self.assertIn("user_prompt_library-alpha.json", rendered)
 
+    def test_dataloader_caption_strategy_lists_filename_option(self):
+        template_dir = Path(__file__).parent.parent / "simpletuner" / "templates"
+        relative_paths = [
+            "components/dataloader/sections/captions.html",
+            "components/dataloader/sections/captions_body.html",
+        ]
+
+        for relative_path in relative_paths:
+            with self.subTest(template=relative_path):
+                contents = (template_dir / relative_path).read_text(encoding="utf-8")
+                self.assertIn('<option value="filename">Filename</option>', contents)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request adds support for using the filename as a caption source in the dataloader's caption strategy options. The main changes update the UI templates to include the new "Filename" option and add a test to ensure its presence.

**UI Updates:**
* `captions.html`, `captions_body.html`: Added a new `<option value="filename">Filename</option>` to the caption strategy dropdowns so users can select filenames as caption sources. [[1]](diffhunk://#diff-92b068c45ce16d51372e087e7f4d992141793313d0fead4ac88ad7250f2b35acR28) [[2]](diffhunk://#diff-938532625bf28998a79df292e5dea95504d0b1756aa733f17ea2817872e728cdR14)
* [`captions_body.html`](diffhunk://#diff-938532625bf28998a79df292e5dea95504d0b1756aa733f17ea2817872e728cdL4-R4): Updated the filter logic to include `"filename"` as a valid caption strategy, ensuring the UI section is shown when this option is selected.

**Testing:**
* [`tests/test_template_rendering.py`](diffhunk://#diff-562f4422acaebed9a4f283b73b183b1e11f5e70bfb89dc3337589d80465ecbd7R222-R233): Added a test to verify that the "Filename" option appears in both relevant template files.