### PR TITLE
anima: support preview-2 and preview-3 flavours with diffusers style paths

### DIFF
--- a/simpletuner/helpers/models/anima/model.py
+++ b/simpletuner/helpers/models/anima/model.py
@@ -231,8 +231,10 @@ class Anima(ImageModelFoundation):
             proxies=getattr(self.config, "proxies", None),
         )
 
-    def _uses_diffusers_repo_layout(self) -> bool:
-        model_path = getattr(self.config, "pretrained_model_name_or_path", None)
+    def _uses_diffusers_repo_layout(self, model_path: Optional[str] = None) -> bool:
+        path_was_provided = model_path is not None
+        if model_path is None:
+            model_path = getattr(self.config, "pretrained_model_name_or_path", None)
         if isinstance(model_path, str):
             normalized_path = model_path.rstrip("/")
             if normalized_path in self.DIFFUSERS_LAYOUT_PATHS:
@@ -240,6 +242,9 @@ class Anima(ImageModelFoundation):
             model_dir = Path(model_path)
             if (model_dir / "transformer" / "config.json").is_file():
                 return True
+
+        if path_was_provided:
+            return False
 
         flavour = getattr(self.config, "model_flavour", None)
         return flavour in self.HUGGINGFACE_PATHS and self.HUGGINGFACE_PATHS[flavour] in self.DIFFUSERS_LAYOUT_PATHS
@@ -292,7 +297,7 @@ class Anima(ImageModelFoundation):
             execution_device=self.accelerator.device.type,
         )
         load_device = self.accelerator.device.type if move_to_device else "cpu"
