### PR TITLE
cog: enforce nsfw checks when running via cloud platform

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -8,5 +8,6 @@ build:
   run:
     - pip install --upgrade pip
     - pip install "simpletuner[cuda]"
+    - python -c "from huggingface_hub import snapshot_download; models={'hf_falconsai':'Falconsai/nsfw_image_detection','hf_adamcodd':'AdamCodd/vit-base-nsfw-detector','hf_hoangtrung':'hoangtrung1801/nsfw-vit-model'}; [snapshot_download(repo_id=repo, allow_patterns=['*.json','*.safetensors','*.bin','*.txt'], local_dir=f'/opt/nsfw-classifier-comparison/{key}') for key, repo in models.items()]"
 
 predict: "predict.py:Predictor"

--- a/simpletuner/cog.py
+++ b/simpletuner/cog.py
@@ -25,6 +25,38 @@ from typing import Any, Dict, List, Optional
 from simpletuner.helpers.configuration.loader import load_config
 from simpletuner.helpers.training.trainer import run_trainer_job
 
+COG_NSFW_CLASSIFIER_MODELS = {
+    "hf_falconsai": "Falconsai/nsfw_image_detection",
+    "hf_adamcodd": "AdamCodd/vit-base-nsfw-detector",
+    "hf_hoangtrung": "hoangtrung1801/nsfw-vit-model",
+}
+COG_NSFW_BAKED_ROOT = "/opt/nsfw-classifier-comparison"
+COG_NSFW_SCORE_THRESHOLD = 0.5
+COG_NSFW_VOTE_THRESHOLD = 2
+COG_NSFW_BACKEND_TYPES = "all"
+COG_NSFW_SAMPLE_TYPES = "image,conditioning"
+
+
+def _has_hf_model_files(model_dir: Path) -> bool:
+    return (model_dir / "config.json").is_file() and (any(model_dir.glob("*.safetensors")) or any(model_dir.glob("*.bin")))
+
+
+def _resolve_cog_nsfw_model_path(model_key: str, model_id: str) -> str:
+    baked_root = Path(os.environ.get("NSFW_CLASSIFIER_MODEL_DIR", COG_NSFW_BAKED_ROOT))
+    baked_dir = baked_root / model_key
+    if _has_hf_model_files(baked_dir):
+        return str(baked_dir)
+    return model_id
+
+
+def build_cog_nsfw_model_specs_csv() -> str:
+    """Return fixed HF classifier specs for Cog-enforced NSFW checks."""
+
+    return ",".join(
+        f"{_resolve_cog_nsfw_model_path(model_key, model_id)}:threshold={COG_NSFW_SCORE_THRESHOLD}"
+        for model_key, model_id in COG_NSFW_CLASSIFIER_MODELS.items()
+    )
+
 
 class CogWebhookReceiver:
     """
@@ -304,6 +336,7 @@ class SimpleTunerCogRunner:
         if webhook_config:
             merged_config["webhook_config"] = webhook_config
 
+        self._force_nsfw_check(merged_config)
         self._apply_hf_token(hf_token)
 
         training_result = run_trainer_job(merged_config)
@@ -447,6 +480,19 @@ class SimpleTunerCogRunner:
         with config_path.open("w", encoding="utf-8") as handle:
             json.dump([dataset_entry], handle, indent=2)
         return config_path
+
+    @staticmethod
+    def _set_cli_arg(config: Dict[str, Any], name: str, value: Any) -> None:
+        config.pop(name, None)
+        config.pop(f"--{name}", None)
+        config[f"--{name}"] = value
+
+    def _force_nsfw_check(self, config: Dict[str, Any]) -> None:
+        self._set_cli_arg(config, "enable_nsfw_check", True)
+        self._set_cli_arg(config, "nsfw_check_models", build_cog_nsfw_model_specs_csv())
+        self._set_cli_arg(config, "nsfw_check_min_votes", COG_NSFW_VOTE_THRESHOLD)
+        self._set_cli_arg(config, "nsfw_check_backend_types", COG_NSFW_BACKEND_TYPES)
+        self._set_cli_arg(config, "nsfw_check_sample_types", COG_NSFW_SAMPLE_TYPES)
 
     def _apply_hf_token(self, hf_token: Optional[str]) -> None:
         """Expose the HF token to downstream libraries via standard env vars."""

--- a/simpletuner/cog.py
+++ b/simpletuner/cog.py
@@ -50,7 +50,7 @@ def _resolve_cog_nsfw_model_path(model_key: str, model_id: str) -> str:
 
 
 def build_cog_nsfw_model_specs_csv() -> str:
-    """Return fixed HF classifier specs for Cog-enforced NSFW checks."""
+    """Return Cog-enforced NSFW classifier specs using baked paths or HF repo IDs."""
 
     return ",".join(
         f"{_resolve_cog_nsfw_model_path(model_key, model_id)}:threshold={COG_NSFW_SCORE_THRESHOLD}"

--- a/tests/test_cog_nsfw_overrides.py
+++ b/tests/test_cog_nsfw_overrides.py
@@ -8,25 +8,31 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 
-def import_cog_module():
-    os.environ["SIMPLETUNER_SKIP_TORCH"] = "1"
-
+def build_cog_dependency_stubs():
     loader_module = types.ModuleType("simpletuner.helpers.configuration.loader")
     loader_module.load_config = lambda *_, **__: {}
 
     trainer_module = types.ModuleType("simpletuner.helpers.training.trainer")
     trainer_module.run_trainer_job = lambda config: dict(config)
 
-    sys.modules["simpletuner.helpers.configuration.loader"] = loader_module
-    sys.modules["simpletuner.helpers.training.trainer"] = trainer_module
-    sys.modules.pop("simpletuner.cog", None)
-    return importlib.import_module("simpletuner.cog")
+    return {
+        "simpletuner.helpers.configuration.loader": loader_module,
+        "simpletuner.helpers.training.trainer": trainer_module,
+    }
 
 
 class TestCogNsfwOverrides(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.cog = import_cog_module()
+        env_patcher = patch.dict(os.environ, {"SIMPLETUNER_SKIP_TORCH": "1"})
+        module_patcher = patch.dict(sys.modules, build_cog_dependency_stubs())
+        env_patcher.start()
+        cls.addClassCleanup(env_patcher.stop)
+        module_patcher.start()
+        cls.addClassCleanup(module_patcher.stop)
+
+        sys.modules.pop("simpletuner.cog", None)
+        cls.cog = importlib.import_module("simpletuner.cog")
 
     def test_force_nsfw_check_replaces_user_values(self):
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_cog_nsfw_overrides.py
+++ b/tests/test_cog_nsfw_overrides.py
@@ -1,0 +1,105 @@
+import importlib
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+
+def import_cog_module():
+    os.environ["SIMPLETUNER_SKIP_TORCH"] = "1"
+
+    loader_module = types.ModuleType("simpletuner.helpers.configuration.loader")
+    loader_module.load_config = lambda *_, **__: {}
+
+    trainer_module = types.ModuleType("simpletuner.helpers.training.trainer")
+    trainer_module.run_trainer_job = lambda config: dict(config)
+
+    sys.modules["simpletuner.helpers.configuration.loader"] = loader_module
+    sys.modules["simpletuner.helpers.training.trainer"] = trainer_module
+    sys.modules.pop("simpletuner.cog", None)
+    return importlib.import_module("simpletuner.cog")
+
+
+class TestCogNsfwOverrides(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.cog = import_cog_module()
+
+    def test_force_nsfw_check_replaces_user_values(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runner = self.cog.SimpleTunerCogRunner(
+                dataset_root=root / "datasets",
+                output_root=root / "output",
+                config_root=root / "config",
+            )
+            config = {
+                "enable_nsfw_check": False,
+                "--nsfw_check_models": "example/bypass",
+                "nsfw_check_min_votes": 1,
+                "--nsfw_check_backend_types": "aws",
+                "nsfw_check_sample_types": "video",
+            }
+
+            runner._force_nsfw_check(config)
+
+        self.assertNotIn("enable_nsfw_check", config)
+        self.assertNotIn("nsfw_check_min_votes", config)
+        self.assertEqual(config["--enable_nsfw_check"], True)
+        self.assertEqual(config["--nsfw_check_min_votes"], 2)
+        self.assertEqual(config["--nsfw_check_backend_types"], "all")
+        self.assertEqual(config["--nsfw_check_sample_types"], "image,conditioning")
+        self.assertIn("Falconsai/nsfw_image_detection:threshold=0.5", config["--nsfw_check_models"])
+        self.assertIn("AdamCodd/vit-base-nsfw-detector:threshold=0.5", config["--nsfw_check_models"])
+        self.assertIn("hoangtrung1801/nsfw-vit-model:threshold=0.5", config["--nsfw_check_models"])
+        self.assertNotIn("Marqo/", config["--nsfw_check_models"])
+
+    def test_model_specs_prefer_baked_classifier_dirs(self):
+        with TemporaryDirectory() as temp_dir:
+            model_dir = Path(temp_dir) / "hf_falconsai"
+            model_dir.mkdir(parents=True)
+            (model_dir / "config.json").write_text("{}", encoding="utf-8")
+            (model_dir / "model.safetensors").write_text("", encoding="utf-8")
+
+            with patch.dict("os.environ", {"NSFW_CLASSIFIER_MODEL_DIR": temp_dir}):
+                specs = self.cog.build_cog_nsfw_model_specs_csv()
+
+        self.assertIn(f"{model_dir}:threshold=0.5", specs)
+        self.assertIn("AdamCodd/vit-base-nsfw-detector:threshold=0.5", specs)
+        self.assertIn("hoangtrung1801/nsfw-vit-model:threshold=0.5", specs)
+
+    def test_run_applies_nsfw_overrides_after_user_config(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runner = self.cog.SimpleTunerCogRunner(
+                dataset_root=root / "datasets",
+                output_root=root / "output",
+                config_root=root / "config",
+            )
+
+            result = runner.run(
+                base_config_dict={"--model_type": "lora", "--enable_nsfw_check": False},
+                dataloader_config_dict=[
+                    {
+                        "id": "remote",
+                        "type": "aws",
+                        "dataset_type": "image",
+                        "aws_data_prefix": "s3://bucket/images",
+                    }
+                ],
+                config_overrides={"--nsfw_check_min_votes": 1},
+                job_id="test-job",
+            )
+
+        training_config = result["training_result"]
+        self.assertEqual(training_config["--enable_nsfw_check"], True)
+        self.assertEqual(training_config["--nsfw_check_min_votes"], 2)
+        self.assertEqual(training_config["--nsfw_check_backend_types"], "all")
+        self.assertEqual(training_config["--nsfw_check_sample_types"], "image,conditioning")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- only applies when running via https://github.com/replicate/cog (eg. https://replicate.com/simpletuner/advanced-trainer)
- other cloud platforms (Vast.ai, RunPod, Modal, and so on) are not impacted
- doesn't change behaviour for local runners