### PR TITLE
(#2712) check whether any ranks have completed their epoch, and force all ranks to follow

### DIFF
--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -345,6 +345,24 @@ class Trainer:
         except Exception:
             return False
 
+    def _distributed_collectives_ready(self) -> bool:
+        try:
+            num_processes = int(getattr(self.accelerator, "num_processes", 1) or 1)
+        except (TypeError, ValueError):
+            num_processes = 1
+        return num_processes > 1 and torch.distributed.is_available() and torch.distributed.is_initialized()
+
+    def _any_rank_reached_epoch_end(self, reached_epoch_end: bool) -> bool:
+        if not self._distributed_collectives_ready():
+            return reached_epoch_end
+
+        device = getattr(self.accelerator, "device", None)
+        if device is None:
+            device = torch.device("cuda", torch.cuda.current_device()) if torch.cuda.is_available() else torch.device("cpu")
+        local_flag = torch.tensor(1 if reached_epoch_end else 0, device=device, dtype=torch.int32)
+        torch.distributed.all_reduce(local_flag, op=torch.distributed.ReduceOp.MAX)
+        return bool(local_flag.item())
+
     def _register_optimizer_attention_params(self, optimizer) -> None:
         try:
             from simpletuner.helpers.training.optimizers.muon import MuonClip
@@ -5609,8 +5627,12 @@ class Trainer:
                         f"Epoch {self.state['current_epoch']}/{self.config.num_train_epochs}, Steps"
                     )
 
-                # If we receive a False from the enumerator, we know we reached the next epoch.
-                if prepared_batch is False:
+                local_epoch_end = prepared_batch is False
+                epoch_end_reached = self._any_rank_reached_epoch_end(local_epoch_end)
+                # If any rank receives False from the enumerator, all ranks must leave the step loop together.
+                if epoch_end_reached:
+                    if not local_epoch_end:
+                        training_logger.debug("Reached the end of epoch because another rank exhausted its dataloader.")
                     if (
                         self._should_checkpoint_epoch(epoch)
                         and not last_step_saved_checkpoint

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -617,6 +617,39 @@ class TestTrainer(unittest.TestCase):
         trainer.grad_norm = grad_value
         return trainer
 
+    def test_any_rank_reached_epoch_end_returns_local_value_without_process_group(self):
+        trainer = object.__new__(Trainer)
+        trainer.accelerator = SimpleNamespace(num_processes=8, device=torch.device("cpu"))
+
+        with (
+            patch("simpletuner.helpers.training.trainer.torch.distributed.is_available", return_value=True),
+            patch("simpletuner.helpers.training.trainer.torch.distributed.is_initialized", return_value=False),
+            patch("simpletuner.helpers.training.trainer.torch.distributed.all_reduce") as mock_all_reduce,
+        ):
+            self.assertTrue(trainer._any_rank_reached_epoch_end(True))
+            self.assertFalse(trainer._any_rank_reached_epoch_end(False))
+
+        mock_all_reduce.assert_not_called()
+
+    def test_any_rank_reached_epoch_end_uses_max_across_distributed_ranks(self):
+        trainer = object.__new__(Trainer)
+        trainer.accelerator = SimpleNamespace(num_processes=8, device=torch.device("cpu"))
+
+        def mark_remote_epoch_end(tensor, op=None):
+            tensor.fill_(1)
+
+        with (
+            patch("simpletuner.helpers.training.trainer.torch.distributed.is_available", return_value=True),
+            patch("simpletuner.helpers.training.trainer.torch.distributed.is_initialized", return_value=True),
+            patch(
+                "simpletuner.helpers.training.trainer.torch.distributed.all_reduce",
+                side_effect=mark_remote_epoch_end,
+            ) as mock_all_reduce,
+        ):
+            self.assertTrue(trainer._any_rank_reached_epoch_end(False))
+
+        mock_all_reduce.assert_called_once()
+
     @patch("simpletuner.helpers.training.trainer.load_config")
     @patch("simpletuner.helpers.training.trainer.safety_check")
     @patch("simpletuner.helpers.training.state_tracker.StateTracker")


### PR DESCRIPTION
Closes #2712 

This pull request improves distributed training reliability and synchronization in the `Trainer` class by ensuring all distributed ranks exit the training loop at the same time when any rank exhausts its dataloader. It introduces new helper methods for distributed collectives, updates the training loop logic, and adds comprehensive tests to verify correct behavior.

**Distributed training synchronization:**

* Added `_distributed_collectives_ready` and `_any_rank_reached_epoch_end` helper methods to `Trainer`, enabling detection of distributed context and collective agreement on epoch end across all ranks. Now, if any rank reaches the end of its dataloader, all ranks exit the step loop together. (`trainer.py`)
* Updated the main training loop to use `_any_rank_reached_epoch_end`, ensuring synchronized epoch transitions and improved logging when a rank exits due to another's dataloader exhaustion. (`trainer.py`)

**Testing improvements:**

* Added unit tests for `_any_rank_reached_epoch_end` to verify correct local behavior without a process group and correct distributed synchronization using `all_reduce`. (`test_trainer.py`)