### PR TITLE
torchao: update to ABI-stable release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,15 @@ def _resolve_ramtorch_dependency() -> str:
     return "ramtorch"
 
 
+PYTORCH_DEPENDENCIES = [
+    "torch>=2.11.0",
+    "torchvision>=0.26.0",
+    "torchaudio>=2.11.0",
+]
+
+TORCHAO_DEPENDENCY = "torchao>=0.17.0,<0.18.0"
+
+
 def _cuda_nightly_base_url() -> str:
     """Return the base URL for CUDA 12 nightly PyTorch wheels."""
     return os.environ.get(
@@ -125,12 +134,10 @@ def build_vllm_cuda13_wheel_url() -> str:
 def get_cuda13_dependencies():
     """Get CUDA 13 specific dependencies (use --extra-index-url https://download.pytorch.org/whl/cu130)."""
     dependencies = [
-        "torch>=2.10.0",
-        "torchvision>=0.25.0",
-        "torchaudio>=2.10.0",
+        *PYTORCH_DEPENDENCIES,
         "triton>=3.3.0",
         "deepspeed>=0.17.2",
-        "torchao>=0.14.0,<0.16.0",
+        TORCHAO_DEPENDENCY,
         "bitsandbytes>=0.45.0",
         "nvidia-cudnn-cu13",
         "nvidia-nccl-cu13",
@@ -158,7 +165,7 @@ def get_cuda_nightly_dependencies():
         build_triton_wheel_url(triton_version, "https://download.pytorch.org/whl/nightly"),
         "bitsandbytes>=0.45.0",
         "deepspeed>=0.17.2",
-        "torchao>=0.14.0,<0.16.0",
+        TORCHAO_DEPENDENCY,
         "nvidia-cudnn-cu12",
         "nvidia-nccl-cu12",
         "nvidia-ml-py>=12.555",
@@ -181,7 +188,7 @@ def get_cuda13_nightly_dependencies():
         build_cuda13_nightly_wheel_url("torchaudio", torchaudio_version),
         build_triton_wheel_url(triton_version, "https://download.pytorch.org/whl/nightly"),
         "deepspeed>=0.17.2",
-        "torchao>=0.14.0,<0.16.0",
+        TORCHAO_DEPENDENCY,
         "bitsandbytes>=0.45.0",
         "nvidia-cudnn-cu13",
         "nvidia-nccl-cu13",
@@ -194,13 +201,11 @@ def get_cuda13_nightly_dependencies():
 def get_cuda_dependencies():
     ramtorch_dep = _resolve_ramtorch_dependency()
     return [
-        "torch>=2.10.0",
-        "torchvision>=0.25.0",
-        "torchaudio>=2.10.0",
+        *PYTORCH_DEPENDENCIES,
         "triton>=3.3.0",
         "bitsandbytes>=0.45.0",
         "deepspeed>=0.17.2",
-        "torchao>=0.14.0,<0.16.0",
+        TORCHAO_DEPENDENCY,
         "nvidia-cudnn-cu12",
         "nvidia-nccl-cu12",
         "nvidia-ml-py>=12.555",
@@ -212,30 +217,24 @@ def get_cuda_dependencies():
 def get_rocm_dependencies():
     """Get ROCm specific dependencies (use --extra-index-url https://download.pytorch.org/whl/rocm7.1)."""
     return [
-        "torch>=2.10.0",
-        "torchvision>=0.25.0",
-        "torchaudio>=2.10.0",
+        *PYTORCH_DEPENDENCIES,
         "triton>=3.3.0",
-        "torchao>=0.14.0,<0.16.0",
+        TORCHAO_DEPENDENCY,
         "ramtorch",
     ]
 
 
 def get_apple_dependencies():
     return [
-        "torch>=2.10.0",
-        "torchvision>=0.25.0",
-        "torchaudio>=2.10.0",
-        "torchao>=0.14.0,<0.16.0",
+        *PYTORCH_DEPENDENCIES,
+        TORCHAO_DEPENDENCY,
     ]
 
 
 def get_cpu_dependencies():
     return [
-        "torch>=2.10.0",
-        "torchvision>=0.25.0",
-        "torchaudio>=2.10.0",
-        "torchao>=0.14.0,<0.16.0",
+        *PYTORCH_DEPENDENCIES,
+        TORCHAO_DEPENDENCY,
     ]
 
 

--- a/tests/test_setup_platform_dependencies.py
+++ b/tests/test_setup_platform_dependencies.py
@@ -1,0 +1,45 @@
+import runpy
+import unittest
+from pathlib import Path
+
+import setuptools
+
+
+def load_setup_kwargs() -> dict:
+    captured: dict = {}
+    original_setup = setuptools.setup
+
+    def fake_setup(**kwargs):
+        captured.update(kwargs)
+
+    setuptools.setup = fake_setup
+    try:
+        runpy.run_path(str(Path(__file__).resolve().parents[1] / "setup.py"))
+    finally:
+        setuptools.setup = original_setup
+
+    return captured
+
+
+class SetupPlatformDependencyTests(unittest.TestCase):
+    def test_platform_extras_use_latest_torchao_with_torch_211_floor(self):
+        extras_require = load_setup_kwargs()["extras_require"]
+
+        for extra_name in ("apple", "cuda", "cuda13", "rocm", "cpu"):
+            with self.subTest(extra=extra_name):
+                dependencies = extras_require[extra_name]
+                self.assertIn("torch>=2.11.0", dependencies)
+                self.assertIn("torchvision>=0.26.0", dependencies)
+                self.assertIn("torchaudio>=2.11.0", dependencies)
+                self.assertIn("torchao>=0.17.0,<0.18.0", dependencies)
+
+    def test_cuda_nightly_extras_use_latest_torchao_range(self):
+        extras_require = load_setup_kwargs()["extras_require"]
+
+        for extra_name in ("cuda-nightly", "cuda13-nightly"):
+            with self.subTest(extra=extra_name):
+                self.assertIn("torchao>=0.17.0,<0.18.0", extras_require[extra_name])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request refactors the way PyTorch and TorchAO dependencies are managed in `setup.py`, ensuring consistency and making it easier to update dependency versions. It also adds new tests to verify that the correct dependency versions are set for all supported platforms.

Dependency management improvements:

* Introduced the `PYTORCH_DEPENDENCIES` list and `TORCHAO_DEPENDENCY` variable in `setup.py` to centralize and standardize the versions of `torch`, `torchvision`, `torchaudio`, and `torchao` used across all platform-specific dependency lists. This reduces duplication and simplifies future updates.
* Updated all platform-specific dependency functions (`get_cuda13_dependencies`, `get_cuda_nightly_dependencies`, `get_cuda13_nightly_dependencies`, `get_cuda_dependencies`, `get_rocm_dependencies`, `get_apple_dependencies`, `get_cpu_dependencies`) to use the new centralized dependency variables, ensuring all platforms use `torch>=2.11.0`, `torchvision>=0.26.0`, `torchaudio>=2.11.0`, and `torchao>=0.17.0,<0.18.0`. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L128-R140) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L161-R168) [[3]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L184-R191) [[4]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L197-R208) [[5]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L215-R237)

Testing enhancements:

* Added a new test file `tests/test_setup_platform_dependencies.py` with tests to verify that all platform-specific extras require the correct minimum versions of PyTorch and TorchAO, and that nightly builds use the updated TorchAO version range.