### PR TITLE
anima: fix PEFT LoRA resume when switching from Anima key layout to Diffusers

### DIFF
--- a/simpletuner/helpers/models/anima/lora_pipeline.py
+++ b/simpletuner/helpers/models/anima/lora_pipeline.py
@@ -157,6 +157,10 @@ _LORA_PARAM_SUFFIXES = (
     "lora_up.weight",
     "lora_down.bias",
     "lora_up.bias",
+    "lora.down.weight",
+    "lora.up.weight",
+    "lora.down.bias",
+    "lora.up.bias",
     "alpha",
 )
 
@@ -292,12 +296,17 @@ def _write_down_up_lora_payload(
     payload: dict[str, torch.Tensor | float],
     converted: dict[str, torch.Tensor],
 ) -> bool:
-    has_down_up = "lora_down.weight" in payload or "lora_up.weight" in payload
+    has_down_up = (
+        "lora_down.weight" in payload
+        or "lora_up.weight" in payload
+        or "lora.down.weight" in payload
+        or "lora.up.weight" in payload
+    )
     if not has_down_up:
         return False
 
-    down_weight = payload.get("lora_down.weight")
-    up_weight = payload.get("lora_up.weight")
+    down_weight = payload.get("lora_down.weight", payload.get("lora.down.weight"))
+    up_weight = payload.get("lora_up.weight", payload.get("lora.up.weight"))
     if down_weight is None or up_weight is None:
         raise ValueError(f"LoRA down/up keys must be paired for module '{module_path}', but one side is missing.")
     if not torch.is_tensor(down_weight) or not torch.is_tensor(up_weight):
@@ -314,8 +323,8 @@ def _write_down_up_lora_payload(
         converted[f"transformer.{module_path}.lora_A.weight"] = down_weight * scale_down
         converted[f"transformer.{module_path}.lora_B.weight"] = up_weight * scale_up
 
-    down_bias = payload.get("lora_down.bias")
-    up_bias = payload.get("lora_up.bias")
+    down_bias = payload.get("lora_down.bias", payload.get("lora.down.bias"))
+    up_bias = payload.get("lora_up.bias", payload.get("lora.up.bias"))
     if down_bias is not None:
         if not torch.is_tensor(down_bias):
             raise ValueError(f"Invalid LoRA tensor payload for module '{module_path}.lora_down.bias'.")
@@ -333,7 +342,12 @@ def _convert_single_lora_module_payload(
     payload: dict[str, torch.Tensor | float],
     converted: dict[str, torch.Tensor],
 ) -> None:
-    has_down_up_keys = "lora_down.weight" in payload or "lora_up.weight" in payload
+    has_down_up_keys = (
+        "lora_down.weight" in payload
+        or "lora_up.weight" in payload
+        or "lora.down.weight" in payload
+        or "lora.up.weight" in payload
+    )
     wrote_direct = _write_direct_lora_payload(
         module_path=module_path,
         payload=payload,
@@ -374,6 +388,15 @@ def _convert_non_diffusers_anima_lora_to_diffusers(
     if len(converted) == 0:
         raise ValueError("No loadable LoRA weights were found in the provided state dict.")
     return converted
+
+
+def _is_diffusers_anima_lora_state_dict(state_dict: dict[str, torch.Tensor]) -> bool:
+    if not state_dict:
+        return False
+    lora_keys = [key for key in state_dict if "lora" in key and "dora_scale" not in key]
+    if not lora_keys:
+        return False
+    return all(key.startswith("transformer.") and ".lora." in key for key in lora_keys)
 
 
 class AnimaLoraLoaderMixin(LoraBaseMixin):
@@ -417,7 +440,10 @@ class AnimaLoraLoaderMixin(LoraBaseMixin):
             allow_pickle=allow_pickle,
         )
 
-        converted_state_dict = _convert_non_diffusers_anima_lora_to_diffusers(state_dict)
+        if _is_diffusers_anima_lora_state_dict(state_dict):
+            converted_state_dict = state_dict
+        else:
+            converted_state_dict = _convert_non_diffusers_anima_lora_to_diffusers(state_dict)
         if return_lora_metadata:
             return converted_state_dict, metadata
         return converted_state_dict

--- a/simpletuner/helpers/models/anima/model.py
+++ b/simpletuner/helpers/models/anima/model.py
@@ -106,10 +106,12 @@ class Anima(ImageModelFoundation):
         latents = batch["latents"]
         input_noise = batch["input_noise"]
         base_sigmas = batch["sigmas"].to(device=latents.device, dtype=latents.dtype).view(-1)
-        base_timesteps = batch["timesteps"].to(device=latents.device, dtype=latents.dtype).view(-1)
+        base_timesteps = self._to_sigma_space_timesteps(
+            batch["timesteps"].to(device=latents.device, dtype=latents.dtype).view(-1)
+        )
         alt_sigmas, alt_timesteps = self.sample_flow_sigmas(batch=batch, state=state)
         alt_sigmas = alt_sigmas.to(device=latents.device, dtype=latents.dtype)
-        alt_timesteps = alt_timesteps.to(device=latents.device, dtype=latents.dtype)
+        alt_timesteps = self._to_sigma_space_timesteps(alt_timesteps.to(device=latents.device, dtype=latents.dtype))
 
         _, _, num_frames, height, width = latents.shape
         p_t, p_h, p_w = self._crepa_self_flow_patch_size()
@@ -587,6 +589,18 @@ class Anima(ImageModelFoundation):
             "negative_prompt_t5xxl_weights": text_embedding["t5xxl_weights"],
         }
 
+    def _to_sigma_space_timesteps(self, timesteps: torch.Tensor) -> torch.Tensor:
+        if timesteps.numel() == 0 or torch.max(timesteps.detach().float()) <= 1.0:
+            return timesteps
+        max_timestep = float(
+            getattr(getattr(getattr(self, "noise_schedule", None), "config", None), "num_train_timesteps", 1000) or 1000
+        )
+        return timesteps / max_timestep
+
+    def sample_flow_sigmas(self, batch: dict, state: dict) -> tuple[torch.Tensor, torch.Tensor]:
+        sigmas, timesteps = super().sample_flow_sigmas(batch=batch, state=state)
+        return sigmas, self._to_sigma_space_timesteps(timesteps)
+
     def prepare_batch(self, batch: dict, state: dict) -> dict:
         batch = super().prepare_batch(batch, state)
         text_encoder_output = batch.get("text_encoder_output")
@@ -617,6 +631,7 @@ class Anima(ImageModelFoundation):
             device=self.accelerator.device,
             dtype=torch.float32,
         )
