### PR TITLE
AnyFlow: initial support for r_timestep across all model families

### DIFF
--- a/simpletuner/helpers/models/ace_step/model.py
+++ b/simpletuner/helpers/models/ace_step/model.py
@@ -1647,15 +1647,26 @@ class ACEStep(AudioModelFoundation):
             raise ValueError("ACE-Step transformer has not been loaded before model_predict was invoked.")
 
         if self._is_v15_layout_active():
-            output = transformer(
-                hidden_states=prepared_batch["noisy_latents"],
-                timestep=prepared_batch["timesteps"],
-                timestep_r=prepared_batch["timesteps"],
-                attention_mask=prepared_batch["attention_mask"],
-                encoder_hidden_states=prepared_batch["encoder_hidden_states"],
-                encoder_attention_mask=prepared_batch.get("encoder_attention_mask"),
-                context_latents=prepared_batch["context_latents"],
-            )
+            call_kwargs = {
+                "hidden_states": prepared_batch["noisy_latents"],
+                "timestep": prepared_batch["timesteps"],
+                "attention_mask": prepared_batch["attention_mask"],
+                "encoder_hidden_states": prepared_batch["encoder_hidden_states"],
+                "encoder_attention_mask": prepared_batch.get("encoder_attention_mask"),
+                "context_latents": prepared_batch["context_latents"],
+            }
+            if self.FLOWMAP_R_TIMESTEP_BATCH_KEY in prepared_batch:
+                applied_flowmap = self._apply_flowmap_r_timestep_kwargs(
+                    call_kwargs,
+                    prepared_batch,
+                    target=getattr(transformer, "forward", transformer),
+                    kwarg_name="timestep_r",
+                )
+                if not applied_flowmap:
+                    call_kwargs["timestep_r"] = prepared_batch["timesteps"]
+            else:
+                call_kwargs["timestep_r"] = prepared_batch["timesteps"]
+            output = transformer(**call_kwargs)
             flow_pred = output[0] if isinstance(output, (tuple, list)) else getattr(output, "sample", None)
             if flow_pred is None and hasattr(output, "__getitem__"):
                 flow_pred = output[0]
@@ -1683,22 +1694,28 @@ class ACEStep(AudioModelFoundation):
         sigmas = prepared_batch["sigmas"]
         ssl_hidden_states = prepared_batch.get("ssl_hidden_states")
 
