### PR TITLE
(#2642) move jobs.db into machine-local storage instead of shared volume by default

### DIFF
--- a/simpletuner/cli/server.py
+++ b/simpletuner/cli/server.py
@@ -118,6 +118,16 @@ def _setup_ssl_config(ssl_key: Optional[str] = None, ssl_cert: Optional[str] = N
         return None
 
 
+def _ensure_server_state_dir() -> None:
+    """Keep server SQLite state local unless the user explicitly overrides it."""
+    if os.environ.get("SIMPLETUNER_STATE_DIR"):
+        return
+
+    from simpletuner.simpletuner_sdk.server.services.cloud.storage.base import get_local_state_dir
+
+    os.environ["SIMPLETUNER_STATE_DIR"] = str(get_local_state_dir())
+
+
 def cmd_server(args) -> int:
     """Handle server command."""
     host = getattr(args, "host", "0.0.0.0")
@@ -129,6 +139,8 @@ def cmd_server(args) -> int:
     ssl_cert = getattr(args, "ssl_cert", None)
     ssl_no_verify = getattr(args, "ssl_no_verify", False)
     env = getattr(args, "env", None)
+
+    _ensure_server_state_dir()
 
     if not os.environ.get("SIMPLETUNER_CONFIG_DIR"):
         webui_configs_dir = _get_webui_configs_dir()

--- a/simpletuner/service_worker.py
+++ b/simpletuner/service_worker.py
@@ -11,6 +11,11 @@ from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
+from simpletuner.simpletuner_sdk.server.services.cloud.storage.base import get_local_state_dir
+
+os.environ.setdefault("SIMPLETUNER_STATE_DIR", str(get_local_state_dir()))
+os.environ.setdefault("SIMPLETUNER_SERVER_ROOT_PID", str(os.getpid()))
+
 from simpletuner.simpletuner_sdk.configuration import Configuration
 
 # Import route modules
@@ -20,8 +25,6 @@ from simpletuner.simpletuner_sdk.server.routes.publishing import router as publi
 from simpletuner.simpletuner_sdk.server.routes.web import router as web_router
 from simpletuner.simpletuner_sdk.server.utils.paths import get_config_directory, get_static_directory, get_template_directory
 from simpletuner.simpletuner_sdk.training_host import TrainingHost
-
-os.environ.setdefault("SIMPLETUNER_SERVER_ROOT_PID", str(os.getpid()))
 
 
 # Pydantic models for request/response

--- a/simpletuner/simpletuner_sdk/server/services/cloud/async_job_store.py
+++ b/simpletuner/simpletuner_sdk/server/services/cloud/async_job_store.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -104,12 +105,16 @@ class AsyncJobStore:
             return cls._instance
 
     def _resolve_config_dir(self) -> Path:
-        """Resolve config directory from WebUIStateStore or default.
+        """Resolve the server state directory.
 
-        Returns the SimpleTuner root directory (e.g. /notebooks/simpletuner
-        or ~/.simpletuner). The database path is then constructed as
-        config_dir / "cloud" / "jobs.db".
+        Returns the SimpleTuner state root directory. The database path is then
+        constructed as state_dir / "cloud" / "jobs.db".
         """
+        from .storage.base import get_default_config_dir
+
+        if os.environ.get("SIMPLETUNER_STATE_DIR"):
+            return get_default_config_dir()
+
         try:
             from .webui_state import WebUIStateStore
 
@@ -119,8 +124,6 @@ class AsyncJobStore:
                 return Path(defaults.configs_dir)
             return store.base_dir.parent
         except Exception:
-            from .storage.base import get_default_config_dir
-
             return get_default_config_dir()
 
     async def _ensure_initialized(self) -> None:

--- a/simpletuner/simpletuner_sdk/server/services/cloud/storage/base.py
+++ b/simpletuner/simpletuner_sdk/server/services/cloud/storage/base.py
@@ -21,22 +21,42 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
-def get_default_config_dir() -> Path:
-    """Get the default configuration directory in a cross-platform manner.
+def get_local_state_dir() -> Path:
+    """Get the local per-machine SimpleTuner state directory.
 
-    Environment variable override:
-        SIMPLETUNER_CONFIG_DIR: If set, use this path directly (useful for testing)
+    This intentionally avoids shared ML workspace paths. SQLite-backed server
+    state should stay local to the machine unless explicitly configured.
+    """
+    if sys.platform == "win32":
+        base = Path(os.environ.get("APPDATA", Path.home() / "AppData" / "Roaming"))
+        return base / "SimpleTuner"
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "SimpleTuner"
+    return Path.home() / ".simpletuner"
+
+
+def get_default_config_dir() -> Path:
+    """Get the default server state directory in a cross-platform manner.
+
+    Environment variable overrides:
+        SIMPLETUNER_STATE_DIR: If set, use this path for server state.
+        SIMPLETUNER_CONFIG_DIR: Legacy fallback for tests/custom deployments.
 
     Returns:
-        Path to the configuration directory:
+        Path to the server state directory:
         - Windows: %APPDATA%/SimpleTuner
         - macOS: ~/Library/Application Support/SimpleTuner
         - Linux: /workspace/simpletuner, /notebooks/simpletuner, or ~/.simpletuner
     """
-    # Check for explicit override (testing, custom deployment)
+    state_override = os.environ.get("SIMPLETUNER_STATE_DIR")
+    if state_override:
+        return Path(state_override).expanduser()
+
+    # Legacy override retained for tests and deployments that already use it
+    # as a state root. New server entry points set SIMPLETUNER_STATE_DIR.
     override = os.environ.get("SIMPLETUNER_CONFIG_DIR")
     if override:
-        return Path(override)
+        return Path(override).expanduser()
 
     if sys.platform == "win32":
         base = Path(os.environ.get("APPDATA", Path.home() / "AppData" / "Roaming"))

--- a/simpletuner/simpletuner_sdk/server/webui_app.py
+++ b/simpletuner/simpletuner_sdk/server/webui_app.py
@@ -1,6 +1,11 @@
 """Create app instance for running with uvicorn."""
 
+import os
+
 from .app import create_unified_app
+from .services.cloud.storage.base import get_local_state_dir
+
+os.environ.setdefault("SIMPLETUNER_STATE_DIR", str(get_local_state_dir()))
 
 # Create the app instance
 app = create_unified_app()

--- a/tests/test_cloud_state_paths.py
+++ b/tests/test_cloud_state_paths.py
@@ -1,0 +1,66 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from simpletuner.cli.server import _ensure_server_state_dir
+from simpletuner.simpletuner_sdk.server.services.cloud.async_job_store import AsyncJobStore
+from simpletuner.simpletuner_sdk.server.services.cloud.storage.base import get_default_config_dir, get_default_db_path
+
+
+class TestCloudStatePaths(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self._tmpdir.name)
+        self._previous = {
+            "SIMPLETUNER_STATE_DIR": os.environ.get("SIMPLETUNER_STATE_DIR"),
+            "SIMPLETUNER_CONFIG_DIR": os.environ.get("SIMPLETUNER_CONFIG_DIR"),
+            "SIMPLETUNER_WEB_UI_CONFIG": os.environ.get("SIMPLETUNER_WEB_UI_CONFIG"),
+        }
+
+    def tearDown(self) -> None:
+        for key, value in self._previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        AsyncJobStore._instance = None
+        self._tmpdir.cleanup()
+
+    def test_state_dir_takes_precedence_over_config_dir(self) -> None:
+        state_dir = self.tmp_path / "local-state"
+        config_dir = self.tmp_path / "shared-config"
+        os.environ["SIMPLETUNER_STATE_DIR"] = str(state_dir)
+        os.environ["SIMPLETUNER_CONFIG_DIR"] = str(config_dir)
+
+        self.assertEqual(get_default_config_dir(), state_dir)
+        self.assertEqual(get_default_db_path("jobs.db"), state_dir / "cloud" / "jobs.db")
+
+    def test_async_job_store_uses_state_dir_before_webui_configs_dir(self) -> None:
+        state_dir = self.tmp_path / "local-state"
+        shared_configs = self.tmp_path / "shared" / "config"
+        webui_dir = self.tmp_path / "webui"
+        webui_dir.mkdir()
+        shared_configs.mkdir(parents=True)
+        (webui_dir / "defaults.json").write_text(
+            json.dumps({"configs_dir": str(shared_configs)}),
+            encoding="utf-8",
+        )
+        os.environ["SIMPLETUNER_STATE_DIR"] = str(state_dir)
+        os.environ["SIMPLETUNER_WEB_UI_CONFIG"] = str(webui_dir)
+
+        store = AsyncJobStore()
+
+        self.assertEqual(store.get_database_path(), state_dir / "cloud" / "jobs.db")
+
+    def test_server_sets_local_state_dir_when_unset(self) -> None:
+        os.environ.pop("SIMPLETUNER_STATE_DIR", None)
+
+        _ensure_server_state_dir()
+
+        self.assertEqual(Path(os.environ["SIMPLETUNER_STATE_DIR"]).expanduser(), get_default_config_dir())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request refactors how the server state directory is determined and set for SimpleTuner, ensuring that SQLite-backed server state is kept local to the machine by default. It introduces a new function for local state directory resolution, updates environment variable handling for state/config directories, and adds comprehensive tests to verify the new logic.

**Server State Directory Handling Improvements:**

* Added `get_local_state_dir()` in `storage/base.py` to explicitly determine a per-machine state directory, avoiding shared workspace paths.
* Updated `get_default_config_dir()` to prioritize the `SIMPLETUNER_STATE_DIR` environment variable, with `SIMPLETUNER_CONFIG_DIR` as a legacy fallback.
* Introduced `_ensure_server_state_dir()` in `cli/server.py` and invoked it in `cmd_server()` to ensure the state directory is set at server startup. [[1]](diffhunk://#diff-5d76858dd57a5ad3e8b7753dc4da38f1ced3397696ef35c9312dd530dbe512c6R121-R130) [[2]](diffhunk://#diff-5d76858dd57a5ad3e8b7753dc4da38f1ced3397696ef35c9312dd530dbe512c6R143-R144)
* Updated entry points (`service_worker.py`, `webui_app.py`) to set `SIMPLETUNER_STATE_DIR` using `get_local_state_dir()` if not already set. [[1]](diffhunk://#diff-0740585010501d9bc77e00b55f2ba300fd6f79e5c36bfb7f35ffbad10dec692bR14-R18) [[2]](diffhunk://#diff-21c7b7c876090185b0c417d455139f5d57e3675eab541bcc31cdc555cd135e8fR3-R8)

**Async Job Store Logic:**

* Modified `AsyncJobStore._resolve_config_dir()` to check for `SIMPLETUNER_STATE_DIR` first, ensuring consistent state directory usage across the server. [[1]](diffhunk://#diff-398a7bb9e5e0e366dc088d4a6b17676f64356875d8a3bfb4e272d7444b043f20L107-R117) [[2]](diffhunk://#diff-398a7bb9e5e0e366dc088d4a6b17676f64356875d8a3bfb4e272d7444b043f20L122-L123)

**Testing:**

* Added `tests/test_cloud_state_paths.py` to verify correct precedence and behavior of state/config directory resolution and environment variable overrides.