### PR TITLE
wan: fix time_text_monkeypatch missing timestep_sign argument

### DIFF
--- a/simpletuner/helpers/models/wan/model.py
+++ b/simpletuner/helpers/models/wan/model.py
@@ -50,16 +50,35 @@ def time_text_monkeypatch(
     timestep: torch.Tensor,
     encoder_hidden_states,
     encoder_hidden_states_image=None,
-    timestep_seq_len=None,
+    timestep_sign=None,
 ):
+    timestep_seq_len: Optional[int] = None
+    if timestep.ndim > 1:
+        timestep_seq_len = timestep.shape[1]
+        timestep = timestep.reshape(-1)
+
     timestep = self.timesteps_proj(timestep)
     if timestep_seq_len is not None:
-        timestep = timestep.unflatten(0, (encoder_hidden_states.shape[0], timestep_seq_len))
+        timestep = timestep.unflatten(0, (-1, timestep_seq_len))
 
     time_embedder_dtype = next(iter(self.time_embedder.parameters())).dtype
     if timestep.dtype != time_embedder_dtype and time_embedder_dtype != torch.int8:
         timestep = timestep.to(time_embedder_dtype)
     temb = self.time_embedder(timestep).type_as(encoder_hidden_states)
+
+    if timestep_sign is not None:
+        time_sign_embed = getattr(self, "time_sign_embed", None)
+        if time_sign_embed is None:
+            raise ValueError(
+                "timestep_sign was provided but the model was loaded without `enable_time_sign_embed=True`. "
+                "Enable TwinFlow (or load a TwinFlow-compatible checkpoint) to use signed-timestep conditioning."
+            )
+        sign_idx = (timestep_sign.view(-1) < 0).long().to(device=temb.device)
+        sign_embedding = time_sign_embed(sign_idx).to(dtype=temb.dtype, device=temb.device)
+        if timestep_seq_len is not None:
+            sign_embedding = sign_embedding.unflatten(0, (-1, timestep_seq_len))
+        temb = temb + sign_embedding
+
     timestep_proj = self.time_proj(self.act_fn(temb))
 
     encoder_hidden_states = self.text_embedder(encoder_hidden_states)

--- a/tests/test_transformers/test_wan_transformer.py
+++ b/tests/test_transformers/test_wan_transformer.py
@@ -1548,6 +1548,24 @@ class TestWanTransformer3DModel(TransformerBaseTest):
         # Test should complete within reasonable time for small model
         self.run_performance_benchmark(model, inputs, max_time_ms=3000.0)
 
+    def test_time_text_monkeypatch_accepts_timestep_sign(self):
+        """Regression test: time_text_monkeypatch must accept timestep_sign kwarg.
+
+        WanTransformer3DModel.forward (wan/transformer.py) unconditionally
+        passes timestep_sign= to condition_embedder for every forward pass,
+        even on non-TwinFlow runs (where the value is None). The monkeypatch
+        signature in wan/model.py must therefore accept this kwarg or every
+        Wan training/validation forward will raise TypeError.
+
+        Originally broken by commit 07e670c4 ("TwinFlow: Wan").
+        """
+        import inspect
+
+        from simpletuner.helpers.models.wan.model import time_text_monkeypatch
+
+        params = inspect.signature(time_text_monkeypatch).parameters
+        self.assertIn("timestep_sign", params)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary                                                                      
                                                                                  
  `WanTransformer3DModel.forward`                                                 
  (`simpletuner/helpers/models/wan/transformer.py:846`) unconditionally passes
  `timestep_sign=` to `self.condition_embedder` on every Wan forward, even on     
  non-TwinFlow runs where the value is `None`. Commit 07e670c4 ("TwinFlow: Wan",
  2025-12-15) added that argument to the call site but did not update the
  `time_text_monkeypatch` signature in `simpletuner/helpers/models/wan/model.py`,
  so every Wan training and validation forward now raises:

  ```
  TypeError: time_text_monkeypatch() got an unexpected keyword argument
  'timestep_sign'.                                                                
  Did you mean 'timestep_seq_len'?
  ```                                                                             
                                                         
  ## Reproducer                                                                   
                                                         
  Any Wan training or validation on `main` (verified at `1a6050f9`):              
  
  ```bash                                                                         
  simpletuner train  # with model_family=wan, model_type=lora
  ```                                                                             
                                                                                  
  Crashes on the first sanity validation, then again on training step 1.          
                                                                                  
  ## Fix                                                                          
                                                         
  Re-aligns `time_text_monkeypatch` with the vendored                             
  `WanTimeTextImageEmbedding.forward` (`wan/transformer.py:253-290`):
                                                                                  
  - Accepts `timestep_sign` and applies the time-sign embedding when the embedder 
  has `time_sign_embed` enabled (preserving the TwinFlow path)
  - Derives `timestep_seq_len` from `timestep.shape` when `timestep.ndim > 1`,    
  matching the vendored forward's tokenwise-timestep handling                     
  `time_text_monkeypatch` signature in `simpletuner/helpers/models/wan/model.py`,
  so every Wan training and validation forward now raises:

  ```
  TypeError: time_text_monkeypatch() got an unexpected keyword argument
  'timestep_sign'.
  Did you mean 'timestep_seq_len'?
  ```

  ## Reproducer

  Any Wan training or validation on `main` (verified at `1a6050f9`):

  ```bash
  simpletuner train  # with model_family=wan, model_type=lora
  ```


  ```
  TypeError: time_text_monkeypatch() got an unexpected keyword argument
  'timestep_sign'.
  Did you mean 'timestep_seq_len'?
  ```

  ## Reproducer

  Any Wan training or validation on `main` (verified at `1a6050f9`):

  ```bash
  simpletuner train  # with model_family=wan, model_type=lora
  ```

  Crashes on the first sanity validation, then again on training step 1.

  ## Fix

  Re-aligns `time_text_monkeypatch` with the vendored
  `WanTimeTextImageEmbedding.forward` (`wan/transformer.py:253-290`):

  - Accepts `timestep_sign` and applies the time-sign embedding when the embedder
  has `time_sign_embed` enabled (preserving the TwinFlow path)
  - Derives `timestep_seq_len` from `timestep.shape` when `timestep.ndim > 1`,
  matching the vendored forward's tokenwise-timestep handling
  - Removes the dead `timestep_seq_len` kwarg, which was never passed by the call
  site

  ## Test plan

  - [x] Added a regression test `test_time_text_monkeypatch_accepts_timestep_sign`
   in `tests/test_transformers/test_wan_transformer.py` that asserts the
  monkeypatch signature accepts `timestep_sign`
  - [x] `python -m unittest -v
  tests.test_transformers.test_wan_transformer.TestWanTransformer3DModel` —
  **22/22 passed**
  - [x] Manually verified Wan 14B LoRA training resumes past sanity validation and
   step 1 with this patch applied