-        output = transformer(
-            hidden_states=noise_latents,
-            attention_mask=attention_mask,
-            encoder_text_hidden_states=text_hidden_states,
-            text_attention_mask=text_attention_mask,
-            speaker_embeds=speaker_embeds,
-            lyric_token_idx=lyric_token_ids,
-            lyric_mask=lyric_mask,
-            timestep=timesteps,
-            timestep_sign=(
+        call_kwargs = {
+            "hidden_states": noise_latents,
+            "attention_mask": attention_mask,
+            "encoder_text_hidden_states": text_hidden_states,
+            "text_attention_mask": text_attention_mask,
+            "speaker_embeds": speaker_embeds,
+            "lyric_token_idx": lyric_token_ids,
+            "lyric_mask": lyric_mask,
+            "timestep": timesteps,
+            "timestep_sign": (
                 prepared_batch.get("twinflow_time_sign") if getattr(self.config, "twinflow_enabled", False) else None
             ),
-            ssl_hidden_states=ssl_hidden_states,
-            return_dict=True,
-            hidden_states_buffer=hidden_states_buffer,
+            "ssl_hidden_states": ssl_hidden_states,
+            "return_dict": True,
+            "hidden_states_buffer": hidden_states_buffer,
+        }
+        self._apply_flowmap_r_timestep_kwargs(
+            call_kwargs,
+            prepared_batch,
+            target=getattr(transformer, "forward", transformer),
         )
+        output = transformer(**call_kwargs)
 
         # Precondition velocity to data prediction: x0_hat = noisy - sigma * v_theta(noisy, sigma)
         data_pred = (-sigmas) * output.sample + noise_latents

--- a/simpletuner/helpers/models/ace_step/model.py
+++ b/simpletuner/helpers/models/ace_step/model.py
@@ -1654,18 +1654,15 @@ class ACEStep(AudioModelFoundation):
                 "encoder_hidden_states": prepared_batch["encoder_hidden_states"],
                 "encoder_attention_mask": prepared_batch.get("encoder_attention_mask"),
                 "context_latents": prepared_batch["context_latents"],
+                "timestep_r": prepared_batch["timesteps"],
             }
-            if self.FLOWMAP_R_TIMESTEP_BATCH_KEY in prepared_batch:
-                applied_flowmap = self._apply_flowmap_r_timestep_kwargs(
-                    call_kwargs,
+            call_kwargs.update(
+                self._get_flowmap_r_timestep_forward_kwargs(
                     prepared_batch,
                     target=getattr(transformer, "forward", transformer),
                     kwarg_name="timestep_r",
                 )
-                if not applied_flowmap:
-                    call_kwargs["timestep_r"] = prepared_batch["timesteps"]
-            else:
-                call_kwargs["timestep_r"] = prepared_batch["timesteps"]
+            )
             output = transformer(**call_kwargs)
             flow_pred = output[0] if isinstance(output, (tuple, list)) else getattr(output, "sample", None)
             if flow_pred is None and hasattr(output, "__getitem__"):

--- a/simpletuner/helpers/models/anima/model.py
+++ b/simpletuner/helpers/models/anima/model.py
@@ -641,6 +641,7 @@ class Anima(ImageModelFoundation):
             t5xxl_ids=prepared_batch.get("t5xxl_ids"),
             t5xxl_weights=prepared_batch.get("t5xxl_weights"),
             hidden_states_buffer=hidden_states_buffer,
+            **self._get_flowmap_r_timestep_forward_kwargs(prepared_batch),
         )
         if hasattr(noise_pred, "sample"):
             noise_pred = noise_pred.sample

--- a/simpletuner/helpers/models/auraflow/model.py
+++ b/simpletuner/helpers/models/auraflow/model.py
@@ -310,6 +310,7 @@ class Auraflow(ImageModelFoundation):
             return_dict=True,
             hidden_states_buffer=hidden_states_buffer,
             grounding_kwargs=grounding_kwargs,
+            **self._get_flowmap_r_timestep_forward_kwargs(prepared_batch),
         ).sample
 
         return {

--- a/simpletuner/helpers/models/chroma/model.py
+++ b/simpletuner/helpers/models/chroma/model.py
@@ -641,6 +641,7 @@ class Chroma(ImageModelFoundation):
             transformer_kwargs["hidden_states_buffer"] = hidden_states_buffer
         if grounding_kwargs is not None:
             transformer_kwargs["grounding_kwargs"] = grounding_kwargs
+        self._apply_flowmap_r_timestep_kwargs(transformer_kwargs, prepared_batch)
 
         if (
             getattr(self.config, "tread_config", None) is not None

--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -400,6 +400,8 @@ class ModelFoundation(ABC):
     MAXIMUM_CANVAS_SIZE = None
     SUPPORTS_LORA = None
     SUPPORTS_CONTROLNET = None
+    FLOWMAP_R_TIMESTEP_BATCH_KEY = "flowmap_r_timesteps"
+    FLOWMAP_R_TIMESTEP_KWARG = "r_timestep"
     STRICT_I2V_FLAVOURS = tuple()
     STRICT_I2V_FOR_ALL_FLAVOURS = False
     DEFAULT_LORA_TARGET = ["to_k", "to_q", "to_v", "to_out.0"]
@@ -1083,6 +1085,77 @@ class ModelFoundation(ABC):
         Must be implemented by the subclass.
         """
         raise NotImplementedError("model_predict must be implemented in the child class.")
+
+    def _forward_accepts_kwarg(self, target: Any, kwarg_name: str) -> bool:
+        signature = inspect.signature(target)
+        for parameter in signature.parameters.values():
+            if parameter.name == kwarg_name:
+                return True
+        return False
+
+    def _flowmap_forward_target(self, target: Any = None) -> Any:
+        if target is not None:
+            return target
+
+        component = getattr(self, "model", None)
+        if component is not None:
+            component = self.unwrap_model(model=component)
+        if component is not None:
+            return getattr(component, "forward", component)
+        raise ValueError(f"{self.NAME} received FlowMap timesteps before a model component was loaded.")
+
+    def _apply_flowmap_r_timestep_kwargs(
+        self,
+        call_kwargs: dict[str, Any],
+        prepared_batch: Mapping[str, Any],
+        *,
+        target: Any = None,
+        kwarg_name: str | None = None,
+    ) -> bool:
+        if self.FLOWMAP_R_TIMESTEP_BATCH_KEY not in prepared_batch:
+            return False
+
+        r_timesteps = prepared_batch[self.FLOWMAP_R_TIMESTEP_BATCH_KEY]
+        if r_timesteps is None:
+            return False
+
+        kwarg_name = kwarg_name or self.FLOWMAP_R_TIMESTEP_KWARG
+        if kwarg_name in call_kwargs:
+            raise ValueError(f"{self.NAME} received duplicate `{kwarg_name}` while applying FlowMap timesteps.")
+
+        forward_target = self._flowmap_forward_target(target)
+        try:
+            accepts_kwarg = self._forward_accepts_kwarg(forward_target, kwarg_name)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"{self.NAME} received `{self.FLOWMAP_R_TIMESTEP_BATCH_KEY}`, but the model component "
+                f"signature could not be inspected for `{kwarg_name}` support."
+            ) from exc
+
+        if not accepts_kwarg:
+            raise ValueError(
+                f"{self.NAME} received `{self.FLOWMAP_R_TIMESTEP_BATCH_KEY}`, but its model component does not "
+                f"accept `{kwarg_name}`. Add model-specific FlowMap interval conditioning before enabling AnyFlow."
+            )
+
+        call_kwargs[kwarg_name] = r_timesteps
+        return True
+
+    def _get_flowmap_r_timestep_forward_kwargs(
+        self,
+        prepared_batch: Mapping[str, Any],
+        *,
+        target: Any = None,
+        kwarg_name: str | None = None,
+    ) -> dict[str, Any]:
+        call_kwargs: dict[str, Any] = {}
+        self._apply_flowmap_r_timestep_kwargs(
+            call_kwargs,
+            prepared_batch,
+            target=target,
+            kwarg_name=kwarg_name,
+        )
+        return call_kwargs
 
     # -------------------------------------------------------------------------
     # Conditioning Capability Methods

--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -1086,12 +1086,31 @@ class ModelFoundation(ABC):
         """
         raise NotImplementedError("model_predict must be implemented in the child class.")
 
+    def _forward_kwarg_support_cache_key(self, target: Any, kwarg_name: str) -> tuple[Any, ...]:
+        owner = getattr(target, "__self__", None)
+        function = getattr(target, "__func__", None)
+        if owner is not None:
+            return (id(owner), id(function) if function is not None else None, kwarg_name)
+        return (id(target), type(target), kwarg_name)
+
     def _forward_accepts_kwarg(self, target: Any, kwarg_name: str) -> bool:
+        cache = getattr(self, "_forward_kwarg_support_cache", None)
+        if cache is None:
+            cache = {}
+            self._forward_kwarg_support_cache = cache
+
+        cache_key = self._forward_kwarg_support_cache_key(target, kwarg_name)
+        if cache_key in cache:
+            return cache[cache_key]
+
         signature = inspect.signature(target)
+        accepts_kwarg = False
         for parameter in signature.parameters.values():
             if parameter.name == kwarg_name:
-                return True
-        return False
+                accepts_kwarg = True
+                break
+        cache[cache_key] = accepts_kwarg
+        return accepts_kwarg
 
     def _flowmap_forward_target(self, target: Any = None) -> Any:
         if target is not None:

--- a/simpletuner/helpers/models/cosmos/model.py
+++ b/simpletuner/helpers/models/cosmos/model.py
@@ -487,6 +487,7 @@ class Cosmos2Image(VideoModelFoundation):
             padding_mask=pad_mask,
             return_dict=False,
             hidden_states_buffer=hidden_states_buffer,
+            **self._get_flowmap_r_timestep_forward_kwargs(prepared_batch),
         )[
             0
         ]  # transformer output

--- a/simpletuner/helpers/models/deepfloyd/model.py
+++ b/simpletuner/helpers/models/deepfloyd/model.py
@@ -164,6 +164,7 @@ class DeepFloydIF(ImageModelFoundation):
                 device=self.accelerator.device,
                 dtype=self.config.base_weight_dtype,
             )
