### PR TITLE
(#2623) validation interval can be off-by-one versus actual epoch end

### DIFF
--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -5519,7 +5519,7 @@ class Trainer:
         if self.validation is None:
             return False
 
-        should_validate = manual_validation_requested or self.validation.would_validate(epoch_end=epoch_end)
+        should_validate = manual_validation_requested or self.validation.would_validate(step=step, epoch_end=epoch_end)
         if should_validate:
             self.mark_optimizer_eval()
             AttentionBackendController.apply(self.config, AttentionPhase.EVAL)
@@ -6281,22 +6281,24 @@ class Trainer:
                     )
                     # Note: training_complete event is emitted after final validation and model save
                     break
-            if epoch_validation_boundary_reached:
-                self._run_intermediary_validation(step, epoch_end=True)
+            epoch_checkpoint_dir = None
             if epoch_checkpoint_pending:
                 epoch_message = f"Epoch {epoch} completed at step {self.state['global_step']}"
                 epoch_upload_to_hub = self.hub_manager is not None and (
                     self.state["global_step"] > self.state["global_resume_step"]
                 )
-                checkpoint_dir = self._run_standard_checkpoint(
+                epoch_checkpoint_dir = self._run_standard_checkpoint(
                     webhook_message=epoch_message,
                     parent_loss=parent_loss,
                     epoch=epoch,
                     upload_to_hub=epoch_upload_to_hub,
                 )
-                if checkpoint_dir:
-                    self._write_checkpoint_epoch(checkpoint_dir, epoch + 1)
-                    self._populate_checkpoint_assets(checkpoint_dir)
+                if epoch_checkpoint_dir:
+                    self._write_checkpoint_epoch(epoch_checkpoint_dir, epoch + 1)
+            if epoch_validation_boundary_reached:
+                self._run_intermediary_validation(step, epoch_end=True)
+            if epoch_checkpoint_dir:
+                self._populate_checkpoint_assets(epoch_checkpoint_dir)
 
             if self.state["global_step"] >= self.config.max_train_steps or (
                 epoch > self.config.num_train_epochs and not self.config.ignore_final_epochs

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -5509,6 +5509,47 @@ class Trainer:
             dirs = sorted(dirs, key=lambda x: int(x.split("-")[1]))
             return dirs[-1] if len(dirs) > 0 else None
 
+    def _run_intermediary_validation(
+        self,
+        step: int,
+        *,
+        manual_validation_requested: bool = False,
+        epoch_end: bool = False,
+    ) -> bool:
+        if self.validation is None:
+            return False
+
+        should_validate = manual_validation_requested or self.validation.would_validate(epoch_end=epoch_end)
+        if should_validate:
+            self.mark_optimizer_eval()
+            AttentionBackendController.apply(self.config, AttentionPhase.EVAL)
+            self.disable_gradient_checkpointing()
+
+        try:
+            self.validation.run_validations(
+                validation_type="intermediary",
+                step=step,
+                force_evaluation=manual_validation_requested,
+                epoch_end=epoch_end,
+            )
+        except Exception as error:
+            from simpletuner.helpers.training.validation import ValidationAbortedException
+
+            if isinstance(error, ValidationAbortedException):
+                raise
+            root_logger = logging.getLogger()
+            root_logger.error(f"Validation run failed at step {step}: {error}")
+            import traceback
+
+            root_logger.debug(traceback.format_exc())
+
+        if should_validate:
+            AttentionBackendController.apply(self.config, AttentionPhase.TRAIN)
+            self.enable_gradient_checkpointing()
+            self.mark_optimizer_train()
+
+        return should_validate
+
     def train(self):
         self.init_trackers()
         self._train_initial_msg()
@@ -5565,6 +5606,7 @@ class Trainer:
                     training_models.append(text_encoder)
 
             epoch_checkpoint_pending = False
+            epoch_validation_boundary_reached = False
             last_step_saved_checkpoint = False
 
             if current_epoch_step is not None:
@@ -5633,6 +5675,7 @@ class Trainer:
                 if epoch_end_reached:
                     if not local_epoch_end:
                         training_logger.debug("Reached the end of epoch because another rank exhausted its dataloader.")
+                    epoch_validation_boundary_reached = True
                     if (
                         self._should_checkpoint_epoch(epoch)
                         and not last_step_saved_checkpoint
@@ -6221,35 +6264,10 @@ class Trainer:
 
                 if self.validation is not None:
                     manual_validation_requested = self._consume_manual_validation_request()
-                    should_validate = manual_validation_requested or self.validation.would_validate()
-                    if should_validate:
-                        self.mark_optimizer_eval()
-                        AttentionBackendController.apply(self.config, AttentionPhase.EVAL)
-                        self.disable_gradient_checkpointing()
-
-                    try:
-                        self.validation.run_validations(
-                            validation_type="intermediary",
-                            step=step,
-                            force_evaluation=manual_validation_requested,
-                        )
-                    except Exception as error:
-                        # Re-raise abort exceptions to allow graceful shutdown
-                        from simpletuner.helpers.training.validation import ValidationAbortedException
-
-                        if isinstance(error, ValidationAbortedException):
-                            raise
-                        # let's not crash training because of a validation error.
-                        root_logger = logging.getLogger()
-                        root_logger.error(f"Validation run failed at step {step}: {error}")
-                        import traceback
-
-                        root_logger.debug(traceback.format_exc())
-
-                    if should_validate:
-                        AttentionBackendController.apply(self.config, AttentionPhase.TRAIN)
-                        self.enable_gradient_checkpointing()
-                        self.mark_optimizer_train()
+                    self._run_intermediary_validation(
+                        step,
+                        manual_validation_requested=manual_validation_requested,
+                    )
                     if step_checkpoint_path:
                         self._populate_checkpoint_assets(step_checkpoint_path)
                 self.accelerator.wait_for_everyone()
@@ -6263,6 +6281,8 @@ class Trainer:
                     )
                     # Note: training_complete event is emitted after final validation and model save
                     break
+            if epoch_validation_boundary_reached:
+                self._run_intermediary_validation(step, epoch_end=True)
             if epoch_checkpoint_pending:
                 epoch_message = f"Epoch {epoch} completed at step {self.state['global_step']}"
                 epoch_upload_to_hub = self.hub_manager is not None and (

--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -14,9 +14,9 @@ from typing import Any, Optional, Union
 import diffusers
 import numpy as np
 import torch
+import wandb
 from tqdm import tqdm
 
-import wandb
 from simpletuner.helpers.caching.memory import reclaim_memory
 from simpletuner.helpers.models.common import AudioModelFoundation, ModelFoundation, VideoModelFoundation
 from simpletuner.helpers.training import validation_audio
@@ -2089,12 +2089,16 @@ class Validation:
         step: int = 0,
         validation_type="intermediary",
         force_evaluation: bool = False,
+        epoch_end: bool = False,
     ):
         # a wrapper for should_perform_intermediary_validation that can run in the training loop
         self._update_state()
-        return self.should_perform_intermediary_validation(step, self.validation_prompt_metadata, validation_type) or (
-            step == 0 and validation_type == "base_model"
-        )
+        return self.should_perform_intermediary_validation(
+            step,
+            self.validation_prompt_metadata,
+            validation_type,
+            epoch_end=epoch_end,
+        ) or (step == 0 and validation_type == "base_model")
 
     def run_validations(
         self,
@@ -2102,6 +2106,7 @@ class Validation:
         validation_type="intermediary",
         force_evaluation: bool = False,
         skip_execution: bool = False,
+        epoch_end: bool = False,
     ):
         self._update_state()
         configured_validation_method = self._validation_method()
@@ -2110,7 +2115,10 @@ class Validation:
         content = self.validation_prompt_metadata.get("validation_prompts", None)
         has_validation_prompts = content is not None and len(content) > 0
         current_step_aligns_with_interval = self.should_perform_intermediary_validation(
-            step, self.validation_prompt_metadata, validation_type
+            step,
+            self.validation_prompt_metadata,
+            validation_type,
+            epoch_end=epoch_end,
         )
         is_base_model_benchmark = step == 0 and validation_type == "base_model"
         epoch_validation_pending = (
@@ -2249,7 +2257,14 @@ class Validation:
 
         return self
 
-    def should_perform_intermediary_validation(self, step, validation_prompts, validation_type):
+    def should_perform_intermediary_validation(
+        self,
+        step,
+        validation_prompts,
+        validation_type,
+        *,
+        epoch_end: bool = False,
+    ):
         if validation_prompts is None or (isinstance(validation_prompts, list) and len(validation_prompts) == 0):
             return False
         step_interval_value = getattr(self.config, "validation_step_interval", None)
@@ -2270,9 +2285,9 @@ class Validation:
         except (TypeError, ValueError):
             epoch_interval = None
 
-        epoch_step_ready = False
+        epoch_step_ready = validation_type == "intermediary" and epoch_end
         num_steps_per_epoch = getattr(self.config, "num_update_steps_per_epoch", None)
-        if num_steps_per_epoch is not None:
+        if not epoch_step_ready and num_steps_per_epoch is not None:
             try:
                 steps_per_epoch_int = int(num_steps_per_epoch)
                 if steps_per_epoch_int > 0:

--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -2300,6 +2300,7 @@ class Validation:
         should_do_step_validation = False
         if (
             validation_prompts
+            and not epoch_end
             and step_interval is not None
             and step_interval > 0
             and self.global_step > self.global_resume_step

--- a/tests/test_dynamic_steps_per_epoch.py
+++ b/tests/test_dynamic_steps_per_epoch.py
@@ -394,6 +394,68 @@ class TestIssue2483Scenario(unittest.TestCase):
             validation_steps, [98, 224], f"Validation should only occur at epoch boundaries. Got: {validation_steps}"
         )
 
+    def test_epoch_end_signal_handles_computed_epoch_length_drift(self):
+        """
+        If the computed schedule is one optimizer step longer than actual
+        dataloader exhaustion, validation should still run at the real epoch
+        boundary used by checkpointing.
+
+        This matches the reported pattern:
+        - checkpoints: 270, 540, 810, 1080, 1417, 1755
+        - validation missed epochs after the schedule changed at epoch 5
+        """
+        validation = Validation.__new__(Validation)
+        validation.config = SimpleNamespace(
+            validation_epoch_interval=1,
+            validation_step_interval=None,
+            num_update_steps_per_epoch=338,
+            gradient_accumulation_steps=4,
+            epoch_batches_schedule={1: 1080, 5: 272},
+        )
+        validation._pending_epoch_validation = None
+        validation._epoch_validations_completed = {1, 2, 3, 4}
+        validation.deepspeed = False
+        validation.accelerator = MagicMock()
+        validation.accelerator.is_main_process = True
+        validation.accelerator.num_processes = 1
+        validation.global_resume_step = 0
+        prompts = [{"prompt": "test"}]
+
+        validation.global_step = 1417
+        validation.current_epoch = 5
+        validation.current_epoch_step = 337
+        self.assertEqual(validation._epoch_relative_step(338), 337)
+        self.assertFalse(
+            validation.should_perform_intermediary_validation(
+                step=1417,
+                validation_prompts=prompts,
+                validation_type="intermediary",
+            )
+        )
+        self.assertTrue(
+            validation.should_perform_intermediary_validation(
+                step=1417,
+                validation_prompts=prompts,
+                validation_type="intermediary",
+                epoch_end=True,
+            )
+        )
+
+        validation._epoch_validations_completed.add(5)
+        validation._pending_epoch_validation = None
+        validation.global_step = 1755
+        validation.current_epoch = 6
+        validation.current_epoch_step = 338
+        self.assertEqual(validation._epoch_relative_step(338), 337)
+        self.assertTrue(
+            validation.should_perform_intermediary_validation(
+                step=1755,
+                validation_prompts=prompts,
+                validation_type="intermediary",
+                epoch_end=True,
+            )
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -651,6 +651,23 @@ class TestTrainer(unittest.TestCase):
 
         mock_all_reduce.assert_called_once()
 
+    def test_run_intermediary_validation_passes_step_to_would_validate(self):
+        trainer = object.__new__(Trainer)
+        validation = MagicMock()
+        validation.would_validate.return_value = False
+        trainer.validation = validation
+
+        result = trainer._run_intermediary_validation(8, epoch_end=True)
+
+        self.assertFalse(result)
+        validation.would_validate.assert_called_once_with(step=8, epoch_end=True)
+        validation.run_validations.assert_called_once_with(
+            validation_type="intermediary",
+            step=8,
+            force_evaluation=False,
+            epoch_end=True,
+        )
+
     @patch("simpletuner.helpers.training.trainer.load_config")
     @patch("simpletuner.helpers.training.trainer.safety_check")
     @patch("simpletuner.helpers.training.state_tracker.StateTracker")

--- a/tests/test_validation_epoch_timing.py
+++ b/tests/test_validation_epoch_timing.py
@@ -230,6 +230,34 @@ class TestValidationEpochBoundaryTiming(unittest.TestCase):
             f"epoch_step={validation.current_epoch_step} should be ~1, not 245",
         )
 
+    def test_epoch_end_signal_does_not_reuse_step_interval_validation(self):
+        validation = self._create_validation(
+            validation_epoch_interval=None,
+            validation_step_interval=10,
+            gradient_accumulation_steps=1,
+        )
+        prompts = [{"prompt": "test"}]
+        validation.global_step = 10
+        validation.current_epoch_step = 10
+        validation.current_epoch = 1
+
+        self.assertTrue(
+            validation.should_perform_intermediary_validation(
+                step=10,
+                validation_prompts=prompts,
+                validation_type="intermediary",
+            )
+        )
+        self.assertFalse(
+            validation.should_perform_intermediary_validation(
+                step=10,
+                validation_prompts=prompts,
+                validation_type="intermediary",
+                epoch_end=True,
+            ),
+            "Epoch-end validation should not duplicate a step-interval validation.",
+        )
+
 
 class TestValidationEpochStepReadyCalculation(unittest.TestCase):
     """Test the epoch_step_ready calculation specifically."""


### PR DESCRIPTION
Closes #2623 

This pull request improves the handling of validation at epoch boundaries during training to ensure that validation always runs at the real end of an epoch, even if the computed schedule drifts from the actual dataloader exhaustion. It also refactors the validation logic for clarity and adds tests for these edge cases.

**Validation logic improvements:**

* Added an `epoch_end` flag to the validation logic in `trainer.py` and `validation.py`, ensuring that validation is correctly triggered at the true epoch boundary, even if the computed schedule is off by one step. This helps prevent missed validations when the epoch length changes dynamically. [[1]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R5512-R5552) [[2]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R5678) [[3]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R6284-R6285) [[4]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09R2092-R2109) [[5]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09L2113-R2121) [[6]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09L2252-R2267) [[7]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09L2273-R2290)

* Refactored the intermediary validation logic into a new `_run_intermediary_validation` method in `trainer.py` for better code organization and reusability. [[1]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R5512-R5552) [[2]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27L6224-L6252)

**Testing improvements:**

* Added a new test, `test_epoch_end_signal_handles_computed_epoch_length_drift`, to verify that validation is correctly triggered at epoch boundaries even when the computed epoch length does not match the actual dataloader exhaustion.

**Minor changes:**

* Moved the `import wandb` statement to the top of `validation.py` for consistency.