### PR TITLE
(#2615) use NV_GPU for visible device list

### DIFF
--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -6596,6 +6596,16 @@ def run_trainer_job(config):
             if tokens:
                 selected_device_ids = tokens
 
+    def _normalize_visible_device_list(value: Optional[str]) -> Optional[str]:
+        if not isinstance(value, str):
+            return None
+        tokens = [token.strip() for token in value.split(",") if token.strip()]
+        if not tokens:
+            return None
+        if len(tokens) == 1 and tokens[0].lower() in {"all", "none", "void"}:
+            return None
+        return ",".join(tokens)
+
     def _resolve_hf_token() -> Optional[str]:
         possible_env_vars = (
             "HUGGINGFACEHUB_API_TOKEN",
@@ -6847,6 +6857,12 @@ def run_trainer_job(config):
 
         if selected_device_ids:
             launch_env["CUDA_VISIBLE_DEVICES"] = ",".join(selected_device_ids)
+        elif not _normalize_visible_device_list(launch_env.get("CUDA_VISIBLE_DEVICES")):
+            provider_visible_devices = _normalize_visible_device_list(launch_env.get("NV_GPU"))
+            if provider_visible_devices is None:
+                provider_visible_devices = _normalize_visible_device_list(launch_env.get("NVIDIA_VISIBLE_DEVICES"))
+            if provider_visible_devices is not None:
+                launch_env["CUDA_VISIBLE_DEVICES"] = provider_visible_devices
 
         config_backend_value: Optional[str] = None
         config_env_value: Optional[str] = None
@@ -6937,11 +6953,36 @@ def run_trainer_job(config):
         if signal_file_path:
             launch_env["SIMPLETUNER_ACCELERATE_SIGNAL_FILE"] = str(signal_file_path)
 
+        extra_args = []
+        if accelerate_extra_args:
+            try:
+                extra_args = shlex.split(str(accelerate_extra_args))
+            except ValueError:
+                launch_logger.warning("Failed to parse accelerate extra args; using raw string")
+                extra_args = [str(accelerate_extra_args)]
+
+        def _has_accelerate_distributed_selector(args: list[str]) -> bool:
+            selectors = {
+                "--multi_gpu",
+                "--cpu",
+                "--tpu",
+                "--use_deepspeed",
+                "--use_fsdp",
+                "--use_megatron_lm",
+            }
+            for arg in args:
+                option = arg.split("=", 1)[0]
+                if option in selectors:
+                    return True
+            return False
+
         cmd = ["accelerate", "launch"]
 
         if config_file_arg:
             cmd.append(f"--config_file={config_file_arg}")
         else:
+            if proc_count > 1 and not _has_accelerate_distributed_selector(extra_args):
+                cmd.append("--multi_gpu")
             cmd.extend(
                 [
                     f"--mixed_precision={launch_env.get('MIXED_PRECISION', 'bf16')}",
@@ -6957,13 +6998,6 @@ def run_trainer_job(config):
                 if same_network_value:
                     cmd.append("--same_network")
 
-        extra_args = []
-        if accelerate_extra_args:
-            try:
-                extra_args = shlex.split(str(accelerate_extra_args))
-            except ValueError:
-                launch_logger.warning("Failed to parse accelerate extra args; using raw string")
-                extra_args = [str(accelerate_extra_args)]
         if extra_args:
             cmd.extend(extra_args)
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -3,6 +3,7 @@
 import importlib.machinery as machinery
 import importlib.util as _importlib_util
 import json
+import os
 import shutil
 import sys
 import tempfile
@@ -846,7 +847,7 @@ class TestTrainer(unittest.TestCase):
         self.assertTrue(instance.abort_called)
         self.assertTrue(instance.should_abort)
 
-    def test_run_trainer_job_honours_single_device_selection(self):
+    def _run_trainer_job_with_captured_popen(self, payload):
         from simpletuner.helpers.training import trainer as trainer_module
 
         captured = {}
@@ -882,18 +883,57 @@ class TestTrainer(unittest.TestCase):
             return DummyProcess()
 
         with patch("subprocess.Popen", side_effect=fake_popen):
-            result = trainer_module.run_trainer_job(
-                {
-                    "accelerate_visible_devices": [1],
-                    "--num_processes": 1,
-                }
-            )
+            result = trainer_module.run_trainer_job(payload)
 
-            self.assertEqual(result, 0)
+        return result, captured
+
+    def test_run_trainer_job_honours_single_device_selection(self):
+        result, captured = self._run_trainer_job_with_captured_popen(
+            {
+                "accelerate_visible_devices": [1],
+                "--num_processes": 1,
+            }
+        )
+
+        self.assertEqual(result, 0)
         self.assertIn("cmd", captured)
         self.assertEqual(captured["cmd"][0], "accelerate")
         self.assertEqual(captured["env"].get("CUDA_VISIBLE_DEVICES"), "1")
         self.assertFalse(any("--accelerate_visible_devices" in arg for arg in captured["cmd"]))
+
+    def test_run_trainer_job_enables_multi_gpu_for_multiple_processes(self):
+        result, captured = self._run_trainer_job_with_captured_popen(
+            {
+                "accelerate_visible_devices": [2, 3],
+                "--num_processes": 2,
+            }
+        )
+
+        self.assertEqual(result, 0)
+        self.assertIn("--multi_gpu", captured["cmd"])
+        self.assertIn("--num_processes=2", captured["cmd"])
+        self.assertEqual(captured["env"].get("CUDA_VISIBLE_DEVICES"), "2,3")
+
+    def test_run_trainer_job_uses_provider_gpu_assignment_when_unset(self):
+        with patch.dict(os.environ, {"NV_GPU": "2,3", "NVIDIA_VISIBLE_DEVICES": "all"}, clear=False):
+            os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+            result, captured = self._run_trainer_job_with_captured_popen({"--num_processes": 2})
+
+        self.assertEqual(result, 0)
+        self.assertIn("--multi_gpu", captured["cmd"])
+        self.assertEqual(captured["env"].get("CUDA_VISIBLE_DEVICES"), "2,3")
+
+    def test_run_trainer_job_does_not_duplicate_accelerate_selector(self):
+        result, captured = self._run_trainer_job_with_captured_popen(
+            {
+                "--num_processes": 2,
+                "accelerate_extra_args": "--use_fsdp",
+            }
+        )
+
+        self.assertEqual(result, 0)
+        self.assertNotIn("--multi_gpu", captured["cmd"])
+        self.assertIn("--use_fsdp", captured["cmd"])
 
     def test_accelerate_manual_triggers_are_relayed(self):
         from simpletuner.helpers.training import trainer as trainer_module


### PR DESCRIPTION
Closes #2615

This pull request improves how device selection and process launching are handled in the training workflow, and adds comprehensive tests to ensure correct behavior in various scenarios. The main changes include normalizing device selection logic, ensuring provider GPU assignments are respected, preventing duplicate accelerator flags, and enhancing test coverage for these cases.

**Device selection and environment handling:**
- Added a `_normalize_visible_device_list` helper to robustly parse and validate device lists from environment variables, ensuring consistent device selection logic.
- Updated the process launch logic to use provider GPU assignments (from `NV_GPU` or `NVIDIA_VISIBLE_DEVICES`) as a fallback when `CUDA_VISIBLE_DEVICES` is unset, after normalization.

**Accelerate launch command improvements:**
- Added logic to automatically append `--multi_gpu` to the `accelerate launch` command when multiple processes are requested, unless a mutually exclusive accelerator selector (like `--use_fsdp`) is already present in extra args, preventing duplicate or conflicting flags.
- Refactored the code for parsing extra accelerator arguments and selector detection, improving maintainability and correctness. [[1]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R6956-R6985) [[2]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27L6960-L6966)

**Test enhancements:**
- Refactored and expanded tests in `tests/test_trainer.py` to cover single and multi-GPU selection, provider GPU assignment fallback, and prevention of duplicate accelerator flags, ensuring the new logic is robust and correct. [[1]](diffhunk://#diff-9f4241cfae54a446e69be20582f2536fa636341a35714881b1ad7dcf7000e371L849-R850) [[2]](diffhunk://#diff-9f4241cfae54a446e69be20582f2536fa636341a35714881b1ad7dcf7000e371L885-R891) [[3]](diffhunk://#diff-9f4241cfae54a446e69be20582f2536fa636341a35714881b1ad7dcf7000e371R904-R937)