+        self._apply_flowmap_r_timestep_kwargs(prediction_kwargs, prepared_batch)
         model_pred = self.model(
             prepared_batch["noisy_latents"].to(
                 device=self.accelerator.device,

--- a/simpletuner/helpers/models/ernie/model.py
+++ b/simpletuner/helpers/models/ernie/model.py
@@ -440,6 +440,7 @@ class Ernie(ImageModelFoundation):
             call_kwargs["hidden_states_buffer"] = hidden_states_buffer
         if getattr(self.config, "twinflow_enabled", False):
             call_kwargs["timestep_sign"] = prepared_batch.get("twinflow_time_sign")
+        self._apply_flowmap_r_timestep_kwargs(call_kwargs, prepared_batch)
 
         model_pred = self.model(**call_kwargs)[0].float()
 

--- a/simpletuner/helpers/models/flux/model.py
+++ b/simpletuner/helpers/models/flux/model.py
@@ -732,6 +732,7 @@ class Flux(ImageModelFoundation):
             flux_transformer_kwargs["hidden_states_buffer"] = hidden_states_buffer
         if grounding_kwargs is not None:
             flux_transformer_kwargs["grounding_kwargs"] = grounding_kwargs
+        self._apply_flowmap_r_timestep_kwargs(flux_transformer_kwargs, prepared_batch)
         if self.config.flux_attention_masked_training:
             attention_mask = prepared_batch["encoder_attention_mask"]
             if attention_mask is None:

--- a/simpletuner/helpers/models/flux2/model.py
+++ b/simpletuner/helpers/models/flux2/model.py
@@ -938,21 +938,21 @@ class Flux2(ImageModelFoundation):
             lat_in = packed_latents
             id_in = img_ids
 
-        # Forward pass using diffusers interface
-        # img_ids and txt_ids need to be 2D (S, 4) for the diffusers transformer
         timestep_sign = prepared_batch.get("twinflow_time_sign") if getattr(self.config, "twinflow_enabled", False) else None
-        output = self.model(
-            hidden_states=lat_in,
-            encoder_hidden_states=txt,
-            timestep=timesteps,
-            timestep_sign=timestep_sign,
-            img_ids=id_in[0] if id_in.ndim == 3 else id_in,
-            txt_ids=txt_ids[0] if txt_ids.ndim == 3 else txt_ids,
-            guidance=guidance,
-            return_dict=True,
-            force_keep_mask=force_keep_mask,
-            hidden_states_buffer=hidden_states_buffer,
-        )
+        transformer_kwargs = {
+            "hidden_states": lat_in,
+            "encoder_hidden_states": txt,
+            "timestep": timesteps,
+            "timestep_sign": timestep_sign,
+            "img_ids": id_in[0] if id_in.ndim == 3 else id_in,
+            "txt_ids": txt_ids[0] if txt_ids.ndim == 3 else txt_ids,
+            "guidance": guidance,
+            "return_dict": True,
+            "force_keep_mask": force_keep_mask,
+            "hidden_states_buffer": hidden_states_buffer,
+        }
+        self._apply_flowmap_r_timestep_kwargs(transformer_kwargs, prepared_batch)
+        output = self.model(**transformer_kwargs)
 
         # Extract sample from output
         model_pred = output.sample

--- a/simpletuner/helpers/models/heartmula/model.py
+++ b/simpletuner/helpers/models/heartmula/model.py
@@ -240,7 +240,12 @@ class HeartMuLa(AudioModelFoundation):
         tokens = prepared_batch["tokens"]
         tokens_mask = prepared_batch["tokens_mask"]
         attention_mask = tokens_mask.any(dim=-1).to(dtype=torch.long)
-        return self.model(tokens=tokens, tokens_mask=tokens_mask, attention_mask=attention_mask)
+        return self.model(
+            tokens=tokens,
+            tokens_mask=tokens_mask,
+            attention_mask=attention_mask,
+            **self._get_flowmap_r_timestep_forward_kwargs(prepared_batch),
+        )
 
     def loss(self, prepared_batch: dict, model_output, apply_conditioning_mask: bool = True):
         del apply_conditioning_mask

--- a/simpletuner/helpers/models/hidream/model.py
+++ b/simpletuner/helpers/models/hidream/model.py
@@ -610,6 +610,7 @@ class HiDream(ImageModelFoundation):
                 return_dict=False,
                 hidden_states_buffer=hidden_states_buffer,
                 grounding_kwargs=grounding_kwargs,
+                **self._get_flowmap_r_timestep_forward_kwargs(prepared_batch),
             )[0]
             * -1  # the model is trained with inverted velocity :(
         )

