### PR TITLE
dataset wizard: fix next button disabled unnecessarily

### DIFF
--- a/simpletuner/static/js/dataset-wizard.js
+++ b/simpletuner/static/js/dataset-wizard.js
@@ -70,6 +70,7 @@
             wizardStep: 1,
             wizardTitle: 'Create Dataset - Step 1',
             saving: false,
+            activeSubTab: sessionStorage.getItem('dataset-viewer-subtab') || 'configuration',
 
             // Dataset blueprints from API
             blueprints: [],

--- a/simpletuner/templates/datasets_tab.html
+++ b/simpletuner/templates/datasets_tab.html
@@ -94,7 +94,7 @@
 </style>
 
 <div class="tab-fragment" id="datasets-tab-content" data-tab-name="datasets"
-     x-data="{...datasetWizardComponent(), activeSubTab: sessionStorage.getItem('dataset-viewer-subtab') || 'configuration'}"
+     x-data="datasetWizardComponent()"
      x-init="loadHints(); init()">
 
     <!-- Sub-tab navigation: Configuration | Viewer -->

--- a/tests/js/dataset_wizard.test.js
+++ b/tests/js/dataset_wizard.test.js
@@ -102,6 +102,7 @@ describe('datasetWizardComponent', () => {
             expect(component.wizardOpen).toBe(false);
             expect(component.wizardStep).toBe(1);
             expect(component.saving).toBe(false);
+            expect(component.activeSubTab).toBe('configuration');
 
             // New folder state
             expect(component.showNewFolderInput).toBe(false);
@@ -126,6 +127,7 @@ describe('datasetWizardComponent', () => {
 
         test('has all required fields for Alpine state management', () => {
             const requiredFields = [
+                'activeSubTab',
                 'showNewFolderInput',
                 'newFolderName',
                 'newFolderError',

--- a/tests/test_webui_e2e.py
+++ b/tests/test_webui_e2e.py
@@ -1263,15 +1263,27 @@ class DatasetWizardUiSmokeTestCase(_TrainerPageMixin, WebUITestCase):
             # Dismiss any visible toast that might block the button
             trainer_page.dismiss_toast()
 
-            trainer_page.wait.until(
-                EC.element_to_be_clickable((By.CSS_SELECTOR, "button[title='Add a dataset to the current configuration']"))
-            ).click()
-
             trainer_page.wait.until(lambda d: d.execute_script("return !!window.datasetWizardComponentInstance"))
+            opened = driver.execute_async_script(
+                """
+                const done = arguments[0];
+                const root = document.querySelector('#datasets-tab-content');
+                const comp = window.Alpine && window.Alpine.$data ? window.Alpine.$data(root) : null;
+                if (!comp) {
+                    done(false);
+                    return;
+                }
+                Promise.resolve(comp.openWizard())
+                    .then(() => done(true))
+                    .catch((err) => done(String(err)));
+                """
+            )
+            self.assertTrue(opened)
 
             state = driver.execute_script(
                 """
-                const comp = window.datasetWizardComponentInstance;
+                const root = document.querySelector('#datasets-tab-content');
+                const comp = window.Alpine && window.Alpine.$data ? window.Alpine.$data(root) : window.datasetWizardComponentInstance;
                 if (!comp) { return { ready: false }; }
                 try {
                     comp.openNewFolderDialog();
@@ -1280,7 +1292,7 @@ class DatasetWizardUiSmokeTestCase(_TrainerPageMixin, WebUITestCase):
                     comp.openUploadModal();
                     const uploadOpen = comp.uploadModalOpen === true;
                     comp.closeUploadModal();
-                    const hasFields = ['showNewFolderInput','newFolderName','newFolderError','uploadModalOpen','selectedUploadFiles','captionModalOpen','captionStatus','pendingCaptions']
+                    const hasFields = ['activeSubTab','showNewFolderInput','newFolderName','newFolderError','uploadModalOpen','selectedUploadFiles','captionModalOpen','captionStatus','pendingCaptions']
                         .every(key => key in comp && typeof comp[key] !== 'undefined');
                     return { ready: true, hasFields, showNewFolder, uploadOpen };
                 } catch (err) {
@@ -1296,7 +1308,8 @@ class DatasetWizardUiSmokeTestCase(_TrainerPageMixin, WebUITestCase):
 
             step_ready = driver.execute_script(
                 """
-                const comp = window.datasetWizardComponentInstance;
+                const root = document.querySelector('#datasets-tab-content');
+                const comp = window.Alpine && window.Alpine.$data ? window.Alpine.$data(root) : window.datasetWizardComponentInstance;
                 if (!comp) { return null; }
                 const captionsStep = comp.getStepNumber('captions');
                 if (!captionsStep) { return null; }
@@ -1348,6 +1361,87 @@ class DatasetWizardUiSmokeTestCase(_TrainerPageMixin, WebUITestCase):
                 self.assertNotIn("is not defined", message)
 
         self.for_each_browser("test_dataset_wizard_initializes_modal_state", scenario)
+
+    def test_dataset_wizard_name_step_enables_next_after_typing(self) -> None:
+        """The Name step should react to Dataset ID input when no primary dataset exists yet."""
+        datasets_root = self.home_path / "datasets"
+        datasets_root.mkdir(parents=True, exist_ok=True)
+        self.seed_defaults(datasets_dir=datasets_root)
+
+        def scenario(driver, _browser):
+            trainer_page = self._trainer_page(driver)
+            trainer_page.navigate_to_trainer()
+            self.dismiss_onboarding(driver)
+            trainer_page.switch_to_datasets_tab()
+            trainer_page.wait_for_tab("datasets")
+            trainer_page.dismiss_toast()
+
+            trainer_page.wait.until(lambda d: d.execute_script("return !!window.datasetWizardComponentInstance"))
+            opened = driver.execute_async_script(
+                """
+                const done = arguments[0];
+                const root = document.querySelector('#datasets-tab-content');
+                const comp = window.Alpine && window.Alpine.$data ? window.Alpine.$data(root) : null;
+                if (!comp) {
+                    done(false);
+                    return;
+                }
+                Promise.resolve(comp.openWizard())
+                    .then(() => done(true))
+                    .catch((err) => done(String(err)));
+                """
+            )
+            self.assertTrue(opened)
+
+            next_button = trainer_page.wait.until(
+                EC.presence_of_element_located(
+                    (By.CSS_SELECTOR, ".dataset-wizard-modal button[aria-label='Continue to next step']")
+                )
+            )
+            self.assertFalse(next_button.is_enabled())
+
+            trainer_page.wait.until(
+                EC.presence_of_element_located((By.CSS_SELECTOR, ".dataset-wizard-modal input[x-model='currentDataset.id']"))
+            )
+            driver.execute_script(
+                """
+                const input = document.querySelector(".dataset-wizard-modal input[x-model='currentDataset.id']");
+                input.value = 'primary-images';
+                input.dispatchEvent(new Event('input', { bubbles: true }));
+                """
+            )
+
+            trainer_page.wait.until(
+                lambda d: d.execute_script(
+                    """
+                    const button = document.querySelector(".dataset-wizard-modal button[aria-label='Continue to next step']");
+                    return button && !button.disabled;
+                    """
+                )
+            )
+
+            state = driver.execute_script(
+                """
+                const root = document.querySelector('#datasets-tab-content');
+                const comp = window.Alpine && window.Alpine.$data ? window.Alpine.$data(root) : window.datasetWizardComponentInstance;
+                return {
+                    canProceed: comp ? comp.canProceed === true : null,
+                    hasPrimaryDatasetAvailable: comp ? comp.hasPrimaryDatasetAvailable === true : null,
+                    regularisationChecked: !!document.querySelector('#regularisationDatasetToggle')?.checked,
+                    infoVisible: (() => {
+                        const alert = document.querySelector('.dataset-wizard-modal .alert-info');
+                        if (!alert) { return null; }
+                        return window.getComputedStyle(alert).display !== 'none';
+                    })()
+                };
+                """
+            )
+            self.assertTrue(state.get("canProceed"), state)
+            self.assertFalse(state.get("hasPrimaryDatasetAvailable"), state)
+            self.assertFalse(state.get("regularisationChecked"), state)
+            self.assertTrue(state.get("infoVisible"), state)
+
+        self.for_each_browser("test_dataset_wizard_name_step_enables_next_after_typing", scenario)
 
 
 class CloudUploadProgressTestCase(_TrainerPageMixin, WebUITestCase):


### PR DESCRIPTION
This pull request improves the state management and testing of the dataset wizard component, focusing on ensuring that the `activeSubTab` state is consistently initialized and tested, and adding a new end-to-end test for the wizard's "Name" step. The changes enhance reliability and maintainability by making the Alpine.js state more predictable and by extending test coverage.

**State management improvements:**

* The `activeSubTab` property is now always initialized from `sessionStorage` (defaulting to `'configuration'`) within the `datasetWizardComponent`, ensuring consistent state across reloads and removing duplicate initialization from the HTML template. [[1]](diffhunk://#diff-0686ced55e44778d6e58196ffd127349b6a648cd15a7da1748a0a055f275bbadR73) [[2]](diffhunk://#diff-3e24b366ce029a395b533299f766d134dc412c4ab01cbc8d5431d4d83cc31827L97-R97)

**Test enhancements:**

* The unit test for `datasetWizardComponent` is updated to check for the presence and correct default value of `activeSubTab`, and to include it in the list of required Alpine.js state fields. [[1]](diffhunk://#diff-2ba279620a05559840ed6bdb73783cf7ed84f08993e9d6a83966b298ce99da4cR105) [[2]](diffhunk://#diff-2ba279620a05559840ed6bdb73783cf7ed84f08993e9d6a83966b298ce99da4cR130)
* The end-to-end test in `test_webui_e2e.py` is updated to robustly access the Alpine.js component instance directly from the DOM, and to verify that `activeSubTab` is present in the component's state. [[1]](diffhunk://#diff-7874cebc94cd13302bd3886017a7564c4905b9e29b7817955eab19d6e3850b0eL1266-R1286) [[2]](diffhunk://#diff-7874cebc94cd13302bd3886017a7564c4905b9e29b7817955eab19d6e3850b0eL1283-R1295) [[3]](diffhunk://#diff-7874cebc94cd13302bd3886017a7564c4905b9e29b7817955eab19d6e3850b0eL1299-R1312)
* A new end-to-end test is added to verify that the "Continue to next step" button in the dataset wizard's "Name" step becomes enabled after entering a dataset ID, and that the component's state reflects the expected values.