### PR TITLE
training configuration wizard step count should be auto determined

### DIFF
--- a/simpletuner/static/js/training-wizard.js
+++ b/simpletuner/static/js/training-wizard.js
@@ -204,7 +204,7 @@ function trainingWizardComponent() {
             {
                 id: 'publishing',
                 label: 'Publishing',
-                title: 'Training Configuration Wizard - Step 5: Publishing',
+                title: 'Training Configuration Wizard - Step 6: Publishing',
                 required: false,
                 validate: function() {
                     if (this.answers.push_to_hub) {
@@ -216,7 +216,7 @@ function trainingWizardComponent() {
             {
                 id: 'checkpoints',
                 label: 'Checkpoints',
-                title: 'Training Configuration Wizard - Step 6: Checkpoints',
+                title: 'Training Configuration Wizard - Step 7: Checkpoints',
                 required: true,
                 validate: function() {
                     const stepRaw = this.answers.checkpoint_step_interval;
@@ -235,7 +235,7 @@ function trainingWizardComponent() {
             {
                 id: 'validations-enable',
                 label: 'Validations',
-                title: 'Training Configuration Wizard - Step 7: Validations',
+                title: 'Training Configuration Wizard - Step 8: Validations',
                 required: true,
                 validate: function() {
                     if (this.answers.enable_validations === null) {
@@ -256,7 +256,7 @@ function trainingWizardComponent() {
             {
                 id: 'logging',
                 label: 'Logging',
-                title: 'Training Configuration Wizard - Step 8: Logging',
+                title: 'Training Configuration Wizard - Step 9: Logging',
                 required: false,
                 validate: function() {
                     if (this.answers.report_to === 'custom-tracker') {
@@ -269,14 +269,14 @@ function trainingWizardComponent() {
             {
                 id: 'dataset',
                 label: 'Dataset',
-                title: 'Training Configuration Wizard - Step 9: Dataset',
+                title: 'Training Configuration Wizard - Step 10: Dataset',
                 required: true,
                 validate: function() { return this.hasExistingDataset || this.datasetConfigured; }
             },
             {
                 id: 'advanced',
                 label: 'Advanced',
-                title: 'Training Configuration Wizard - Step 10: Advanced Settings',
+                title: 'Training Configuration Wizard - Step 11: Advanced Settings',
                 required: false,
                 validate: function() {
                     if (this.advancedMode === 'manual') {
@@ -306,6 +306,24 @@ function trainingWizardComponent() {
             const visibleSteps = this.visibleSteps;
             const step = visibleSteps[this.currentStepIndex] || visibleSteps[0] || this.steps[0];
             return step;
+        },
+
+        get currentStepTitle() {
+            const visibleSteps = this.visibleSteps;
+            const step = this.currentStep;
+            if (!step) {
+                return 'Training Configuration Wizard';
+            }
+            if (step.id === 'review') {
+                return step.title || 'Training Configuration Wizard - Review Configuration';
+            }
+            const visibleIndex = visibleSteps.findIndex(visibleStep => visibleStep.id === step.id);
+            const stepNumber = visibleIndex >= 0 ? visibleIndex + 1 : this.currentStepIndex + 1;
+            const rawTitle = step.title || step.label || '';
+            const titleLabel = rawTitle.includes(':')
+                ? rawTitle.slice(rawTitle.indexOf(':') + 1).trim()
+                : (step.label || rawTitle);
+            return `Training Configuration Wizard - Step ${stepNumber}: ${titleLabel}`;
         },
 
         get canProceed() {

--- a/simpletuner/templates/partials/training_wizard_modal.html
+++ b/simpletuner/templates/partials/training_wizard_modal.html
@@ -14,7 +14,7 @@
         <!-- Header with title and close button -->
         <div class="modal-header">
             <h5 class="modal-title">
-                🧙 <span x-text="currentStep.title"></span>
+                🧙 <span x-text="currentStepTitle"></span>
             </h5>
             <button type="button" class="btn-close" aria-label="Close" @click="closeWizard()"></button>
         </div>
@@ -668,7 +668,7 @@
                 </div>
             </div>
 
-            <!-- Step 5: Publishing -->
+            <!-- Step 6: Publishing -->
             <div x-show="currentStep.id === 'publishing'" class="wizard-step-content">
                 <h6 class="wizard-question">Do you want to publish your model to Hugging Face Hub?</h6>
                 <p class="text-muted mb-4">Automatically upload your trained model when complete.</p>
@@ -753,7 +753,7 @@
                 </div>
             </div>
 
-            <!-- Step 6: Checkpoint Frequency -->
+            <!-- Step 7: Checkpoint Frequency -->
             <div x-show="currentStep.id === 'checkpoints'" class="wizard-step-content">
                 <h6 class="wizard-question">How often should checkpoints be saved?</h6>
                 <p class="text-muted mb-4">Checkpoints let you resume training and pick the best model version.</p>
@@ -805,7 +805,7 @@
                 </div>
             </div>
 
-            <!-- Step 7: Validations -->
+            <!-- Step 8: Validations -->
             <div x-show="currentStep.id === 'validations-enable'" class="wizard-step-content">
                 <h6 class="wizard-question">Do you want to run validations during training?</h6>
                 <p class="text-muted mb-4">Validations generate sample images to monitor training progress.</p>
@@ -938,7 +938,7 @@
                 </div>
             </div>
 
-            <!-- Step 8: Logging Platform -->
+            <!-- Step 9: Logging Platform -->
             <div x-show="currentStep.id === 'logging'" class="wizard-step-content">
                 <h6 class="wizard-question">Enable logging to external platform?</h6>
                 <p class="text-muted mb-4">Track metrics, losses, and generated images externally (optional).</p>
@@ -994,7 +994,7 @@
                 </div>
             </div>
 
-            <!-- Step 9: Dataset Configuration -->
+            <!-- Step 10: Dataset Configuration -->
             <div x-show="currentStep.id === 'dataset'" class="wizard-step-content">
                 <h6 class="wizard-question">Configure your training dataset</h6>
 
@@ -1019,7 +1019,7 @@
                 </div>
             </div>
 
-            <!-- Step 10: Advanced Settings -->
+            <!-- Step 11: Advanced Settings -->
             <div x-show="currentStep.id === 'advanced'" class="wizard-step-content">
                 <h6 class="wizard-question">Configure learning rate and optimizer?</h6>
                 <p class="text-muted mb-4">Pick a preset tailored to your training mode or adjust the values manually.</p>

--- a/tests/js/training_wizard.test.js
+++ b/tests/js/training_wizard.test.js
@@ -1,0 +1,47 @@
+/**
+ * Tests for the training configuration wizard component.
+ */
+
+const { trainingWizardComponent } = require('../../simpletuner/static/js/training-wizard.js');
+
+describe('trainingWizardComponent step titles', () => {
+    let component;
+
+    beforeEach(() => {
+        component = trainingWizardComponent();
+    });
+
+    test('numbered static step titles are unique and sequential', () => {
+        const numberedTitles = component.steps
+            .map((step) => step.title.match(/Step (\d+):/))
+            .filter(Boolean)
+            .map((match) => Number(match[1]));
+
+        expect(numberedTitles).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+    });
+
+    test('currentStepTitle follows visible step order when optional variant step is hidden', () => {
+        component.answers.model_family = 'sdxl';
+        component.answers.model_flavour = null;
+
+        const visibleIds = component.visibleSteps.map((step) => step.id);
+        expect(visibleIds).not.toContain('model-flavour');
+
+        component.currentStepIndex = visibleIds.indexOf('publishing');
+
+        expect(component.currentStepTitle).toBe('Training Configuration Wizard - Step 5: Publishing');
+    });
+
+    test('currentStepTitle follows visible step order when optional variant step is visible', () => {
+        component.answers.model_family = 'flux';
+        component.answers.model_flavour = 'dev';
+        component.modelFlavours = ['dev', 'schnell'];
+
+        const visibleIds = component.visibleSteps.map((step) => step.id);
+        expect(visibleIds).toContain('model-flavour');
+
+        component.currentStepIndex = visibleIds.indexOf('publishing');
+
+        expect(component.currentStepTitle).toBe('Training Configuration Wizard - Step 6: Publishing');
+    });
+});


### PR DESCRIPTION
This pull request improves the step titling system in the Training Configuration Wizard, ensuring accurate, sequential, and context-aware step titles both in the UI and underlying logic. It also introduces tests to verify the correctness of step numbering and title display, especially when optional steps are conditionally shown or hidden.

Step title and numbering improvements:

* Updated the `title` field for each wizard step in `training-wizard.js` to reflect the correct sequential step numbers, accounting for the shifting of steps when optional steps are present or absent. [[1]](diffhunk://#diff-27fef881ef39b4775a02409502600abb573fda3d03a9f5ba4116edd35202aa19L207-R207) [[2]](diffhunk://#diff-27fef881ef39b4775a02409502600abb573fda3d03a9f5ba4116edd35202aa19L219-R219) [[3]](diffhunk://#diff-27fef881ef39b4775a02409502600abb573fda3d03a9f5ba4116edd35202aa19L238-R238) [[4]](diffhunk://#diff-27fef881ef39b4775a02409502600abb573fda3d03a9f5ba4116edd35202aa19L259-R259) [[5]](diffhunk://#diff-27fef881ef39b4775a02409502600abb573fda3d03a9f5ba4116edd35202aa19L272-R279)
* Added a computed property `currentStepTitle` to `trainingWizardComponent` that dynamically generates the step title based on visible steps and the current step, ensuring the displayed step number matches the user's progress regardless of hidden steps.

UI updates:

* Updated all step headers in `training_wizard_modal.html` to match the new step numbering and to use the `currentStepTitle` property for the modal title, ensuring consistency in the UI. [[1]](diffhunk://#diff-aea45edd9043b177273a26687bcf1cc715ed038214429509ef625271ad86798eL17-R17) [[2]](diffhunk://#diff-aea45edd9043b177273a26687bcf1cc715ed038214429509ef625271ad86798eL671-R671) [[3]](diffhunk://#diff-aea45edd9043b177273a26687bcf1cc715ed038214429509ef625271ad86798eL756-R756) [[4]](diffhunk://#diff-aea45edd9043b177273a26687bcf1cc715ed038214429509ef625271ad86798eL808-R808) [[5]](diffhunk://#diff-aea45edd9043b177273a26687bcf1cc715ed038214429509ef625271ad86798eL941-R941) [[6]](diffhunk://#diff-aea45edd9043b177273a26687bcf1cc715ed038214429509ef625271ad86798eL997-R997) [[7]](diffhunk://#diff-aea45edd9043b177273a26687bcf1cc715ed038214429509ef625271ad86798eL1022-R1022)

Testing enhancements:

* Added a new test suite `training_wizard.test.js` to verify that static step titles are unique and sequential, and that `currentStepTitle` adapts correctly when optional steps are shown or hidden.