--- a/simpletuner/helpers/models/hunyuanvideo/model.py
+++ b/simpletuner/helpers/models/hunyuanvideo/model.py
@@ -725,6 +725,7 @@ class HunyuanVideo(VideoModelFoundation):
             image_embeds=image_embeds,
             return_dict=False,
             hidden_states_buffer=hidden_states_buffer,
+            **self._get_flowmap_r_timestep_forward_kwargs(prepared_batch, kwarg_name="timestep_r"),
         )[0]
         return {
             "model_prediction": model_pred,

--- a/simpletuner/helpers/models/kandinsky5_image/model.py
+++ b/simpletuner/helpers/models/kandinsky5_image/model.py
@@ -500,6 +500,7 @@ class Kandinsky5Image(ImageModelFoundation):
             )
         if hidden_states_buffer is not None:
             transformer_kwargs["hidden_states_buffer"] = hidden_states_buffer
+        self._apply_flowmap_r_timestep_kwargs(transformer_kwargs, prepared_batch)
 
         model_output = self.model(
             hidden_states=latents.to(dtype),

--- a/simpletuner/helpers/models/kandinsky5_video/model.py
+++ b/simpletuner/helpers/models/kandinsky5_video/model.py
@@ -552,6 +552,7 @@ class Kandinsky5Video(VideoModelFoundation):
         grounding_kwargs = self._build_grounding_position_net_kwargs(prepared_batch.get("grounding_batch"))
         if grounding_kwargs is not None:
             transformer_kwargs["grounding_kwargs"] = grounding_kwargs
+        self._apply_flowmap_r_timestep_kwargs(transformer_kwargs, prepared_batch)
 
         model_output = self.model(
             hidden_states=latents.to(dtype),

--- a/simpletuner/helpers/models/kolors/model.py
+++ b/simpletuner/helpers/models/kolors/model.py
@@ -218,6 +218,7 @@ class Kolors(ImageModelFoundation):
                     added_cond_kwargs=prepared_batch["added_cond_kwargs"],
                     cross_attention_kwargs=cross_attention_kwargs,
                     return_dict=False,
+                    **self._get_flowmap_r_timestep_forward_kwargs(prepared_batch),
                 )[0]
                 urepa_hidden = capture.get_captured()
         else:
@@ -238,6 +239,7 @@ class Kolors(ImageModelFoundation):
                 added_cond_kwargs=prepared_batch["added_cond_kwargs"],
                 cross_attention_kwargs=cross_attention_kwargs,
                 return_dict=False,
+                **self._get_flowmap_r_timestep_forward_kwargs(prepared_batch),
             )[0]
 
         return {

--- a/simpletuner/helpers/models/longcat_image/model.py
+++ b/simpletuner/helpers/models/longcat_image/model.py
@@ -734,6 +734,7 @@ class LongCatImage(ImageModelFoundation):
             img_ids=img_ids_input,
             hidden_states_buffer=hidden_states_buffer,
             return_dict=False,
+            **self._get_flowmap_r_timestep_forward_kwargs(prepared_batch),
         )[0]
 
         if self._is_edit_flavour():

--- a/simpletuner/helpers/models/longcat_video/model.py
+++ b/simpletuner/helpers/models/longcat_video/model.py
@@ -416,6 +416,7 @@ class LongCatVideo(VideoModelFoundation):
             num_cond_latents=cond_count,
             return_dict=False,
             hidden_states_buffer=hidden_states_buffer,
+            **self._get_flowmap_r_timestep_forward_kwargs(prepared_batch),
         )[0]
 
         if cond_count > 0 and model_pred.dim() == 5 and model_pred.shape[2] > cond_count:

--- a/simpletuner/helpers/models/ltxvideo/model.py
+++ b/simpletuner/helpers/models/ltxvideo/model.py
@@ -374,6 +374,7 @@ class LTXVideo(VideoModelFoundation):
         grounding_kwargs = self._build_grounding_position_net_kwargs(prepared_batch.get("grounding_batch"))
         if grounding_kwargs is not None:
             transformer_kwargs["grounding_kwargs"] = grounding_kwargs
+        self._apply_flowmap_r_timestep_kwargs(transformer_kwargs, prepared_batch)
 
         model_output = self.model(
             packed_noisy_latents,

--- a/simpletuner/helpers/models/ltxvideo2/model.py
+++ b/simpletuner/helpers/models/ltxvideo2/model.py
@@ -1601,6 +1601,7 @@ class LTXVideo2(VideoModelFoundation):
         grounding_kwargs = self._build_grounding_position_net_kwargs(prepared_batch.get("grounding_batch"))
         if grounding_kwargs is not None:
             transformer_kwargs["grounding_kwargs"] = grounding_kwargs
+        self._apply_flowmap_r_timestep_kwargs(transformer_kwargs, prepared_batch)
 
         model_output = self.model(**transformer_kwargs)
         if capture_hidden:

--- a/simpletuner/helpers/models/lumina2/model.py
+++ b/simpletuner/helpers/models/lumina2/model.py
@@ -238,6 +238,7 @@ class Lumina2(ImageModelFoundation):
             "return_dict": False,
             "hidden_states_buffer": hidden_states_buffer,
         }
+        self._apply_flowmap_r_timestep_kwargs(lumina_transformer_kwargs, prepared_batch)
 
         # Get model prediction
         model_pred = self.model(**lumina_transformer_kwargs)[0]

--- a/simpletuner/helpers/models/omnigen/model.py
+++ b/simpletuner/helpers/models/omnigen/model.py
@@ -372,6 +372,7 @@ class OmniGen(ImageModelFoundation):
             input_image_sizes=processed_data["input_image_sizes"] or {},
             return_dict=False,
             hidden_states_buffer=hidden_states_buffer,
