### PR TITLE
Fix safetensors checkpoint corruption caused by memory-mapped in-place overwrite

### DIFF
--- a/simpletuner/helpers/training/save_hooks.py
+++ b/simpletuner/helpers/training/save_hooks.py
@@ -349,7 +349,7 @@ class SaveHookManager:
             return False
         try:
             with safe_open(target_path, framework="pt", device="cpu") as handle:
-                tensors = {key: handle.get_tensor(key) for key in handle.keys()}
+                tensors = {key: handle.get_tensor(key).clone() for key in handle.keys()}
                 existing_metadata = handle.metadata() or {}
             combined_metadata = dict(existing_metadata)
             combined_metadata.update(metadata)


### PR DESCRIPTION
When _append_metadata_to_safetensors() reads tensors via safe_open() and then re-saves them to the same file path, the tensors are memory-mapped views into the original file. Writing to the same path truncates the file while the tensors still point at the now-invalid file memory, resulting in corrupted checkpoint data (all values become zero or extreme magnitudes like 1e-19 to 1e37 instead of normal bf16 magnitudes).

This causes all periodic checkpoint LoRA weights (subdirectory checkpoints like checkpoint-XXX/pytorch_lora_weights.safetensors) to produce completely black images during inference, while the root-level save (which skips this method) remains unaffected.

Tested this while fine-tuning a StableDiffusion3.5-Large with LoRa.

Fix: clone each tensor after reading to break the memory-mapped reference before overwriting the file.