-        if self._uses_diffusers_repo_layout():
+        if self._uses_diffusers_repo_layout(model_path):
             load_kwargs = {
                 "pretrained_model_name_or_path": model_path,
                 "subfolder": "text_encoder",
@@ -346,7 +351,7 @@ class Anima(ImageModelFoundation):
         model_path = self.config.pretrained_model_name_or_path
         revision = getattr(self.config, "revision", None)
         load_device = self.accelerator.device.type if move_to_device else "cpu"
-        if self._uses_diffusers_repo_layout():
+        if self._uses_diffusers_repo_layout(model_path):
             load_kwargs = {
                 "pretrained_model_name_or_path": model_path,
                 "subfolder": "vae",

--- a/simpletuner/helpers/models/anima/model.py
+++ b/simpletuner/helpers/models/anima/model.py
@@ -63,12 +63,16 @@ class Anima(ImageModelFoundation):
 
     MODEL_CLASS = AnimaTransformerModel
     MODEL_SUBFOLDER = "split_files/diffusion_models"
+    DIFFUSERS_MODEL_SUBFOLDER = "transformer"
     PIPELINE_CLASSES = {PipelineTypes.TEXT2IMG: AnimaPipeline}
 
-    DEFAULT_MODEL_FLAVOUR = "preview"
+    DEFAULT_MODEL_FLAVOUR = "preview-3"
     HUGGINGFACE_PATHS = {
-        "preview": "circlestone-labs/Anima",
+        "preview-3": "CalamitousFelicitousness/Anima-Preview-3-sdnext-diffusers",
+        "preview-2": "CalamitousFelicitousness/Anima-Preview-2-sdnext-diffusers",
+        "preview": "CalamitousFelicitousness/Anima-sdnext-diffusers",
     }
+    DIFFUSERS_LAYOUT_PATHS = set(HUGGINGFACE_PATHS.values())
     MODEL_LICENSE = "other"
 
     TEXT_ENCODER_CONFIGURATION = {
@@ -227,14 +231,39 @@ class Anima(ImageModelFoundation):
             proxies=getattr(self.config, "proxies", None),
         )
 
+    def _uses_diffusers_repo_layout(self) -> bool:
+        model_path = getattr(self.config, "pretrained_model_name_or_path", None)
+        if isinstance(model_path, str):
+            normalized_path = model_path.rstrip("/")
+            if normalized_path in self.DIFFUSERS_LAYOUT_PATHS:
+                return True
+            model_dir = Path(model_path)
+            if (model_dir / "transformer" / "config.json").is_file():
+                return True
+
+        flavour = getattr(self.config, "model_flavour", None)
+        return flavour in self.HUGGINGFACE_PATHS and self.HUGGINGFACE_PATHS[flavour] in self.DIFFUSERS_LAYOUT_PATHS
+
+    def load_model(self, move_to_device: bool = True):
+        self.MODEL_SUBFOLDER = (
+            self.DIFFUSERS_MODEL_SUBFOLDER if self._uses_diffusers_repo_layout() else "split_files/diffusion_models"
+        )
+        return super().load_model(move_to_device=move_to_device)
+
     def _prompt_tokenizer_sources(self) -> tuple[str, str]:
         model_path = getattr(self.config, "pretrained_model_name_or_path", None)
         if isinstance(model_path, str):
             model_dir = Path(model_path)
+            qwen_dir = model_dir / "tokenizer"
+            t5_dir = model_dir / "t5_tokenizer"
+            if qwen_dir.is_dir() and t5_dir.is_dir():
+                return str(qwen_dir), str(t5_dir)
             qwen_dir = model_dir / "prompt_tokenizer_qwen"
             t5_dir = model_dir / "prompt_tokenizer_t5"
             if qwen_dir.is_dir() and t5_dir.is_dir():
                 return str(qwen_dir), str(t5_dir)
+            if self._uses_diffusers_repo_layout():
+                return f"{model_path}::tokenizer", f"{model_path}::t5_tokenizer"
         return _QWEN_TOKENIZER_SOURCE, _T5_TOKENIZER_SOURCE
 
     def load_text_tokenizer(self):
@@ -257,18 +286,43 @@ class Anima(ImageModelFoundation):
             or self.config.pretrained_model_name_or_path
         )
         revision = getattr(self.config, "text_encoder_revision", None) or getattr(self.config, "revision", None)
-        weight_path = _resolve_weight_path(
-            model_path,
-            filename=DEFAULT_ANIMA_TEXT_ENCODER_FILENAME,
-            subfolder="split_files/text_encoders",
-            revision=revision,
-        )
         dtype = resolve_text_encoder_dtype(
             model_dtype=self.config.weight_dtype,
             text_encoder_dtype="auto",
             execution_device=self.accelerator.device.type,
         )
         load_device = self.accelerator.device.type if move_to_device else "cpu"
+        if self._uses_diffusers_repo_layout():
+            load_kwargs = {
+                "pretrained_model_name_or_path": model_path,
+                "subfolder": "text_encoder",
+                "revision": revision,
+                "torch_dtype": dtype,
+                "local_files_only": bool(getattr(self.config, "local_files_only", False)),
+                "cache_dir": getattr(self.config, "cache_dir", None),
+                "force_download": bool(getattr(self.config, "force_download", False)),
+            }
+            token = getattr(self.config, "token", None)
+            if token is not None:
+                load_kwargs["token"] = token
+            text_encoder = Qwen3Model.from_pretrained(**load_kwargs)
+            text_encoder.eval().requires_grad_(False)
+            text_encoder.to(device=load_device, dtype=dtype)
+            self.text_encoders = [text_encoder]
+            self.text_encoder = text_encoder
+            self.text_encoder_1 = text_encoder
+            if not move_to_device:
+                text_encoder.to("cpu")
+            if getattr(self, "prompt_tokenizer", None) is None:
+                self.load_text_tokenizer()
+            return
+
+        weight_path = _resolve_weight_path(
+            model_path,
+            filename=DEFAULT_ANIMA_TEXT_ENCODER_FILENAME,
+            subfolder="split_files/text_encoders",
+            revision=revision,
+        )
         text_encoder = load_text_encoder_single_file(
             file_path=weight_path,
             device=load_device,
@@ -291,13 +345,34 @@ class Anima(ImageModelFoundation):
     def load_vae(self, move_to_device: bool = True):
         model_path = self.config.pretrained_model_name_or_path
         revision = getattr(self.config, "revision", None)
+        load_device = self.accelerator.device.type if move_to_device else "cpu"
+        if self._uses_diffusers_repo_layout():
+            load_kwargs = {
+                "pretrained_model_name_or_path": model_path,
+                "subfolder": "vae",
+                "revision": revision,
+                "torch_dtype": self.config.weight_dtype,
+                "local_files_only": bool(getattr(self.config, "local_files_only", False)),
+                "cache_dir": getattr(self.config, "cache_dir", None),
+                "force_download": bool(getattr(self.config, "force_download", False)),
+            }
+            token = getattr(self.config, "token", None)
+            if token is not None:
+                load_kwargs["token"] = token
+            self.vae = self.AUTOENCODER_CLASS.from_pretrained(**load_kwargs)
+            self.vae.eval().requires_grad_(False)
+            self.vae.to(device=load_device, dtype=self.config.weight_dtype)
+            self.AUTOENCODER_SCALING_FACTOR = getattr(self.vae.config, "scaling_factor", 1.0)
+            if not move_to_device:
+                self.vae.to("cpu")
+            return
+
         weight_path = _resolve_weight_path(
             model_path,
             filename=DEFAULT_ANIMA_VAE_FILENAME,
             subfolder="split_files/vae",
             revision=revision,
         )
-        load_device = self.accelerator.device.type if move_to_device else "cpu"
         self.vae = load_vae_single_file(
             weight_path,
             device=load_device,

--- a/simpletuner/helpers/models/anima/model.py
+++ b/simpletuner/helpers/models/anima/model.py
@@ -231,7 +231,12 @@ class Anima(ImageModelFoundation):
             proxies=getattr(self.config, "proxies", None),
         )
 
-    def _uses_diffusers_repo_layout(self, model_path: Optional[str] = None) -> bool:
+    def _uses_diffusers_repo_layout(
+        self,
+        model_path: Optional[str] = None,
+        *,
+        component_subfolder: str = "transformer",
+    ) -> bool:
         path_was_provided = model_path is not None
         if model_path is None:
             model_path = getattr(self.config, "pretrained_model_name_or_path", None)
@@ -240,14 +245,19 @@ class Anima(ImageModelFoundation):
             if normalized_path in self.DIFFUSERS_LAYOUT_PATHS:
                 return True
             model_dir = Path(model_path)
-            if (model_dir / "transformer" / "config.json").is_file():
+            if (model_dir / component_subfolder / "config.json").is_file():
                 return True
 
-        if path_was_provided:
+        if path_was_provided or model_path is not None:
             return False
 
         flavour = getattr(self.config, "model_flavour", None)
         return flavour in self.HUGGINGFACE_PATHS and self.HUGGINGFACE_PATHS[flavour] in self.DIFFUSERS_LAYOUT_PATHS
+
+    def _add_hf_token_kwarg(self, load_kwargs: dict) -> None:
+        token = getattr(self.config, "token", None)
+        if token not in (None, False):
+            load_kwargs["token"] = token
 
     def load_model(self, move_to_device: bool = True):
         self.MODEL_SUBFOLDER = (
@@ -297,7 +307,7 @@ class Anima(ImageModelFoundation):
             execution_device=self.accelerator.device.type,
         )
         load_device = self.accelerator.device.type if move_to_device else "cpu"
-        if self._uses_diffusers_repo_layout(model_path):
+        if self._uses_diffusers_repo_layout(model_path, component_subfolder="text_encoder"):
             load_kwargs = {
                 "pretrained_model_name_or_path": model_path,
                 "subfolder": "text_encoder",
@@ -307,9 +317,7 @@ class Anima(ImageModelFoundation):
                 "cache_dir": getattr(self.config, "cache_dir", None),
                 "force_download": bool(getattr(self.config, "force_download", False)),
             }
-            token = getattr(self.config, "token", None)
-            if token is not None:
-                load_kwargs["token"] = token
+            self._add_hf_token_kwarg(load_kwargs)
             text_encoder = Qwen3Model.from_pretrained(**load_kwargs)
             text_encoder.eval().requires_grad_(False)
             text_encoder.to(device=load_device, dtype=dtype)
@@ -351,7 +359,7 @@ class Anima(ImageModelFoundation):
         model_path = self.config.pretrained_model_name_or_path
         revision = getattr(self.config, "revision", None)
         load_device = self.accelerator.device.type if move_to_device else "cpu"
-        if self._uses_diffusers_repo_layout(model_path):
+        if self._uses_diffusers_repo_layout(model_path, component_subfolder="vae"):
             load_kwargs = {
                 "pretrained_model_name_or_path": model_path,
                 "subfolder": "vae",
@@ -361,9 +369,7 @@ class Anima(ImageModelFoundation):
                 "cache_dir": getattr(self.config, "cache_dir", None),
                 "force_download": bool(getattr(self.config, "force_download", False)),
             }
-            token = getattr(self.config, "token", None)
-            if token is not None:
-                load_kwargs["token"] = token
+            self._add_hf_token_kwarg(load_kwargs)
             self.vae = self.AUTOENCODER_CLASS.from_pretrained(**load_kwargs)
             self.vae.eval().requires_grad_(False)
             self.vae.to(device=load_device, dtype=self.config.weight_dtype)

--- a/simpletuner/helpers/models/anima/transformer.py
+++ b/simpletuner/helpers/models/anima/transformer.py
@@ -414,8 +414,14 @@ class AnimaTransformerModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
             resolved_dir = (
                 os.path.join(pretrained_model_name_or_path, subfolder) if subfolder else pretrained_model_name_or_path
             )
-        if subfolder == "transformer" or (resolved_dir and os.path.isfile(os.path.join(resolved_dir, "config.json"))):
+        if resolved_dir and os.path.isfile(os.path.join(resolved_dir, "config.json")):
             return super().from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+
+        if subfolder == "transformer":
+            try:
+                return super().from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+            except (OSError, ValueError):
+                pass
 
         return cls.from_single_file(
             pretrained_model_name_or_path,

--- a/simpletuner/helpers/models/anima/transformer.py
+++ b/simpletuner/helpers/models/anima/transformer.py
@@ -414,7 +414,7 @@ class AnimaTransformerModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
             resolved_dir = (
                 os.path.join(pretrained_model_name_or_path, subfolder) if subfolder else pretrained_model_name_or_path
             )
-        if resolved_dir and os.path.isfile(os.path.join(resolved_dir, "config.json")):
+        if subfolder == "transformer" or (resolved_dir and os.path.isfile(os.path.join(resolved_dir, "config.json"))):
             return super().from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
 
         return cls.from_single_file(

--- a/tests/test_anima_model.py
+++ b/tests/test_anima_model.py
@@ -73,7 +73,7 @@ class TestAnimaModel(unittest.TestCase):
             local_files_only=True,
             cache_dir=None,
             force_download=False,
-            token=None,
+            token=False,
         )
         model.prompt_tokenizer = object()
         model.text_encoders = None
@@ -96,10 +96,82 @@ class TestAnimaModel(unittest.TestCase):
 
         mock_text_encoder.assert_called_once()
         self.assertEqual(mock_text_encoder.call_args.kwargs["subfolder"], "text_encoder")
+        self.assertNotIn("token", mock_text_encoder.call_args.kwargs)
         fake_autoencoder.from_pretrained.assert_called_once()
         self.assertEqual(fake_autoencoder.from_pretrained.call_args.kwargs["subfolder"], "vae")
+        self.assertNotIn("token", fake_autoencoder.from_pretrained.call_args.kwargs)
         self.assertIs(model.text_encoder, text_encoder)
         self.assertIs(model.vae, vae)
+
+    def test_text_encoder_override_uses_resolved_path_layout(self):
+        from simpletuner.helpers.models.anima.model import Anima
+
+        model = Anima.__new__(Anima)
+        model.accelerator = SimpleNamespace(device=torch.device("cpu"))
+        model.config = SimpleNamespace(
+            pretrained_model_name_or_path="CalamitousFelicitousness/Anima-Preview-3-sdnext-diffusers",
+            pretrained_text_encoder_model_name_or_path="circlestone-labs/Anima",
+            model_flavour="preview-3",
+            revision=None,
+            text_encoder_revision=None,
+            weight_dtype=torch.float32,
+            local_files_only=True,
+            cache_dir=None,
+            force_download=False,
+            token=None,
+        )
+        model.prompt_tokenizer = object()
+        model.text_encoders = None
+        text_encoder = MagicMock()
+
+        with (
+            patch("simpletuner.helpers.models.anima.model.Qwen3Model.from_pretrained") as mock_from_pretrained,
+            patch(
+                "simpletuner.helpers.models.anima.model._resolve_weight_path",
+                return_value="weights.safetensors",
+            ) as mock_resolve,
+            patch("simpletuner.helpers.models.anima.model.load_text_encoder_single_file", return_value=text_encoder),
+        ):
+            model.load_text_encoder(move_to_device=False)
+
+        mock_from_pretrained.assert_not_called()
+        mock_resolve.assert_called_once_with(
+            "circlestone-labs/Anima",
+            filename="model.safetensors",
+            subfolder="split_files/text_encoders",
+            revision=None,
+        )
+        self.assertIs(model.text_encoder, text_encoder)
+
+    def test_model_flavour_does_not_override_explicit_legacy_layout(self):
+        from simpletuner.helpers.models.anima.model import Anima
+
+        model = Anima.__new__(Anima)
+        model.config = SimpleNamespace(
+            pretrained_model_name_or_path="circlestone-labs/Anima",
+            model_flavour="preview-3",
+        )
+
+        self.assertFalse(model._uses_diffusers_repo_layout())
+
+    def test_transformer_subfolder_falls_back_to_single_file_when_diffusers_load_fails(self):
+        from simpletuner.helpers.models.anima.transformer import AnimaTransformerModel
+
+        sentinel = object()
+        with (
+            patch(
+                "simpletuner.helpers.models.anima.transformer.ModelMixin.from_pretrained",
+                side_effect=OSError("missing transformer/config.json"),
+            ) as mock_from_pretrained,
+            patch.object(AnimaTransformerModel, "from_single_file", return_value=sentinel) as mock_from_single_file,
+        ):
+            result = AnimaTransformerModel.from_pretrained("circlestone-labs/Anima", subfolder="transformer")
+
+        self.assertIs(result, sentinel)
+        mock_from_pretrained.assert_called_once()
+        mock_from_single_file.assert_called_once()
+        self.assertEqual(mock_from_single_file.call_args.args[0], "circlestone-labs/Anima")
+        self.assertEqual(mock_from_single_file.call_args.kwargs["subfolder"], "transformer")
 
     def test_transformer_import(self):
         from simpletuner.helpers.models.anima.transformer import AnimaTransformerModel

--- a/tests/test_anima_model.py
+++ b/tests/test_anima_model.py
@@ -15,7 +15,91 @@ class TestAnimaModel(unittest.TestCase):
 
         self.assertIsNotNone(Anima)
         self.assertEqual(Anima.NAME, "Anima")
-        self.assertEqual(Anima.DEFAULT_MODEL_FLAVOUR, "preview")
+        self.assertEqual(Anima.DEFAULT_MODEL_FLAVOUR, "preview-3")
+
+    def test_model_flavours_use_converted_diffusers_repos(self):
+        from simpletuner.helpers.models.anima.model import Anima
+
+        self.assertEqual(
+            Anima.HUGGINGFACE_PATHS["preview-3"],
+            "CalamitousFelicitousness/Anima-Preview-3-sdnext-diffusers",
+        )
+        self.assertEqual(
+            Anima.HUGGINGFACE_PATHS["preview-2"],
+            "CalamitousFelicitousness/Anima-Preview-2-sdnext-diffusers",
+        )
+        self.assertEqual(
+            Anima.HUGGINGFACE_PATHS["preview"],
+            "CalamitousFelicitousness/Anima-sdnext-diffusers",
+        )
+
+    def test_diffusers_layout_switches_component_sources(self):
+        from simpletuner.helpers.models.anima.model import Anima
+        from simpletuner.helpers.models.common import ImageModelFoundation
+
+        model = Anima.__new__(Anima)
+        model.config = SimpleNamespace(
+            pretrained_model_name_or_path="CalamitousFelicitousness/Anima-Preview-3-sdnext-diffusers",
+            model_flavour="preview-3",
+        )
+
+        self.assertTrue(model._uses_diffusers_repo_layout())
+        self.assertEqual(
+            model._prompt_tokenizer_sources(),
+            (
+                "CalamitousFelicitousness/Anima-Preview-3-sdnext-diffusers::tokenizer",
+                "CalamitousFelicitousness/Anima-Preview-3-sdnext-diffusers::t5_tokenizer",
+            ),
+        )
+
+        with patch.object(ImageModelFoundation, "load_model", return_value="loaded") as mock_load_model:
+            self.assertEqual(model.load_model(move_to_device=False), "loaded")
+
+        self.assertEqual(model.MODEL_SUBFOLDER, "transformer")
+        mock_load_model.assert_called_once_with(move_to_device=False)
+
+    def test_diffusers_layout_loads_text_encoder_and_vae_from_standard_subfolders(self):
+        from simpletuner.helpers.models.anima.model import Anima
+
+        model = Anima.__new__(Anima)
+        model.accelerator = SimpleNamespace(device=torch.device("cpu"))
+        model.config = SimpleNamespace(
+            pretrained_model_name_or_path="CalamitousFelicitousness/Anima-Preview-2-sdnext-diffusers",
+            pretrained_text_encoder_model_name_or_path=None,
+            model_flavour="preview-2",
+            revision=None,
+            text_encoder_revision=None,
+            weight_dtype=torch.float32,
+            local_files_only=True,
+            cache_dir=None,
+            force_download=False,
+            token=None,
+        )
+        model.prompt_tokenizer = object()
+        model.text_encoders = None
+        text_encoder = MagicMock()
+        text_encoder.eval.return_value = text_encoder
+        text_encoder.requires_grad_.return_value = text_encoder
+        vae = MagicMock(config=SimpleNamespace(scaling_factor=0.18215))
+        vae.eval.return_value = vae
+        vae.requires_grad_.return_value = vae
+        fake_autoencoder = SimpleNamespace(from_pretrained=MagicMock(return_value=vae))
+
+        with (
+            patch(
+                "simpletuner.helpers.models.anima.model.Qwen3Model.from_pretrained", return_value=text_encoder
+            ) as mock_text_encoder,
+            patch.object(Anima, "AUTOENCODER_CLASS", fake_autoencoder),
+        ):
+            model.load_text_encoder(move_to_device=False)
+            model.load_vae(move_to_device=False)
+
+        mock_text_encoder.assert_called_once()
+        self.assertEqual(mock_text_encoder.call_args.kwargs["subfolder"], "text_encoder")
+        fake_autoencoder.from_pretrained.assert_called_once()
+        self.assertEqual(fake_autoencoder.from_pretrained.call_args.kwargs["subfolder"], "vae")
+        self.assertIs(model.text_encoder, text_encoder)
+        self.assertIs(model.vae, vae)
 
     def test_transformer_import(self):
         from simpletuner.helpers.models.anima.transformer import AnimaTransformerModel


### PR DESCRIPTION
This pull request updates the Anima model integration to support loading from HuggingFace repositories that use the standard Diffusers layout, in addition to the existing custom layout. The changes include logic to automatically detect the repository layout and adjust component loading accordingly. The update also expands test coverage to ensure correct behavior for both layouts.

**Diffusers repository layout support:**

* Added detection logic in `Anima` (`model.py`) to determine if a HuggingFace repo uses the Diffusers layout, based on model path, flavour, or presence of certain files. The model now dynamically switches subfolders and loading logic for model, text encoder, and VAE components as needed. [[1]](diffhunk://#diff-66e251d021f0fc4ffd20b2e7d60bd4c639bf11b6c31fafaa15883c63825b3adcR66-R75) [[2]](diffhunk://#diff-66e251d021f0fc4ffd20b2e7d60bd4c639bf11b6c31fafaa15883c63825b3adcR234-R266)
* Updated the default model flavour and HuggingFace repo paths to point to converted Diffusers-format repositories.

**Component loading improvements:**

* Modified `load_text_encoder` and `load_vae` in `Anima` to load components from standard Diffusers subfolders (`text_encoder`, `vae`) when appropriate, using the correct arguments for HuggingFace `from_pretrained`. [[1]](diffhunk://#diff-66e251d021f0fc4ffd20b2e7d60bd4c639bf11b6c31fafaa15883c63825b3adcL260-R325) [[2]](diffhunk://#diff-66e251d021f0fc4ffd20b2e7d60bd4c639bf11b6c31fafaa15883c63825b3adcR348-L300)
* Adjusted tokenizer source resolution to support both legacy and Diffusers layouts.
* Updated `AnimaTransformerModel.from_pretrained` to ensure proper handling of the `transformer` subfolder in Diffusers layout.

**Testing enhancements:**

* Added comprehensive tests to verify that the Anima model correctly detects Diffusers layout, switches subfolders, and loads all components as expected for both layouts.