+            **self._get_flowmap_r_timestep_forward_kwargs(prepared_batch),
         )[0]
 
         crepa_hidden = None

--- a/simpletuner/helpers/models/pixart/model.py
+++ b/simpletuner/helpers/models/pixart/model.py
@@ -282,6 +282,7 @@ class PixartSigma(ImageModelFoundation):
             cross_attention_kwargs=cross_attention_kwargs,
             return_dict=False,
             hidden_states_buffer=hidden_states_buffer,
+            **self._get_flowmap_r_timestep_forward_kwargs(prepared_batch),
         )[0].chunk(2, dim=1)[0]
 
         return {

--- a/simpletuner/helpers/models/qwen_image/model.py
+++ b/simpletuner/helpers/models/qwen_image/model.py
@@ -1239,6 +1239,7 @@ class QwenImage(ImageModelFoundation):
                 and "timestep_sign" in inspect.signature(self.model.__call__).parameters
             ):
                 call_kwargs["timestep_sign"] = prepared_batch.get("twinflow_time_sign")
+            self._apply_flowmap_r_timestep_kwargs(call_kwargs, prepared_batch)
             noise_pred = self.model(**call_kwargs)[0]
 
         target_ndim = target_latents.dim()
@@ -1394,6 +1395,7 @@ class QwenImage(ImageModelFoundation):
                 and "timestep_sign" in inspect.signature(self.model.__call__).parameters
             ):
                 call_kwargs["timestep_sign"] = prepared_batch.get("twinflow_time_sign")
+            self._apply_flowmap_r_timestep_kwargs(call_kwargs, prepared_batch)
             noise_pred = self.model(**call_kwargs)[0]
 
         noise_pred = noise_pred[:, : packed_latents.size(1)]
@@ -1543,6 +1545,7 @@ class QwenImage(ImageModelFoundation):
                 and "timestep_sign" in inspect.signature(self.model.__call__).parameters
             ):
                 call_kwargs["timestep_sign"] = prepared_batch.get("twinflow_time_sign")
+            self._apply_flowmap_r_timestep_kwargs(call_kwargs, prepared_batch)
             noise_pred = self.model(**call_kwargs)[0]
 
         noise_pred = noise_pred[:, : packed_latents.size(1)]

--- a/simpletuner/helpers/models/sana/model.py
+++ b/simpletuner/helpers/models/sana/model.py
@@ -172,22 +172,24 @@ class Sana(ImageModelFoundation):
             sequence_length=self._latent_sequence_length(prepared_batch["noisy_latents"]),
         )
         grounding_kwargs = self._build_grounding_position_net_kwargs(prepared_batch.get("grounding_batch"))