+        timesteps = self._to_sigma_space_timesteps(timesteps)
         hidden_states_buffer = self._new_hidden_state_buffer()
 
         noise_pred = self.model(

--- a/tests/test_anima_model.py
+++ b/tests/test_anima_model.py
@@ -388,6 +388,36 @@ class TestAnimaModel(unittest.TestCase):
 
         self.assertNotIn("proxies", mock_download.call_args.kwargs)
 
+    def test_lora_state_dict_preserves_diffusers_peft_checkpoint_keys(self):
+        from simpletuner.helpers.models.anima.lora_pipeline import AnimaLoraLoaderMixin
+
+        down = torch.randn(4, 8)
+        up = torch.randn(8, 4)
+        state_dict = {
+            "transformer.core.transformer_blocks.0.attn1.to_k.lora.down.weight": down,
+            "transformer.core.transformer_blocks.0.attn1.to_k.lora.up.weight": up,
+        }
+
+        loaded = AnimaLoraLoaderMixin.lora_state_dict(state_dict)
+
+        self.assertIs(loaded["transformer.core.transformer_blocks.0.attn1.to_k.lora.down.weight"], down)
+        self.assertIs(loaded["transformer.core.transformer_blocks.0.attn1.to_k.lora.up.weight"], up)
+
+    def test_lora_converter_accepts_peft_down_up_suffixes(self):
+        from simpletuner.helpers.models.anima.lora_pipeline import _convert_non_diffusers_anima_lora_to_diffusers
+
+        down = torch.randn(4, 8)
+        up = torch.randn(8, 4)
+        converted = _convert_non_diffusers_anima_lora_to_diffusers(
+            {
+                "blocks.0.self_attn.k_proj.lora.down.weight": down,
+                "blocks.0.self_attn.k_proj.lora.up.weight": up,
+            }
+        )
+
+        self.assertIs(converted["transformer.core.transformer_blocks.0.attn1.to_k.lora_A.weight"], down)
+        self.assertIs(converted["transformer.core.transformer_blocks.0.attn1.to_k.lora_B.weight"], up)
+
     def test_transformer_validation_guards(self):
         from simpletuner.helpers.models.anima.transformer import _AdapterAttention, _RotaryEmbedding
 
@@ -429,7 +459,7 @@ class TestAnimaModel(unittest.TestCase):
         self.assertEqual(result["sigmas"].shape, (1, 1, 1, 4, 4))
         self.assertEqual(result["crepa_teacher_timesteps"].shape, (1,))
         unique_timesteps = torch.unique(result["timesteps"].view(-1)).cpu()
-        torch.testing.assert_close(unique_timesteps, torch.tensor([200.0, 800.0], dtype=torch.float32))
+        torch.testing.assert_close(unique_timesteps, torch.tensor([0.2, 0.8], dtype=torch.float32))
         self.assertTrue(torch.equal(result["crepa_self_flow_mask"], fake_mask_rand < 0.5))
 
     def test_model_predict_preserves_tokenwise_timesteps_and_capture_override(self):
@@ -442,7 +472,7 @@ class TestAnimaModel(unittest.TestCase):
 
         def _forward(hidden_states, timestep, encoder_hidden_states, **kwargs):
             kwargs["hidden_states_buffer"]["layer_7"] = captured
-            self.assertTrue(torch.equal(timestep, torch.tensor([[100.0, 900.0, 100.0, 900.0]], dtype=torch.float32)))
+            torch.testing.assert_close(timestep, torch.tensor([[0.1, 0.9, 0.1, 0.9]], dtype=torch.float32))
             return (torch.randn(1, 16, 1, 4, 4),)
 
         model.model = MagicMock(side_effect=_forward, config=SimpleNamespace(patch_size=(1, 2, 2)))
@@ -464,6 +494,22 @@ class TestAnimaModel(unittest.TestCase):
         self.assertIs(result["crepa_hidden_states"], captured)
         self.assertIs(result["hidden_states_buffer"], model._new_hidden_state_buffer.return_value)
         self.assertEqual(result["model_prediction"].shape, (1, 16, 1, 4, 4))
+
+    def test_sample_flow_sigmas_returns_sigma_space_model_timesteps(self):
+        from simpletuner.helpers.models.anima.model import Anima
+        from simpletuner.helpers.models.common import ImageModelFoundation
+
+        model = Anima.__new__(Anima)
+        model.noise_schedule = SimpleNamespace(config=SimpleNamespace(num_train_timesteps=1000))
+        with patch.object(
+            ImageModelFoundation,
+            "sample_flow_sigmas",
+            return_value=(torch.tensor([0.25, 0.75]), torch.tensor([250.0, 750.0])),
+        ):
+            sigmas, timesteps = model.sample_flow_sigmas(batch={}, state={})
+
+        torch.testing.assert_close(sigmas, torch.tensor([0.25, 0.75]))
+        torch.testing.assert_close(timesteps, torch.tensor([0.25, 0.75]))
 
     def test_model_predict_preserves_frame_axis_to_match_flow_target(self):
         from simpletuner.helpers.models.anima.model import Anima


### PR DESCRIPTION
This pull request adds support for alternative LoRA (Low-Rank Adaptation) key naming conventions in the Anima model pipeline and ensures consistent handling of timesteps by normalizing them to sigma space. It also introduces new helper methods and test coverage to validate these behaviors. The changes improve compatibility with different LoRA checkpoint formats and standardize timestep processing throughout the model.

**LoRA key compatibility improvements:**

* Added support for alternative LoRA key suffixes (`lora.down.weight`, `lora.up.weight`, etc.) throughout the pipeline, ensuring compatibility with PEFT and diffusers-style checkpoints. This includes updates to key detection, payload writing, and conversion methods (`lora_pipeline.py`). [[1]](diffhunk://#diff-2437fd1763eac47a0401803f8c2167e6f602d77356057f13151a92190a02f7c2R160-R163) [[2]](diffhunk://#diff-2437fd1763eac47a0401803f8c2167e6f602d77356057f13151a92190a02f7c2L295-R309) [[3]](diffhunk://#diff-2437fd1763eac47a0401803f8c2167e6f602d77356057f13151a92190a02f7c2L317-R327) [[4]](diffhunk://#diff-2437fd1763eac47a0401803f8c2167e6f602d77356057f13151a92190a02f7c2L336-R350)
* Introduced the `_is_diffusers_anima_lora_state_dict` function to detect if a state dict is already in diffusers format, and updated `lora_state_dict` to skip conversion when appropriate. [[1]](diffhunk://#diff-2437fd1763eac47a0401803f8c2167e6f602d77356057f13151a92190a02f7c2R393-R401) [[2]](diffhunk://#diff-2437fd1763eac47a0401803f8c2167e6f602d77356057f13151a92190a02f7c2R443-R445)

**Timestep normalization and processing:**

* Implemented the `_to_sigma_space_timesteps` helper method in the `Anima` model to normalize timesteps to the [0, 1] sigma space, and integrated it into batch preparation, flow sampling, and model prediction. [[1]](diffhunk://#diff-66e251d021f0fc4ffd20b2e7d60bd4c639bf11b6c31fafaa15883c63825b3adcL109-R114) [[2]](diffhunk://#diff-66e251d021f0fc4ffd20b2e7d60bd4c639bf11b6c31fafaa15883c63825b3adcR592-R603) [[3]](diffhunk://#diff-66e251d021f0fc4ffd20b2e7d60bd4c639bf11b6c31fafaa15883c63825b3adcR634)
* Updated tests to expect normalized timesteps in sigma space, ensuring correct behavior and coverage for the new logic. [[1]](diffhunk://#diff-df404e12e9243c40ad553a5c09a69f448e882aa2dc56fb62f628a6ce2faaed56L432-R462) [[2]](diffhunk://#diff-df404e12e9243c40ad553a5c09a69f448e882aa2dc56fb62f628a6ce2faaed56L445-R475) [[3]](diffhunk://#diff-df404e12e9243c40ad553a5c09a69f448e882aa2dc56fb62f628a6ce2faaed56R498-R513)

**Test enhancements:**

* Added tests to verify that diffusers/PEFT-style LoRA checkpoint keys are preserved and that the converter accepts both old and new key suffixes.
* Added a test to confirm that `sample_flow_sigmas` returns timesteps in sigma space.