### PR TITLE
(#2613) add option --delete_invalid_checkpoints

### DIFF
--- a/documentation/OPTIONS.es.md
+++ b/documentation/OPTIONS.es.md
@@ -1455,6 +1455,13 @@ Mapeo de opciones upstream (LayerSync → SimpleTuner):
 
 > ℹ️ Los modelos transformer como PixArt, SD3 o Hunyuan usan los nombres de subcarpeta `transformer` y `transformer_ema`.
 
+### `--delete_invalid_checkpoints`
+
+- **Qué**: Elimina checkpoints locales que no puedan cargarse al reanudar.
+- **Comportamiento**: Con `--resume_from_checkpoint=latest`, SimpleTuner elimina checkpoints locales inválidos e intenta el siguiente checkpoint más reciente. Los checkpoints nuevos escriben un archivo `.guard` después de guardar los archivos necesarios para reanudar, por lo que un checkpoint más nuevo sin ese guard puede descartarse cuando existe un checkpoint anterior con guard.
+- **Seguridad**: Solo se eliminan directorios de checkpoint locales dentro de `output_dir`. Las rutas explícitas de checkpoint siguen mostrando el fallo original de carga después de la eliminación.
+- **Predeterminado**: `false`
+
 ### `--disk_low_threshold`
 
 - **Qué**: Espacio mínimo libre en disco requerido antes de guardar checkpoints.
@@ -1744,6 +1751,7 @@ usage: train.py [-h] --model_family
                 [--checkpoint_epoch_interval CHECKPOINT_EPOCH_INTERVAL]
                 [--checkpointing_rolling_steps CHECKPOINTING_ROLLING_STEPS]
                 [--checkpointing_use_tempdir [CHECKPOINTING_USE_TEMPDIR]]
+                [--delete_invalid_checkpoints [DELETE_INVALID_CHECKPOINTS]]
                 [--checkpoints_rolling_total_limit CHECKPOINTS_ROLLING_TOTAL_LIMIT]
                 [--tracker_run_name TRACKER_RUN_NAME]
                 [--tracker_project_name TRACKER_PROJECT_NAME]
@@ -2440,6 +2448,9 @@ options:
   --checkpointing_use_tempdir [CHECKPOINTING_USE_TEMPDIR]
                         Use temporary directory for checkpoint files before
                         final save
+  --delete_invalid_checkpoints [DELETE_INVALID_CHECKPOINTS]
+                        Delete local checkpoints that cannot be loaded while
+                        resuming.
   --checkpoints_rolling_total_limit CHECKPOINTS_ROLLING_TOTAL_LIMIT
                         Maximum number of rolling checkpoints to keep
   --tracker_run_name TRACKER_RUN_NAME

--- a/documentation/OPTIONS.hi.md
+++ b/documentation/OPTIONS.hi.md
@@ -1453,6 +1453,13 @@ Upstream option mapping (LayerSync → SimpleTuner):
 
 > ℹ️ PixArt, SD3, या Hunyuan जैसे transformer मॉडल `transformer` और `transformer_ema` subfolder नाम उपयोग करते हैं।
 
+### `--delete_invalid_checkpoints`
+
+- **What**: resume करते समय जो local checkpoints load नहीं हो सकते उन्हें delete करें।
+- **Behavior**: `--resume_from_checkpoint=latest` के साथ SimpleTuner invalid local checkpoints हटाकर next latest checkpoint आज़माता है। नए checkpoints resume के लिए जरूरी files सेव होने के बाद `.guard` file लिखते हैं, इसलिए किसी पुराने guarded checkpoint के मौजूद होने पर बिना guard वाला नया checkpoint discard किया जा सकता है।
+- **Safety**: केवल `output_dir` के अंदर local checkpoint directories delete होते हैं। explicit checkpoint paths deletion के बाद भी original load failure raise करते हैं।
+- **Default**: `false`
+
 ### `--disk_low_threshold`
 
 - **What**: checkpoint saves से पहले आवश्यक न्यूनतम खाली disk space।
@@ -1742,6 +1749,7 @@ usage: train.py [-h] --model_family
                 [--checkpoint_epoch_interval CHECKPOINT_EPOCH_INTERVAL]
                 [--checkpointing_rolling_steps CHECKPOINTING_ROLLING_STEPS]
                 [--checkpointing_use_tempdir [CHECKPOINTING_USE_TEMPDIR]]
+                [--delete_invalid_checkpoints [DELETE_INVALID_CHECKPOINTS]]
                 [--checkpoints_rolling_total_limit CHECKPOINTS_ROLLING_TOTAL_LIMIT]
                 [--tracker_run_name TRACKER_RUN_NAME]
                 [--tracker_project_name TRACKER_PROJECT_NAME]
@@ -2438,6 +2446,9 @@ options:
   --checkpointing_use_tempdir [CHECKPOINTING_USE_TEMPDIR]
                         Use temporary directory for checkpoint files before
                         final save
+  --delete_invalid_checkpoints [DELETE_INVALID_CHECKPOINTS]
+                        Delete local checkpoints that cannot be loaded while
+                        resuming.
   --checkpoints_rolling_total_limit CHECKPOINTS_ROLLING_TOTAL_LIMIT
                         Maximum number of rolling checkpoints to keep
   --tracker_run_name TRACKER_RUN_NAME

--- a/documentation/OPTIONS.ja.md
+++ b/documentation/OPTIONS.ja.md
@@ -1457,6 +1457,13 @@ LayerSync は同一 Transformer 内の「学生」レイヤーを、より強い
 
 > ℹ️ PixArt、SD3、Hunyuan などの Transformer モデルは `transformer` と `transformer_ema` のサブフォルダ名を使用します。
 
+### `--delete_invalid_checkpoints`
+
+- **内容**: 再開時に読み込めないローカルチェックポイントを削除します。
+- **動作**: `--resume_from_checkpoint=latest` では、SimpleTuner は無効なローカルチェックポイントを削除し、次に新しいチェックポイントを試します。新しいチェックポイントは再開に必要なファイルを保存した後に `.guard` ファイルを書き込むため、より新しいチェックポイントにその guard がなく、古い guarded チェックポイントがある場合は破棄できます。
+- **安全性**: 削除対象は `output_dir` 配下のローカルチェックポイントディレクトリだけです。明示的なチェックポイントパスでは、削除後も元の読み込み失敗を送出します。
+- **既定**: `false`
+
 ### `--disk_low_threshold`
 
 - **内容**: チェックポイント保存前に必要な最小空きディスク容量。
@@ -1746,6 +1753,7 @@ usage: train.py [-h] --model_family
                 [--checkpoint_epoch_interval CHECKPOINT_EPOCH_INTERVAL]
                 [--checkpointing_rolling_steps CHECKPOINTING_ROLLING_STEPS]
                 [--checkpointing_use_tempdir [CHECKPOINTING_USE_TEMPDIR]]
+                [--delete_invalid_checkpoints [DELETE_INVALID_CHECKPOINTS]]
                 [--checkpoints_rolling_total_limit CHECKPOINTS_ROLLING_TOTAL_LIMIT]
                 [--tracker_run_name TRACKER_RUN_NAME]
                 [--tracker_project_name TRACKER_PROJECT_NAME]
@@ -2441,6 +2449,9 @@ options:
   --checkpointing_use_tempdir [CHECKPOINTING_USE_TEMPDIR]
                         Use temporary directory for checkpoint files before
                         final save
+  --delete_invalid_checkpoints [DELETE_INVALID_CHECKPOINTS]
+                        Delete local checkpoints that cannot be loaded while
+                        resuming.
   --checkpoints_rolling_total_limit CHECKPOINTS_ROLLING_TOTAL_LIMIT
                         Maximum number of rolling checkpoints to keep
   --tracker_run_name TRACKER_RUN_NAME

--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -1460,6 +1460,13 @@ Upstream option mapping (LayerSync → SimpleTuner):
 
 > ℹ️ Transformer models such as PixArt, SD3, or Hunyuan, use the `transformer` and `transformer_ema` subfolder names.
 
+### `--delete_invalid_checkpoints`
+
+- **What**: Delete local checkpoints that cannot be loaded while resuming.
+- **Behavior**: With `--resume_from_checkpoint=latest`, SimpleTuner removes invalid local checkpoints and retries the next latest checkpoint. New checkpoints write a `.guard` file after the required resume files are saved, so a newer checkpoint missing that guard can be discarded when an older guarded checkpoint exists.
+- **Safety**: Only local checkpoint directories under `output_dir` are deleted. Explicit checkpoint paths still raise the original load failure after deletion.
+- **Default**: `false`
+
 ### `--disk_low_threshold`
 
 - **What**: Minimum free disk space required before checkpoint saves.
@@ -1749,6 +1756,7 @@ usage: train.py [-h] --model_family
                 [--checkpoint_epoch_interval CHECKPOINT_EPOCH_INTERVAL]
                 [--checkpointing_rolling_steps CHECKPOINTING_ROLLING_STEPS]
                 [--checkpointing_use_tempdir [CHECKPOINTING_USE_TEMPDIR]]
+                [--delete_invalid_checkpoints [DELETE_INVALID_CHECKPOINTS]]
                 [--checkpoints_rolling_total_limit CHECKPOINTS_ROLLING_TOTAL_LIMIT]
                 [--tracker_run_name TRACKER_RUN_NAME]
                 [--tracker_project_name TRACKER_PROJECT_NAME]
@@ -2445,6 +2453,9 @@ options:
   --checkpointing_use_tempdir [CHECKPOINTING_USE_TEMPDIR]
                         Use temporary directory for checkpoint files before
                         final save
+  --delete_invalid_checkpoints [DELETE_INVALID_CHECKPOINTS]
+                        Delete local checkpoints that cannot be loaded while
+                        resuming.
   --checkpoints_rolling_total_limit CHECKPOINTS_ROLLING_TOTAL_LIMIT
                         Maximum number of rolling checkpoints to keep
   --tracker_run_name TRACKER_RUN_NAME

--- a/documentation/OPTIONS.pt-BR.md
+++ b/documentation/OPTIONS.pt-BR.md
@@ -1451,6 +1451,13 @@ Mapeamento de opcoes upstream (LayerSync → SimpleTuner):
 
 > ℹ️ Modelos transformer como PixArt, SD3 ou Hunyuan usam os subdiretorios `transformer` e `transformer_ema`.
 
+### `--delete_invalid_checkpoints`
+
+- **O que**: Remove checkpoints locais que nao podem ser carregados ao retomar.
+- **Comportamento**: Com `--resume_from_checkpoint=latest`, o SimpleTuner remove checkpoints locais invalidos e tenta o proximo checkpoint mais recente. Checkpoints novos gravam um arquivo `.guard` depois que os arquivos necessarios para retomada sao salvos, entao um checkpoint mais novo sem esse guard pode ser descartado quando existe um checkpoint anterior com guard.
+- **Seguranca**: Somente diretorios locais de checkpoint dentro de `output_dir` sao removidos. Caminhos explicitos de checkpoint ainda levantam a falha original de carregamento depois da remocao.
+- **Padrao**: `false`
+
 ### `--disk_low_threshold`
 
 - **O que**: Espaco minimo livre em disco necessario antes de salvar checkpoints.
@@ -1740,6 +1747,7 @@ usage: train.py [-h] --model_family
                 [--checkpoint_epoch_interval CHECKPOINT_EPOCH_INTERVAL]
                 [--checkpointing_rolling_steps CHECKPOINTING_ROLLING_STEPS]
                 [--checkpointing_use_tempdir [CHECKPOINTING_USE_TEMPDIR]]
+                [--delete_invalid_checkpoints [DELETE_INVALID_CHECKPOINTS]]
                 [--checkpoints_rolling_total_limit CHECKPOINTS_ROLLING_TOTAL_LIMIT]
                 [--tracker_run_name TRACKER_RUN_NAME]
                 [--tracker_project_name TRACKER_PROJECT_NAME]
@@ -2435,6 +2443,9 @@ options:
   --checkpointing_use_tempdir [CHECKPOINTING_USE_TEMPDIR]
                         Use temporary directory for checkpoint files before
                         final save
+  --delete_invalid_checkpoints [DELETE_INVALID_CHECKPOINTS]
+                        Delete local checkpoints that cannot be loaded while
+                        resuming.
   --checkpoints_rolling_total_limit CHECKPOINTS_ROLLING_TOTAL_LIMIT
                         Maximum number of rolling checkpoints to keep
   --tracker_run_name TRACKER_RUN_NAME

--- a/documentation/OPTIONS.zh.md
+++ b/documentation/OPTIONS.zh.md
@@ -1459,6 +1459,13 @@ LayerSync 通过在同一 Transformer 内让“学生”层对齐更强的“教
 
 > ℹ️ PixArt、SD3、Hunyuan 等 Transformer 模型使用 `transformer` 与 `transformer_ema` 子目录名称。
 
+### `--delete_invalid_checkpoints`
+
+- **内容**：恢复时删除无法加载的本地检查点。
+- **行为**：使用 `--resume_from_checkpoint=latest` 时，SimpleTuner 会删除无效的本地检查点并尝试下一个最新检查点。新的检查点会在保存恢复所需文件后写入 `.guard` 文件，因此当存在较旧的 guarded 检查点时，可以丢弃缺少该 guard 的较新检查点。
+- **安全性**：只会删除 `output_dir` 下的本地检查点目录。显式检查点路径在删除后仍会抛出原始加载失败。
+- **默认**：`false`
+
 ### `--disk_low_threshold`
 
 - **内容**：检查点保存前所需的最小可用磁盘空间。
@@ -1748,6 +1755,7 @@ usage: train.py [-h] --model_family
                 [--checkpoint_epoch_interval CHECKPOINT_EPOCH_INTERVAL]
                 [--checkpointing_rolling_steps CHECKPOINTING_ROLLING_STEPS]
                 [--checkpointing_use_tempdir [CHECKPOINTING_USE_TEMPDIR]]
+                [--delete_invalid_checkpoints [DELETE_INVALID_CHECKPOINTS]]
                 [--checkpoints_rolling_total_limit CHECKPOINTS_ROLLING_TOTAL_LIMIT]
                 [--tracker_run_name TRACKER_RUN_NAME]
                 [--tracker_project_name TRACKER_PROJECT_NAME]
@@ -2443,6 +2451,9 @@ options:
   --checkpointing_use_tempdir [CHECKPOINTING_USE_TEMPDIR]
                         Use temporary directory for checkpoint files before
                         final save
+  --delete_invalid_checkpoints [DELETE_INVALID_CHECKPOINTS]
+                        Delete local checkpoints that cannot be loaded while
+                        resuming.
   --checkpoints_rolling_total_limit CHECKPOINTS_ROLLING_TOTAL_LIMIT
                         Maximum number of rolling checkpoints to keep
   --tracker_run_name TRACKER_RUN_NAME

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -86,7 +86,11 @@ from simpletuner.helpers.training.state_tracker import StateTracker
 from simpletuner.helpers.training.validation import Validation, prepare_validation_prompt_list
 from simpletuner.helpers.training.wrappers import unwrap_model
 from simpletuner.helpers.utils import ramtorch as ramtorch_utils
-from simpletuner.helpers.utils.checkpoint_manager import CHECKPOINT_MANIFEST_FILENAME, CheckpointManager
+from simpletuner.helpers.utils.checkpoint_manager import (
+    CHECKPOINT_GUARD_FILENAME,
+    CHECKPOINT_MANIFEST_FILENAME,
+    CheckpointManager,
+)
 from simpletuner.helpers.webhooks.events import (
     attach_timestamp,
     checkpoint_event,
@@ -4117,6 +4121,48 @@ class Trainer:
             metadata["modelspec_architecture"] = self.model_hooks.get_modelspec_architecture()
         return {key: value for key, value in metadata.items() if value not in (None, "")}
 
+    def _checkpoint_dir_is_in_output_dir(self, checkpoint_dir: str) -> bool:
+        output_dir = getattr(self.config, "output_dir", None)
+        if not output_dir:
+            return False
+        try:
+            return os.path.commonpath([os.path.abspath(output_dir), os.path.abspath(checkpoint_dir)]) == os.path.abspath(
+                output_dir
+            )
+        except ValueError:
+            return False
+
+    def _checkpoint_has_guard(self, checkpoint_name: str, checkpoint_dir: str) -> bool:
+        if self.checkpoint_manager and self._checkpoint_dir_is_in_output_dir(checkpoint_dir):
+            return self.checkpoint_manager.has_guard(checkpoint_name)
+        return os.path.exists(os.path.join(checkpoint_dir, CHECKPOINT_GUARD_FILENAME))
+
+    def _delete_invalid_resume_checkpoint(self, checkpoint_dir: str, reason: str) -> bool:
+        checkpoint_name = os.path.basename(checkpoint_dir.rstrip(os.sep))
+        if not checkpoint_name.startswith("checkpoint-"):
+            logger.warning(f"Refusing to delete invalid resume path outside checkpoint naming: {checkpoint_dir}")
+            return False
+        if not self._checkpoint_dir_is_in_output_dir(checkpoint_dir):
+            logger.warning(f"Refusing to delete invalid checkpoint outside output_dir: {checkpoint_dir}")
+            return False
+
+        logger.warning(f"Deleting invalid checkpoint {checkpoint_dir}: {reason}")
+        self.checkpoint_state_remove(self.config.output_dir, checkpoint_name)
+        return True
+
+    def _delete_unguarded_latest_checkpoint(self, checkpoint_name: str, checkpoint_dir: str) -> bool:
+        if self._checkpoint_has_guard(checkpoint_name, checkpoint_dir):
+            return False
+        latest_guarded = (
+            self.checkpoint_manager.get_latest_checkpoint(require_guard=True) if self.checkpoint_manager else None
+        )
+        if latest_guarded in (None, checkpoint_name):
+            return False
+        return self._delete_invalid_resume_checkpoint(
+            checkpoint_dir,
+            f"missing checkpoint completion guard {CHECKPOINT_GUARD_FILENAME}",
+        )
+
     def init_resume_checkpoint(self, lr_scheduler):
         # Potentially load in the weights and states from a previous save
         self.config.total_steps_remaining_at_start = self.config.max_train_steps
@@ -4127,35 +4173,69 @@ class Trainer:
             logger.info(f"Not resuming from checkpoint.")
             return lr_scheduler
         resume_value = str(self.config.resume_from_checkpoint)
-        checkpoint_dir = None
-        if resume_value != "latest" and self._resume_path_is_remote(resume_value):
-            checkpoint_dir = self._download_remote_checkpoint(resume_value)
-            path = os.path.basename(checkpoint_dir.rstrip("/"))
-        elif resume_value != "latest":
-            path = os.path.basename(resume_value.rstrip("/"))
-        else:
-            # Get the most recent checkpoint
-            path = self.checkpoint_state_latest(self.config.output_dir)
-            logger.info(f"Checking {path} for latest checkpoint.")
+        delete_invalid_value = getattr(self.config, "delete_invalid_checkpoints", False)
+        if isinstance(delete_invalid_value, unittest_mock.Mock):
+            delete_invalid_value = False
+        delete_invalid_checkpoints = bool(delete_invalid_value)
+        resume_latest = resume_value == "latest"
+        deleted_checkpoint_names: set[str] = set()
 
-        if path is None:
-            logger.info(f"Checkpoint '{self.config.resume_from_checkpoint}' does not exist. Starting a new training run.")
-            event = lifecycle_stage_event(
-                key="init_resume_checkpoint",
-                label="Resume Checkpoint",
-                status="completed",
-                message="No model to resume. Beginning fresh training run.",
-                job_id=self.job_id,
-            )
-            self._emit_event(event)
+        while True:
+            checkpoint_dir = None
+            if resume_value != "latest" and self._resume_path_is_remote(resume_value):
+                checkpoint_dir = self._download_remote_checkpoint(resume_value)
+                path = os.path.basename(checkpoint_dir.rstrip("/"))
+            elif resume_value != "latest":
+                path = os.path.basename(resume_value.rstrip("/"))
+            else:
+                # Get the most recent checkpoint
+                path = self.checkpoint_state_latest(self.config.output_dir)
+                logger.info(f"Checking {path} for latest checkpoint.")
 
-            self.config.resume_from_checkpoint = None
-            return lr_scheduler
+            if path is None:
+                logger.info(
+                    f"Checkpoint '{self.config.resume_from_checkpoint}' does not exist. Starting a new training run."
+                )
+                event = lifecycle_stage_event(
+                    key="init_resume_checkpoint",
+                    label="Resume Checkpoint",
+                    status="completed",
+                    message="No model to resume. Beginning fresh training run.",
+                    job_id=self.job_id,
+                )
+                self._emit_event(event)
 
-        if checkpoint_dir is None:
-            checkpoint_dir = os.path.join(self.config.output_dir, path)
-        logger.info(f"Resuming from checkpoint {checkpoint_dir}")
-        self.accelerator.load_state(checkpoint_dir)
+                self.config.resume_from_checkpoint = None
+                return lr_scheduler
+
+            if path in deleted_checkpoint_names:
+                raise RuntimeError(f"Invalid checkpoint {path} was not removed; refusing to retry it.")
+
+            if checkpoint_dir is None:
+                checkpoint_dir = os.path.join(self.config.output_dir, path)
+
+            if (
+                delete_invalid_checkpoints
+                and resume_latest
+                and self._delete_unguarded_latest_checkpoint(path, checkpoint_dir)
+            ):
+                deleted_checkpoint_names.add(path)
+                continue
+
+            logger.info(f"Resuming from checkpoint {checkpoint_dir}")
+            try:
+                self.accelerator.load_state(checkpoint_dir)
+            except Exception as exc:
+                if not delete_invalid_checkpoints:
+                    raise
+                if not self._delete_invalid_resume_checkpoint(checkpoint_dir, str(exc)):
+                    raise
+                deleted_checkpoint_names.add(path)
+                if resume_latest:
+                    logger.warning("Trying the next latest checkpoint after deleting the invalid checkpoint.")
+                    continue
+                raise
+            break
 
         # Re-apply block swap device placement after checkpoint load
         # (checkpoint may have restored model to GPU, overwriting our block swap setup)
@@ -5393,12 +5473,19 @@ class Trainer:
             logger.warning("Unable to describe registered models before checkpoint: %s", describe_err)
 
         plugin = getattr(getattr(self.accelerator, "state", None), "fsdp_plugin", None)
-        fsdp_v2_run = (
-            getattr(self.accelerator, "distributed_type", DistributedType.NO) == DistributedType.FSDP
-            and getattr(plugin, "fsdp_version", 1) == 2
+        distributed_type = getattr(self.accelerator, "distributed_type", DistributedType.NO)
+        fsdp_v2_run = distributed_type == DistributedType.FSDP and getattr(plugin, "fsdp_version", 1) == 2
+        is_main_process = getattr(self.accelerator, "is_main_process", True)
+        all_processes_saving = bool(
+            getattr(self.config, "use_deepspeed_optimizer", False) or getattr(self.config, "fsdp_enable", False)
         )
         if fsdp_v2_run:
             logger.info("FSDP v2 detected; saving with sharded state dict (_use_dtensor disabled for NCCL compatibility).")
+        if is_main_process:
+            try:
+                os.remove(os.path.join(save_path_tmp, CHECKPOINT_GUARD_FILENAME))
+            except FileNotFoundError:
+                pass
         self.accelerator.save_state(save_path_tmp)
         if hasattr(self.model, "save_flow_custom_timestep_state"):
             self.model.save_flow_custom_timestep_state(save_path_tmp)
@@ -5442,13 +5529,21 @@ class Trainer:
                         self.model_hooks.training_state_path,
                     ),
                 )
-        if self.checkpoint_manager and getattr(self.accelerator, "is_main_process", True):
-            self.checkpoint_manager.write_manifest(
+        if self.accelerator is not None and distributed_type != DistributedType.NO and all_processes_saving:
+            self.accelerator.wait_for_everyone()
+        if is_main_process:
+            checkpoint_manager = self.checkpoint_manager or CheckpointManager(output_dir)
+            checkpoint_manager.write_manifest(
                 save_path_tmp,
                 metadata=self._build_checkpoint_manifest_metadata(),
             )
-        if save_path != save_path_tmp:
+            checkpoint_manager.write_guard(save_path_tmp)
+        if self.accelerator is not None and distributed_type != DistributedType.NO and all_processes_saving:
+            self.accelerator.wait_for_everyone()
+        if save_path != save_path_tmp and is_main_process:
             os.rename(save_path_tmp, save_path)
+        if self.accelerator is not None and distributed_type != DistributedType.NO and all_processes_saving:
+            self.accelerator.wait_for_everyone()
         event = checkpoint_event(
             path=save_path,
             label=f"Checkpoint saved to {save_path}",

--- a/simpletuner/helpers/utils/checkpoint_manager.py
+++ b/simpletuner/helpers/utils/checkpoint_manager.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional, Tuple
 logger = logging.getLogger(__name__)
 
 CHECKPOINT_MANIFEST_FILENAME = "checkpoint_manifest.json"
+CHECKPOINT_GUARD_FILENAME = ".guard"
 
 
 class CheckpointManager:
@@ -59,8 +60,11 @@ class CheckpointManager:
         checkpoints.sort(key=lambda x: x.get("step", 0), reverse=True)
         return checkpoints
 
-    def get_latest_checkpoint(self) -> Optional[str]:
+    def get_latest_checkpoint(self, require_guard: bool = False) -> Optional[str]:
         """Get the path to the latest checkpoint.
+
+        Args:
+            require_guard: Only consider checkpoints with the completion guard.
 
         Returns:
             Checkpoint directory name or None if no checkpoints exist
@@ -68,11 +72,17 @@ class CheckpointManager:
         try:
             dirs = os.listdir(self.output_dir) if os.path.exists(self.output_dir) else []
             checkpoint_dirs = [d for d in dirs if d.startswith("checkpoint") and not d.endswith("tmp")]
+            if require_guard:
+                checkpoint_dirs = [d for d in checkpoint_dirs if self.has_guard(d)]
             checkpoint_dirs = sorted(checkpoint_dirs, key=lambda x: int(x.split("-")[1]))
             return checkpoint_dirs[-1] if checkpoint_dirs else None
         except Exception as e:
             logger.debug(f"Error getting latest checkpoint: {e}")
             return None
+
+    def has_guard(self, checkpoint_name: str) -> bool:
+        """Return whether a checkpoint has the final completion guard."""
+        return os.path.exists(os.path.join(self.output_dir, checkpoint_name, CHECKPOINT_GUARD_FILENAME))
 
     def validate_checkpoint(self, checkpoint_name: str) -> Tuple[bool, Optional[str]]:
         """Validate a checkpoint for resuming training.
@@ -135,7 +145,13 @@ class CheckpointManager:
         files = [
             str(path.relative_to(root).as_posix())
             for path in root.rglob("*")
-            if path.is_file() and path.name != CHECKPOINT_MANIFEST_FILENAME
+            if path.is_file()
+            and path.name
+            not in {
+                CHECKPOINT_MANIFEST_FILENAME,
+                CHECKPOINT_GUARD_FILENAME,
+                f"{CHECKPOINT_GUARD_FILENAME}.tmp",
+            }
         ]
         files.sort()
         manifest: Dict[str, object] = {
@@ -148,6 +164,17 @@ class CheckpointManager:
         with manifest_path.open("w") as handle:
             json.dump(manifest, handle, indent=2)
         return manifest
+
+    def write_guard(self, checkpoint_path: str) -> None:
+        """Write the checkpoint completion guard as the final checkpoint file."""
+        root = Path(checkpoint_path)
+        if not root.exists():
+            raise FileNotFoundError(f"Checkpoint path does not exist: {checkpoint_path}")
+        guard_path = root / CHECKPOINT_GUARD_FILENAME
+        guard_tmp_path = root / f"{CHECKPOINT_GUARD_FILENAME}.tmp"
+        with guard_tmp_path.open("w") as handle:
+            handle.write("complete\n")
+        guard_tmp_path.replace(guard_path)
 
     def load_manifest(self, checkpoint_path: str) -> Optional[Dict[str, object]]:
         """Load a checkpoint manifest if present."""

--- a/simpletuner/helpers/utils/checkpoint_manager.py
+++ b/simpletuner/helpers/utils/checkpoint_manager.py
@@ -172,7 +172,7 @@ class CheckpointManager:
             raise FileNotFoundError(f"Checkpoint path does not exist: {checkpoint_path}")
         guard_path = root / CHECKPOINT_GUARD_FILENAME
         guard_tmp_path = root / f"{CHECKPOINT_GUARD_FILENAME}.tmp"
-        with guard_tmp_path.open("w") as handle:
+        with guard_tmp_path.open("w", encoding="utf-8", newline="\n") as handle:
             handle.write("complete\n")
         guard_tmp_path.replace(guard_path)
 

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/logging_fields.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/logging_fields.py
@@ -141,6 +141,24 @@ def register_logging_fields(registry: "FieldRegistry") -> None:
         )
     )
 
+    registry._add_field(
+        ConfigField(
+            name="delete_invalid_checkpoints",
+            arg_name="--delete_invalid_checkpoints",
+            ui_label="Delete Invalid Resume Checkpoints",
+            field_type=FieldType.CHECKBOX,
+            tab="training",
+            section="checkpointing",
+            subsection="advanced",
+            default_value=False,
+            help_text="Delete local checkpoints that cannot be loaded while resuming.",
+            tooltip="When resuming from latest, invalid checkpoints are removed and the next latest checkpoint is tried.",
+            importance=ImportanceLevel.ADVANCED,
+            order=5,
+            documentation="OPTIONS.md#--delete_invalid_checkpoints",
+        )
+    )
+
     # Checkpoints Rolling Total Limit
     registry._add_field(
         ConfigField(
@@ -156,7 +174,7 @@ def register_logging_fields(registry: "FieldRegistry") -> None:
             help_text="Maximum number of rolling checkpoints to keep",
             tooltip="When using rolling checkpoints, limit the number of checkpoints in the rolling window.",
             importance=ImportanceLevel.ADVANCED,
-            order=5,
+            order=6,
         )
     )
 

--- a/tests/test_checkpoint_cleanup.py
+++ b/tests/test_checkpoint_cleanup.py
@@ -41,6 +41,20 @@ class CheckpointCleanupTestCase(unittest.TestCase):
         self.assertEqual(len(remaining), 1)
         self.assertEqual(remaining[0], "checkpoint-5")
 
+    def test_manager_guard_marks_latest_complete_checkpoint(self) -> None:
+        self.manager.write_guard(os.path.join(self.tempdir.name, "checkpoint-3"))
+        self.manager.write_guard(os.path.join(self.tempdir.name, "checkpoint-4"))
+
+        self.assertTrue(self.manager.has_guard("checkpoint-4"))
+        self.assertEqual(self.manager.get_latest_checkpoint(require_guard=True), "checkpoint-4")
+
+        guard_tmp = Path(self.tempdir.name) / "checkpoint-4" / ".guard.tmp"
+        guard_tmp.write_text("partial", encoding="utf-8")
+        manifest = self.manager.write_manifest(os.path.join(self.tempdir.name, "checkpoint-4"))
+
+        self.assertNotIn(".guard", manifest["files"])
+        self.assertNotIn(".guard.tmp", manifest["files"])
+
     def test_preview_and_execute_cleanup_counts(self) -> None:
         with self._patch_manager():
             preview = self.service.preview_cleanup("env", limit=1)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -18,6 +18,7 @@ import torch
 
 from simpletuner.helpers.publishing.providers.s3 import S3PublishingProvider
 from simpletuner.helpers.training.state_tracker import StateTracker
+from simpletuner.helpers.utils.checkpoint_manager import CheckpointManager
 
 _OPTIONAL_MODULES = {
     "wandb",
@@ -598,7 +599,7 @@ sys.modules.setdefault("wandb", wandb_module)
 from simpletuner.helpers.data_backend.dataset_types import DatasetType
 from simpletuner.helpers.models.common import PredictionTypes
 from simpletuner.helpers.training.attention_backend import AttentionBackendMode
-from simpletuner.helpers.training.trainer import Trainer
+from simpletuner.helpers.training.trainer import DistributedType, Trainer
 
 # Import test configuration to suppress logging/warnings
 try:
@@ -1693,6 +1694,163 @@ class TestTrainer(unittest.TestCase):
             manifest_filename="checkpoint_manifest.json",
         )
         trainer.accelerator.load_state.assert_called_with("/path/to/output/checkpoint-100")
+
+    @patch("simpletuner.helpers.training.trainer.AttentionBackendController.on_load_checkpoint")
+    def test_init_resume_checkpoint_deletes_invalid_latest_and_retries(self, mock_attention_backend):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "checkpoint-100").mkdir()
+            Path(tmpdir, "checkpoint-200").mkdir()
+
+            trainer = object.__new__(Trainer)
+            trainer.model = Mock()
+            trainer.config = SimpleNamespace(
+                output_dir=tmpdir,
+                resume_from_checkpoint="latest",
+                total_steps_remaining_at_start=100,
+                global_resume_step=1,
+                num_train_epochs=1,
+                max_train_steps=100,
+                musubi_blocks_to_swap=0,
+                lr_scheduler="constant",
+                learning_rate=0.001,
+                is_schedulefree=False,
+                overrode_max_train_steps=False,
+                ignore_final_epochs=False,
+                optimizer="adamw",
+                delete_invalid_checkpoints=True,
+            )
+            trainer.accelerator = Mock(num_processes=1)
+            trainer.accelerator.load_state.side_effect = [RuntimeError("bad safetensors"), None]
+            trainer.accelerator.wait_for_everyone = Mock()
+            trainer.state = {"global_step": 0, "first_epoch": 1, "current_epoch": 1}
+            trainer.optimizer = Mock(param_groups=[{"lr": 0.1}])
+            trainer.distiller = None
+            trainer.job_id = "test-job"
+            trainer._emit_event = Mock()
+            trainer.checkpoint_manager = CheckpointManager(tmpdir)
+
+            lr_scheduler = Mock()
+            lr_scheduler.state_dict.return_value = {"base_lrs": [0.1], "_last_lr": [0.1]}
+
+            with patch("simpletuner.helpers.training.state_tracker.StateTracker.get_data_backends", return_value={}):
+                with patch("simpletuner.helpers.training.state_tracker.StateTracker.get_global_step", return_value=100):
+                    with patch("simpletuner.helpers.training.state_tracker.StateTracker.set_global_resume_step"):
+                        with patch(
+                            "simpletuner.helpers.training.state_tracker.StateTracker.get_training_state", return_value={}
+                        ):
+                            with patch("simpletuner.helpers.training.state_tracker.StateTracker.get_epoch", return_value=1):
+                                with patch("simpletuner.helpers.training.state_tracker.StateTracker.set_epoch"):
+                                    trainer.init_resume_checkpoint(lr_scheduler=lr_scheduler)
+
+            deleted_path = Path(tmpdir, "checkpoint-200")
+            self.assertFalse(deleted_path.exists())
+            trainer.accelerator.load_state.assert_any_call(os.path.join(tmpdir, "checkpoint-200"))
+            trainer.accelerator.load_state.assert_any_call(os.path.join(tmpdir, "checkpoint-100"))
+
+    @patch("simpletuner.helpers.training.trainer.AttentionBackendController.on_load_checkpoint")
+    def test_init_resume_checkpoint_deletes_unguarded_latest_when_guarded_checkpoint_exists(self, mock_attention_backend):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            checkpoint_100 = Path(tmpdir, "checkpoint-100")
+            checkpoint_100.mkdir()
+            Path(tmpdir, "checkpoint-200").mkdir()
+            checkpoint_manager = CheckpointManager(tmpdir)
+            checkpoint_manager.write_guard(str(checkpoint_100))
+
+            trainer = object.__new__(Trainer)
+            trainer.model = Mock()
+            trainer.config = SimpleNamespace(
+                output_dir=tmpdir,
+                resume_from_checkpoint="latest",
+                total_steps_remaining_at_start=100,
+                global_resume_step=1,
+                num_train_epochs=1,
+                max_train_steps=100,
+                musubi_blocks_to_swap=0,
+                lr_scheduler="constant",
+                learning_rate=0.001,
+                is_schedulefree=False,
+                overrode_max_train_steps=False,
+                ignore_final_epochs=False,
+                optimizer="adamw",
+                delete_invalid_checkpoints=True,
+            )
+            trainer.accelerator = Mock(num_processes=1)
+            trainer.accelerator.load_state = Mock()
+            trainer.accelerator.wait_for_everyone = Mock()
+            trainer.state = {"global_step": 0, "first_epoch": 1, "current_epoch": 1}
+            trainer.optimizer = Mock(param_groups=[{"lr": 0.1}])
+            trainer.distiller = None
+            trainer.job_id = "test-job"
+            trainer._emit_event = Mock()
+            trainer.checkpoint_manager = checkpoint_manager
+
+            lr_scheduler = Mock()
+            lr_scheduler.state_dict.return_value = {"base_lrs": [0.1], "_last_lr": [0.1]}
+
+            with patch("simpletuner.helpers.training.state_tracker.StateTracker.get_data_backends", return_value={}):
+                with patch("simpletuner.helpers.training.state_tracker.StateTracker.get_global_step", return_value=100):
+                    with patch("simpletuner.helpers.training.state_tracker.StateTracker.set_global_resume_step"):
+                        with patch(
+                            "simpletuner.helpers.training.state_tracker.StateTracker.get_training_state", return_value={}
+                        ):
+                            with patch("simpletuner.helpers.training.state_tracker.StateTracker.get_epoch", return_value=1):
+                                with patch("simpletuner.helpers.training.state_tracker.StateTracker.set_epoch"):
+                                    trainer.init_resume_checkpoint(lr_scheduler=lr_scheduler)
+
+            self.assertFalse(Path(tmpdir, "checkpoint-200").exists())
+            trainer.accelerator.load_state.assert_called_once_with(os.path.join(tmpdir, "checkpoint-100"))
+
+    @patch("simpletuner.helpers.training.trainer.AttentionBackendController.on_save_checkpoint")
+    def test_checkpoint_state_save_writes_completion_guard(self, mock_attention_backend):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trainer = object.__new__(Trainer)
+            trainer.config = SimpleNamespace(
+                output_dir=tmpdir,
+                checkpointing_use_tempdir=False,
+                disk_low_threshold=None,
+                use_deepspeed_optimizer=False,
+                fsdp_enable=False,
+            )
+            trainer.state = {"global_step": 100}
+            trainer.job_id = "test-job"
+            trainer.model = SimpleNamespace()
+            trainer.model_hooks = SimpleNamespace(
+                training_state_path="training_state.json",
+                get_modelspec_architecture=Mock(return_value="test/lora"),
+            )
+            trainer.checkpoint_manager = CheckpointManager(tmpdir)
+            trainer.mark_optimizer_eval = Mock()
+            trainer.mark_optimizer_train = Mock()
+            trainer._emit_event = Mock()
+            trainer._run_post_checkpoint_script = Mock()
+
+            checkpoint_dir = Path(tmpdir) / "checkpoint-100"
+            stale_guard = checkpoint_dir / ".guard"
+            checkpoint_dir.mkdir()
+            stale_guard.write_text("stale", encoding="utf-8")
+
+            def save_state(path):
+                Path(path).mkdir(parents=True, exist_ok=True)
+                (Path(path) / "pytorch_lora_weights.safetensors").write_bytes(b"weights")
+
+            trainer.accelerator = SimpleNamespace(
+                _models=[],
+                is_main_process=True,
+                distributed_type=DistributedType.NO,
+                save_state=Mock(side_effect=save_state),
+                wait_for_everyone=Mock(),
+            )
+
+            with patch("simpletuner.helpers.training.state_tracker.StateTracker.get_data_backends", return_value={}):
+                save_path = trainer.checkpoint_state_save(tmpdir)
+
+            self.assertEqual(save_path, str(checkpoint_dir))
+            self.assertEqual(stale_guard.read_text(encoding="utf-8"), "complete\n")
+            self.assertTrue((checkpoint_dir / "checkpoint_manifest.json").exists())
+            manifest = trainer.checkpoint_manager.load_manifest(str(checkpoint_dir))
+            self.assertIn("pytorch_lora_weights.safetensors", manifest["files"])
+            self.assertNotIn(".guard", manifest["files"])
+            trainer.accelerator.wait_for_everyone.assert_not_called()
 
     @patch("simpletuner.helpers.training.trainer.logger")
     def test_init_resume_checkpoint_prodigy_without_split_groups(self, mock_logger):


### PR DESCRIPTION
Closes #2613 

Adds `--delete_invalid_checkpoints` option which will allow administrator to bypass broken checkpoints on resume, reducing time wasted on GPU instances.