-        model_pred = self.model(
-            hidden_states=prepared_batch["noisy_latents"].to(
+        transformer_kwargs = {
+            "hidden_states": prepared_batch["noisy_latents"].to(
                 device=self.accelerator.device,
                 dtype=self.config.base_weight_dtype,
             ),
-            timestep=timesteps,
-            timestep_sign=prepared_batch.get("twinflow_time_sign"),
-            encoder_attention_mask=prepared_batch["encoder_attention_mask"],
-            encoder_hidden_states=prepared_batch["encoder_hidden_states"].to(
+            "timestep": timesteps,
+            "timestep_sign": prepared_batch.get("twinflow_time_sign"),
+            "encoder_attention_mask": prepared_batch["encoder_attention_mask"],
+            "encoder_hidden_states": prepared_batch["encoder_hidden_states"].to(
                 device=self.accelerator.device,
                 dtype=self.config.base_weight_dtype,
             ),
-            return_dict=False,
-            hidden_states_buffer=hidden_states_buffer,
-            grounding_kwargs=grounding_kwargs,
-        )[0]
+            "return_dict": False,
+            "hidden_states_buffer": hidden_states_buffer,
+            "grounding_kwargs": grounding_kwargs,
+        }
+        self._apply_flowmap_r_timestep_kwargs(transformer_kwargs, prepared_batch)
+        model_pred = self.model(**transformer_kwargs)[0]
 
         return {
             "model_prediction": model_pred,

--- a/simpletuner/helpers/models/sanavideo/model.py
+++ b/simpletuner/helpers/models/sanavideo/model.py
@@ -323,6 +323,7 @@ class SanaVideo(VideoModelFoundation):
         grounding_kwargs = self._build_grounding_position_net_kwargs(prepared_batch.get("grounding_batch"))
         if grounding_kwargs is not None:
             transformer_kwargs["grounding_kwargs"] = grounding_kwargs
+        self._apply_flowmap_r_timestep_kwargs(transformer_kwargs, prepared_batch)
 
         model_output = self.model(
             noisy_latents,

--- a/simpletuner/helpers/models/sd1x/model.py
+++ b/simpletuner/helpers/models/sd1x/model.py
@@ -213,6 +213,7 @@ class StableDiffusion1(ImageModelFoundation):
                     ),
                     cross_attention_kwargs=cross_attention_kwargs,
                     return_dict=False,
+                    **self._get_flowmap_r_timestep_forward_kwargs(prepared_batch),
                 )[0]
                 urepa_hidden = capture.get_captured()
         else:
@@ -228,6 +229,7 @@ class StableDiffusion1(ImageModelFoundation):
                 ),
                 cross_attention_kwargs=cross_attention_kwargs,
                 return_dict=False,
+                **self._get_flowmap_r_timestep_forward_kwargs(prepared_batch),
             )[0]
 
         return {

--- a/simpletuner/helpers/models/sd3/model.py
+++ b/simpletuner/helpers/models/sd3/model.py
@@ -451,25 +451,27 @@ class SD3(ImageModelFoundation):
         hidden_states_buffer = self._new_hidden_state_buffer()
         timesteps = prepared_batch["timesteps"].to(device=self.accelerator.device, dtype=self.config.weight_dtype)
         grounding_kwargs = self._build_grounding_position_net_kwargs(prepared_batch.get("grounding_batch"))
-        model_pred = self.model(
-            hidden_states=prepared_batch["noisy_latents"].to(
+        transformer_kwargs = {
+            "hidden_states": prepared_batch["noisy_latents"].to(
                 device=self.accelerator.device,
                 dtype=self.config.base_weight_dtype,
             ),
-            timestep=timesteps,
-            timestep_sign=prepared_batch.get("twinflow_time_sign"),
-            encoder_hidden_states=prepared_batch["encoder_hidden_states"].to(
+            "timestep": timesteps,
+            "timestep_sign": prepared_batch.get("twinflow_time_sign"),
+            "encoder_hidden_states": prepared_batch["encoder_hidden_states"].to(
                 device=self.accelerator.device,
                 dtype=self.config.base_weight_dtype,
             ),
-            pooled_projections=prepared_batch["add_text_embeds"].to(
+            "pooled_projections": prepared_batch["add_text_embeds"].to(
                 device=self.accelerator.device,
                 dtype=self.config.weight_dtype,
             ),
-            return_dict=False,
-            hidden_states_buffer=hidden_states_buffer,
-            grounding_kwargs=grounding_kwargs,
-        )[0]
+            "return_dict": False,
+            "hidden_states_buffer": hidden_states_buffer,
+            "grounding_kwargs": grounding_kwargs,
+        }
+        self._apply_flowmap_r_timestep_kwargs(transformer_kwargs, prepared_batch)
+        model_pred = self.model(**transformer_kwargs)[0]
 
         return {
             "model_prediction": model_pred,

--- a/simpletuner/helpers/models/sdxl/model.py
+++ b/simpletuner/helpers/models/sdxl/model.py
@@ -295,6 +295,7 @@ class SDXL(ImageModelFoundation):
                     added_cond_kwargs=prepared_batch["added_cond_kwargs"],
                     cross_attention_kwargs=cross_attention_kwargs,
                     return_dict=False,
+                    **self._get_flowmap_r_timestep_forward_kwargs(prepared_batch),
                 )[0]
                 urepa_hidden = capture.get_captured()
         else:
@@ -315,6 +316,7 @@ class SDXL(ImageModelFoundation):
                 added_cond_kwargs=prepared_batch["added_cond_kwargs"],
                 cross_attention_kwargs=cross_attention_kwargs,
                 return_dict=False,
+                **self._get_flowmap_r_timestep_forward_kwargs(prepared_batch),
             )[0]
 
         return {

--- a/simpletuner/helpers/models/stable_cascade/model.py
+++ b/simpletuner/helpers/models/stable_cascade/model.py
@@ -426,6 +426,7 @@ class StableCascadeStageC(ImageModelFoundation):
             clip_text_pooled=pooled,
             clip_img=clip_img,
             return_dict=False,
+            **self._get_flowmap_r_timestep_forward_kwargs(prepared_batch),
         )[0]
 
         return {"model_prediction": model_output}

--- a/simpletuner/helpers/models/wan/model.py
+++ b/simpletuner/helpers/models/wan/model.py
@@ -1232,6 +1232,7 @@ class Wan(VideoModelFoundation):
             wan_transformer_kwargs["grounding_kwargs"] = grounding_kwargs
 
         self._apply_i2v_conditioning_to_kwargs(prepared_batch, wan_transformer_kwargs)
+        self._apply_flowmap_r_timestep_kwargs(wan_transformer_kwargs, prepared_batch)
 
         # For masking with TREAD, avoid dropping any tokens that are in the mask
         if (

--- a/simpletuner/helpers/models/wan_s2v/model.py
+++ b/simpletuner/helpers/models/wan_s2v/model.py
@@ -391,6 +391,7 @@ class WanS2V(VideoModelFoundation):
         force_keep_mask = prepared_batch.get("force_keep_mask")
         if force_keep_mask is not None:
             wan_s2v_kwargs["force_keep_mask"] = force_keep_mask
+        self._apply_flowmap_r_timestep_kwargs(wan_s2v_kwargs, prepared_batch)
 
         model_output = self.model(**wan_s2v_kwargs)
 

--- a/simpletuner/helpers/models/z_image/model.py
+++ b/simpletuner/helpers/models/z_image/model.py
@@ -453,6 +453,7 @@ class ZImage(ImageModelFoundation):
             call_kwargs["timestep_sign"] = prepared_batch.get("twinflow_time_sign")
         if hidden_states_buffer is not None:
             call_kwargs["hidden_states_buffer"] = hidden_states_buffer
+        self._apply_flowmap_r_timestep_kwargs(call_kwargs, prepared_batch)
         model_out_list = self.model(
             latent_list,
             normalized_t,

--- a/simpletuner/helpers/models/z_image_omni/model.py
+++ b/simpletuner/helpers/models/z_image_omni/model.py
@@ -524,17 +524,21 @@ class ZImageOmni(ImageModelFoundation):
         )
 
         hidden_states_buffer = self._new_hidden_state_buffer()
+        call_kwargs = {
+            "timestep_sign": (
+                prepared_batch.get("twinflow_time_sign") if getattr(self.config, "twinflow_enabled", False) else None
+            ),
+            "return_dict": False,
+            "hidden_states_buffer": hidden_states_buffer,
+        }
+        self._apply_flowmap_r_timestep_kwargs(call_kwargs, prepared_batch)
         model_out_list = self.model(
             [sample for sample in latents],
             normalized_t,
             prompt_list,
             cond_latent_list,
             siglip_feats,
-            timestep_sign=(
-                prepared_batch.get("twinflow_time_sign") if getattr(self.config, "twinflow_enabled", False) else None
-            ),
-            return_dict=False,
-            hidden_states_buffer=hidden_states_buffer,
+            **call_kwargs,
         )[0]
 
         noise_pred = torch.stack([out.float() for out in model_out_list], dim=0)

--- a/tests/test_flowmap_r_timestep_kwargs.py
+++ b/tests/test_flowmap_r_timestep_kwargs.py
@@ -1,4 +1,6 @@
+import inspect
 import unittest
+from unittest.mock import patch
 
 import torch
 
@@ -95,6 +97,27 @@ class FlowMapRTimestepKwargsTests(unittest.TestCase):
 
         self.assertTrue(applied)
         self.assertIs(call_kwargs["timestep_r"], r_timesteps)
+
+    def test_forward_signature_support_is_cached(self):
+        r_timesteps = torch.tensor([0.25, 0.5])
+        target = _AcceptsRTimestep()
+
+        with patch(
+            "simpletuner.helpers.models.common.inspect.signature",
+            wraps=inspect.signature,
+        ) as signature:
+            self.model._apply_flowmap_r_timestep_kwargs(
+                {},
+                {self.model.FLOWMAP_R_TIMESTEP_BATCH_KEY: r_timesteps},
+                target=target.forward,
+            )
+            self.model._apply_flowmap_r_timestep_kwargs(
+                {},
+                {self.model.FLOWMAP_R_TIMESTEP_BATCH_KEY: r_timesteps},
+                target=target.forward,
+            )
+
+        self.assertEqual(signature.call_count, 1)
 
     def test_unsupported_forward_raises(self):
         with self.assertRaisesRegex(ValueError, "does not accept `r_timestep`"):

--- a/tests/test_flowmap_r_timestep_kwargs.py
+++ b/tests/test_flowmap_r_timestep_kwargs.py
@@ -1,0 +1,125 @@
+import unittest
+
+import torch
+
+from simpletuner.helpers.models.common import ModelFoundation
+
+
+class _DummyFoundation(ModelFoundation):
+    NAME = "dummy"
+
+    def model_predict(self, prepared_batch, custom_timesteps: list | None = None):
+        return prepared_batch
+
+    def _encode_prompts(self, prompts: list, is_negative_prompt: bool = False):
+        return prompts
+
+    def convert_text_embed_for_pipeline(self, text_embedding: torch.Tensor) -> dict:
+        return {"prompt_embeds": text_embedding}
+
+    def convert_negative_text_embed_for_pipeline(self, text_embedding: torch.Tensor) -> dict:
+        return {"negative_prompt_embeds": text_embedding}
+
+
+class _AcceptsRTimestep:
+    def forward(self, hidden_states=None, r_timestep=None):
+        return hidden_states, r_timestep
+
+
+class _AcceptsTimestepR:
+    def forward(self, hidden_states=None, timestep_r=None):
+        return hidden_states, timestep_r
+
+
+class _RejectsRTimestep:
+    def forward(self, hidden_states=None, timestep=None):
+        return hidden_states, timestep
+
+
+class _AcceptsArbitraryKwargs:
+    def forward(self, hidden_states=None, **kwargs):
+        return hidden_states, kwargs
+
+
+class FlowMapRTimestepKwargsTests(unittest.TestCase):
+    def setUp(self):
+        self.model = _DummyFoundation.__new__(_DummyFoundation)
+
+    def test_absent_key_leaves_kwargs_unchanged(self):
+        call_kwargs = {"timestep": torch.tensor([1.0])}
+
+        applied = self.model._apply_flowmap_r_timestep_kwargs(
+            call_kwargs,
+            {},
+            target=_RejectsRTimestep().forward,
+        )
+
+        self.assertFalse(applied)
+        self.assertEqual(set(call_kwargs), {"timestep"})
+
+    def test_none_key_leaves_kwargs_unchanged(self):
+        call_kwargs = {"timestep": torch.tensor([1.0])}
+
+        applied = self.model._apply_flowmap_r_timestep_kwargs(
+            call_kwargs,
+            {self.model.FLOWMAP_R_TIMESTEP_BATCH_KEY: None},
+            target=_RejectsRTimestep().forward,
+        )
+
+        self.assertFalse(applied)
+        self.assertEqual(set(call_kwargs), {"timestep"})
+
+    def test_supported_r_timestep_is_forwarded(self):
+        r_timesteps = torch.tensor([0.25, 0.5])
+        call_kwargs = {}
+
+        applied = self.model._apply_flowmap_r_timestep_kwargs(
+            call_kwargs,
+            {self.model.FLOWMAP_R_TIMESTEP_BATCH_KEY: r_timesteps},
+            target=_AcceptsRTimestep().forward,
+        )
+
+        self.assertTrue(applied)
+        self.assertIs(call_kwargs["r_timestep"], r_timesteps)
+
+    def test_supported_model_specific_kwarg_is_forwarded(self):
+        r_timesteps = torch.tensor([0.25, 0.5])
+        call_kwargs = {}
+
+        applied = self.model._apply_flowmap_r_timestep_kwargs(
+            call_kwargs,
+            {self.model.FLOWMAP_R_TIMESTEP_BATCH_KEY: r_timesteps},
+            target=_AcceptsTimestepR().forward,
+            kwarg_name="timestep_r",
+        )
+
+        self.assertTrue(applied)
+        self.assertIs(call_kwargs["timestep_r"], r_timesteps)
+
+    def test_unsupported_forward_raises(self):
+        with self.assertRaisesRegex(ValueError, "does not accept `r_timestep`"):
+            self.model._apply_flowmap_r_timestep_kwargs(
+                {},
+                {self.model.FLOWMAP_R_TIMESTEP_BATCH_KEY: torch.tensor([0.5])},
+                target=_RejectsRTimestep().forward,
+            )
+
+    def test_arbitrary_kwargs_do_not_count_as_model_support(self):
+        with self.assertRaisesRegex(ValueError, "does not accept `r_timestep`"):
+            self.model._apply_flowmap_r_timestep_kwargs(
+                {},
+                {self.model.FLOWMAP_R_TIMESTEP_BATCH_KEY: torch.tensor([0.5])},
+                target=_AcceptsArbitraryKwargs().forward,
+            )
+
+    def test_duplicate_kwarg_raises(self):
+        with self.assertRaisesRegex(ValueError, "duplicate `r_timestep`"):
+            self.model._apply_flowmap_r_timestep_kwargs(
+                {"r_timestep": torch.tensor([0.25])},
+                {self.model.FLOWMAP_R_TIMESTEP_BATCH_KEY: torch.tensor([0.5])},
+                target=_AcceptsRTimestep().forward,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces a unified and extensible approach for handling FlowMap r-timestep conditioning across multiple model classes in the codebase. The changes add helper methods to the `ModelFoundation` base class to standardize how FlowMap r-timestep arguments are detected and injected into model forward passes, and then update all relevant model classes to use these helpers. This improves maintainability, reduces code duplication, and makes it easier to support FlowMap features across new and existing models.

Key changes include:

**Core infrastructure for FlowMap r-timestep support:**

* Added `FLOWMAP_R_TIMESTEP_BATCH_KEY` and `FLOWMAP_R_TIMESTEP_KWARG` constants, and new helper methods (`_apply_flowmap_r_timestep_kwargs`, `_get_flowmap_r_timestep_forward_kwargs`, etc.) to the `ModelFoundation` base class in `common.py` to encapsulate FlowMap r-timestep argument handling and injection logic. [[1]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR403-R404) [[2]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR1089-R1159)

**Refactoring and standardization in model classes:**

* Updated all model `model_predict` methods to use the new helper methods for injecting FlowMap r-timestep arguments, replacing previous ad-hoc or missing handling. This includes models such as `ace_step`, `anima`, `auraflow`, `chroma`, `cosmos`, `deepfloyd`, `ernie`, `flux`, `flux2`, `heartmula`, `hidream`, `hunyuanvideo`, `kandinsky5_image`, `kandinsky5_video`, `kolors`, `longcat_image`, `longcat_video`, `ltxvideo`, and `ltxvideo2`. [[1]](diffhunk://#diff-e34e7b7e69a677399426b34f91fd1a10bb8e9f9f5a9eea54c8de088c103acebbL1650-R1669) [[2]](diffhunk://#diff-e34e7b7e69a677399426b34f91fd1a10bb8e9f9f5a9eea54c8de088c103acebbL1686-R1718) [[3]](diffhunk://#diff-66e251d021f0fc4ffd20b2e7d60bd4c639bf11b6c31fafaa15883c63825b3adcR644) [[4]](diffhunk://#diff-bb687de4a71d62f31bb7b892a22f0a94108d93d0323112a0bc221680a2890b5fR313) [[5]](diffhunk://#diff-571111f5431ee4a79012ae61ee50c3b6dffca3fbe3ccbdeba0a3132ca48343e7R644) [[6]](diffhunk://#diff-01ff9e59af344fe6857ccb05e1e335ed6c7029d571dfae4d6014dea582b36cfeR490) [[7]](diffhunk://#diff-68d87fba290a2ecb1f23edb2f5c8b5f44f32ad2726ad772612d1450947b81845R167) [[8]](diffhunk://#diff-a7ab6ed794f36a5aab241bc3bef2485e76dc6458967c677b52139d344390d362R443) [[9]](diffhunk://#diff-5aa130951df78ab03d60ca20b1126a94d40fb0035ac90907eb33b3de05345489R735) [[10]](diffhunk://#diff-2390d666883fb499d80e71fbe6b05b21e5141f934149c7fc66937368b6ae0c02L941-R955) [[11]](diffhunk://#diff-f75955529c86ae86b45707973af4702f3df11f9f575f417411fdde0a72559e9fL243-R248) [[12]](diffhunk://#diff-df6046a31196ac9ebae68e69c519f1db8029fb3d44f975605572c7d42401211dR613) [[13]](diffhunk://#diff-7415b0e19fb3d9edd0f57963ccdbfc2ea8946e23297f845a1f4948b75bead27bR728) [[14]](diffhunk://#diff-0e4e8215bf58377859f3a1fdcdc6830fc78a66180571a8644da1d0fc68214e25R503) [[15]](diffhunk://#diff-555e034e93759554c225e9431fea3e2f0142064207a2137c357006586161e252R555) [[16]](diffhunk://#diff-cc63a213fb94c7942037e1111f05b8aeafffed71c65b3f67f07e1961937da9a2R221) [[17]](diffhunk://#diff-cc63a213fb94c7942037e1111f05b8aeafffed71c65b3f67f07e1961937da9a2R242) [[18]](diffhunk://#diff-3c31404afbc2794ab1cade7c5646a388854e745fb3a5df70800b65737dc035daR737) [[19]](diffhunk://#diff-035c3b65c204f1bfbde1b88ca07e0d537e119d009ba012a6c430ac360e4ff07dR419) [[20]](diffhunk://#diff-d7441e8a834b13258f78e0abaf1c9d0974251cb17c3fdd3dec47d0e54a179f08R377) [[21]](diffhunk://#diff-64820a284b076801c442da19649e63dc4a2e00e645d7f92abbc5754b3dbae22fR1604)

**Error handling and validation:**

* The new helper methods include robust error checking to ensure that FlowMap r-timestep arguments are only injected when supported by the model's forward method, and provide clear error messages otherwise.

These changes collectively make FlowMap r-timestep support more robust, consistent, and easier to extend across all supported models.