### PR TITLE
SDXL LoRA keys fix for ComfyUI

### DIFF
--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -53,6 +53,7 @@ from simpletuner.helpers.training.lora_format import (
     PEFTLoRAFormat,
     convert_comfyui_to_diffusers,
     convert_diffusers_to_comfyui,
+    convert_diffusers_to_comfyui_sd_lora,
     detect_state_dict_format,
     normalize_lora_format,
 )
@@ -1726,8 +1727,11 @@ class ModelFoundation(ABC):
             raise ValueError("save_directory is required to save LoRA weights.")
 
         adapter_metadata = {}
+        component_adapter_metadata = {}
         for key, value in kwargs.items():
             if key.endswith("lora_adapter_metadata") and isinstance(value, dict):
+                component_name = key.removesuffix("_lora_adapter_metadata")
+                component_adapter_metadata[component_name] = value
                 adapter_metadata.update(value)
 
         lora_format = normalize_lora_format(getattr(self.config, "lora_format", None))
@@ -1766,6 +1770,13 @@ class ModelFoundation(ABC):
                     from simpletuner.helpers.models.flux2.pipeline import _convert_diffusers_flux2_lora_to_comfyui
 
                     converted = _convert_diffusers_flux2_lora_to_comfyui(weights, adapter_metadata=adapter_metadata)
