### PR TITLE
CREPA: fix for Z-Image hidden dim discovery

### DIFF
--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -5646,6 +5646,10 @@ class ImageModelFoundation(PipelineSupportMixin, VaeLatentScalingMixin, ModelFou
         hidden_size = getattr(config, "hidden_size", None)
         if hidden_size is not None:
             return int(hidden_size)
+        # Fallback: dim (Z-Image and related single-stream transformer configs)
+        dim = getattr(config, "dim", None)
+        if dim is not None:
+            return int(dim)
         return None
 
     def _init_urepa_regularizer(self):

--- a/tests/test_z_image_model.py
+++ b/tests/test_z_image_model.py
@@ -107,6 +107,12 @@ class ZImageModelTests(unittest.TestCase):
         torch.testing.assert_close(received_t, torch.full((1, 16), 0.9, dtype=torch.float32))
         self.assertTrue(torch.equal(output["crepa_hidden_states"], torch.full((1, 16, 8), 7.0)))
 
+    def test_infer_crepa_hidden_size_uses_transformer_dim(self):
+        model = self._build_model()
+        model.model.config = types.SimpleNamespace(dim=3840)
+
+        self.assertEqual(model._infer_crepa_hidden_size(), 3840)
+
     def test_prepare_crepa_self_flow_batch_creates_tokenwise_timesteps(self):
         model = self._build_model()
         model.sample_flow_sigmas = mock.MagicMock(


### PR DESCRIPTION
This pull request adds a fallback mechanism for inferring the hidden size in model configurations and introduces a corresponding test to ensure this behavior works as expected.

**Model configuration inference improvements:**

* Updated the `_infer_crepa_hidden_size` method in `simpletuner/helpers/models/common.py` to fall back to using the `dim` attribute if `hidden_size` is not present, improving compatibility with Z-Image and similar transformer configs.

**Testing enhancements:**

* Added a test `test_infer_crepa_hidden_size_uses_transformer_dim` in `tests/test_z_image_model.py` to verify that `_infer_crepa_hidden_size` correctly uses the `dim` attribute when present.