+                elif model_family in {"sd1x", "sdxl"}:
+                    converted = convert_diffusers_to_comfyui_sd_lora(
+                        weights,
+                        adapter_metadata=adapter_metadata,
+                        component_adapter_metadata=component_adapter_metadata,
+                        sdxl=(model_family == "sdxl"),
+                    )
                 else:
                     converted = convert_diffusers_to_comfyui(
                         weights,

--- a/simpletuner/helpers/training/lora_format.py
+++ b/simpletuner/helpers/training/lora_format.py
@@ -116,6 +116,98 @@ def _resolve_alpha_for_module(module_key: str, weight: Any, adapter_metadata: Op
     return None
 
 
+def _kohya_component_prefix(component_prefix: str, *, sdxl: bool) -> Optional[str]:
+    component = component_prefix.removesuffix(".")
+    if component == "unet":
+        return "lora_unet"
+    if component == "text_encoder":
+        return "lora_te1" if sdxl else "lora_te"
+    if component == "text_encoder_2":
+        return "lora_te2"
+    return None
+
+
+def _component_metadata(
+    component_prefix: str,
+    adapter_metadata: Optional[dict],
+    component_adapter_metadata: Optional[dict[str, dict]],
+) -> Optional[dict]:
+    component = component_prefix.removesuffix(".")
+    if component_adapter_metadata and component in component_adapter_metadata:
+        return component_adapter_metadata[component]
+    return adapter_metadata
+
+
+def _kohya_module_key(module_key: str, component_prefix: str, *, sdxl: bool) -> Optional[str]:
+    kohya_prefix = _kohya_component_prefix(component_prefix, sdxl=sdxl)
+    if kohya_prefix is None or not module_key.startswith(component_prefix):
+        return None
+
+    module_path = module_key.removeprefix(component_prefix)
+    module_path = module_path.replace(".processor.", ".")
+    return f"{kohya_prefix}_{module_path.replace('.', '_')}"
+
+
+def convert_diffusers_to_comfyui_sd_lora(
+    state_dict: Dict[str, Any],
+    *,
+    adapter_metadata: Optional[dict] = None,
+    component_adapter_metadata: Optional[dict[str, dict]] = None,
+    sdxl: bool = True,
+) -> Dict[str, Any]:
+    """
+    Convert SD/SDXL Diffusers/PEFT LoRA keys to the Kohya-style names ComfyUI
+    maps for UNet and CLIP LoRA loading.
+    """
+    converted: Dict[str, Any] = {}
+    alpha_entries: Dict[str, torch.Tensor] = {}
+
+    suffix_map = {
+        ".lora.down.weight": ".lora_down.weight",
+        ".lora.up.weight": ".lora_up.weight",
+        ".lora_A.weight": ".lora_down.weight",
+        ".lora_B.weight": ".lora_up.weight",
+    }
+
+    for key, weight in state_dict.items():
+        component_prefix = next(
+            (prefix for prefix in ("unet.", "text_encoder.", "text_encoder_2.") if key.startswith(prefix)),
+            None,
+        )
+        if component_prefix is None:
+            converted[key] = weight
+            continue
+
+        matched_suffix = next((suffix for suffix in suffix_map if key.endswith(suffix)), None)
+        if matched_suffix is None:
+            converted[key] = weight
+            continue
+
+        module_key = key[: -len(matched_suffix)]
+        kohya_key = _kohya_module_key(module_key, component_prefix, sdxl=sdxl)
+        if kohya_key is None:
+            converted[key] = weight
+            continue
+
+        new_key = f"{kohya_key}{suffix_map[matched_suffix]}"
+        converted[new_key] = weight
+
+        if suffix_map[matched_suffix] == ".lora_down.weight" and kohya_key not in alpha_entries:
+            metadata = _component_metadata(component_prefix, adapter_metadata, component_adapter_metadata)
+            alpha_value = _resolve_alpha_for_module(
+                module_key.removeprefix(component_prefix),
+                weight,
+                metadata,
+            )
+            if alpha_value is not None:
+                alpha_entries[kohya_key] = torch.tensor(alpha_value, dtype=torch.float32)
+
+    for module_key, alpha_value in alpha_entries.items():
+        converted[f"{module_key}.alpha"] = alpha_value
+
+    return converted
+
+
 def convert_diffusers_to_comfyui(
     state_dict: Dict[str, Any],
     *,

--- a/tests/test_lora_metadata.py
+++ b/tests/test_lora_metadata.py
@@ -79,11 +79,38 @@ class _DummySavePipeline:
         save_function(packed, filename)
 
 
+class _DummySDXLSavePipeline:
+    @classmethod
+    def save_lora_weights(
+        cls,
+        save_directory,
+        unet_lora_layers=None,
+        text_encoder_lora_layers=None,
+        text_encoder_2_lora_layers=None,
+        save_function=None,
+        weight_name=None,
+        safe_serialization=True,
+        **kwargs,
+    ):
+        if save_function is None:
+            raise ValueError("save_function is required for this test pipeline")
+        filename = os.path.join(save_directory, weight_name or "pytorch_lora_weights.safetensors")
+        packed = {}
+        packed.update({f"unet.{key}": value for key, value in (unet_lora_layers or {}).items()})
+        packed.update({f"text_encoder.{key}": value for key, value in (text_encoder_lora_layers or {}).items()})
+        packed.update({f"text_encoder_2.{key}": value for key, value in (text_encoder_2_lora_layers or {}).items()})
+        save_function(packed, filename)
+
+
 class _DummySaveModel:
     PIPELINE_CLASSES = {PipelineTypes.TEXT2IMG: _DummySavePipeline, PipelineTypes.CONTROLNET: _DummySavePipeline}
 
     def __init__(self, model_family, lora_format="comfyui", controlnet=False):
         self.config = SimpleNamespace(model_family=model_family, lora_format=lora_format, controlnet=controlnet)
+
+
+class _DummySDXLSaveModel(_DummySaveModel):
+    PIPELINE_CLASSES = {PipelineTypes.TEXT2IMG: _DummySDXLSavePipeline, PipelineTypes.CONTROLNET: _DummySDXLSavePipeline}
 
 
 _ema_stub = SimpleNamespace(
@@ -259,6 +286,61 @@ class FluxPipelineMetadataTests(unittest.TestCase):
 
 
 class ComfyUILoraPrefixTests(unittest.TestCase):
+    def test_sdxl_models_write_kohya_comfyui_keys(self):
+        unet_weights = {
+            "down_blocks.1.attentions.0.transformer_blocks.0.attn1.to_k.lora.down.weight": torch.zeros(4, 8),
+            "down_blocks.1.attentions.0.transformer_blocks.0.attn1.to_k.lora.up.weight": torch.zeros(8, 4),
+            "down_blocks.1.attentions.0.transformer_blocks.0.attn1.to_out.0.lora.down.weight": torch.zeros(4, 8),
+            "down_blocks.1.attentions.0.transformer_blocks.0.attn1.to_out.0.lora.up.weight": torch.zeros(8, 4),
+        }
+        text_encoder_weights = {
+            "text_model.encoder.layers.0.self_attn.q_proj.lora.down.weight": torch.zeros(4, 8),
+            "text_model.encoder.layers.0.self_attn.q_proj.lora.up.weight": torch.zeros(8, 4),
+        }
+        text_encoder_2_weights = {
+            "text_model.encoder.layers.0.self_attn.k_proj.lora.down.weight": torch.zeros(4, 8),
+            "text_model.encoder.layers.0.self_attn.k_proj.lora.up.weight": torch.zeros(8, 4),
+        }
+        model = _DummySDXLSaveModel(model_family="sdxl")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ModelFoundation.save_lora_weights(
+                model,
+                save_directory=tmpdir,
+                unet_lora_layers=unet_weights,
+                text_encoder_lora_layers=text_encoder_weights,
+                text_encoder_2_lora_layers=text_encoder_2_weights,
+                unet_lora_adapter_metadata={"lora_alpha": 8},
+                text_encoder_lora_adapter_metadata={"lora_alpha": 4},
+                text_encoder_2_lora_adapter_metadata={"lora_alpha": 6},
+            )
+
+            lora_path = os.path.join(tmpdir, "pytorch_lora_weights.safetensors")
+            with safe_open(lora_path, framework="pt", device="cpu") as handle:
+                keys = list(handle.keys())
+                unet_alpha = handle.get_tensor("lora_unet_down_blocks_1_attentions_0_transformer_blocks_0_attn1_to_k.alpha")
+                text_encoder_alpha = handle.get_tensor("lora_te1_text_model_encoder_layers_0_self_attn_q_proj.alpha")
+                text_encoder_2_alpha = handle.get_tensor("lora_te2_text_model_encoder_layers_0_self_attn_k_proj.alpha")
+
+        self.assertIn(
+            "lora_unet_down_blocks_1_attentions_0_transformer_blocks_0_attn1_to_k.lora_down.weight",
+            keys,
+        )
+        self.assertIn(
+            "lora_unet_down_blocks_1_attentions_0_transformer_blocks_0_attn1_to_k.lora_up.weight",
+            keys,
+        )
+        self.assertIn(
+            "lora_unet_down_blocks_1_attentions_0_transformer_blocks_0_attn1_to_out_0.lora_down.weight",
+            keys,
+        )
+        self.assertIn("lora_te1_text_model_encoder_layers_0_self_attn_q_proj.lora_down.weight", keys)
+        self.assertIn("lora_te2_text_model_encoder_layers_0_self_attn_k_proj.lora_up.weight", keys)
+        self.assertFalse(any(key.startswith("diffusion_model.down_blocks.") for key in keys))
+        self.assertEqual(unet_alpha.item(), 8)
+        self.assertEqual(text_encoder_alpha.item(), 4)
+        self.assertEqual(text_encoder_2_alpha.item(), 6)
+
     def test_non_native_transformer_models_write_diffusion_model_prefix(self):
         weights = {
             "blocks.0.attn.to_q.lora.down.weight": torch.zeros(4, 8),


### PR DESCRIPTION
This pull request adds support for saving LoRA weights from SDXL models in the Kohya-style key format used by ComfyUI, ensuring correct mapping and metadata for each model component. It introduces a new conversion function, updates the save logic to utilize this function for SD1.x and SDXL models, and adds comprehensive tests to validate the new behavior.

**SDXL/ComfyUI LoRA Key Conversion Support:**

* Added `convert_diffusers_to_comfyui_sd_lora` to convert SD/SDXL Diffusers/PEFT LoRA keys to Kohya-style keys for ComfyUI, including proper handling of alpha values and component-specific metadata.
* Updated `save_lora_weights` and related save logic to use the new conversion function for `sd1x` and `sdxl` model families, passing component adapter metadata as needed. [[1]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR56) [[2]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR1730-R1734) [[3]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR1773-R1779)

**Testing Enhancements:**

* Added `_DummySDXLSavePipeline` and `_DummySDXLSaveModel` test classes to simulate SDXL model saving with component-specific LoRA weights and metadata.
* Implemented a new test, `test_sdxl_models_write_kohya_comfyui_keys`, to verify that SDXL models save LoRA weights with correct Kohya/ComfyUI keys and alpha values for each component.