### PR TITLE
AnyFlow: transformer-specific plumbing for all model families

### DIFF
--- a/simpletuner/helpers/models/ace_step/transformer.py
+++ b/simpletuner/helpers/models/ace_step/transformer.py
@@ -29,6 +29,14 @@ from diffusers.models.modeling_utils import ModelMixin
 from diffusers.utils import BaseOutput
 from torch import nn
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
+
 from .attention import LinearTransformerBlock, t2i_modulate
 from .lyrics_utils.lyric_encoder import ConformerEncoder as LyricEncoder
 
@@ -255,6 +263,8 @@ class ACEStepTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromO
         max_height: int = 16,
         max_width: int = 4096,
         enable_time_sign_embed: bool = False,
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
         **kwargs,
     ):
         super().__init__()
@@ -296,6 +306,14 @@ class ACEStepTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromO
 
         self.time_proj = Timesteps(num_channels=256, flip_sin_to_cos=True, downscale_freq_shift=0)
         self.timestep_embedder = TimestepEmbedding(in_channels=256, time_embed_dim=self.inner_dim)
+        self.delta_timestep_embedder: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
         self.t_block = nn.Sequential(nn.SiLU(), nn.Linear(self.inner_dim, 6 * self.inner_dim, bias=True))
         # Signed-time embedding for TwinFlow-style negative time handling.
         self.time_sign_embed: Optional[nn.Embedding] = None
@@ -351,6 +369,13 @@ class ACEStepTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromO
 
     def set_gradient_checkpointing_backend(self, backend: str):
         self.gradient_checkpointing_backend = backend
+
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="ACEStep")
+        if self.delta_timestep_embedder is None:
+            self.delta_timestep_embedder = clone_flowmap_embedder(self.timestep_embedder)
+        set_flowmap_gate(self, gate_value)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
 
     # Copied from diffusers.models.unets.unet_3d_condition.UNet3DConditionModel.enable_forward_chunking
     def enable_forward_chunking(self, chunk_size: Optional[int] = None, dim: int = 0) -> None:
@@ -469,6 +494,7 @@ class ACEStepTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromO
         encoder_hidden_mask: torch.Tensor,
         timestep: Optional[torch.Tensor],
         timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
         ssl_hidden_states: Optional[List[torch.Tensor]] = None,
         output_length: int = 0,
         block_controlnet_hidden_states: Optional[Union[List[torch.Tensor], torch.Tensor]] = None,
@@ -515,6 +541,28 @@ class ACEStepTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromO
             timestep,
             dtype=hidden_states.dtype,
         )
+        if r_timestep is not None:
+            if self.delta_timestep_embedder is None or self.flowmap_deltatime_type is None:
+                raise ValueError(
+                    "ACEStep FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training."
+                )
+            delta_timestep = prepare_flowmap_delta_timestep(
+                timestep,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                model_name="ACEStep",
+            )
+            delta_emb = _acestep_apply_tokenwise_timestep_embed(
+                self.time_proj,
+                self.delta_timestep_embedder,
+                delta_timestep,
+                dtype=hidden_states.dtype,
+            )
+            embedded_timestep = blend_flowmap_embeddings(
+                embedded_timestep,
+                delta_emb,
+                self.flowmap_delta_emb_gate,
+            )
         if timestep_sign is not None:
             if self.time_sign_embed is None:
                 raise ValueError(
@@ -661,6 +709,7 @@ class ACEStepTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromO
         lyric_mask: Optional[torch.LongTensor] = None,
         timestep: Optional[torch.Tensor] = None,
         timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
         ssl_hidden_states: Optional[List[torch.Tensor]] = None,
         block_controlnet_hidden_states: Optional[Union[List[torch.Tensor], torch.Tensor]] = None,
         controlnet_scale: Union[float, torch.Tensor] = 1.0,
@@ -684,6 +733,7 @@ class ACEStepTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromO
             encoder_hidden_mask=encoder_hidden_mask,
             timestep=timestep,
             timestep_sign=timestep_sign,
+            r_timestep=r_timestep,
             ssl_hidden_states=ssl_hidden_states,
             output_length=output_length,
             block_controlnet_hidden_states=block_controlnet_hidden_states,

--- a/simpletuner/helpers/models/anima/transformer.py
+++ b/simpletuner/helpers/models/anima/transformer.py
@@ -11,7 +11,7 @@ from typing import Any, Optional
 
 import torch
 import torch.nn.functional as F
-from diffusers import CosmosTransformer3DModel, ModelMixin
+from diffusers import ModelMixin
 from diffusers.configuration_utils import ConfigMixin, register_to_config
 from diffusers.loaders import PeftAdapterMixin
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
@@ -20,6 +20,8 @@ from diffusers.utils import USE_PEFT_BACKEND, set_weights_and_activate_adapters
 from huggingface_hub import hf_hub_download
 from safetensors.torch import load_file
 from torch import nn
+
+from simpletuner.helpers.models.cosmos.transformer import CosmosTransformer3DModel
 
 DEFAULT_ANIMA_TRANSFORMER_FILENAME = "anima-preview.safetensors"
 DIFFUSERS_LLM_ADAPTER_FILENAME = "llm_adapter/diffusion_pytorch_model.safetensors"
@@ -325,6 +327,8 @@ class AnimaTransformerModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         adapter_dim: int = 1024,
         adapter_layers: int = 6,
         adapter_heads: int = 16,
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ):
         super().__init__()
         core = _create_anima_transformer_core_model(
@@ -339,6 +343,8 @@ class AnimaTransformerModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
             max_size=tuple(max_size),
             patch_size=tuple(patch_size),
             rope_scale=tuple(rope_scale),
+            gate_value=gate_value,
+            deltatime_type=deltatime_type,
         )
         _patch_diffusers_rmsnorm_to_anima(core)
         self.core = core
@@ -369,6 +375,7 @@ class AnimaTransformerModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         timestep: torch.Tensor,
         encoder_hidden_states: torch.Tensor,
         return_dict: bool = True,
+        r_timestep: Optional[torch.Tensor] = None,
         **kwargs: Any,
     ) -> Transformer2DModelOutput | tuple[torch.Tensor]:
         t5xxl_ids = kwargs.pop("t5xxl_ids", None)
@@ -401,6 +408,7 @@ class AnimaTransformerModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
             sample = self.core(
                 hidden_states=hidden_states,
                 timestep=timestep,
+                r_timestep=r_timestep,
                 encoder_hidden_states=encoder_hidden_states,
                 padding_mask=padding_mask,
                 return_dict=False,
@@ -412,6 +420,10 @@ class AnimaTransformerModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         if not return_dict:
             return (sample,)
         return Transformer2DModelOutput(sample=sample)
+
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.core.enable_flowmap_time_conditioning(gate_value=gate_value, deltatime_type=deltatime_type)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
 
     def set_adapters(
         self,
@@ -668,6 +680,8 @@ def _create_anima_transformer_core_model(
     max_size: tuple[int, int, int] = (128, 240, 240),
     patch_size: tuple[int, int, int] = (1, 2, 2),
     rope_scale: tuple[float, float, float] = (1.0, 4.0, 4.0),
+    gate_value: Optional[float] = None,
+    deltatime_type: Optional[str] = None,
 ) -> CosmosTransformer3DModel:
     return CosmosTransformer3DModel(
         in_channels=in_channels,
@@ -683,6 +697,8 @@ def _create_anima_transformer_core_model(
         rope_scale=rope_scale,
         concat_padding_mask=True,
         extra_pos_embed_type=None,
+        gate_value=gate_value,
+        deltatime_type=deltatime_type,
     )
 
 

--- a/simpletuner/helpers/models/auraflow/transformer.py
+++ b/simpletuner/helpers/models/auraflow/transformer.py
@@ -19,6 +19,13 @@ from diffusers.models.normalization import AdaLayerNormZero, FP32LayerNorm
 from diffusers.utils import USE_PEFT_BACKEND, is_torch_version, logging, scale_lora_layers, unscale_lora_layers
 from diffusers.utils.torch_utils import maybe_allow_in_graph
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
 from simpletuner.helpers.training.tread import TREADRouter
@@ -402,6 +409,8 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
         enable_time_sign_embed: bool = False,
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ):
         super().__init__()
         default_out_channels = in_channels
@@ -421,6 +430,8 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
             enable_time_sign_embed=enable_time_sign_embed,
             musubi_blocks_to_swap=musubi_blocks_to_swap,
             musubi_block_swap_device=musubi_block_swap_device,
+            gate_value=gate_value,
+            deltatime_type=deltatime_type,
         )
         self.out_channels = effective_out_channels
         self.inner_dim = self.config.num_attention_heads * self.config.attention_head_dim
@@ -441,6 +452,14 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
         )
         self.time_step_embed = Timesteps(num_channels=256, downscale_freq_shift=0, scale=1000, flip_sin_to_cos=True)
         self.time_step_proj = TimestepEmbedding(in_channels=256, time_embed_dim=self.inner_dim)
+        self.delta_time_step_proj: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
         # Signed-time embedding for TwinFlow-style negative time handling.
         self.time_sign_embed: Optional[nn.Embedding] = None
         if enable_time_sign_embed:
@@ -503,6 +522,13 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
         """Set the TREAD router and routing configuration."""
         self._tread_router = router
         self._tread_routes = routes
+
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="AuraFlow")
+        if self.delta_time_step_proj is None:
+            self.delta_time_step_proj = clone_flowmap_embedder(self.time_step_proj)
+        set_flowmap_gate(self, gate_value)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
 
     def enable_forward_chunking(self, chunk_size: Optional[int] = None, dim: int = 0) -> None:
         """
@@ -633,6 +659,7 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
         block_controlnet_hidden_states: List = None,
         return_dict: bool = True,
         skip_layers: Optional[List[int]] = None,
+        r_timestep: Optional[torch.Tensor] = None,
         force_keep_mask: Optional[torch.Tensor] = None,
         hidden_states_buffer: Optional[dict] = None,
         grounding_kwargs: dict | None = None,
@@ -682,6 +709,7 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
             sequence_length=hidden_states.shape[1],
             dtype=next(self.parameters()).dtype,
             device=hidden_states.device,
+            r_timestep=r_timestep,
         )
         if timestep_sign is not None:
             if self.time_sign_embed is None:
@@ -1048,17 +1076,39 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
         sequence_length: int,
         dtype: torch.dtype,
         device: torch.device,
+        r_timestep: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if timestep.ndim != 2:
+        if timestep.ndim != 2 and r_timestep is None:
             temb = self.time_step_embed(timestep).to(dtype=dtype)
-            return self.time_step_proj(temb)
+            return self.time_step_proj(temb).to(device=device, dtype=dtype)
 
-        if timestep.shape[0] != batch_size or timestep.shape[1] != sequence_length:
+        if timestep.ndim == 2 and (timestep.shape[0] != batch_size or timestep.shape[1] != sequence_length):
             raise ValueError(
                 f"AuraFlow tokenwise timestep embedding expected shape ({batch_size}, {sequence_length}), got {tuple(timestep.shape)}."
             )
 
-        timestep_flat = timestep.reshape(-1)
+        timestep_flat = timestep.reshape(-1) if timestep.ndim == 2 else timestep
         temb = self.time_step_embed(timestep_flat).to(dtype=dtype)
         temb = self.time_step_proj(temb)
-        return temb.view(batch_size, sequence_length, -1).to(device=device, dtype=dtype)
+        if timestep.ndim == 2:
+            temb = temb.view(batch_size, sequence_length, -1)
+
+        if r_timestep is not None:
+            if self.delta_time_step_proj is None or self.flowmap_deltatime_type is None:
+                raise ValueError(
+                    "AuraFlow FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training."
+                )
+            delta_timestep = prepare_flowmap_delta_timestep(
+                timestep,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                model_name="AuraFlow",
+            )
+            delta_flat = delta_timestep.reshape(-1) if delta_timestep.ndim == 2 else delta_timestep
+            delta_temb = self.time_step_embed(delta_flat).to(dtype=dtype)
+            delta_temb = self.delta_time_step_proj(delta_temb)
+            if delta_timestep.ndim == 2:
+                delta_temb = delta_temb.view(delta_timestep.shape[0], delta_timestep.shape[1], -1)
+            temb = blend_flowmap_embeddings(temb, delta_temb, self.flowmap_delta_emb_gate)
+
+        return temb.to(device=device, dtype=dtype)

--- a/simpletuner/helpers/models/chroma/transformer.py
+++ b/simpletuner/helpers/models/chroma/transformer.py
@@ -22,6 +22,13 @@ from diffusers.utils.torch_utils import maybe_allow_in_graph
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.attention_backend import AttentionBackendController
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
@@ -585,6 +592,8 @@ class ChromaTransformer2DModel(
         enable_time_sign_embed: bool = False,
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ):
         super().__init__()
         effective_out_channels = out_channels or in_channels
@@ -604,6 +613,8 @@ class ChromaTransformer2DModel(
             enable_time_sign_embed=enable_time_sign_embed,
             musubi_blocks_to_swap=musubi_blocks_to_swap,
             musubi_block_swap_device=musubi_block_swap_device,
+            gate_value=gate_value,
+            deltatime_type=deltatime_type,
         )
         self.out_channels = effective_out_channels
         self.inner_dim = num_attention_heads * attention_head_dim
@@ -625,6 +636,14 @@ class ChromaTransformer2DModel(
             hidden_dim=approximator_hidden_dim,
             n_layers=approximator_layers,
         )
+        self.delta_distilled_guidance_layer: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
 
         self.context_embedder = nn.Linear(joint_attention_dim, self.inner_dim)
         self.x_embedder = nn.Linear(in_channels, self.inner_dim)
@@ -681,6 +700,13 @@ class ChromaTransformer2DModel(
         self._tread_router = router
         self._tread_routes = routes
 
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="Chroma")
+        if self.delta_distilled_guidance_layer is None:
+            self.delta_distilled_guidance_layer = clone_flowmap_embedder(self.distilled_guidance_layer)
+        set_flowmap_gate(self, gate_value)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
+
     @staticmethod
     def _route_rope(rope, info, keep_len: int, batch: int):
         """
@@ -705,6 +731,7 @@ class ChromaTransformer2DModel(
         encoder_hidden_states: torch.Tensor = None,
         timestep: torch.LongTensor = None,
         timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
         img_ids: torch.Tensor = None,
         txt_ids: torch.Tensor = None,
         attention_mask: torch.Tensor = None,
@@ -742,6 +769,21 @@ class ChromaTransformer2DModel(
 
         input_vec = _chroma_tokenwise_time_conditioning(self.time_text_embed, timestep)
         pooled_temb = self.distilled_guidance_layer(input_vec)
+        if r_timestep is not None:
+            if self.delta_distilled_guidance_layer is None or self.flowmap_deltatime_type is None:
+                raise ValueError(
+                    "Chroma FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training."
+                )
+            r_timestep = r_timestep.to(device=timestep.device, dtype=timestep.dtype) * 1000
+            delta_timestep = prepare_flowmap_delta_timestep(
+                timestep,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                model_name="Chroma",
+            )
+            delta_input_vec = _chroma_tokenwise_time_conditioning(self.time_text_embed, delta_timestep)
+            delta_pooled_temb = self.delta_distilled_guidance_layer(delta_input_vec)
+            pooled_temb = blend_flowmap_embeddings(pooled_temb, delta_pooled_temb, self.flowmap_delta_emb_gate)
         if timestep_sign is not None:
             if self.time_sign_embed is None:
                 raise ValueError(

--- a/simpletuner/helpers/models/chroma/transformer.py
+++ b/simpletuner/helpers/models/chroma/transformer.py
@@ -20,8 +20,6 @@ from diffusers.utils import USE_PEFT_BACKEND, deprecate, logging, scale_lora_lay
 from diffusers.utils.import_utils import is_torch_npu_available
 from diffusers.utils.torch_utils import maybe_allow_in_graph
 
-logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
-
 from simpletuner.helpers.models.flowmap import (
     blend_flowmap_embeddings,
     clone_flowmap_embedder,
@@ -34,6 +32,8 @@ from simpletuner.helpers.training.attention_backend import AttentionBackendContr
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
 from simpletuner.helpers.training.qk_clip_logging import publish_attention_max_logits
 from simpletuner.helpers.training.tread import TREADRouter
+
+logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 def _store_hidden_state(buffer, key: str, hidden_states: torch.Tensor, image_tokens_start: int | None = None):

--- a/simpletuner/helpers/models/cosmos/transformer.py
+++ b/simpletuner/helpers/models/cosmos/transformer.py
@@ -134,7 +134,7 @@ class CosmosEmbedding(PatchableModule):
         hidden_states: torch.Tensor,
         timestep: torch.LongTensor,
         r_timestep: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         if timestep.ndim == 2:
             batch_size, sequence_length = timestep.shape
             timesteps_proj = self.time_proj(timestep.reshape(-1)).type_as(hidden_states)

--- a/simpletuner/helpers/models/cosmos/transformer.py
+++ b/simpletuner/helpers/models/cosmos/transformer.py
@@ -32,6 +32,13 @@ from diffusers.models.modeling_utils import ModelMixin
 from diffusers.models.normalization import RMSNorm
 from diffusers.utils import USE_PEFT_BACKEND, is_torchvision_available, logging, scale_lora_layers, unscale_lora_layers
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.qk_clip_logging import publish_attention_max_logits
 from simpletuner.helpers.training.tread import TREADRouter
@@ -109,18 +116,61 @@ class CosmosEmbedding(PatchableModule):
         self.time_proj = Timesteps(embedding_dim, flip_sin_to_cos=True, downscale_freq_shift=0.0)
         self.t_embedder = CosmosTimestepEmbedding(embedding_dim, condition_dim)
         self.norm = RMSNorm(embedding_dim, eps=1e-6, elementwise_affine=True)
+        self.delta_t_embedder: Optional[PatchableModule] = None
+        self.delta_norm: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
 
-    def forward(self, hidden_states: torch.Tensor, timestep: torch.LongTensor) -> torch.Tensor:
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="Cosmos")
+        if self.delta_t_embedder is None:
+            self.delta_t_embedder = clone_flowmap_embedder(self.t_embedder)
+        if self.delta_norm is None:
+            self.delta_norm = clone_flowmap_embedder(self.norm)
+        set_flowmap_gate(self, gate_value)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.LongTensor,
+        r_timestep: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
         if timestep.ndim == 2:
             batch_size, sequence_length = timestep.shape
             timesteps_proj = self.time_proj(timestep.reshape(-1)).type_as(hidden_states)
             temb = self.t_embedder(timesteps_proj).view(batch_size, sequence_length, -1)
             embedded_timestep = self.norm(timesteps_proj).view(batch_size, sequence_length, -1)
-            return temb, embedded_timestep
+        else:
+            timesteps_proj = self.time_proj(timestep).type_as(hidden_states)
+            temb = self.t_embedder(timesteps_proj)
+            embedded_timestep = self.norm(timesteps_proj)
 
-        timesteps_proj = self.time_proj(timestep).type_as(hidden_states)
-        temb = self.t_embedder(timesteps_proj)
-        embedded_timestep = self.norm(timesteps_proj)
+        if r_timestep is not None:
+            if self.delta_t_embedder is None or self.delta_norm is None or self.flowmap_deltatime_type is None:
+                raise ValueError(
+                    "Cosmos FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training."
+                )
+            delta_timestep = prepare_flowmap_delta_timestep(
+                timestep,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                model_name="Cosmos",
+            )
+            if delta_timestep.ndim == 2:
+                batch_size, sequence_length = delta_timestep.shape
+                delta_proj = self.time_proj(delta_timestep.reshape(-1)).type_as(hidden_states)
+                delta_temb = self.delta_t_embedder(delta_proj).view(batch_size, sequence_length, -1)
+                delta_embedded_timestep = self.delta_norm(delta_proj).view(batch_size, sequence_length, -1)
+            else:
+                delta_proj = self.time_proj(delta_timestep).type_as(hidden_states)
+                delta_temb = self.delta_t_embedder(delta_proj)
+                delta_embedded_timestep = self.delta_norm(delta_proj)
+            temb = blend_flowmap_embeddings(temb, delta_temb, self.flowmap_delta_emb_gate)
+            embedded_timestep = blend_flowmap_embeddings(
+                embedded_timestep,
+                delta_embedded_timestep,
+                self.flowmap_delta_emb_gate,
+            )
         return temb, embedded_timestep
 
 
@@ -548,6 +598,8 @@ class CosmosTransformer3DModel(PatchableModule, ModelMixin, ConfigMixin, FromOri
         extra_pos_embed_type: Optional[str] = "learnable",
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ) -> None:
         super().__init__()
         self.register_to_config(
@@ -566,6 +618,8 @@ class CosmosTransformer3DModel(PatchableModule, ModelMixin, ConfigMixin, FromOri
             extra_pos_embed_type=extra_pos_embed_type,
             musubi_blocks_to_swap=musubi_blocks_to_swap,
             musubi_block_swap_device=musubi_block_swap_device,
+            gate_value=gate_value,
+            deltatime_type=deltatime_type,
         )
         hidden_size = num_attention_heads * attention_head_dim
 
@@ -591,6 +645,11 @@ class CosmosTransformer3DModel(PatchableModule, ModelMixin, ConfigMixin, FromOri
 
         # 3. Time Embedding
         self.time_embed = CosmosEmbedding(hidden_size, hidden_size)
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
 
         # 4. Transformer Blocks
         self.transformer_blocks = MutableModuleList(
@@ -628,6 +687,10 @@ class CosmosTransformer3DModel(PatchableModule, ModelMixin, ConfigMixin, FromOri
         self._tread_router = None
         self._tread_routes = None
 
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.time_embed.enable_flowmap_time_conditioning(gate_value=gate_value, deltatime_type=deltatime_type)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
+
     def set_router(self, router: TREADRouter, routes: Optional[List[Dict]] = None):
         """Set TREAD router and routes for token reduction during training."""
         self._tread_router = router
@@ -646,6 +709,7 @@ class CosmosTransformer3DModel(PatchableModule, ModelMixin, ConfigMixin, FromOri
         force_keep_mask: Optional[torch.Tensor] = None,
         return_dict: bool = True,
         hidden_states_buffer: Optional[dict] = None,
+        r_timestep: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if joint_attention_kwargs is not None:
             joint_attention_kwargs = joint_attention_kwargs.copy()
@@ -755,7 +819,7 @@ class CosmosTransformer3DModel(PatchableModule, ModelMixin, ConfigMixin, FromOri
 
         # 4. Timestep embeddings
         if timestep.ndim == 1:
-            temb, embedded_timestep = self.time_embed(hidden_states, timestep)
+            temb, embedded_timestep = self.time_embed(hidden_states, timestep, r_timestep=r_timestep)
         elif timestep.ndim == 2:
             if timestep.shape[1] != token_count:
                 raise ValueError(
@@ -767,7 +831,7 @@ class CosmosTransformer3DModel(PatchableModule, ModelMixin, ConfigMixin, FromOri
                 raise ValueError(
                     f"Cosmos expected tokenwise timesteps for batch size {batch_size}, got {timestep.shape[0]}."
                 )
-            temb, embedded_timestep = self.time_embed(hidden_states, timestep)
+            temb, embedded_timestep = self.time_embed(hidden_states, timestep, r_timestep=r_timestep)
         elif timestep.ndim == 5:
             assert timestep.shape == (
                 batch_size,
@@ -777,7 +841,9 @@ class CosmosTransformer3DModel(PatchableModule, ModelMixin, ConfigMixin, FromOri
                 1,
             ), f"Expected timestep to have shape [B, 1, T, 1, 1], but got {timestep.shape}"
             timestep = timestep.flatten()
-            temb, embedded_timestep = self.time_embed(hidden_states, timestep)
+            if r_timestep is not None and r_timestep.ndim == 5:
+                r_timestep = r_timestep.flatten()
+            temb, embedded_timestep = self.time_embed(hidden_states, timestep, r_timestep=r_timestep)
             # We can do this because num_frames == post_patch_num_frames, as p_t is 1
             temb, embedded_timestep = (
                 x.view(batch_size, post_patch_num_frames, 1, 1, -1)

--- a/simpletuner/helpers/models/ernie/transformer.py
+++ b/simpletuner/helpers/models/ernie/transformer.py
@@ -72,6 +72,7 @@ class ErnieImageTransformer2DModel(
         force_keep_mask: Optional[torch.Tensor] = None,
         hidden_states_buffer: Optional[dict] = None,
         timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
         skip_layers: Optional[List[int]] = None,
     ):
         device, dtype = hidden_states.device, hidden_states.dtype
@@ -132,6 +133,8 @@ class ErnieImageTransformer2DModel(
 
         timestep_proj = self.time_proj(timestep).to(dtype=dtype)
         conditioning = self.time_embedding(timestep_proj)
+        if r_timestep is not None:
+            conditioning = self._apply_flowmap_time_conditioning(timestep, r_timestep, conditioning, dtype)
         if timestep_sign is not None:
             if self.time_sign_embed is None:
                 raise ValueError(

--- a/simpletuner/helpers/models/ernie/transformer_diffusers.py
+++ b/simpletuner/helpers/models/ernie/transformer_diffusers.py
@@ -32,6 +32,13 @@ from diffusers.models.modeling_utils import ModelMixin
 from diffusers.models.normalization import RMSNorm
 from diffusers.utils import BaseOutput, logging
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -307,6 +314,8 @@ class ErnieImageTransformer2DModel(ModelMixin, ConfigMixin):
         enable_time_sign_embed: bool = False,
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ):
         super().__init__()
         self.hidden_size = hidden_size
@@ -322,6 +331,14 @@ class ErnieImageTransformer2DModel(ModelMixin, ConfigMixin):
         self.text_proj = nn.Linear(text_in_dim, hidden_size, bias=False) if text_in_dim != hidden_size else None
         self.time_proj = Timesteps(hidden_size, flip_sin_to_cos=False, downscale_freq_shift=0)
         self.time_embedding = TimestepEmbedding(hidden_size, hidden_size)
+        self.delta_time_embedding: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
         self.time_sign_embed = None
         if enable_time_sign_embed:
             self.time_sign_embed = nn.Embedding(2, hidden_size)
@@ -351,6 +368,34 @@ class ErnieImageTransformer2DModel(ModelMixin, ConfigMixin):
             logger=logger,
         )
 
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="ERNIE")
+        if self.delta_time_embedding is None:
+            self.delta_time_embedding = clone_flowmap_embedder(self.time_embedding)
+        set_flowmap_gate(self, gate_value)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
+
+    def _apply_flowmap_time_conditioning(
+        self,
+        timestep: torch.Tensor,
+        r_timestep: torch.Tensor,
+        conditioning: torch.Tensor,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        if self.delta_time_embedding is None or self.flowmap_deltatime_type is None:
+            raise ValueError("ERNIE FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training.")
+        delta_timestep = prepare_flowmap_delta_timestep(
+            timestep,
+            r_timestep,
+            self.flowmap_deltatime_type,
+            model_name="ERNIE",
+        )
+        delta_proj = self.time_proj(delta_timestep.reshape(-1)).to(dtype=dtype)
+        delta_conditioning = self.delta_time_embedding(delta_proj)
+        if delta_timestep.ndim > 1:
+            delta_conditioning = delta_conditioning.view(*delta_timestep.shape, -1)
+        return blend_flowmap_embeddings(conditioning, delta_conditioning, self.flowmap_delta_emb_gate)
+
     @property
     def device(self):
         return next(self.x_embedder.parameters()).device
@@ -364,6 +409,7 @@ class ErnieImageTransformer2DModel(ModelMixin, ConfigMixin):
         text_lens: torch.Tensor,
         return_dict: bool = True,
         timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
         skip_layers: Optional[List[int]] = None,
     ):
         device, dtype = hidden_states.device, hidden_states.dtype
@@ -421,6 +467,8 @@ class ErnieImageTransformer2DModel(ModelMixin, ConfigMixin):
         sample = self.time_proj(timestep)
         sample = sample.to(dtype=dtype)
         c = self.time_embedding(sample)
+        if r_timestep is not None:
+            c = self._apply_flowmap_time_conditioning(timestep, r_timestep, c, dtype)
         if timestep_sign is not None:
             if self.time_sign_embed is None:
                 raise ValueError(

--- a/simpletuner/helpers/models/flowmap.py
+++ b/simpletuner/helpers/models/flowmap.py
@@ -1,0 +1,115 @@
+import copy
+from typing import Any
+
+import torch
+
+
+def clone_flowmap_embedder(embedder: torch.nn.Module) -> torch.nn.Module:
+    return copy.deepcopy(embedder)
+
+
+def validate_flowmap_deltatime_type(deltatime_type: str, *, model_name: str) -> str:
+    if deltatime_type not in ("r", "t-r"):
+        raise ValueError(f"{model_name} FlowMap deltatime_type must be 'r' or 't-r'.")
+    return deltatime_type
+
+
+def set_flowmap_gate(module: torch.nn.Module, gate_value: float, *, buffer_name: str = "flowmap_delta_emb_gate") -> None:
+    gate = getattr(module, buffer_name)
+    gate.data = torch.tensor([float(gate_value)], device=gate.device, dtype=gate.dtype)
+
+
+def prepare_flowmap_delta_timestep(
+    timestep: torch.Tensor,
+    r_timestep: torch.Tensor,
+    deltatime_type: str,
+    *,
+    model_name: str,
+) -> torch.Tensor:
+    validate_flowmap_deltatime_type(deltatime_type, model_name=model_name)
+    if not torch.is_tensor(r_timestep):
+        raise TypeError(f"{model_name} FlowMap r_timestep must be a torch.Tensor, got {type(r_timestep).__name__}.")
+
+    r_timestep = r_timestep.to(device=timestep.device, dtype=timestep.dtype)
+    if timestep.ndim == 0:
+        if r_timestep.ndim == 0:
+            pass
+        elif r_timestep.numel() == 1:
+            r_timestep = r_timestep.reshape(())
+        else:
+            raise ValueError(
+                f"{model_name} FlowMap expected scalar r_timestep for scalar timesteps, got shape {tuple(r_timestep.shape)}."
+            )
+    elif timestep.ndim == 1:
+        if r_timestep.ndim == 0:
+            r_timestep = r_timestep.expand(timestep.shape[0])
+        elif r_timestep.ndim == 1:
+            if r_timestep.shape[0] == 1:
+                r_timestep = r_timestep.expand(timestep.shape[0])
+            elif r_timestep.shape[0] != timestep.shape[0]:
+                raise ValueError(
+                    f"{model_name} FlowMap expected 1 or {timestep.shape[0]} r_timestep values, got {r_timestep.shape[0]}."
+                )
+        else:
+            raise ValueError(
+                f"{model_name} FlowMap expected scalar or 1D r_timestep for batch timesteps, got shape {tuple(r_timestep.shape)}."
+            )
+    elif timestep.ndim == 2:
+        if r_timestep.ndim == 0:
+            r_timestep = r_timestep.expand(timestep.shape)
+        elif r_timestep.ndim == 1:
+            if r_timestep.shape[0] == 1:
+                r_timestep = r_timestep.expand(timestep.shape[0])
+            elif r_timestep.shape[0] != timestep.shape[0]:
+                raise ValueError(
+                    f"{model_name} FlowMap expected 1 or {timestep.shape[0]} batch r_timestep values, got {r_timestep.shape[0]}."
+                )
+            r_timestep = r_timestep[:, None].expand(-1, timestep.shape[1])
+        elif r_timestep.ndim == 2:
+            if r_timestep.shape[1] != timestep.shape[1]:
+                raise ValueError(
+                    f"{model_name} FlowMap tokenwise r_timestep expected sequence length {timestep.shape[1]}, got {r_timestep.shape[1]}."
+                )
+            if r_timestep.shape[0] == 1:
+                r_timestep = r_timestep.expand(timestep.shape[0], -1)
+            elif r_timestep.shape[0] != timestep.shape[0]:
+                raise ValueError(
+                    f"{model_name} FlowMap tokenwise r_timestep expected batch size {timestep.shape[0]}, got {r_timestep.shape[0]}."
+                )
+        else:
+            raise ValueError(
+                f"{model_name} FlowMap expected scalar, 1D, or 2D r_timestep, got shape {tuple(r_timestep.shape)}."
+            )
+    else:
+        raise ValueError(f"{model_name} FlowMap expected scalar, 1D, or 2D timesteps, got shape {tuple(timestep.shape)}.")
+
+    if deltatime_type == "r":
+        return r_timestep
+    return timestep - r_timestep
+
+
+def flowmap_timestep_embedding(
+    *,
+    time_proj: Any,
+    timestep_embedder: torch.nn.Module,
+    timestep: torch.Tensor,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    original_shape = timestep.shape
+    timestep_flat = timestep.reshape(-1)
+    timesteps_proj = time_proj(timestep_flat)
+    embedding = timestep_embedder(timesteps_proj.to(dtype=dtype))
+    if timestep.ndim > 1:
+        embedding = embedding.view(*original_shape, -1)
+    return embedding
+
+
+def blend_flowmap_embeddings(
+    base_embedding: torch.Tensor,
+    delta_embedding: torch.Tensor,
+    gate: torch.Tensor,
+) -> torch.Tensor:
+    gate = gate.to(device=base_embedding.device, dtype=base_embedding.dtype)
+    return (1.0 - gate) * base_embedding + gate * delta_embedding.to(
+        device=base_embedding.device, dtype=base_embedding.dtype
+    )

--- a/simpletuner/helpers/models/flux/transformer.py
+++ b/simpletuner/helpers/models/flux/transformer.py
@@ -33,6 +33,14 @@ try:
 except:
     pass
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    flowmap_timestep_embedding,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.models.flux.attention import FluxAttnProcessor3_0, FluxSingleAttnProcessor3_0
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
@@ -258,6 +266,95 @@ def _flux_tokenwise_conditioning(
             )
         conditioning = conditioning_module(flat_timestep, guidance.reshape(-1), repeated_pooled)
 
+    return conditioning.view(batch_size, sequence_length, -1)
+
+
+def _flux_tokenwise_flowmap_conditioning(
+    conditioning_module,
+    delta_timestep_embedder: Optional[nn.Module],
+    timestep: torch.Tensor,
+    pooled_projections: torch.Tensor,
+    r_timestep: torch.Tensor,
+    deltatime_type: Optional[str],
+    gate: torch.Tensor,
+    guidance: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    if delta_timestep_embedder is None or deltatime_type is None:
+        raise ValueError("Flux FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training.")
+
+    delta_timestep = prepare_flowmap_delta_timestep(
+        timestep,
+        r_timestep,
+        deltatime_type,
+        model_name="Flux",
+    )
+
+    def embed_time(time_values: torch.Tensor) -> torch.Tensor:
+        return flowmap_timestep_embedding(
+            time_proj=conditioning_module.time_proj,
+            timestep_embedder=conditioning_module.timestep_embedder,
+            timestep=time_values,
+            dtype=pooled_projections.dtype,
+        )
+
+    def embed_delta_time(time_values: torch.Tensor) -> torch.Tensor:
+        return flowmap_timestep_embedding(
+            time_proj=conditioning_module.time_proj,
+            timestep_embedder=delta_timestep_embedder,
+            timestep=time_values,
+            dtype=pooled_projections.dtype,
+        )
+
+    if timestep.ndim != 2:
+        conditioning = blend_flowmap_embeddings(embed_time(timestep), embed_delta_time(delta_timestep), gate)
+        if guidance is not None:
+            guidance_proj = conditioning_module.time_proj(guidance)
+            conditioning = conditioning + conditioning_module.guidance_embedder(
+                guidance_proj.to(dtype=pooled_projections.dtype)
+            )
+        return conditioning + conditioning_module.text_embedder(pooled_projections)
+
+    batch_size, sequence_length = timestep.shape
+    repeated_pooled = (
+        pooled_projections[:, None, :].expand(-1, sequence_length, -1).reshape(-1, pooled_projections.shape[-1])
+    )
+    flat_timestep = timestep.reshape(-1)
+    flat_delta_timestep = delta_timestep.reshape(-1)
+
+    conditioning = blend_flowmap_embeddings(embed_time(flat_timestep), embed_delta_time(flat_delta_timestep), gate)
+    if guidance is not None:
+        if not torch.is_tensor(guidance):
+            guidance = torch.tensor(guidance, device=timestep.device, dtype=timestep.dtype)
+        else:
+            guidance = guidance.to(device=timestep.device, dtype=timestep.dtype)
+        if guidance.ndim == 0:
+            guidance = guidance.expand(batch_size, sequence_length)
+        elif guidance.ndim == 1:
+            if guidance.shape[0] == 1:
+                guidance = guidance.expand(batch_size)
+            elif guidance.shape[0] != batch_size:
+                raise ValueError(
+                    f"Flux tokenwise guidance expected 1 or {batch_size} batch values, got {guidance.shape[0]}."
+                )
+            guidance = guidance[:, None].expand(-1, sequence_length)
+        elif guidance.ndim == 2:
+            if guidance.shape[1] != sequence_length:
+                raise ValueError(
+                    f"Flux tokenwise guidance expected sequence length {sequence_length}, got {guidance.shape[1]}."
+                )
+            if guidance.shape[0] == 1:
+                guidance = guidance.expand(batch_size, -1)
+            elif guidance.shape[0] != batch_size:
+                raise ValueError(f"Flux tokenwise guidance expected batch size {batch_size}, got {guidance.shape[0]}.")
+        else:
+            raise ValueError(
+                f"Flux guidance expected scalar, 1D batch tensor, or 2D tokenwise tensor, got shape {tuple(guidance.shape)}."
+            )
+
+        guidance_proj = conditioning_module.time_proj(guidance.reshape(-1))
+        conditioning = conditioning + conditioning_module.guidance_embedder(guidance_proj.to(dtype=pooled_projections.dtype))
+
+    conditioning = conditioning + conditioning_module.text_embedder(repeated_pooled)
     return conditioning.view(batch_size, sequence_length, -1)
 
 
@@ -544,6 +641,8 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
         enable_time_sign_embed: bool = False,
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ):
         super().__init__()
         self.register_to_config(
@@ -560,6 +659,8 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
             musubi_blocks_to_swap=musubi_blocks_to_swap,
             musubi_block_swap_device=musubi_block_swap_device,
             enable_time_sign_embed=enable_time_sign_embed,
+            gate_value=gate_value,
+            deltatime_type=deltatime_type,
         )
         self.out_channels = in_channels
         self.inner_dim = self.config.num_attention_heads * self.config.attention_head_dim
@@ -572,6 +673,14 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
             embedding_dim=self.inner_dim,
             pooled_projection_dim=self.config.pooled_projection_dim,
         )
+        self.delta_timestep_embedder: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
         # Signed-time embedding for TwinFlow adversarial branch; row 0 = positive/zero, row 1 = negative.
         self.time_sign_embed: Optional[nn.Embedding] = None
         if enable_time_sign_embed:
@@ -627,6 +736,13 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
     def set_router(self, router: TREADRouter, routes: List[Dict[str, Any]]):
         self._tread_router = router
         self._tread_routes = routes
+
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="Flux")
+        if self.delta_timestep_embedder is None:
+            self.delta_timestep_embedder = clone_flowmap_embedder(self.time_text_embed.timestep_embedder)
+        set_flowmap_gate(self, gate_value)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
 
     @property
     # Copied from diffusers.models.unets.unet_2d_condition.UNet2DConditionModel.attn_processors
@@ -727,6 +843,7 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
         txt_ids: torch.Tensor = None,
         guidance: torch.Tensor = None,
         timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
         joint_attention_kwargs: Optional[Dict[str, Any]] = None,
         controlnet_block_samples=None,
         controlnet_single_block_samples=None,
@@ -780,6 +897,8 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
         hidden_states = self.x_embedder(hidden_states)
 
         timestep = timestep.to(device=hidden_states.device, dtype=torch.float32) * 1000
+        if r_timestep is not None:
+            r_timestep = r_timestep.to(device=hidden_states.device, dtype=torch.float32) * 1000
         if guidance is not None:
             guidance = guidance.to(device=hidden_states.device, dtype=torch.float32) * 1000
         else:
@@ -821,7 +940,19 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
             sign_idx = (sign_tensor.reshape(-1) < 0).long().to(device=hidden_states.device)
             sign_emb = self.time_sign_embed(sign_idx)
 
-        temb = _flux_tokenwise_conditioning(self.time_text_embed, timestep, pooled_projections, guidance)
+        if r_timestep is None:
+            temb = _flux_tokenwise_conditioning(self.time_text_embed, timestep, pooled_projections, guidance)
+        else:
+            temb = _flux_tokenwise_flowmap_conditioning(
+                self.time_text_embed,
+                self.delta_timestep_embedder,
+                timestep,
+                pooled_projections,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                self.flowmap_delta_emb_gate,
+                guidance,
+            )
         if sign_emb is not None:
             if temb.ndim == 3:
                 sign_emb = sign_emb.view(temb.shape[0], temb.shape[1], -1)

--- a/simpletuner/helpers/models/flux2/transformer.py
+++ b/simpletuner/helpers/models/flux2/transformer.py
@@ -30,6 +30,13 @@ from diffusers.models.modeling_utils import ModelMixin
 from diffusers.models.normalization import AdaLayerNormContinuous
 from diffusers.utils import USE_PEFT_BACKEND, is_torch_npu_available, logging, scale_lora_layers, unscale_lora_layers
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.qk_clip_logging import publish_attention_max_logits
 
@@ -658,6 +665,9 @@ class Flux2TimestepGuidanceEmbeddings(nn.Module):
         self.timestep_embedder = TimestepEmbedding(
             in_channels=in_channels, time_embed_dim=embedding_dim, sample_proj_bias=bias
         )
+        self.delta_timestep_embedder: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
 
         self.guidance_embedder = None
         if guidance_embeds:
@@ -665,13 +675,39 @@ class Flux2TimestepGuidanceEmbeddings(nn.Module):
                 in_channels=in_channels, time_embed_dim=embedding_dim, sample_proj_bias=bias
             )
 
-    def forward(self, timestep: torch.Tensor, guidance: Optional[torch.Tensor] = None) -> torch.Tensor:
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="Flux2")
+        if self.delta_timestep_embedder is None:
+            self.delta_timestep_embedder = clone_flowmap_embedder(self.timestep_embedder)
+        set_flowmap_gate(self, gate_value)
+
+    def forward(
+        self,
+        timestep: torch.Tensor,
+        guidance: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
         original_shape = timestep.shape
         timestep_flat = timestep.reshape(-1)
         timesteps_proj = self.time_proj(timestep_flat)
         timesteps_emb = self.timestep_embedder(timesteps_proj.to(timestep_flat.dtype))
         if timestep.ndim > 1:
             timesteps_emb = timesteps_emb.view(*original_shape, -1)
+        if r_timestep is not None:
+            if self.delta_timestep_embedder is None or self.flowmap_deltatime_type is None:
+                raise ValueError("Flux2 FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training.")
+            delta_timestep = prepare_flowmap_delta_timestep(
+                timestep,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                model_name="Flux2",
+            )
+            delta_timestep_flat = delta_timestep.reshape(-1)
+            delta_timesteps_proj = self.time_proj(delta_timestep_flat)
+            delta_timesteps_emb = self.delta_timestep_embedder(delta_timesteps_proj.to(timestep_flat.dtype))
+            if delta_timestep.ndim > 1:
+                delta_timesteps_emb = delta_timesteps_emb.view(*delta_timestep.shape, -1)
+            timesteps_emb = blend_flowmap_embeddings(timesteps_emb, delta_timesteps_emb, self.flowmap_delta_emb_gate)
 
         if guidance is not None and self.guidance_embedder is not None:
             if not torch.is_tensor(guidance):
@@ -809,6 +845,8 @@ class Flux2Transformer2DModel(
         enable_time_sign_embed: bool = False,
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ):
         super().__init__()
         self.out_channels = out_channels or in_channels
@@ -821,6 +859,11 @@ class Flux2Transformer2DModel(
         self.time_guidance_embed = Flux2TimestepGuidanceEmbeddings(
             in_channels=timestep_guidance_channels, embedding_dim=self.inner_dim, bias=False, guidance_embeds=guidance_embeds
         )
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
         # Signed-time embedding for TwinFlow-style negative time handling.
         self.time_sign_embed: Optional[nn.Embedding] = None
         if enable_time_sign_embed:
@@ -923,6 +966,10 @@ class Flux2Transformer2DModel(
             )
         self._tread_routes = normalized_routes
 
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.time_guidance_embed.enable_flowmap_time_conditioning(gate_value=gate_value, deltatime_type=deltatime_type)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
+
     def _get_tread_route_for_layer(self, layer_idx: int) -> Optional[Dict[str, Any]]:
         """Get the TREAD route configuration for a given layer index."""
         if self._tread_routes is None:
@@ -938,6 +985,7 @@ class Flux2Transformer2DModel(
         encoder_hidden_states: torch.Tensor = None,
         timestep: torch.LongTensor = None,
         timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
         img_ids: torch.Tensor = None,
         txt_ids: torch.Tensor = None,
         guidance: torch.Tensor = None,
@@ -993,10 +1041,12 @@ class Flux2Transformer2DModel(
 
         # 1. Calculate timestep embedding and modulation parameters
         timestep = timestep.to(hidden_states.dtype) * 1000
+        if r_timestep is not None:
+            r_timestep = r_timestep.to(device=hidden_states.device, dtype=hidden_states.dtype) * 1000
         if guidance is not None:
             guidance = guidance.to(hidden_states.dtype) * 1000
 
-        temb = self.time_guidance_embed(timestep, guidance)
+        temb = self.time_guidance_embed(timestep, guidance, r_timestep=r_timestep)
         if timestep_sign is not None:
             if self.time_sign_embed is None:
                 raise ValueError(

--- a/simpletuner/helpers/models/hidream/transformer.py
+++ b/simpletuner/helpers/models/hidream/transformer.py
@@ -13,6 +13,14 @@ from diffusers.utils import USE_PEFT_BACKEND, is_torch_version, logging, scale_l
 from diffusers.utils.torch_utils import maybe_allow_in_graph
 from einops import repeat
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    flowmap_timestep_embedding,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
 from simpletuner.helpers.training.qk_clip_logging import publish_attention_max_logits
@@ -152,6 +160,9 @@ class TimestepEmbed(nn.Module):
             downscale_freq_shift=0,
         )
         self.timestep_embedder = TimestepEmbedding(in_channels=frequency_embedding_size, time_embed_dim=hidden_size)
+        self.delta_timestep_embedder: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
         # Signed-time embedding for TwinFlow-style negative time handling.
         self.time_sign_embed: Optional[nn.Embedding] = None
         if enable_time_sign_embed:
@@ -165,14 +176,45 @@ class TimestepEmbed(nn.Module):
             if m.bias is not None:
                 nn.init.constant_(m.bias, 0)
 
-    def forward(self, timesteps, wdtype, timestep_sign: Optional[torch.Tensor] = None):
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="HiDream")
+        if self.delta_timestep_embedder is None:
+            self.delta_timestep_embedder = clone_flowmap_embedder(self.timestep_embedder)
+        set_flowmap_gate(self, gate_value)
+
+    def forward(
+        self,
+        timesteps,
+        wdtype,
+        timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
+    ):
         if timesteps.ndim == 2:
             batch_size, sequence_length = timesteps.shape
-            t_emb = self.time_proj(timesteps.reshape(-1)).to(dtype=wdtype)
-            t_emb = self.timestep_embedder(t_emb).view(batch_size, sequence_length, -1)
-        else:
-            t_emb = self.time_proj(timesteps).to(dtype=wdtype)
-            t_emb = self.timestep_embedder(t_emb)
+        t_emb = flowmap_timestep_embedding(
+            time_proj=self.time_proj,
+            timestep_embedder=self.timestep_embedder,
+            timestep=timesteps,
+            dtype=wdtype,
+        )
+        if r_timestep is not None:
+            if self.delta_timestep_embedder is None or self.flowmap_deltatime_type is None:
+                raise ValueError(
+                    "HiDream FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training."
+                )
+            delta_timestep = prepare_flowmap_delta_timestep(
+                timesteps,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                model_name="HiDream",
+            )
+            delta_emb = flowmap_timestep_embedding(
+                time_proj=self.time_proj,
+                timestep_embedder=self.delta_timestep_embedder,
+                timestep=delta_timestep,
+                dtype=wdtype,
+            )
+            t_emb = blend_flowmap_embeddings(t_emb, delta_emb, self.flowmap_delta_emb_gate)
         if timestep_sign is not None:
             if self.time_sign_embed is None:
                 raise ValueError(
@@ -961,6 +1003,8 @@ class HiDreamImageTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, P
         enable_time_sign_embed: bool = False,
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ):
         super().__init__()
         effective_out_channels = out_channels or in_channels
@@ -983,12 +1027,19 @@ class HiDreamImageTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, P
             enable_time_sign_embed=enable_time_sign_embed,
             musubi_blocks_to_swap=musubi_blocks_to_swap,
             musubi_block_swap_device=musubi_block_swap_device,
+            gate_value=gate_value,
+            deltatime_type=deltatime_type,
         )
         self.out_channels = effective_out_channels
         self.inner_dim = self.config.num_attention_heads * self.config.attention_head_dim
         self.llama_layers = llama_layers
 
         self.t_embedder = TimestepEmbed(self.inner_dim, enable_time_sign_embed=enable_time_sign_embed)
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
         self.p_embedder = PooledEmbed(text_emb_dim, self.inner_dim)
         self.x_embedder = PatchEmbed(
             patch_size=patch_size,
@@ -1122,6 +1173,10 @@ class HiDreamImageTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, P
                 f"HiDream expected scalar, 1D batch tensor, or 2D tokenwise tensor, got shape {tuple(timesteps.shape)}."
             )
         return timesteps
+
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.t_embedder.enable_flowmap_time_conditioning(gate_value=gate_value, deltatime_type=deltatime_type)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
 
     def unpatchify(self, x: torch.Tensor, img_sizes: List[Tuple[int, int]], is_training: bool) -> List[torch.Tensor]:
         if 0 and is_training:
@@ -1293,6 +1348,7 @@ class HiDreamImageTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, P
         hidden_states: torch.Tensor,
         timesteps: torch.LongTensor = None,
         timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
         t5_hidden_states: torch.Tensor = None,
         llama_hidden_states: torch.Tensor = None,
         pooled_embeds: torch.Tensor = None,
@@ -1349,9 +1405,14 @@ class HiDreamImageTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, P
         # Apply gradient checkpointing to this step if enabled
         if self.training and self.gradient_checkpointing:
 
-            def create_custom_forward_timestep(timesteps, timestep_sign=None):
+            def create_custom_forward_timestep(timesteps, timestep_sign=None, r_timestep=None):
                 def custom_forward(t_embedder):
-                    return t_embedder(timesteps, hidden_states_type, timestep_sign=timestep_sign)
+                    return t_embedder(
+                        timesteps,
+                        hidden_states_type,
+                        timestep_sign=timestep_sign,
+                        r_timestep=r_timestep,
+                    )
 
                 return custom_forward
 
@@ -1371,11 +1432,14 @@ class HiDreamImageTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, P
             ckpt_kwargs = {"use_reentrant": False} if is_torch_version(">=", "1.11.0") else {}
 
             timesteps = self.expand_timesteps(timesteps, batch_size, hidden_states.device)
+            r_timesteps = (
+                self.expand_timesteps(r_timestep, batch_size, hidden_states.device) if r_timestep is not None else None
+            )
             sign = timestep_sign
             if sign is not None:
                 sign = sign.to(device=hidden_states.device, dtype=timesteps.dtype)
             timesteps_emb = checkpoint_fn(
-                create_custom_forward_timestep(timesteps, sign),
+                create_custom_forward_timestep(timesteps, sign, r_timesteps),
                 self.t_embedder,
                 **ckpt_kwargs,
             )
@@ -1392,10 +1456,13 @@ class HiDreamImageTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, P
         else:
             # Standard processing without checkpointing
             timesteps = self.expand_timesteps(timesteps, batch_size, hidden_states.device)
+            r_timesteps = (
+                self.expand_timesteps(r_timestep, batch_size, hidden_states.device) if r_timestep is not None else None
+            )
             sign = timestep_sign
             if sign is not None:
                 sign = sign.to(device=hidden_states.device, dtype=timesteps.dtype)
-            timesteps = self.t_embedder(timesteps, hidden_states_type, timestep_sign=sign)
+            timesteps = self.t_embedder(timesteps, hidden_states_type, timestep_sign=sign, r_timestep=r_timesteps)
             p_embedder = self.p_embedder(pooled_embeds)
             if timesteps.ndim == 3:
                 adaln_input = timesteps + p_embedder.unsqueeze(1)

--- a/simpletuner/helpers/models/hunyuanvideo/transformer.py
+++ b/simpletuner/helpers/models/hunyuanvideo/transformer.py
@@ -35,6 +35,13 @@ from diffusers.models.modeling_utils import ModelMixin
 from diffusers.models.normalization import AdaLayerNormContinuous, AdaLayerNormZero
 from diffusers.utils import USE_PEFT_BACKEND, logging, scale_lora_layers, unscale_lora_layers
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -258,6 +265,15 @@ class HunyuanVideo15TimeEmbedding(nn.Module):
         if use_meanflow:
             self.time_proj_r = Timesteps(num_channels=256, flip_sin_to_cos=True, downscale_freq_shift=0)
             self.timestep_embedder_r = TimestepEmbedding(in_channels=256, time_embed_dim=embedding_dim)
+        self.delta_timestep_embedder: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
+
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="HunyuanVideo")
+        if self.delta_timestep_embedder is None:
+            self.delta_timestep_embedder = clone_flowmap_embedder(self.timestep_embedder)
+        set_flowmap_gate(self, gate_value)
 
     def forward(
         self,
@@ -271,6 +287,21 @@ class HunyuanVideo15TimeEmbedding(nn.Module):
         timesteps_emb = self.timestep_embedder(timesteps_proj.to(dtype=timestep_flat.dtype))
         if timestep.ndim > 1:
             timesteps_emb = timesteps_emb.view(*original_shape, -1)
+        if timestep_r is not None and self.flowmap_deltatime_type is not None:
+            if self.delta_timestep_embedder is None:
+                raise ValueError("HunyuanVideo FlowMap time conditioning is missing the delta timestep embedder.")
+            delta_timestep = prepare_flowmap_delta_timestep(
+                timestep,
+                timestep_r,
+                self.flowmap_deltatime_type,
+                model_name="HunyuanVideo",
+            )
+            delta_timestep_flat = delta_timestep.reshape(-1)
+            delta_proj = self.time_proj(delta_timestep_flat)
+            delta_emb = self.delta_timestep_embedder(delta_proj.to(dtype=timestep_flat.dtype))
+            if delta_timestep.ndim > 1:
+                delta_emb = delta_emb.view(*delta_timestep.shape, -1)
+            timesteps_emb = blend_flowmap_embeddings(timesteps_emb, delta_emb, self.flowmap_delta_emb_gate)
         if timestep_sign is not None:
             if self.time_sign_embed is None:
                 raise ValueError(
@@ -310,7 +341,11 @@ class HunyuanVideo15TimeEmbedding(nn.Module):
                 sign_emb = sign_emb.view(*original_shape, -1)
             timesteps_emb = timesteps_emb + sign_emb
 
-        if timestep_r is not None:
+        if timestep_r is not None and self.flowmap_deltatime_type is None:
+            if self.time_proj_r is None or self.timestep_embedder_r is None:
+                raise ValueError(
+                    "HunyuanVideo received `timestep_r`, but neither mean-flow nor FlowMap time conditioning is enabled."
+                )
             if timestep.ndim == 2 and timestep_r.ndim == 1:
                 timestep_r = timestep_r[:, None].expand(-1, timestep.shape[1])
             elif timestep.ndim == 2 and timestep_r.ndim == 2:
@@ -751,6 +786,8 @@ class HunyuanVideo15Transformer3DModel(
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
         enable_time_sign_embed: bool = False,
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ) -> None:
         super().__init__()
         self._tread_router = None
@@ -774,6 +811,11 @@ class HunyuanVideo15Transformer3DModel(
             use_meanflow=use_meanflow,
             enable_time_sign_embed=enable_time_sign_embed,
         )
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
 
         self.cond_type_embed = nn.Embedding(3, inner_dim)
 
@@ -801,6 +843,10 @@ class HunyuanVideo15Transformer3DModel(
             swap_device=musubi_block_swap_device,
             logger=logger,
         )
+
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.time_embed.enable_flowmap_time_conditioning(gate_value=gate_value, deltatime_type=deltatime_type)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
 
     def forward(
         self,

--- a/simpletuner/helpers/models/kandinsky5_video/transformer_kandinsky5.py
+++ b/simpletuner/helpers/models/kandinsky5_video/transformer_kandinsky5.py
@@ -30,6 +30,13 @@ from diffusers.models.modeling_utils import ModelMixin
 from diffusers.utils import logging
 from torch import Tensor
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
 from simpletuner.helpers.training.qk_clip_logging import publish_attention_max_logits
@@ -204,20 +211,54 @@ class Kandinsky5TimeEmbeddings(nn.Module):
         self.in_layer = nn.Linear(model_dim, time_dim, bias=True)
         self.activation = nn.SiLU()
         self.out_layer = nn.Linear(time_dim, time_dim, bias=True)
+        self.delta_in_layer: Optional[nn.Module] = None
+        self.delta_out_layer: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
         # Signed-time embedding for TwinFlow-style negative time handling.
         self.time_sign_embed: Optional[nn.Embedding] = None
         if enable_time_sign_embed:
             self.time_sign_embed = nn.Embedding(2, time_dim)
             nn.init.zeros_(self.time_sign_embed.weight)
 
-    @torch.autocast(device_type="cuda", dtype=torch.float32)
-    def forward(self, time, timestep_sign: Optional[torch.Tensor] = None):
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="Kandinsky5")
+        if self.delta_in_layer is None:
+            self.delta_in_layer = clone_flowmap_embedder(self.in_layer)
+        if self.delta_out_layer is None:
+            self.delta_out_layer = clone_flowmap_embedder(self.out_layer)
+        set_flowmap_gate(self, gate_value)
+
+    def _embed_time(self, time: torch.Tensor, in_layer: nn.Module, out_layer: nn.Module) -> torch.Tensor:
         original_shape = time.shape
         time = time.reshape(-1)
         args = torch.outer(time, self.freqs.to(device=time.device))
         time_embed = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
-        time_embed = self.out_layer(self.activation(self.in_layer(time_embed)))
-        time_embed = time_embed.view(*original_shape, -1)
+        time_embed = out_layer(self.activation(in_layer(time_embed)))
+        return time_embed.view(*original_shape, -1)
+
+    @torch.autocast(device_type="cuda", dtype=torch.float32)
+    def forward(
+        self,
+        time,
+        timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
+    ):
+        original_shape = time.shape
+        time_embed = self._embed_time(time, self.in_layer, self.out_layer)
+        if r_timestep is not None:
+            if self.delta_in_layer is None or self.delta_out_layer is None or self.flowmap_deltatime_type is None:
+                raise ValueError(
+                    "Kandinsky5 FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training."
+                )
+            delta_timestep = prepare_flowmap_delta_timestep(
+                time,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                model_name="Kandinsky5",
+            )
+            delta_embed = self._embed_time(delta_timestep, self.delta_in_layer, self.delta_out_layer)
+            time_embed = blend_flowmap_embeddings(time_embed, delta_embed, self.flowmap_delta_emb_gate)
         if timestep_sign is not None:
             if self.time_sign_embed is None:
                 raise ValueError(
@@ -696,6 +737,8 @@ class Kandinsky5Transformer3DModel(
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
         enable_time_sign_embed: bool = False,
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ):
         super().__init__()
 
@@ -714,6 +757,11 @@ class Kandinsky5Transformer3DModel(
             time_dim,
             enable_time_sign_embed=enable_time_sign_embed,
         )
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
         self.text_embeddings = Kandinsky5TextEmbeddings(in_text_dim, model_dim)
         self.pooled_text_embeddings = Kandinsky5TextEmbeddings(in_text_dim2, time_dim)
         self.visual_embeddings = Kandinsky5VisualEmbeddings(visual_embed_dim, model_dim, patch_size)
@@ -741,6 +789,10 @@ class Kandinsky5Transformer3DModel(
             swap_device=musubi_block_swap_device,
             logger=logger,
         )
+
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.time_embeddings.enable_flowmap_time_conditioning(gate_value=gate_value, deltatime_type=deltatime_type)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
 
     def set_gradient_checkpointing_backend(self, backend: str):
         self.gradient_checkpointing_backend = backend
@@ -783,6 +835,7 @@ class Kandinsky5Transformer3DModel(
         hidden_states_buffer: Optional[dict] = None,
         timestep_sign: Optional[torch.Tensor] = None,
         grounding_kwargs: Optional[Dict[str, Any]] = None,
+        r_timestep: Optional[torch.Tensor] = None,
     ) -> Union[Transformer2DModelOutput, torch.FloatTensor]:
         """
         Forward pass of the Kandinsky5 3D Transformer.
@@ -815,6 +868,7 @@ class Kandinsky5Transformer3DModel(
         time_embed = self.time_embeddings(
             time,
             timestep_sign=timestep_sign,
+            r_timestep=r_timestep,
         )
         pooled_time_embed = self.pooled_text_embeddings(pooled_text_embed)
         if time_embed.dim() == 2:

--- a/simpletuner/helpers/models/longcat_image/transformer.py
+++ b/simpletuner/helpers/models/longcat_image/transformer.py
@@ -17,6 +17,14 @@ from diffusers.models.transformers.transformer_flux import (
     FluxTransformerBlock,
 )
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    flowmap_timestep_embedding,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 
 logger = get_logger(__name__, log_level="INFO")
@@ -36,21 +44,52 @@ class TimestepEmbeddings(nn.Module):
         super().__init__()
         self.time_proj = Timesteps(num_channels=256, flip_sin_to_cos=True, downscale_freq_shift=0)
         self.timestep_embedder = TimestepEmbedding(in_channels=256, time_embed_dim=embedding_dim)
+        self.delta_timestep_embedder: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
         # Signed-time embedding for TwinFlow-style negative time handling.
         self.time_sign_embed: Optional[nn.Embedding] = None
         if enable_time_sign_embed:
             self.time_sign_embed = nn.Embedding(2, embedding_dim)
             nn.init.zeros_(self.time_sign_embed.weight)
 
-    def forward(self, timestep, hidden_dtype, timestep_sign: Optional[torch.Tensor] = None):
-        if timestep.ndim == 2:
-            batch_size, sequence_length = timestep.shape
-            flat_timestep = timestep.reshape(-1)
-            timesteps_proj = self.time_proj(flat_timestep)
-            temb = self.timestep_embedder(timesteps_proj.to(dtype=hidden_dtype)).view(batch_size, sequence_length, -1)
-        else:
-            timesteps_proj = self.time_proj(timestep)
-            temb = self.timestep_embedder(timesteps_proj.to(dtype=hidden_dtype))
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="LongCat-Image")
+        if self.delta_timestep_embedder is None:
+            self.delta_timestep_embedder = clone_flowmap_embedder(self.timestep_embedder)
+        set_flowmap_gate(self, gate_value)
+
+    def forward(
+        self,
+        timestep,
+        hidden_dtype,
+        timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
+    ):
+        temb = flowmap_timestep_embedding(
+            time_proj=self.time_proj,
+            timestep_embedder=self.timestep_embedder,
+            timestep=timestep,
+            dtype=hidden_dtype,
+        )
+        if r_timestep is not None:
+            if self.delta_timestep_embedder is None or self.flowmap_deltatime_type is None:
+                raise ValueError(
+                    "LongCat-Image FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training."
+                )
+            delta_timestep = prepare_flowmap_delta_timestep(
+                timestep,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                model_name="LongCat-Image",
+            )
+            delta_emb = flowmap_timestep_embedding(
+                time_proj=self.time_proj,
+                timestep_embedder=self.delta_timestep_embedder,
+                timestep=delta_timestep,
+                dtype=hidden_dtype,
+            )
+            temb = blend_flowmap_embeddings(temb, delta_emb, self.flowmap_delta_emb_gate)
         if timestep_sign is not None:
             if self.time_sign_embed is None:
                 raise ValueError(
@@ -256,6 +295,8 @@ class LongCatImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         enable_time_sign_embed: bool = False,
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ):
         super().__init__()
         self.out_channels = in_channels
@@ -264,6 +305,11 @@ class LongCatImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
 
         self.pos_embed = FluxPosEmbed(theta=10000, axes_dim=axes_dims_rope)
         self.time_embed = TimestepEmbeddings(embedding_dim=self.inner_dim, enable_time_sign_embed=enable_time_sign_embed)
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
 
         self.context_embedder = nn.Linear(joint_attention_dim, self.inner_dim)
         self.x_embedder = torch.nn.Linear(in_channels, self.inner_dim)
@@ -307,6 +353,10 @@ class LongCatImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
             logger=logger,
         )
 
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.time_embed.enable_flowmap_time_conditioning(gate_value=gate_value, deltatime_type=deltatime_type)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -318,6 +368,7 @@ class LongCatImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         guidance: torch.Tensor = None,
         return_dict: bool = True,
         hidden_states_buffer: Optional[dict] = None,
+        r_timestep: Optional[torch.Tensor] = None,
     ) -> Union[torch.FloatTensor, Transformer2DModelOutput]:
         """
         Args:
@@ -361,9 +412,11 @@ class LongCatImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
             )
 
         timestep = timestep * 1000
+        if r_timestep is not None:
+            r_timestep = r_timestep.to(device=hidden_states.device, dtype=hidden_states.dtype) * 1000
         guidance = guidance.to(hidden_states.dtype) * 1000 if guidance is not None else None
 
-        temb = self.time_embed(timestep, hidden_states.dtype, timestep_sign=timestep_sign)
+        temb = self.time_embed(timestep, hidden_states.dtype, timestep_sign=timestep_sign, r_timestep=r_timestep)
         encoder_hidden_states = self.context_embedder(encoder_hidden_states)
         txt_len = encoder_hidden_states.shape[1]
 

--- a/simpletuner/helpers/models/longcat_video/transformer.py
+++ b/simpletuner/helpers/models/longcat_video/transformer.py
@@ -14,6 +14,13 @@ from diffusers.models.attention_dispatch import dispatch_attention_fn
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 from diffusers.models.modeling_utils import ModelMixin
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 
 logger = logging.getLogger(__name__)
@@ -257,6 +264,9 @@ class TimestepEmbedder(nn.Module):
             nn.SiLU(),
             nn.Linear(t_embed_dim, t_embed_dim, bias=True),
         )
+        self.delta_mlp: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
 
     @staticmethod
     def timestep_embedding(t, dim, max_period=10000):
@@ -269,7 +279,19 @@ class TimestepEmbedder(nn.Module):
             embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
         return embedding
 
-    def forward(self, t, dtype, timestep_sign: Optional[torch.Tensor] = None):
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="LongCat-Video")
+        if self.delta_mlp is None:
+            self.delta_mlp = clone_flowmap_embedder(self.mlp)
+        set_flowmap_gate(self, gate_value)
+
+    def forward(
+        self,
+        t,
+        dtype,
+        timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
+    ):
         reshape = None
         if t.ndim == 2:
             reshape = t.shape
@@ -278,6 +300,28 @@ class TimestepEmbedder(nn.Module):
         if t_freq.dtype != dtype:
             t_freq = t_freq.to(dtype)
         t_emb = self.mlp(t_freq)
+        if reshape is not None:
+            t_emb = t_emb.view(reshape[0], reshape[1], -1)
+        if r_timestep is not None:
+            if self.delta_mlp is None or self.flowmap_deltatime_type is None:
+                raise ValueError(
+                    "LongCat-Video FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training."
+                )
+            base_timestep = t.view(*reshape) if reshape is not None else t
+            delta_timestep = prepare_flowmap_delta_timestep(
+                base_timestep,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                model_name="LongCat-Video",
+            )
+            delta_flat = delta_timestep.reshape(-1) if delta_timestep.ndim == 2 else delta_timestep
+            delta_freq = self.timestep_embedding(delta_flat, self.frequency_embedding_size)
+            if delta_freq.dtype != dtype:
+                delta_freq = delta_freq.to(dtype)
+            delta_emb = self.delta_mlp(delta_freq)
+            if delta_timestep.ndim == 2:
+                delta_emb = delta_emb.view(delta_timestep.shape[0], delta_timestep.shape[1], -1)
+            t_emb = blend_flowmap_embeddings(t_emb, delta_emb, self.flowmap_delta_emb_gate)
         if timestep_sign is not None:
             if self.time_sign_embed is None:
                 raise ValueError(
@@ -314,6 +358,8 @@ class TimestepEmbedder(nn.Module):
                         f"got shape {tuple(sign_tensor.shape)}."
                     )
                 sign_idx = (sign_tensor.reshape(-1) < 0).long().to(device=t_emb.device)
+                sign_emb = self.time_sign_embed(sign_idx).to(dtype=t_emb.dtype, device=t_emb.device)
+                t_emb = t_emb + sign_emb.view(batch_size, sequence_length, -1)
             else:
                 if sign_tensor.ndim == 0:
                     sign_tensor = sign_tensor.expand(t_emb.shape[0])
@@ -330,9 +376,7 @@ class TimestepEmbedder(nn.Module):
                         f"got shape {tuple(sign_tensor.shape)}."
                     )
                 sign_idx = (sign_tensor.reshape(-1) < 0).long().to(device=t_emb.device)
-            t_emb = t_emb + self.time_sign_embed(sign_idx).to(dtype=t_emb.dtype, device=t_emb.device)
-        if reshape is not None:
-            t_emb = t_emb.view(reshape[0], reshape[1], -1)
+                t_emb = t_emb + self.time_sign_embed(sign_idx).to(dtype=t_emb.dtype, device=t_emb.device)
         return t_emb
 
 
@@ -1017,6 +1061,8 @@ class LongCatVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
         enable_time_sign_embed: bool = False,
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ) -> None:
         super().__init__()
 
@@ -1031,6 +1077,11 @@ class LongCatVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
             frequency_embedding_size=frequency_embedding_size,
             enable_time_sign_embed=enable_time_sign_embed,
         )
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
         self.y_embedder = CaptionEmbedder(in_channels=caption_channels, hidden_size=hidden_size)
 
         self.blocks = nn.ModuleList(
@@ -1066,6 +1117,10 @@ class LongCatVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
     def set_gradient_checkpointing_backend(self, backend: str):
         self.gradient_checkpointing_backend = backend
 
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.t_embedder.enable_flowmap_time_conditioning(gate_value=gate_value, deltatime_type=deltatime_type)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
+
     def forward(
         self,
         hidden_states,
@@ -1079,6 +1134,7 @@ class LongCatVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         offload_kv_cache=False,
         return_dict: bool = True,
         timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
         hidden_states_buffer: Optional[dict] = None,
     ):
         if kv_cache_dict is None:
@@ -1158,7 +1214,7 @@ class LongCatVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         hidden_states = self.x_embedder(hidden_states)
 
         with torch.autocast(device_type=timestep.device.type, dtype=torch.float32, enabled=timestep.device.type == "cuda"):
-            t = self.t_embedder(timestep.float(), dtype=torch.float32, timestep_sign=sign)
+            t = self.t_embedder(timestep.float(), dtype=torch.float32, timestep_sign=sign, r_timestep=r_timestep)
 
         encoder_hidden_states = self.y_embedder(encoder_hidden_states)
 

--- a/simpletuner/helpers/models/ltxvideo/transformer.py
+++ b/simpletuner/helpers/models/ltxvideo/transformer.py
@@ -32,6 +32,13 @@ from diffusers.models.normalization import AdaLayerNormSingle, RMSNorm
 from diffusers.utils import USE_PEFT_BACKEND, deprecate, is_torch_version, logging, scale_lora_layers, unscale_lora_layers
 from diffusers.utils.torch_utils import maybe_allow_in_graph
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
 from simpletuner.helpers.training.tread import TREADRouter
@@ -455,6 +462,8 @@ class LTXVideoTransformer3DModel(
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
         enable_time_sign_embed: bool = False,
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ) -> None:
         super().__init__()
 
@@ -478,6 +487,8 @@ class LTXVideoTransformer3DModel(
             musubi_blocks_to_swap=musubi_blocks_to_swap,
             musubi_block_swap_device=musubi_block_swap_device,
             enable_time_sign_embed=enable_time_sign_embed,
+            gate_value=gate_value,
+            deltatime_type=deltatime_type,
         )
 
         out_channels = effective_out_channels
@@ -487,6 +498,14 @@ class LTXVideoTransformer3DModel(
 
         self.scale_shift_table = nn.Parameter(torch.randn(2, inner_dim) / inner_dim**0.5)
         self.time_embed = AdaLayerNormSingle(inner_dim, use_additional_conditions=False)
+        self.delta_timestep_embedder: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
 
         self.caption_projection = PixArtAlphaTextProjection(in_features=caption_channels, hidden_size=inner_dim)
 
@@ -543,12 +562,20 @@ class LTXVideoTransformer3DModel(
         self._tread_router = router
         self._tread_routes = routes
 
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="LTXVideo")
+        if self.delta_timestep_embedder is None:
+            self.delta_timestep_embedder = clone_flowmap_embedder(self.time_embed.emb.timestep_embedder)
+        set_flowmap_gate(self, gate_value)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
         encoder_hidden_states: torch.Tensor,
         timestep: torch.LongTensor,
         encoder_attention_mask: torch.Tensor,
+        r_timestep: Optional[torch.Tensor] = None,
         num_frames: Optional[int] = None,
         height: Optional[int] = None,
         width: Optional[int] = None,
@@ -595,11 +622,35 @@ class LTXVideoTransformer3DModel(
             post_patch_width = width // self.config.patch_size
         hidden_states = self.proj_in(hidden_states)
 
-        temb, embedded_timestep = self.time_embed(
-            timestep.flatten(),
-            batch_size=batch_size,
-            hidden_dtype=hidden_states.dtype,
-        )
+        if r_timestep is None:
+            temb, embedded_timestep = self.time_embed(
+                timestep.flatten(),
+                batch_size=batch_size,
+                hidden_dtype=hidden_states.dtype,
+            )
+        else:
+            if self.delta_timestep_embedder is None or self.flowmap_deltatime_type is None:
+                raise ValueError(
+                    "LTXVideo FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training."
+                )
+            emb = self.time_embed.emb
+            timestep_flat = timestep.flatten()
+            timesteps_proj = emb.time_proj(timestep_flat)
+            embedded_timestep = emb.timestep_embedder(timesteps_proj.to(dtype=hidden_states.dtype))
+            delta_timestep = prepare_flowmap_delta_timestep(
+                timestep,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                model_name="LTXVideo",
+            )
+            delta_proj = emb.time_proj(delta_timestep.flatten())
+            delta_emb = self.delta_timestep_embedder(delta_proj.to(dtype=hidden_states.dtype))
+            embedded_timestep = blend_flowmap_embeddings(
+                embedded_timestep,
+                delta_emb,
+                self.flowmap_delta_emb_gate,
+            )
+            temb = self.time_embed.linear(self.time_embed.silu(embedded_timestep))
 
         temb = temb.view(batch_size, -1, temb.size(-1))
         embedded_timestep = embedded_timestep.view(batch_size, -1, embedded_timestep.size(-1))

--- a/simpletuner/helpers/models/ltxvideo2/transformer.py
+++ b/simpletuner/helpers/models/ltxvideo2/transformer.py
@@ -30,6 +30,13 @@ from diffusers.models.modeling_utils import ModelMixin
 from diffusers.models.normalization import RMSNorm
 from diffusers.utils import USE_PEFT_BACKEND, BaseOutput, is_torch_version, logging, scale_lora_layers, unscale_lora_layers
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
 from simpletuner.helpers.training.tread import TREADRouter
@@ -1201,6 +1208,8 @@ class LTX2VideoTransformer3DModel(
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
         enable_time_sign_embed: bool = False,
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ) -> None:
         super().__init__()
 
@@ -1232,6 +1241,15 @@ class LTX2VideoTransformer3DModel(
         self.audio_time_embed = LTX2AdaLayerNormSingle(
             audio_inner_dim, num_mod_params=audio_time_emb_mod_params, use_additional_conditions=False
         )
+        self.delta_timestep_embedder: Optional[nn.Module] = None
+        self.audio_delta_timestep_embedder: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
 
         # 3.2. Global Cross Attention Modulation Parameters
         # Used in the audio-to-video and video-to-audio cross attention layers as a global set of modulation params,
@@ -1394,6 +1412,56 @@ class LTX2VideoTransformer3DModel(
         self._tread_router = router
         self._tread_routes = routes
 
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="LTXVideo2")
+        if self.delta_timestep_embedder is None:
+            self.delta_timestep_embedder = clone_flowmap_embedder(self.time_embed.emb.timestep_embedder)
+        if self.audio_delta_timestep_embedder is None:
+            self.audio_delta_timestep_embedder = clone_flowmap_embedder(self.audio_time_embed.emb.timestep_embedder)
+        set_flowmap_gate(self, gate_value)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
+
+    def _prepare_flowmap_time_embedding(
+        self,
+        embedding_module: LTX2AdaLayerNormSingle,
+        delta_timestep_embedder: Optional[nn.Module],
+        timestep: torch.Tensor,
+        *,
+        batch_size: int,
+        hidden_dtype: torch.dtype,
+        r_timestep: Optional[torch.Tensor],
+        model_name: str,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if r_timestep is None:
+            return embedding_module(
+                timestep.flatten(),
+                batch_size=batch_size,
+                hidden_dtype=hidden_dtype,
+            )
+        if delta_timestep_embedder is None or self.flowmap_deltatime_type is None:
+            raise ValueError(
+                f"{model_name} FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training."
+            )
+
+        emb = embedding_module.emb
+        timestep_flat = timestep.flatten()
+        timesteps_proj = emb.time_proj(timestep_flat)
+        embedded_timestep = emb.timestep_embedder(timesteps_proj.to(dtype=hidden_dtype))
+        delta_timestep = prepare_flowmap_delta_timestep(
+            timestep,
+            r_timestep,
+            self.flowmap_deltatime_type,
+            model_name=model_name,
+        )
+        delta_proj = emb.time_proj(delta_timestep.flatten())
+        delta_emb = delta_timestep_embedder(delta_proj.to(dtype=hidden_dtype))
+        embedded_timestep = blend_flowmap_embeddings(
+            embedded_timestep,
+            delta_emb,
+            self.flowmap_delta_emb_gate,
+        )
+        return embedding_module.linear(embedding_module.silu(embedded_timestep)), embedded_timestep
+
     @staticmethod
     def _route_rope(rope, info, keep_len: int):
         if rope is None:
@@ -1423,6 +1491,7 @@ class LTX2VideoTransformer3DModel(
         encoder_hidden_states: torch.Tensor,
         audio_encoder_hidden_states: torch.Tensor,
         timestep: torch.LongTensor,
+        r_timestep: Optional[torch.Tensor] = None,
         audio_timestep: Optional[torch.LongTensor] = None,
         sigma: Optional[torch.Tensor] = None,
         audio_sigma: Optional[torch.Tensor] = None,
@@ -1493,10 +1562,15 @@ class LTX2VideoTransformer3DModel(
             audio_rotary_emb = self.audio_rope(audio_coords, device=audio_hidden_states.device)
 
             audio_hidden_states = self.audio_proj_in(audio_hidden_states)
-            temb_audio, audio_embedded_timestep = self.audio_time_embed(
-                audio_timestep.flatten() if audio_timestep is not None else timestep.flatten(),
+            audio_base_timestep = audio_timestep if audio_timestep is not None else timestep
+            temb_audio, audio_embedded_timestep = self._prepare_flowmap_time_embedding(
+                self.audio_time_embed,
+                self.audio_delta_timestep_embedder,
+                audio_base_timestep,
                 batch_size=batch_size,
                 hidden_dtype=audio_hidden_states.dtype,
+                r_timestep=r_timestep,
+                model_name="LTXVideo2 audio",
             )
             temb_audio = temb_audio.view(batch_size, -1, temb_audio.size(-1))
             audio_embedded_timestep = audio_embedded_timestep.view(batch_size, -1, audio_embedded_timestep.size(-1))
@@ -1617,6 +1691,7 @@ class LTX2VideoTransformer3DModel(
             return AudioVisualModelOutput(sample=output, audio_sample=audio_output)
 
         # Determine timestep for audio.
+        audio_timestep_uses_video_timestep = audio_timestep is None
         audio_timestep = audio_timestep if audio_timestep is not None else timestep
         audio_sigma = audio_sigma if audio_sigma is not None else sigma
 
@@ -1668,18 +1743,26 @@ class LTX2VideoTransformer3DModel(
         # 3.1. Prepare global modality (video and audio) timestep embedding and modulation parameters
         # temb is used in the transformer blocks (as expected), while embedded_timestep is used for the output layer
         # modulation with scale_shift_table (and similarly for audio)
-        temb, embedded_timestep = self.time_embed(
-            timestep.flatten(),
+        temb, embedded_timestep = self._prepare_flowmap_time_embedding(
+            self.time_embed,
+            self.delta_timestep_embedder,
+            timestep,
             batch_size=batch_size,
             hidden_dtype=hidden_states.dtype,
+            r_timestep=r_timestep,
+            model_name="LTXVideo2",
         )
         temb = temb.view(batch_size, -1, temb.size(-1))
         embedded_timestep = embedded_timestep.view(batch_size, -1, embedded_timestep.size(-1))
 
-        temb_audio, audio_embedded_timestep = self.audio_time_embed(
-            audio_timestep.flatten(),
+        temb_audio, audio_embedded_timestep = self._prepare_flowmap_time_embedding(
+            self.audio_time_embed,
+            self.audio_delta_timestep_embedder,
+            audio_timestep,
             batch_size=batch_size,
             hidden_dtype=audio_hidden_states.dtype,
+            r_timestep=r_timestep if audio_timestep_uses_video_timestep else None,
+            model_name="LTXVideo2 audio",
         )
         temb_audio = temb_audio.view(batch_size, -1, temb_audio.size(-1))
         audio_embedded_timestep = audio_embedded_timestep.view(batch_size, -1, audio_embedded_timestep.size(-1))

--- a/simpletuner/helpers/models/lumina2/transformer.py
+++ b/simpletuner/helpers/models/lumina2/transformer.py
@@ -39,6 +39,14 @@ from diffusers.models.modeling_utils import ModelMixin
 from diffusers.models.normalization import LuminaLayerNormContinuous, LuminaRMSNormZero, RMSNorm
 from diffusers.utils import USE_PEFT_BACKEND, logging, scale_lora_layers, unscale_lora_layers
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    flowmap_timestep_embedding,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -68,20 +76,51 @@ class Lumina2CombinedTimestepCaptionEmbedding(nn.Module):
         self.timestep_embedder = TimestepEmbedding(
             in_channels=frequency_embedding_size, time_embed_dim=min(hidden_size, 1024)
         )
+        self.delta_timestep_embedder: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
 
         self.caption_embedder = nn.Sequential(
             RMSNorm(cap_feat_dim, eps=norm_eps), nn.Linear(cap_feat_dim, hidden_size, bias=True)
         )
 
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="Lumina2")
+        if self.delta_timestep_embedder is None:
+            self.delta_timestep_embedder = clone_flowmap_embedder(self.timestep_embedder)
+        set_flowmap_gate(self, gate_value)
+
     def forward(
-        self, hidden_states: torch.Tensor, timestep: torch.Tensor, encoder_hidden_states: torch.Tensor
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        r_timestep: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        if timestep.ndim == 2:
-            timestep_proj = self.time_proj(timestep.reshape(-1)).type_as(hidden_states)
-            time_embed = self.timestep_embedder(timestep_proj).view(timestep.shape[0], timestep.shape[1], -1)
-        else:
-            timestep_proj = self.time_proj(timestep).type_as(hidden_states)
-            time_embed = self.timestep_embedder(timestep_proj)
+        time_embed = flowmap_timestep_embedding(
+            time_proj=self.time_proj,
+            timestep_embedder=self.timestep_embedder,
+            timestep=timestep,
+            dtype=hidden_states.dtype,
+        ).to(device=hidden_states.device, dtype=hidden_states.dtype)
+        if r_timestep is not None:
+            if self.delta_timestep_embedder is None or self.flowmap_deltatime_type is None:
+                raise ValueError(
+                    "Lumina2 FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training."
+                )
+            delta_timestep = prepare_flowmap_delta_timestep(
+                timestep,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                model_name="Lumina2",
+            )
+            delta_embed = flowmap_timestep_embedding(
+                time_proj=self.time_proj,
+                timestep_embedder=self.delta_timestep_embedder,
+                timestep=delta_timestep,
+                dtype=hidden_states.dtype,
+            ).to(device=hidden_states.device, dtype=hidden_states.dtype)
+            time_embed = blend_flowmap_embeddings(time_embed, delta_embed, self.flowmap_delta_emb_gate)
         caption_embed = self.caption_embedder(encoder_hidden_states)
         return time_embed, caption_embed
 
@@ -419,6 +458,8 @@ class Lumina2Transformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromO
         cap_feat_dim: int = 1024,
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ) -> None:
         super().__init__()
         self.out_channels = out_channels or in_channels
@@ -433,6 +474,11 @@ class Lumina2Transformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromO
         self.time_caption_embed = Lumina2CombinedTimestepCaptionEmbedding(
             hidden_size=hidden_size, cap_feat_dim=cap_feat_dim, norm_eps=norm_eps
         )
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
 
         # 2. Noise and context refinement blocks
         self.noise_refiner = nn.ModuleList(
@@ -500,12 +546,17 @@ class Lumina2Transformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromO
             logger=logger,
         )
 
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.time_caption_embed.enable_flowmap_time_conditioning(gate_value=gate_value, deltatime_type=deltatime_type)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
         timestep: torch.Tensor,
         encoder_hidden_states: torch.Tensor,
         encoder_attention_mask: torch.Tensor,
+        r_timestep: Optional[torch.Tensor] = None,
         attention_kwargs: Optional[Dict[str, Any]] = None,
         return_dict: bool = True,
         hidden_states_buffer: Optional[dict] = None,
@@ -532,7 +583,12 @@ class Lumina2Transformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromO
                 f"Lumina2 tokenwise timesteps expected shape ({batch_size}, {sequence_length}), got {tuple(timestep.shape)}."
             )
 
-        temb, encoder_hidden_states = self.time_caption_embed(hidden_states, timestep, encoder_hidden_states)
+        temb, encoder_hidden_states = self.time_caption_embed(
+            hidden_states,
+            timestep,
+            encoder_hidden_states,
+            r_timestep=r_timestep,
+        )
 
         (
             hidden_states,

--- a/simpletuner/helpers/models/omnigen/transformer.py
+++ b/simpletuner/helpers/models/omnigen/transformer.py
@@ -36,6 +36,13 @@ from diffusers.models.modeling_utils import ModelMixin
 from diffusers.models.normalization import AdaLayerNorm, RMSNorm
 from diffusers.utils import logging
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -377,6 +384,8 @@ class OmniGenTransformer2DModel(ModelMixin, ConfigMixin):
         timestep_activation_fn: str = "silu",
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ):
         super().__init__()
         self.in_channels = in_channels
@@ -392,6 +401,15 @@ class OmniGenTransformer2DModel(ModelMixin, ConfigMixin):
         self.time_proj = Timesteps(time_step_dim, flip_sin_to_cos, downscale_freq_shift)
         self.time_token = TimestepEmbedding(time_step_dim, hidden_size, timestep_activation_fn)
         self.t_embedder = TimestepEmbedding(time_step_dim, hidden_size, timestep_activation_fn)
+        self.delta_time_token: Optional[nn.Module] = None
+        self.delta_t_embedder: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
 
         self.embed_tokens = nn.Embedding(vocab_size, hidden_size, pad_token_id)
         self.rope = OmniGenSuScaledRotaryEmbedding(
@@ -422,6 +440,15 @@ class OmniGenTransformer2DModel(ModelMixin, ConfigMixin):
             logger=logger,
         )
 
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="OmniGen")
+        if self.delta_time_token is None:
+            self.delta_time_token = clone_flowmap_embedder(self.time_token)
+        if self.delta_t_embedder is None:
+            self.delta_t_embedder = clone_flowmap_embedder(self.t_embedder)
+        set_flowmap_gate(self, gate_value)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
+
     def _get_multimodal_embeddings(
         self, input_ids: torch.Tensor, input_img_latents: List[torch.Tensor], input_image_sizes: Dict
     ) -> Optional[torch.Tensor]:
@@ -450,6 +477,7 @@ class OmniGenTransformer2DModel(ModelMixin, ConfigMixin):
         position_ids: torch.Tensor,
         return_dict: bool = True,
         hidden_states_buffer: Optional[dict] = None,
+        r_timestep: Optional[torch.Tensor] = None,
     ) -> Union[Transformer2DModelOutput, Tuple[torch.Tensor]]:
         batch_size, num_channels, height, width = hidden_states.shape
         p = self.config.patch_size
@@ -500,6 +528,36 @@ class OmniGenTransformer2DModel(ModelMixin, ConfigMixin):
             pooled_timestep_proj = timestep_proj
 
         time_token = self.time_token(pooled_timestep_proj).unsqueeze(1)
+        if r_timestep is not None:
+            if self.delta_time_token is None or self.delta_t_embedder is None or self.flowmap_deltatime_type is None:
+                raise ValueError(
+                    "OmniGen FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training."
+                )
+            delta_timestep = prepare_flowmap_delta_timestep(
+                timestep,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                model_name="OmniGen",
+            )
+            if delta_timestep.ndim == 2:
+                delta_timestep_proj = (
+                    self.time_proj(delta_timestep.reshape(-1))
+                    .type_as(hidden_states)
+                    .view(
+                        batch_size,
+                        num_tokens_for_output_image,
+                        -1,
+                    )
+                )
+                delta_temb = self.delta_t_embedder(delta_timestep_proj)
+                delta_pooled_timestep_proj = delta_timestep_proj.mean(dim=1)
+            else:
+                delta_timestep_proj = self.time_proj(delta_timestep).type_as(hidden_states)
+                delta_temb = self.delta_t_embedder(delta_timestep_proj)
+                delta_pooled_timestep_proj = delta_timestep_proj
+            temb = blend_flowmap_embeddings(temb, delta_temb, self.flowmap_delta_emb_gate)
+            delta_time_token = self.delta_time_token(delta_pooled_timestep_proj).unsqueeze(1)
+            time_token = blend_flowmap_embeddings(time_token, delta_time_token, self.flowmap_delta_emb_gate)
 
         condition_tokens = self._get_multimodal_embeddings(input_ids, input_img_latents, input_image_sizes)
         if condition_tokens is not None:

--- a/simpletuner/helpers/models/pixart/transformer.py
+++ b/simpletuner/helpers/models/pixart/transformer.py
@@ -27,6 +27,13 @@ from diffusers.models.normalization import AdaLayerNormSingle
 from diffusers.utils import logging
 from torch import nn
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.tread import TREADRouter
 from simpletuner.helpers.utils.patching import CallableDict, MutableModuleList, PatchableModule
@@ -221,6 +228,8 @@ class PixArtTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAda
         attention_type: Optional[str] = "default",
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ):
         super().__init__()
 
@@ -265,6 +274,8 @@ class PixArtTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAda
             attention_type=attention_type,
             musubi_blocks_to_swap=musubi_blocks_to_swap,
             musubi_block_swap_device=musubi_block_swap_device,
+            gate_value=gate_value,
+            deltatime_type=deltatime_type,
         )
 
         # Set some common variables used across the board.
@@ -323,6 +334,14 @@ class PixArtTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAda
         )
 
         self.adaln_single = AdaLayerNormSingle(self.inner_dim, use_additional_conditions=self.use_additional_conditions)
+        self.delta_timestep_embedder: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
         self.caption_projection = None
         if self.config.caption_channels is not None:
             self.caption_projection = PixArtAlphaTextProjection(
@@ -451,6 +470,13 @@ class PixArtTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAda
         self._tread_router = router
         self._tread_routes = routes
 
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="PixArt")
+        if self.delta_timestep_embedder is None:
+            self.delta_timestep_embedder = clone_flowmap_embedder(self.adaln_single.emb.timestep_embedder)
+        set_flowmap_gate(self, gate_value)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -465,6 +491,7 @@ class PixArtTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAda
         return_dict: bool = True,
         force_keep_mask: Optional[torch.Tensor] = None,
         hidden_states_buffer: Optional[dict] = None,
+        r_timestep: Optional[torch.Tensor] = None,
     ):
         """
         The [`PixArtTransformer2DModel`] forward method.
@@ -531,6 +558,7 @@ class PixArtTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAda
             batch_size=batch_size,
             hidden_dtype=hidden_states.dtype,
             sequence_length=hidden_states.shape[1],
+            r_timestep=r_timestep,
         )
 
         if self.caption_projection is not None:
@@ -689,8 +717,9 @@ class PixArtTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAda
         batch_size: int,
         hidden_dtype: torch.dtype,
         sequence_length: int,
+        r_timestep: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if timestep.ndim != 2:
+        if timestep.ndim != 2 and r_timestep is None:
             return self.adaln_single(
                 timestep,
                 added_cond_kwargs,
@@ -704,9 +733,29 @@ class PixArtTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAda
             )
 
         emb = self.adaln_single.emb
-        timestep_flat = timestep.reshape(-1)
+        timestep_flat = timestep.reshape(-1) if timestep.ndim == 2 else timestep
         timesteps_proj = emb.time_proj(timestep_flat)
-        timesteps_emb = emb.timestep_embedder(timesteps_proj.to(dtype=hidden_dtype)).view(batch_size, sequence_length, -1)
+        timesteps_emb = emb.timestep_embedder(timesteps_proj.to(dtype=hidden_dtype))
+        if timestep.ndim == 2:
+            timesteps_emb = timesteps_emb.view(batch_size, sequence_length, -1)
+
+        if r_timestep is not None:
+            if self.delta_timestep_embedder is None or self.flowmap_deltatime_type is None:
+                raise ValueError(
+                    "PixArt FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training."
+                )
+            delta_timestep = prepare_flowmap_delta_timestep(
+                timestep,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                model_name="PixArt",
+            )
+            delta_flat = delta_timestep.reshape(-1) if delta_timestep.ndim == 2 else delta_timestep
+            delta_proj = emb.time_proj(delta_flat)
+            delta_emb = self.delta_timestep_embedder(delta_proj.to(dtype=hidden_dtype))
+            if delta_timestep.ndim == 2:
+                delta_emb = delta_emb.view(delta_timestep.shape[0], delta_timestep.shape[1], -1)
+            timesteps_emb = blend_flowmap_embeddings(timesteps_emb, delta_emb, self.flowmap_delta_emb_gate)
 
         if self.use_additional_conditions:
             resolution = added_cond_kwargs["resolution"]
@@ -715,7 +764,10 @@ class PixArtTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAda
             resolution_emb = emb.resolution_embedder(resolution_emb).reshape(batch_size, -1)
             aspect_ratio_emb = emb.additional_condition_proj(aspect_ratio.flatten()).to(hidden_dtype)
             aspect_ratio_emb = emb.aspect_ratio_embedder(aspect_ratio_emb).reshape(batch_size, -1)
-            size_cond = torch.cat([resolution_emb, aspect_ratio_emb], dim=1).unsqueeze(1).expand(-1, sequence_length, -1)
+            if timesteps_emb.ndim == 3:
+                size_cond = torch.cat([resolution_emb, aspect_ratio_emb], dim=1).unsqueeze(1).expand(-1, sequence_length, -1)
+            else:
+                size_cond = torch.cat([resolution_emb, aspect_ratio_emb], dim=1)
             embedded_timestep = timesteps_emb + size_cond
         else:
             embedded_timestep = timesteps_emb

--- a/simpletuner/helpers/models/qwen_image/transformer.py
+++ b/simpletuner/helpers/models/qwen_image/transformer.py
@@ -34,6 +34,13 @@ from diffusers.models.normalization import AdaLayerNormContinuous, RMSNorm
 from diffusers.utils import USE_PEFT_BACKEND, deprecate, logging, scale_lora_layers, unscale_lora_layers
 from diffusers.utils.torch_utils import maybe_allow_in_graph
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.qk_clip_logging import publish_attention_max_logits
 from simpletuner.helpers.training.tread import TREADRouter
@@ -361,6 +368,9 @@ class QwenTimestepProjEmbeddings(nn.Module):
         self.time_proj = Timesteps(num_channels=256, flip_sin_to_cos=True, downscale_freq_shift=0, scale=1000)
         self.timestep_embedder = TimestepEmbedding(in_channels=256, time_embed_dim=embedding_dim)
         self.timestep_embedder.time_embed_dim = embedding_dim
+        self.delta_timestep_embedder: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
         # Signed-time embedding for TwinFlow-style negative time handling.
         self.time_sign_embed: Optional[nn.Embedding] = None
         if enable_time_sign_embed:
@@ -408,7 +418,19 @@ class QwenTimestepProjEmbeddings(nn.Module):
         sign_idx = (sign_tensor.view(-1) < 0).long().to(device=target_device)
         return conditioning + self.time_sign_embed(sign_idx).to(dtype=conditioning.dtype, device=target_device)
 
-    def forward(self, timestep, hidden_states, timestep_sign: Optional[torch.Tensor] = None):
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="Qwen")
+        if self.delta_timestep_embedder is None:
+            self.delta_timestep_embedder = clone_flowmap_embedder(self.timestep_embedder)
+        set_flowmap_gate(self, gate_value)
+
+    def forward(
+        self,
+        timestep,
+        hidden_states,
+        timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
+    ):
         target_device = hidden_states.device
         target_dtype = hidden_states.dtype
 
@@ -421,6 +443,13 @@ class QwenTimestepProjEmbeddings(nn.Module):
                 self.timestep_embedder = self.timestep_embedder.to(device=target_device)
             if embedder_params[0].dtype != target_dtype:
                 self.timestep_embedder = self.timestep_embedder.to(dtype=target_dtype)
+        if self.delta_timestep_embedder is not None:
+            delta_embedder_params = list(self.delta_timestep_embedder.parameters())
+            if delta_embedder_params:
+                if delta_embedder_params[0].device != target_device:
+                    self.delta_timestep_embedder = self.delta_timestep_embedder.to(device=target_device)
+                if delta_embedder_params[0].dtype != target_dtype:
+                    self.delta_timestep_embedder = self.delta_timestep_embedder.to(dtype=target_dtype)
 
         timestep = timestep.to(device=target_device)
         if timestep.ndim == 2:
@@ -431,6 +460,27 @@ class QwenTimestepProjEmbeddings(nn.Module):
             timesteps_proj = self.time_proj(timestep)
             timesteps_proj = timesteps_proj.to(device=target_device, dtype=target_dtype)
             conditioning = self.timestep_embedder(timesteps_proj)
+
+        if r_timestep is not None:
+            if self.delta_timestep_embedder is None or self.flowmap_deltatime_type is None:
+                raise ValueError("Qwen FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training.")
+            delta_timestep = prepare_flowmap_delta_timestep(
+                timestep,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                model_name="Qwen",
+            )
+            if delta_timestep.ndim == 2:
+                delta_timesteps_proj = self.time_proj(delta_timestep.reshape(-1))
+                delta_timesteps_proj = delta_timesteps_proj.to(device=target_device, dtype=target_dtype)
+                delta_conditioning = self.delta_timestep_embedder(delta_timesteps_proj).view(
+                    delta_timestep.shape[0], delta_timestep.shape[1], -1
+                )
+            else:
+                delta_timesteps_proj = self.time_proj(delta_timestep)
+                delta_timesteps_proj = delta_timesteps_proj.to(device=target_device, dtype=target_dtype)
+                delta_conditioning = self.delta_timestep_embedder(delta_timesteps_proj)
+            conditioning = blend_flowmap_embeddings(conditioning, delta_conditioning, self.flowmap_delta_emb_gate)
 
         if conditioning.dtype != target_dtype:
             conditioning = conditioning.to(dtype=target_dtype)
@@ -974,6 +1024,8 @@ class QwenImageTransformer2DModel(
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
         enable_time_sign_embed: bool = False,
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ):
         super().__init__()
         self.out_channels = out_channels or in_channels
@@ -985,6 +1037,11 @@ class QwenImageTransformer2DModel(
             embedding_dim=self.inner_dim,
             enable_time_sign_embed=enable_time_sign_embed,
         )
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
         self.time_sign_embed = self.time_text_embed.time_sign_embed
 
         self.txt_norm = RMSNorm(joint_attention_dim, eps=1e-6)
@@ -1024,6 +1081,10 @@ class QwenImageTransformer2DModel(
         """Set TREAD router and routes for token reduction during training."""
         self._tread_router = router
         self._tread_routes = routes
+
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.time_text_embed.enable_flowmap_time_conditioning(gate_value=gate_value, deltatime_type=deltatime_type)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
 
     def _tokenize_hidden_states(self, hidden_states: torch.Tensor) -> Tuple[torch.Tensor, Optional[int], Optional[int]]:
         """
@@ -1106,6 +1167,7 @@ class QwenImageTransformer2DModel(
         encoder_hidden_states_mask: torch.Tensor = None,
         timestep: torch.LongTensor = None,
         timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
         img_shapes: Optional[List[Tuple[int, int, int]]] = None,
         txt_seq_lens: Optional[List[int]] = None,
         guidance: torch.Tensor = None,  # TODO: this should probably be removed
@@ -1207,11 +1269,15 @@ class QwenImageTransformer2DModel(
         if guidance is not None:
             guidance = guidance.to(hidden_states.dtype) * 1000
 
-        temb = (
-            self.time_text_embed(timestep, hidden_states, timestep_sign=timestep_sign)
-            if guidance is None
-            else self.time_text_embed(timestep, guidance, hidden_states, timestep_sign=timestep_sign)
-        )
+        if guidance is None:
+            temb = self.time_text_embed(
+                timestep,
+                hidden_states,
+                timestep_sign=timestep_sign,
+                r_timestep=r_timestep,
+            )
+        else:
+            temb = self.time_text_embed(timestep, guidance, hidden_states, timestep_sign=timestep_sign)
 
         image_rotary_emb = self.pos_embed(img_shapes, txt_seq_lens=text_seq_len, device=hidden_states.device)
 

--- a/simpletuner/helpers/models/sana/transformer.py
+++ b/simpletuner/helpers/models/sana/transformer.py
@@ -26,6 +26,13 @@ from diffusers.models.normalization import AdaLayerNormSingle, RMSNorm
 from diffusers.utils import USE_PEFT_BACKEND, is_torch_version, logging, scale_lora_layers, unscale_lora_layers
 from torch import nn
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
 from simpletuner.helpers.training.tread import TREADRouter
@@ -355,6 +362,8 @@ class SanaTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
         enable_time_sign_embed: bool = False,
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ) -> None:
         super().__init__()
 
@@ -394,6 +403,8 @@ class SanaTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
             enable_time_sign_embed=enable_time_sign_embed,
             musubi_blocks_to_swap=musubi_blocks_to_swap,
             musubi_block_swap_device=musubi_block_swap_device,
+            gate_value=gate_value,
+            deltatime_type=deltatime_type,
         )
 
         out_channels = effective_out_channels
@@ -415,6 +426,14 @@ class SanaTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
 
         # condition embeddings
         self.time_embed = AdaLayerNormSingle(inner_dim)
+        self.delta_timestep_embedder: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
         # Signed-time embedding for TwinFlow-style negative time handling.
         self.time_sign_embed: Optional[nn.Embedding] = None
         if enable_time_sign_embed:
@@ -557,12 +576,20 @@ class SanaTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
         for name, module in self.named_children():
             fn_recursive_attn_processor(name, module, processor)
 
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="Sana")
+        if self.delta_timestep_embedder is None:
+            self.delta_timestep_embedder = clone_flowmap_embedder(self.time_embed.emb.timestep_embedder)
+        set_flowmap_gate(self, gate_value)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
         encoder_hidden_states: torch.Tensor,
         timestep: torch.LongTensor,
         timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
         encoder_attention_mask: Optional[torch.Tensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
         attention_kwargs: Optional[dict] = None,
@@ -618,6 +645,7 @@ class SanaTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
             batch_size=batch_size,
             hidden_dtype=hidden_states.dtype,
             sequence_length=hidden_states.shape[1],
+            r_timestep=r_timestep,
         )
         if timestep_sign is not None:
             if self.time_sign_embed is None:
@@ -813,21 +841,43 @@ class SanaTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
         batch_size: int,
         hidden_dtype: torch.dtype,
         sequence_length: int,
+        r_timestep: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        if timestep.ndim != 2:
+        if timestep.ndim != 2 and r_timestep is None:
             return self.time_embed(timestep, batch_size=batch_size, hidden_dtype=hidden_dtype)
 
-        if timestep.shape[0] != batch_size or timestep.shape[1] != sequence_length:
+        if timestep.ndim == 2 and (timestep.shape[0] != batch_size or timestep.shape[1] != sequence_length):
             raise ValueError(
                 f"Sana tokenwise timestep embedding expected shape ({batch_size}, {sequence_length}), got {tuple(timestep.shape)}."
             )
 
         emb = self.time_embed.emb
-        timestep_flat = timestep.reshape(-1)
+        timestep_flat = timestep.reshape(-1) if timestep.ndim == 2 else timestep
         timesteps_proj = emb.time_proj(timestep_flat)
-        embedded_timestep = emb.timestep_embedder(timesteps_proj.to(dtype=hidden_dtype)).view(
-            batch_size, sequence_length, -1
-        )
+        embedded_timestep = emb.timestep_embedder(timesteps_proj.to(dtype=hidden_dtype))
+        if timestep.ndim == 2:
+            embedded_timestep = embedded_timestep.view(batch_size, sequence_length, -1)
+
+        if r_timestep is not None:
+            if self.delta_timestep_embedder is None or self.flowmap_deltatime_type is None:
+                raise ValueError("Sana FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training.")
+            delta_timestep = prepare_flowmap_delta_timestep(
+                timestep,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                model_name="Sana",
+            )
+            delta_flat = delta_timestep.reshape(-1) if delta_timestep.ndim == 2 else delta_timestep
+            delta_proj = emb.time_proj(delta_flat)
+            delta_emb = self.delta_timestep_embedder(delta_proj.to(dtype=hidden_dtype))
+            if delta_timestep.ndim == 2:
+                delta_emb = delta_emb.view(delta_timestep.shape[0], delta_timestep.shape[1], -1)
+            embedded_timestep = blend_flowmap_embeddings(
+                embedded_timestep,
+                delta_emb,
+                self.flowmap_delta_emb_gate,
+            )
+
         modulation = self.time_embed.linear(self.time_embed.silu(embedded_timestep))
         return modulation, embedded_timestep
 

--- a/simpletuner/helpers/models/sanavideo/transformer.py
+++ b/simpletuner/helpers/models/sanavideo/transformer.py
@@ -30,6 +30,13 @@ from diffusers.models.normalization import AdaLayerNormSingle, RMSNorm
 from diffusers.utils import USE_PEFT_BACKEND, logging, scale_lora_layers, unscale_lora_layers
 from torch import nn
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
 from simpletuner.helpers.training.qk_clip_logging import publish_attention_max_logits
@@ -268,6 +275,9 @@ class SanaCombinedTimestepGuidanceEmbeddings(nn.Module):
         super().__init__()
         self.time_proj = Timesteps(num_channels=256, flip_sin_to_cos=True, downscale_freq_shift=0)
         self.timestep_embedder = TimestepEmbedding(in_channels=256, time_embed_dim=embedding_dim)
+        self.delta_timestep_embedder: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
         self.time_sign_embed: Optional[nn.Embedding] = None
         if enable_time_sign_embed:
             self.time_sign_embed = nn.Embedding(2, embedding_dim)
@@ -279,12 +289,19 @@ class SanaCombinedTimestepGuidanceEmbeddings(nn.Module):
         self.silu = nn.SiLU()
         self.linear = nn.Linear(embedding_dim, 6 * embedding_dim, bias=True)
 
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="SanaVideo")
+        if self.delta_timestep_embedder is None:
+            self.delta_timestep_embedder = clone_flowmap_embedder(self.timestep_embedder)
+        set_flowmap_gate(self, gate_value)
+
     def forward(
         self,
         timestep: torch.Tensor,
         guidance: torch.Tensor = None,
         hidden_dtype: torch.dtype = None,
         timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
     ):
         tokenwise_timestep = timestep.ndim == 2
         if tokenwise_timestep:
@@ -297,6 +314,21 @@ class SanaCombinedTimestepGuidanceEmbeddings(nn.Module):
 
         timesteps_proj = self.time_proj(flat_timestep)
         timesteps_emb = self.timestep_embedder(timesteps_proj.to(dtype=hidden_dtype))  # (N, D)
+        if r_timestep is not None:
+            if self.delta_timestep_embedder is None or self.flowmap_deltatime_type is None:
+                raise ValueError(
+                    "SanaVideo FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training."
+                )
+            delta_timestep = prepare_flowmap_delta_timestep(
+                timestep,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                model_name="SanaVideo",
+            )
+            delta_flat = delta_timestep.reshape(-1) if delta_timestep.ndim == 2 else delta_timestep
+            delta_proj = self.time_proj(delta_flat)
+            delta_emb = self.delta_timestep_embedder(delta_proj.to(dtype=hidden_dtype))
+            timesteps_emb = blend_flowmap_embeddings(timesteps_emb, delta_emb, self.flowmap_delta_emb_gate)
 
         if guidance is None:
             raise ValueError(
@@ -672,6 +704,8 @@ class SanaVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fro
         enable_time_sign_embed: bool = False,
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ) -> None:
         super().__init__()
 
@@ -695,6 +729,14 @@ class SanaVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fro
             if enable_time_sign_embed:
                 self.time_sign_embed = nn.Embedding(2, inner_dim)
                 nn.init.zeros_(self.time_sign_embed.weight)
+        self.delta_timestep_embedder: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
 
         self.caption_projection = PixArtAlphaTextProjection(in_features=caption_channels, hidden_size=inner_dim)
         self.caption_norm = RMSNorm(inner_dim, eps=1e-5, elementwise_affine=True)
@@ -734,12 +776,23 @@ class SanaVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fro
             logger=logger,
         )
 
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        if hasattr(self.time_embed, "enable_flowmap_time_conditioning"):
+            self.time_embed.enable_flowmap_time_conditioning(gate_value=gate_value, deltatime_type=deltatime_type)
+        else:
+            self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="SanaVideo")
+            if self.delta_timestep_embedder is None:
+                self.delta_timestep_embedder = clone_flowmap_embedder(self.time_embed.emb.timestep_embedder)
+            set_flowmap_gate(self, gate_value)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
         encoder_hidden_states: torch.Tensor,
         timestep: torch.Tensor,
         timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
         guidance: Optional[torch.Tensor] = None,
         encoder_attention_mask: Optional[torch.Tensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
@@ -808,19 +861,53 @@ class SanaVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fro
 
         if guidance is not None:
             timestep, embedded_timestep = self.time_embed(
-                timestep, guidance=guidance, hidden_dtype=hidden_states.dtype, timestep_sign=timestep_sign
+                timestep,
+                guidance=guidance,
+                hidden_dtype=hidden_states.dtype,
+                timestep_sign=timestep_sign,
+                r_timestep=r_timestep,
             )
         else:
-            projected_timestep, embedded_timestep = self.time_embed(
-                timestep.flatten() if tokenwise_timestep else timestep,
-                batch_size=batch_size,
-                hidden_dtype=hidden_states.dtype,
-            )
-            if tokenwise_timestep:
-                timestep = projected_timestep.view(batch_size, token_count, projected_timestep.size(-1))
-                embedded_timestep = embedded_timestep.view(batch_size, token_count, embedded_timestep.size(-1))
+            base_timestep = timestep
+            if r_timestep is None:
+                projected_timestep, embedded_timestep = self.time_embed(
+                    timestep.flatten() if tokenwise_timestep else timestep,
+                    batch_size=batch_size,
+                    hidden_dtype=hidden_states.dtype,
+                )
+                if tokenwise_timestep:
+                    timestep = projected_timestep.view(batch_size, token_count, projected_timestep.size(-1))
+                    embedded_timestep = embedded_timestep.view(batch_size, token_count, embedded_timestep.size(-1))
+                else:
+                    timestep = projected_timestep
             else:
-                timestep = projected_timestep
+                if self.delta_timestep_embedder is None or self.flowmap_deltatime_type is None:
+                    raise ValueError(
+                        "SanaVideo FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training."
+                    )
+                emb = self.time_embed.emb
+                timestep_flat = base_timestep.reshape(-1) if tokenwise_timestep else base_timestep
+                timesteps_proj = emb.time_proj(timestep_flat)
+                embedded_timestep = emb.timestep_embedder(timesteps_proj.to(dtype=hidden_states.dtype))
+                if tokenwise_timestep:
+                    embedded_timestep = embedded_timestep.view(batch_size, token_count, -1)
+                delta_timestep = prepare_flowmap_delta_timestep(
+                    base_timestep,
+                    r_timestep,
+                    self.flowmap_deltatime_type,
+                    model_name="SanaVideo",
+                )
+                delta_flat = delta_timestep.reshape(-1) if delta_timestep.ndim == 2 else delta_timestep
+                delta_proj = emb.time_proj(delta_flat)
+                delta_emb = self.delta_timestep_embedder(delta_proj.to(dtype=hidden_states.dtype))
+                if delta_timestep.ndim == 2:
+                    delta_emb = delta_emb.view(delta_timestep.shape[0], delta_timestep.shape[1], -1)
+                embedded_timestep = blend_flowmap_embeddings(
+                    embedded_timestep,
+                    delta_emb,
+                    self.flowmap_delta_emb_gate,
+                )
+                timestep = self.time_embed.linear(self.time_embed.silu(embedded_timestep))
             if timestep_sign is not None:
                 if self.time_sign_embed is None:
                     raise ValueError(

--- a/simpletuner/helpers/models/sd3/transformer.py
+++ b/simpletuner/helpers/models/sd3/transformer.py
@@ -28,6 +28,14 @@ from diffusers.models.modeling_utils import ModelMixin
 from diffusers.models.normalization import AdaLayerNormContinuous
 from diffusers.utils import USE_PEFT_BACKEND, is_torch_version, logging, scale_lora_layers, unscale_lora_layers
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    flowmap_timestep_embedding,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
 from simpletuner.helpers.training.tread import TREADRouter
@@ -59,6 +67,54 @@ def _sd3_tokenwise_conditioning(
         pooled_projections[:, None, :].expand(-1, sequence_length, -1).reshape(-1, pooled_projections.shape[-1])
     )
     conditioning = conditioning_module(flat_timestep, repeated_pooled)
+    return conditioning.view(batch_size, sequence_length, -1)
+
+
+def _sd3_tokenwise_flowmap_conditioning(
+    conditioning_module: CombinedTimestepTextProjEmbeddings,
+    delta_timestep_embedder: Optional[nn.Module],
+    timestep: torch.Tensor,
+    pooled_projections: torch.Tensor,
+    r_timestep: torch.Tensor,
+    deltatime_type: Optional[str],
+    gate: torch.Tensor,
+) -> torch.Tensor:
+    if delta_timestep_embedder is None or deltatime_type is None:
+        raise ValueError("SD3 FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training.")
+
+    delta_timestep = prepare_flowmap_delta_timestep(
+        timestep,
+        r_timestep,
+        deltatime_type,
+        model_name="SD3",
+    )
+
+    def embed_time(time_values: torch.Tensor, timestep_embedder: nn.Module) -> torch.Tensor:
+        return flowmap_timestep_embedding(
+            time_proj=conditioning_module.time_proj,
+            timestep_embedder=timestep_embedder,
+            timestep=time_values,
+            dtype=pooled_projections.dtype,
+        )
+
+    if timestep.ndim != 2:
+        timestep_emb = embed_time(timestep, conditioning_module.timestep_embedder)
+        delta_emb = embed_time(delta_timestep, delta_timestep_embedder)
+        return blend_flowmap_embeddings(timestep_emb, delta_emb, gate) + conditioning_module.text_embedder(
+            pooled_projections
+        )
+
+    batch_size, sequence_length = timestep.shape
+    flat_timestep = timestep.reshape(-1)
+    flat_delta_timestep = delta_timestep.reshape(-1)
+    repeated_pooled = (
+        pooled_projections[:, None, :].expand(-1, sequence_length, -1).reshape(-1, pooled_projections.shape[-1])
+    )
+    timestep_emb = embed_time(flat_timestep, conditioning_module.timestep_embedder)
+    delta_emb = embed_time(flat_delta_timestep, delta_timestep_embedder)
+    conditioning = blend_flowmap_embeddings(timestep_emb, delta_emb, gate) + conditioning_module.text_embedder(
+        repeated_pooled
+    )
     return conditioning.view(batch_size, sequence_length, -1)
 
 
@@ -240,6 +296,8 @@ class SD3Transformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapte
         enable_time_sign_embed: bool = False,
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ):
         super().__init__()
         default_out_channels = in_channels
@@ -261,6 +319,8 @@ class SD3Transformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapte
             enable_time_sign_embed=enable_time_sign_embed,
             musubi_blocks_to_swap=musubi_blocks_to_swap,
             musubi_block_swap_device=musubi_block_swap_device,
+            gate_value=gate_value,
+            deltatime_type=deltatime_type,
         )
         self.out_channels = effective_out_channels
         self.inner_dim = self.config.num_attention_heads * self.config.attention_head_dim
@@ -277,6 +337,14 @@ class SD3Transformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapte
             embedding_dim=self.inner_dim,
             pooled_projection_dim=self.config.pooled_projection_dim,
         )
+        self.delta_timestep_embedder: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
         # Signed-time embedding for TwinFlow adversarial branch; row 0 = positive/zero, row 1 = negative.
         self.time_sign_embed: Optional[nn.Embedding] = None
         if enable_time_sign_embed:
@@ -323,6 +391,13 @@ class SD3Transformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapte
     def set_router(self, router: TREADRouter, routes: List[Dict[str, Any]]):
         self._tread_router = router
         self._tread_routes = routes
+
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="SD3")
+        if self.delta_timestep_embedder is None:
+            self.delta_timestep_embedder = clone_flowmap_embedder(self.time_text_embed.timestep_embedder)
+        set_flowmap_gate(self, gate_value)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
 
     # Copied from diffusers.models.unets.unet_3d_condition.UNet3DConditionModel.enable_forward_chunking
     def enable_forward_chunking(self, chunk_size: Optional[int] = None, dim: int = 0) -> None:
@@ -477,6 +552,7 @@ class SD3Transformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapte
         pooled_projections: torch.FloatTensor = None,
         timestep: torch.LongTensor = None,
         timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
         block_controlnet_hidden_states: List = None,
         joint_attention_kwargs: Optional[Dict[str, Any]] = None,
         return_dict: bool = True,
@@ -575,7 +651,18 @@ class SD3Transformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapte
             if timestep.ndim == 2:
                 sign_emb = sign_emb.view(timestep.shape[0], timestep.shape[1], -1)
 
-        temb = _sd3_tokenwise_conditioning(self.time_text_embed, timestep, pooled_projections)
+        if r_timestep is None:
+            temb = _sd3_tokenwise_conditioning(self.time_text_embed, timestep, pooled_projections)
+        else:
+            temb = _sd3_tokenwise_flowmap_conditioning(
+                self.time_text_embed,
+                self.delta_timestep_embedder,
+                timestep,
+                pooled_projections,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                self.flowmap_delta_emb_gate,
+            )
         if sign_emb is not None:
             temb = temb + sign_emb.to(device=hidden_states.device, dtype=temb.dtype)
         if temb.ndim == 3:

--- a/simpletuner/helpers/models/wan/transformer.py
+++ b/simpletuner/helpers/models/wan/transformer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import math
 import os
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -242,6 +243,9 @@ class WanTimeTextImageEmbedding(nn.Module):
         if enable_time_sign_embed:
             self.time_sign_embed = nn.Embedding(2, dim)
             nn.init.zeros_(self.time_sign_embed.weight)
+        self.delta_embedder: Optional[TimestepEmbedding] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
         self.act_fn = nn.SiLU()
         self.time_proj = nn.Linear(dim, time_proj_dim)
         self.text_embedder = PixArtAlphaTextProjection(text_embed_dim, dim, act_fn="gelu_tanh")
@@ -250,26 +254,98 @@ class WanTimeTextImageEmbedding(nn.Module):
         if image_embed_dim is not None:
             self.image_embedder = WanImageEmbedding(image_embed_dim, dim)
 
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        if deltatime_type not in ("r", "t-r"):
+            raise ValueError("Wan FlowMap deltatime_type must be 'r' or 't-r'.")
+        if self.delta_embedder is None:
+            self.delta_embedder = copy.deepcopy(self.time_embedder)
+        self.flowmap_deltatime_type = deltatime_type
+        self.flowmap_delta_emb_gate.data = torch.tensor(
+            [float(gate_value)],
+            device=self.flowmap_delta_emb_gate.device,
+            dtype=self.flowmap_delta_emb_gate.dtype,
+        )
+
+    def _embed_timestep(
+        self,
+        timestep: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        embedder: TimestepEmbedding,
+    ) -> tuple[torch.Tensor, Optional[int]]:
+        timestep_seq_len: Optional[int] = None
+        if timestep.ndim > 1:
+            timestep_seq_len = timestep.shape[1]
+            timestep = timestep.reshape(-1)
+
+        projected_timestep = self.timesteps_proj(timestep)
+        if timestep_seq_len is not None:
+            projected_timestep = projected_timestep.unflatten(0, (-1, timestep_seq_len))
+
+        embedder_dtype = next(iter(embedder.parameters())).dtype
+        if projected_timestep.dtype != embedder_dtype and embedder_dtype != torch.int8:
+            projected_timestep = projected_timestep.to(embedder_dtype)
+        return embedder(projected_timestep).type_as(encoder_hidden_states), timestep_seq_len
+
+    def _prepare_flowmap_delta_timestep(self, timestep: torch.Tensor, r_timestep: torch.Tensor) -> torch.Tensor:
+        if self.delta_embedder is None or self.flowmap_deltatime_type is None:
+            raise ValueError("Wan FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training.")
+
+        r_timestep = r_timestep.to(device=timestep.device, dtype=timestep.dtype)
+        if timestep.ndim == 1:
+            if r_timestep.ndim == 0:
+                r_timestep = r_timestep.expand(timestep.shape[0])
+            elif r_timestep.ndim == 1:
+                if r_timestep.shape[0] == 1:
+                    r_timestep = r_timestep.expand(timestep.shape[0])
+                elif r_timestep.shape[0] != timestep.shape[0]:
+                    raise ValueError(
+                        f"Wan FlowMap expected 1 or {timestep.shape[0]} r_timestep values, got {r_timestep.shape[0]}."
+                    )
+            else:
+                raise ValueError(
+                    f"Wan FlowMap expected scalar or 1D r_timestep for batch timesteps, got shape {tuple(r_timestep.shape)}."
+                )
+        elif timestep.ndim == 2:
+            if r_timestep.ndim == 0:
+                r_timestep = r_timestep.expand(timestep.shape)
+            elif r_timestep.ndim == 1:
+                if r_timestep.shape[0] == 1:
+                    r_timestep = r_timestep.expand(timestep.shape[0])
+                elif r_timestep.shape[0] != timestep.shape[0]:
+                    raise ValueError(
+                        f"Wan FlowMap expected 1 or {timestep.shape[0]} batch r_timestep values, got {r_timestep.shape[0]}."
+                    )
+                r_timestep = r_timestep[:, None].expand(-1, timestep.shape[1])
+            elif r_timestep.ndim == 2:
+                if r_timestep.shape != timestep.shape:
+                    raise ValueError(
+                        f"Wan FlowMap tokenwise r_timestep expected shape {tuple(timestep.shape)}, got {tuple(r_timestep.shape)}."
+                    )
+            else:
+                raise ValueError(f"Wan FlowMap expected scalar, 1D, or 2D r_timestep, got shape {tuple(r_timestep.shape)}.")
+        else:
+            raise ValueError(f"Wan FlowMap expected 1D or 2D timesteps, got shape {tuple(timestep.shape)}.")
+
+        if self.flowmap_deltatime_type == "r":
+            return r_timestep
+        if self.flowmap_deltatime_type == "t-r":
+            return timestep - r_timestep
+        raise ValueError(f"Unsupported Wan FlowMap deltatime_type '{self.flowmap_deltatime_type}'.")
+
     def forward(
         self,
         timestep: torch.Tensor,
         encoder_hidden_states: torch.Tensor,
         encoder_hidden_states_image: Optional[torch.Tensor] = None,
         timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
     ):
-        timestep_seq_len: Optional[int] = None
-        if timestep.ndim > 1:
-            timestep_seq_len = timestep.shape[1]
-            timestep = timestep.reshape(-1)
-
-        timestep = self.timesteps_proj(timestep)
-        if timestep_seq_len is not None:
-            timestep = timestep.unflatten(0, (-1, timestep_seq_len))
-
-        time_embedder_dtype = next(iter(self.time_embedder.parameters())).dtype
-        if timestep.dtype != time_embedder_dtype and time_embedder_dtype != torch.int8:
-            timestep = timestep.to(time_embedder_dtype)
-        temb = self.time_embedder(timestep).type_as(encoder_hidden_states)
+        temb, timestep_seq_len = self._embed_timestep(timestep, encoder_hidden_states, self.time_embedder)
+        if r_timestep is not None:
+            delta_timestep = self._prepare_flowmap_delta_timestep(timestep, r_timestep)
+            delta_emb, _ = self._embed_timestep(delta_timestep, encoder_hidden_states, self.delta_embedder)
+            gate = self.flowmap_delta_emb_gate.to(device=temb.device, dtype=temb.dtype)
+            temb = (1.0 - gate) * temb + gate * delta_emb
         if timestep_sign is not None:
             if self.time_sign_embed is None:
                 raise ValueError(
@@ -646,6 +722,8 @@ class WanTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrigi
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
         enable_time_sign_embed: bool = False,
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ) -> None:
         super().__init__()
         effective_out_channels = out_channels or in_channels
@@ -670,6 +748,8 @@ class WanTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrigi
             musubi_blocks_to_swap=musubi_blocks_to_swap,
             musubi_block_swap_device=musubi_block_swap_device,
             enable_time_sign_embed=enable_time_sign_embed,
+            gate_value=gate_value,
+            deltatime_type=deltatime_type,
         )
 
         inner_dim = num_attention_heads * attention_head_dim
@@ -730,6 +810,15 @@ class WanTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrigi
             swap_device=musubi_block_swap_device,
             logger=logger,
         )
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
+
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.condition_embedder.enable_flowmap_time_conditioning(gate_value=gate_value, deltatime_type=deltatime_type)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
 
     def set_time_embedding_v2_1(self, force_2_1_time_embedding: bool) -> None:
         """
@@ -791,6 +880,7 @@ class WanTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrigi
         encoder_hidden_states: torch.Tensor,
         encoder_hidden_states_image: Optional[torch.Tensor] = None,
         timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
         skip_layers: Optional[List[int]] = None,
         return_dict: bool = True,
         attention_kwargs: Optional[Dict[str, Any]] = None,
@@ -828,6 +918,8 @@ class WanTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrigi
             # Wan 2.1 uses a single timestep per batch entry. When forcing 2.1 behaviour with Wan 2.2
             # checkpoints we fall back to the first timestep value which matches the reference implementation.
             timestep = timestep[..., 0].contiguous()
+            if r_timestep is not None and r_timestep.dim() > 1:
+                r_timestep = r_timestep[..., 0].contiguous()
             if timestep_sign is not None and timestep_sign.dim() > 1:
                 timestep_sign = timestep_sign[..., 0].contiguous()
         else:
@@ -841,9 +933,18 @@ class WanTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrigi
                     "WanTransformer3DModel received tokenwise timestep_sign values with sequence length "
                     f"{timestep_sign.shape[1]}, but the latent token sequence length is {token_sequence_length}."
                 )
+            if r_timestep is not None and r_timestep.ndim > 1 and r_timestep.shape[1] != token_sequence_length:
+                raise ValueError(
+                    "WanTransformer3DModel received tokenwise r_timestep values with sequence length "
+                    f"{r_timestep.shape[1]}, but the latent token sequence length is {token_sequence_length}."
+                )
 
         temb, timestep_proj, encoder_hidden_states, encoder_hidden_states_image = self.condition_embedder(
-            timestep, encoder_hidden_states, encoder_hidden_states_image, timestep_sign=timestep_sign
+            timestep,
+            encoder_hidden_states,
+            encoder_hidden_states_image,
+            timestep_sign=timestep_sign,
+            r_timestep=r_timestep,
         )
         timestep_proj = timestep_proj.unflatten(-1, (6, -1))
 

--- a/simpletuner/helpers/models/wan_s2v/transformer.py
+++ b/simpletuner/helpers/models/wan_s2v/transformer.py
@@ -30,6 +30,13 @@ from diffusers.models.modeling_utils import ModelMixin
 from diffusers.models.normalization import AdaLayerNorm, FP32LayerNorm
 from diffusers.utils import USE_PEFT_BACKEND, logging, scale_lora_layers, unscale_lora_layers
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.tread import TREADRouter
 
@@ -631,6 +638,9 @@ class WanTimeTextAudioPoseEmbedding(nn.Module):
 
         self.timesteps_proj = Timesteps(num_channels=time_freq_dim, flip_sin_to_cos=True, downscale_freq_shift=0)
         self.time_embedder = TimestepEmbedding(in_channels=time_freq_dim, time_embed_dim=dim)
+        self.delta_embedder: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
         self.act_fn = nn.SiLU()
         self.time_proj = nn.Linear(dim, time_proj_dim)
         self.text_embedder = PixArtAlphaTextProjection(text_embed_dim, dim, act_fn="gelu_tanh")
@@ -643,12 +653,20 @@ class WanTimeTextAudioPoseEmbedding(nn.Module):
         )
         self.pose_embedder = nn.Conv3d(pose_embed_dim, dim, kernel_size=patch_size, stride=patch_size)
 
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="WanS2V")
+        if self.delta_embedder is None:
+            self.delta_embedder = clone_flowmap_embedder(self.time_embedder)
+        set_flowmap_gate(self, gate_value)
+
     def project_timestep(
         self,
         timestep: torch.Tensor,
         dtype_reference: torch.Tensor,
         timestep_seq_len: Optional[int] = None,
+        r_timestep: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        original_timestep = timestep
         if timestep.ndim > 1:
             timestep_seq_len = timestep.shape[1]
             timestep = timestep.reshape(-1)
@@ -661,6 +679,28 @@ class WanTimeTextAudioPoseEmbedding(nn.Module):
         if timestep.dtype != time_embedder_dtype and time_embedder_dtype != torch.int8:
             timestep = timestep.to(time_embedder_dtype)
         temb = self.time_embedder(timestep).type_as(dtype_reference)
+        if r_timestep is not None:
+            if self.delta_embedder is None or self.flowmap_deltatime_type is None:
+                raise ValueError(
+                    "WanS2V FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training."
+                )
+            delta_timestep = prepare_flowmap_delta_timestep(
+                original_timestep,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                model_name="WanS2V",
+            )
+            delta_seq_len = delta_timestep.shape[1] if delta_timestep.ndim > 1 else None
+            if delta_timestep.ndim > 1:
+                delta_timestep = delta_timestep.reshape(-1)
+            delta_projected = self.timesteps_proj(delta_timestep)
+            if delta_seq_len is not None:
+                delta_projected = delta_projected.unflatten(0, (-1, delta_seq_len))
+            delta_embedder_dtype = next(iter(self.delta_embedder.parameters())).dtype
+            if delta_projected.dtype != delta_embedder_dtype and delta_embedder_dtype != torch.int8:
+                delta_projected = delta_projected.to(delta_embedder_dtype)
+            delta_temb = self.delta_embedder(delta_projected).type_as(dtype_reference)
+            temb = blend_flowmap_embeddings(temb, delta_temb, self.flowmap_delta_emb_gate)
         timestep_proj = self.time_proj(self.act_fn(temb))
         return temb, timestep_proj
 
@@ -671,11 +711,13 @@ class WanTimeTextAudioPoseEmbedding(nn.Module):
         audio_hidden_states: torch.Tensor,
         pose_hidden_states: Optional[torch.Tensor] = None,
         timestep_seq_len: Optional[int] = None,
+        r_timestep: Optional[torch.Tensor] = None,
     ):
         temb, timestep_proj = self.project_timestep(
             timestep,
             encoder_hidden_states,
             timestep_seq_len=timestep_seq_len,
+            r_timestep=r_timestep,
         )
 
         encoder_hidden_states = self.text_embedder(encoder_hidden_states)
@@ -916,6 +958,8 @@ class WanS2VTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
         zero_timestep: bool = True,
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ):
         super().__init__()
 
@@ -959,6 +1003,11 @@ class WanS2VTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
             enable_adain=enable_adain,
             num_weighted_avg_layers=num_weighted_avg_layers,
         )
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
 
         # Transformer blocks
         self.blocks = nn.ModuleList(
@@ -994,6 +1043,10 @@ class WanS2VTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
             swap_device=musubi_block_swap_device,
             logger=logger,
         )
+
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.condition_embedder.enable_flowmap_time_conditioning(gate_value=gate_value, deltatime_type=deltatime_type)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
 
     def _set_gradient_checkpointing(self, module, value=False):
         if hasattr(module, "gradient_checkpointing"):
@@ -1069,6 +1122,7 @@ class WanS2VTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
         hidden_state_layer: Optional[int] = None,
         hidden_states_buffer: Optional[Dict[str, torch.Tensor]] = None,
         force_keep_mask: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, Transformer2DModelOutput]:
         """
         Forward pass for S2V generation.
@@ -1124,6 +1178,7 @@ class WanS2VTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
             encoder_hidden_states,
             audio_embeds,
             pose_latents,
+            r_timestep=r_timestep,
         )
         timestep_proj = timestep_proj.unflatten(-1, (6, -1))
 

--- a/simpletuner/helpers/models/z_image/transformer.py
+++ b/simpletuner/helpers/models/z_image/transformer.py
@@ -30,6 +30,13 @@ from diffusers.models.normalization import RMSNorm
 from diffusers.utils.torch_utils import maybe_allow_in_graph
 from torch.nn.utils.rnn import pad_sequence
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.qk_clip_logging import publish_attention_max_logits
 from simpletuner.helpers.training.tread import TREADRouter
@@ -83,6 +90,9 @@ class TimestepEmbedder(nn.Module):
                 bias=True,
             ),
         )
+        self.delta_mlp: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
 
         self.frequency_embedding_size = frequency_embedding_size
 
@@ -99,7 +109,18 @@ class TimestepEmbedder(nn.Module):
                 embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
             return embedding
 
-    def forward(self, t, timestep_sign: Optional[torch.Tensor] = None):
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="Z-Image")
+        if self.delta_mlp is None:
+            self.delta_mlp = clone_flowmap_embedder(self.mlp)
+        set_flowmap_gate(self, gate_value)
+
+    def forward(
+        self,
+        t,
+        timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
+    ):
         if t.ndim == 2:
             t_freq = self.timestep_embedding(t.reshape(-1), self.frequency_embedding_size)
         else:
@@ -110,6 +131,27 @@ class TimestepEmbedder(nn.Module):
         t_emb = self.mlp(t_freq)
         if t.ndim == 2:
             t_emb = t_emb.view(t.shape[0], t.shape[1], -1)
+        if r_timestep is not None:
+            if self.delta_mlp is None or self.flowmap_deltatime_type is None:
+                raise ValueError(
+                    "Z-Image FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training."
+                )
+            delta_timestep = prepare_flowmap_delta_timestep(
+                t,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                model_name="Z-Image",
+            )
+            if delta_timestep.ndim == 2:
+                delta_freq = self.timestep_embedding(delta_timestep.reshape(-1), self.frequency_embedding_size)
+            else:
+                delta_freq = self.timestep_embedding(delta_timestep, self.frequency_embedding_size)
+            if weight_dtype.is_floating_point:
+                delta_freq = delta_freq.to(weight_dtype)
+            delta_emb = self.delta_mlp(delta_freq)
+            if delta_timestep.ndim == 2:
+                delta_emb = delta_emb.view(delta_timestep.shape[0], delta_timestep.shape[1], -1)
+            t_emb = blend_flowmap_embeddings(t_emb, delta_emb, self.flowmap_delta_emb_gate)
         if timestep_sign is not None:
             if self.time_sign_embed is None:
                 raise ValueError(
@@ -455,6 +497,8 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
         enable_time_sign_embed: bool = False,
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ) -> None:
         super().__init__()
         self.in_channels = in_channels
@@ -515,6 +559,11 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
             mid_size=1024,
             enable_time_sign_embed=enable_time_sign_embed,
         )
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
         self.cap_embedder = nn.Sequential(
             RMSNorm(cap_feat_dim, eps=norm_eps),
             nn.Linear(cap_feat_dim, dim, bias=True),
@@ -546,6 +595,10 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
     def set_router(self, router: TREADRouter, routes: List[Dict[str, Any]]):
         self._tread_router = router
         self._tread_routes = routes
+
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.t_embedder.enable_flowmap_time_conditioning(gate_value=gate_value, deltatime_type=deltatime_type)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
 
     def unpatchify(self, x: List[torch.Tensor], size: List[Tuple], patch_size, f_patch_size) -> List[torch.Tensor]:
         pH = pW = patch_size
@@ -678,6 +731,7 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
         t,
         cap_feats: List[torch.Tensor],
         timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
         patch_size=2,
         f_patch_size=1,
         joint_attention_kwargs: Optional[Dict[str, Any]] = None,
@@ -691,6 +745,8 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
         bsz = len(x)
         device = x[0].device
         t = t * self.t_scale
+        if r_timestep is not None:
+            r_timestep = r_timestep.to(device=t.device, dtype=t.dtype) * self.t_scale
 
         (
             x,
@@ -717,7 +773,7 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
                 raise ValueError(
                     f"Z-Image tokenwise timesteps expected shape ({bsz}, {expected_length}), got {tuple(t.shape)}."
                 )
-            adaln_input = self.t_embedder(t, timestep_sign=timestep_sign)
+            adaln_input = self.t_embedder(t, timestep_sign=timestep_sign, r_timestep=r_timestep)
             padded_adaln = []
             for batch_idx, padded_len in enumerate(x_item_seqlens):
                 pad_len = padded_len - x_image_seqlens[batch_idx]
@@ -728,7 +784,7 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
                     padded_adaln.append(adaln_input[batch_idx])
             adaln_input = torch.stack(padded_adaln, dim=0)
         else:
-            adaln_input = self.t_embedder(t, timestep_sign=timestep_sign)
+            adaln_input = self.t_embedder(t, timestep_sign=timestep_sign, r_timestep=r_timestep)
 
         x = torch.cat(x, dim=0)
         x = self.all_x_embedder[f"{patch_size}-{f_patch_size}"](x)

--- a/simpletuner/helpers/models/z_image_omni/transformer.py
+++ b/simpletuner/helpers/models/z_image_omni/transformer.py
@@ -32,6 +32,13 @@ from diffusers.models.normalization import RMSNorm
 from diffusers.utils.torch_utils import maybe_allow_in_graph
 from torch.nn.utils.rnn import pad_sequence
 
+from simpletuner.helpers.models.flowmap import (
+    blend_flowmap_embeddings,
+    clone_flowmap_embedder,
+    prepare_flowmap_delta_timestep,
+    set_flowmap_gate,
+    validate_flowmap_deltatime_type,
+)
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.qk_clip_logging import publish_attention_max_logits
 from simpletuner.helpers.training.tread import TREADRouter
@@ -77,6 +84,9 @@ class TimestepEmbedder(nn.Module):
             nn.SiLU(),
             nn.Linear(mid_size, out_size, bias=True),
         )
+        self.delta_mlp: Optional[nn.Module] = None
+        self.flowmap_deltatime_type: Optional[str] = None
+        self.register_buffer("flowmap_delta_emb_gate", torch.tensor([0.25], dtype=torch.float32), persistent=False)
 
         self.frequency_embedding_size = frequency_embedding_size
 
@@ -93,7 +103,18 @@ class TimestepEmbedder(nn.Module):
                 embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
             return embedding
 
-    def forward(self, t, timestep_sign: Optional[torch.Tensor] = None):
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="Z-Image Omni")
+        if self.delta_mlp is None:
+            self.delta_mlp = clone_flowmap_embedder(self.mlp)
+        set_flowmap_gate(self, gate_value)
+
+    def forward(
+        self,
+        t,
+        timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
+    ):
         reshape = None
         if t.ndim == 2:
             reshape = t.shape
@@ -107,6 +128,26 @@ class TimestepEmbedder(nn.Module):
         elif compute_dtype is not None:
             t_freq = t_freq.to(compute_dtype)
         t_emb = self.mlp(t_freq)
+        if r_timestep is not None:
+            if self.delta_mlp is None or self.flowmap_deltatime_type is None:
+                raise ValueError(
+                    "Z-Image Omni FlowMap conditioning requires `enable_flowmap_time_conditioning()` before training."
+                )
+            delta_timestep = prepare_flowmap_delta_timestep(
+                t,
+                r_timestep,
+                self.flowmap_deltatime_type,
+                model_name="Z-Image Omni",
+            )
+            if delta_timestep.ndim == 2:
+                delta_timestep = delta_timestep.reshape(-1)
+            delta_freq = self.timestep_embedding(delta_timestep, self.frequency_embedding_size)
+            if weight_dtype.is_floating_point:
+                delta_freq = delta_freq.to(weight_dtype)
+            elif compute_dtype is not None:
+                delta_freq = delta_freq.to(compute_dtype)
+            delta_emb = self.delta_mlp(delta_freq)
+            t_emb = blend_flowmap_embeddings(t_emb, delta_emb, self.flowmap_delta_emb_gate)
         if timestep_sign is not None:
             if self.time_sign_embed is None:
                 raise ValueError(
@@ -543,6 +584,8 @@ class ZImageOmniTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fr
         enable_time_sign_embed: bool = False,
         musubi_blocks_to_swap: int = 0,
         musubi_block_swap_device: str = "cpu",
+        gate_value: Optional[float] = None,
+        deltatime_type: Optional[str] = None,
     ) -> None:
         super().__init__()
         self.in_channels = in_channels
@@ -616,6 +659,11 @@ class ZImageOmniTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fr
             mid_size=1024,
             enable_time_sign_embed=enable_time_sign_embed,
         )
+        if deltatime_type is not None:
+            self.enable_flowmap_time_conditioning(
+                gate_value=0.25 if gate_value is None else float(gate_value),
+                deltatime_type=deltatime_type,
+            )
         self.cap_embedder = nn.Sequential(RMSNorm(cap_feat_dim, eps=norm_eps), nn.Linear(cap_feat_dim, dim, bias=True))
         self.siglip_embedder = nn.Sequential(
             RMSNorm(siglip_feat_dim, eps=norm_eps), nn.Linear(siglip_feat_dim, dim, bias=True)
@@ -646,6 +694,10 @@ class ZImageOmniTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fr
     def set_router(self, router: TREADRouter, routes: List[Dict[str, Any]]):
         self._tread_router = router
         self._tread_routes = routes
+
+    def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
+        self.t_embedder.enable_flowmap_time_conditioning(gate_value=gate_value, deltatime_type=deltatime_type)
+        self.register_to_config(gate_value=float(gate_value), deltatime_type=deltatime_type)
 
     def unpatchify(
         self,
@@ -963,6 +1015,7 @@ class ZImageOmniTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fr
         patch_size=2,
         f_patch_size=1,
         timestep_sign: Optional[torch.Tensor] = None,
+        r_timestep: Optional[torch.Tensor] = None,
         skip_layers: Optional[List[int]] = None,
         force_keep_mask: Optional[torch.Tensor] = None,
         return_dict: bool = True,
@@ -994,13 +1047,18 @@ class ZImageOmniTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fr
                     f"Z-Image Omni expected tokenwise timesteps with sequence length {expected_token_count}, got {t.shape[1]}."
                 )
         t = torch.cat([t, torch.ones_like(t, dtype=t.dtype, device=device)], dim=0)
+        if r_timestep is not None:
+            r_timestep = r_timestep.to(device=t.device, dtype=t.dtype)
+            r_timestep = torch.cat([r_timestep, torch.ones_like(r_timestep, dtype=r_timestep.dtype, device=device)], dim=0)
         if timestep_sign is not None:
             timestep_sign = torch.cat(
                 [timestep_sign, torch.ones_like(timestep_sign, dtype=timestep_sign.dtype, device=device)],
                 dim=0,
             )
         t = t * self.t_scale
-        t = self.t_embedder(t, timestep_sign=timestep_sign)
+        if r_timestep is not None:
+            r_timestep = r_timestep * self.t_scale
+        t = self.t_embedder(t, timestep_sign=timestep_sign, r_timestep=r_timestep)
 
         t_noisy = t[:bsz]
         t_clean = t[bsz:]

--- a/tests/test_flowmap_transformer_conditioning.py
+++ b/tests/test_flowmap_transformer_conditioning.py
@@ -1,0 +1,130 @@
+import unittest
+
+import torch
+from diffusers.models.embeddings import CombinedTimestepTextProjEmbeddings
+
+from simpletuner.helpers.models.flowmap import clone_flowmap_embedder, prepare_flowmap_delta_timestep
+from simpletuner.helpers.models.flux2.transformer import Flux2TimestepGuidanceEmbeddings
+from simpletuner.helpers.models.flux.transformer import _flux_tokenwise_conditioning, _flux_tokenwise_flowmap_conditioning
+from simpletuner.helpers.models.sd3.transformer import _sd3_tokenwise_conditioning, _sd3_tokenwise_flowmap_conditioning
+
+
+class TestFlowMapTransformerConditioning(unittest.TestCase):
+    def test_prepare_delta_timestep_supports_batch_and_tokenwise(self):
+        timestep = torch.tensor([0.8, 0.4])
+        r_timestep = torch.tensor([0.2])
+
+        delta = prepare_flowmap_delta_timestep(timestep, r_timestep, "r", model_name="Test")
+        self.assertTrue(torch.equal(delta, torch.tensor([0.2, 0.2])))
+
+        delta = prepare_flowmap_delta_timestep(timestep, r_timestep, "t-r", model_name="Test")
+        self.assertTrue(torch.allclose(delta, torch.tensor([0.6, 0.2])))
+
+        tokenwise_timestep = torch.tensor([[0.8, 0.7], [0.4, 0.3]])
+        tokenwise_delta = prepare_flowmap_delta_timestep(
+            tokenwise_timestep,
+            torch.tensor([0.2, 0.1]),
+            "r",
+            model_name="Test",
+        )
+        expected = torch.tensor([[0.2, 0.2], [0.1, 0.1]])
+        self.assertTrue(torch.equal(tokenwise_delta, expected))
+
+    def test_flux_flowmap_equal_r_matches_base_conditioning(self):
+        torch.manual_seed(0)
+        conditioning = CombinedTimestepTextProjEmbeddings(embedding_dim=32, pooled_projection_dim=16)
+        delta_embedder = clone_flowmap_embedder(conditioning.timestep_embedder)
+        timestep = torch.tensor([[0.2, 0.4, 0.6], [0.3, 0.5, 0.7]], dtype=torch.float32)
+        pooled = torch.randn(2, 16)
+        gate = torch.tensor([0.25])
+
+        base = _flux_tokenwise_conditioning(conditioning, timestep, pooled)
+        flowmap = _flux_tokenwise_flowmap_conditioning(
+            conditioning,
+            delta_embedder,
+            timestep,
+            pooled,
+            timestep,
+            "r",
+            gate,
+        )
+
+        self.assertTrue(torch.allclose(flowmap, base, atol=1e-6))
+
+    def test_flux_flowmap_different_r_changes_conditioning(self):
+        torch.manual_seed(1)
+        conditioning = CombinedTimestepTextProjEmbeddings(embedding_dim=32, pooled_projection_dim=16)
+        delta_embedder = clone_flowmap_embedder(conditioning.timestep_embedder)
+        timestep = torch.tensor([0.2, 0.4], dtype=torch.float32)
+        pooled = torch.randn(2, 16)
+        gate = torch.tensor([0.25])
+
+        base = _flux_tokenwise_conditioning(conditioning, timestep, pooled)
+        flowmap = _flux_tokenwise_flowmap_conditioning(
+            conditioning,
+            delta_embedder,
+            timestep,
+            pooled,
+            torch.zeros_like(timestep),
+            "r",
+            gate,
+        )
+
+        self.assertFalse(torch.allclose(flowmap, base, atol=1e-6))
+
+    def test_sd3_flowmap_equal_r_matches_base_conditioning(self):
+        torch.manual_seed(2)
+        conditioning = CombinedTimestepTextProjEmbeddings(embedding_dim=32, pooled_projection_dim=16)
+        delta_embedder = clone_flowmap_embedder(conditioning.timestep_embedder)
+        timestep = torch.tensor([[0.2, 0.4, 0.6], [0.3, 0.5, 0.7]], dtype=torch.float32)
+        pooled = torch.randn(2, 16)
+        gate = torch.tensor([0.25])
+
+        base = _sd3_tokenwise_conditioning(conditioning, timestep, pooled)
+        flowmap = _sd3_tokenwise_flowmap_conditioning(
+            conditioning,
+            delta_embedder,
+            timestep,
+            pooled,
+            timestep,
+            "r",
+            gate,
+        )
+
+        self.assertTrue(torch.allclose(flowmap, base, atol=1e-6))
+
+    def test_flux2_embedding_requires_enable_for_r_timestep(self):
+        embedding = Flux2TimestepGuidanceEmbeddings(in_channels=16, embedding_dim=32, guidance_embeds=True)
+        timestep = torch.tensor([0.2, 0.4], dtype=torch.float32)
+        guidance = torch.tensor([0.5, 0.6], dtype=torch.float32)
+
+        with self.assertRaisesRegex(ValueError, "enable_flowmap_time_conditioning"):
+            embedding(timestep, guidance, r_timestep=timestep)
+
+    def test_flux2_flowmap_equal_r_matches_base_conditioning(self):
+        torch.manual_seed(3)
+        embedding = Flux2TimestepGuidanceEmbeddings(in_channels=16, embedding_dim=32, guidance_embeds=True)
+        embedding.enable_flowmap_time_conditioning(gate_value=0.25, deltatime_type="r")
+        timestep = torch.tensor([0.2, 0.4], dtype=torch.float32)
+        guidance = torch.tensor([0.5, 0.6], dtype=torch.float32)
+
+        base = embedding(timestep, guidance)
+        flowmap = embedding(timestep, guidance, r_timestep=timestep)
+
+        self.assertTrue(torch.allclose(flowmap, base, atol=1e-6))
+
+    def test_flux2_flowmap_different_r_changes_conditioning(self):
+        torch.manual_seed(4)
+        embedding = Flux2TimestepGuidanceEmbeddings(in_channels=16, embedding_dim=32, guidance_embeds=True)
+        embedding.enable_flowmap_time_conditioning(gate_value=0.25, deltatime_type="r")
+        timestep = torch.tensor([0.2, 0.4], dtype=torch.float32)
+        guidance = torch.tensor([0.5, 0.6], dtype=torch.float32)
+
+        base = embedding(timestep, guidance)
+        flowmap = embedding(timestep, guidance, r_timestep=torch.zeros_like(timestep))
+
+        self.assertFalse(torch.allclose(flowmap, base, atol=1e-6))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_transformers/test_wan_transformer.py
+++ b/tests/test_transformers/test_wan_transformer.py
@@ -577,6 +577,64 @@ class TestWanTimeTextImageEmbedding(TransformerBaseTest, EmbeddingTestMixin):
         # Image embedding should be None since no image embedder and no image tokens supplied
         self.assertIsNone(image_emb)
 
+    def test_flowmap_requires_enable_before_forward(self):
+        """FlowMap r-timesteps should require explicit delta embedder setup."""
+        embedding = WanTimeTextImageEmbedding(**self.embedding_config)
+
+        timestep = torch.randint(0, 1000, (self.batch_size,))
+        r_timestep = torch.zeros_like(timestep)
+        encoder_hidden_states = torch.randn(self.batch_size, 77, self.embedding_config["text_embed_dim"])
+
+        with self.assertRaisesRegex(ValueError, "enable_flowmap_time_conditioning"):
+            embedding.forward(
+                timestep=timestep,
+                r_timestep=r_timestep,
+                encoder_hidden_states=encoder_hidden_states,
+            )
+
+    def test_flowmap_identical_r_matches_base_timestep_embedding(self):
+        """With copied delta weights, r=t should preserve the original timestep embedding."""
+        embedding = WanTimeTextImageEmbedding(**self.embedding_config)
+
+        timestep = torch.randint(0, 1000, (self.batch_size,))
+        encoder_hidden_states = torch.randn(self.batch_size, 77, self.embedding_config["text_embed_dim"])
+
+        base_temb, base_timestep_proj, _, _ = embedding.forward(
+            timestep=timestep,
+            encoder_hidden_states=encoder_hidden_states,
+        )
+        embedding.enable_flowmap_time_conditioning(gate_value=0.25, deltatime_type="r")
+        flow_temb, flow_timestep_proj, _, _ = embedding.forward(
+            timestep=timestep,
+            r_timestep=timestep,
+            encoder_hidden_states=encoder_hidden_states,
+        )
+
+        self.assertTrue(torch.allclose(flow_temb, base_temb, atol=1e-6, rtol=1e-6))
+        self.assertTrue(torch.allclose(flow_timestep_proj, base_timestep_proj, atol=1e-6, rtol=1e-6))
+
+    def test_flowmap_different_r_changes_timestep_embedding(self):
+        """FlowMap r-timesteps should affect the timestep conditioning."""
+        embedding = WanTimeTextImageEmbedding(**self.embedding_config)
+        embedding.enable_flowmap_time_conditioning(gate_value=0.25, deltatime_type="r")
+
+        timestep = torch.full((self.batch_size,), 900)
+        r_timestep = torch.zeros_like(timestep)
+        encoder_hidden_states = torch.randn(self.batch_size, 77, self.embedding_config["text_embed_dim"])
+
+        base_temb, _, _, _ = embedding.forward(
+            timestep=timestep,
+            r_timestep=timestep,
+            encoder_hidden_states=encoder_hidden_states,
+        )
+        flow_temb, _, _, _ = embedding.forward(
+            timestep=timestep,
+            r_timestep=r_timestep,
+            encoder_hidden_states=encoder_hidden_states,
+        )
+
+        self.assertFalse(torch.allclose(flow_temb, base_temb))
+
     def test_timestep_projection_processing(self):
         """Test timestep projection and processing."""
         embedding = WanTimeTextImageEmbedding(**self.embedding_config)
@@ -1231,6 +1289,29 @@ class TestWanTransformer3DModel(TransformerBaseTest):
             output_tensor = output
 
         # Output should have same spatial structure as input
+        expected_shape = (batch_size, self.model_config["out_channels"], num_frames, height, width)
+        self.assert_tensor_shape(output_tensor, expected_shape)
+
+    def test_forward_pass_with_flowmap_r_timestep(self):
+        """Test FlowMap r-timestep conditioning through the full Wan transformer."""
+        model = WanTransformer3DModel(**self.model_config)
+        model.enable_flowmap_time_conditioning(gate_value=0.25, deltatime_type="r")
+
+        batch_size, in_channels, num_frames, height, width = 2, 16, 4, 8, 8
+        hidden_states = torch.randn(batch_size, in_channels, num_frames, height, width)
+        timestep = torch.randint(0, 1000, (batch_size,))
+        r_timestep = torch.zeros_like(timestep)
+        encoder_hidden_states = torch.randn(batch_size, 77, self.model_config["text_dim"])
+
+        with torch.no_grad():
+            output = model.forward(
+                hidden_states=hidden_states,
+                timestep=timestep,
+                r_timestep=r_timestep,
+                encoder_hidden_states=encoder_hidden_states,
+            )
+
+        output_tensor = output.sample if hasattr(output, "sample") else output
         expected_shape = (batch_size, self.model_config["out_channels"], num_frames, height, width)
         self.assert_tensor_shape(output_tensor, expected_shape)
         self.assert_no_nan_or_inf(output_tensor)


### PR DESCRIPTION
This pull request introduces FlowMap time conditioning support to several transformer models (`ACEStep`, `Anima`, `AuraFlow`, and `Chroma`) within the `simpletuner.helpers.models` package. The main changes enable these models to accept and process an additional reference timestep (`r_timestep`) for advanced time-based conditioning, with configurable blending and delta calculation. The implementation is modular, allowing activation of this feature via a new method and related constructor arguments.

**FlowMap Time Conditioning Support:**

* Added `gate_value` and `deltatime_type` parameters to the constructors of `ACEStep`, `Anima`, `AuraFlow`, and `Chroma` transformer models, enabling configuration of FlowMap time conditioning. [[1]](diffhunk://#diff-a3b484a0f69b7f7a72b0e5a6c86069fc46172a0ee22e54c1d80bbdd8cfaf704bR266-R267) [[2]](diffhunk://#diff-7c1dc40272484f25b0e4b71131aed062fb49f5dad62b1e62bca93763591d8dfaR330-R331) [[3]](diffhunk://#diff-12fa44f4ca1a10294383d8e7cd1db43d9b4581d04da0f5a36ed72dd385f23b3aR412-R413) [[4]](diffhunk://#diff-1e836d669cbd355cab74022e2eec2abb058e907223d6f5249d04739b0fb5a025R595-R596)
* Added `enable_flowmap_time_conditioning` method to each model, initializing required modules and registering configuration for FlowMap support. [[1]](diffhunk://#diff-a3b484a0f69b7f7a72b0e5a6c86069fc46172a0ee22e54c1d80bbdd8cfaf704bR373-R379) [[2]](diffhunk://#diff-7c1dc40272484f25b0e4b71131aed062fb49f5dad62b1e62bca93763591d8dfaR424-R427) [[3]](diffhunk://#diff-12fa44f4ca1a10294383d8e7cd1db43d9b4581d04da0f5a36ed72dd385f23b3aR526-R532)
* Integrated FlowMap utility functions (`blend_flowmap_embeddings`, `clone_flowmap_embedder`, `prepare_flowmap_delta_timestep`, etc.) into all relevant files. [[1]](diffhunk://#diff-a3b484a0f69b7f7a72b0e5a6c86069fc46172a0ee22e54c1d80bbdd8cfaf704bR32-R39) [[2]](diffhunk://#diff-12fa44f4ca1a10294383d8e7cd1db43d9b4581d04da0f5a36ed72dd385f23b3aR22-R28) [[3]](diffhunk://#diff-1e836d669cbd355cab74022e2eec2abb058e907223d6f5249d04739b0fb5a025R25-R31)

**Forward Pass and Embedding Logic Updates:**

* Extended model `forward` methods and internal embedding preparation to accept and process the new `r_timestep` argument, blending delta timestep embeddings as required. [[1]](diffhunk://#diff-a3b484a0f69b7f7a72b0e5a6c86069fc46172a0ee22e54c1d80bbdd8cfaf704bR497) [[2]](diffhunk://#diff-a3b484a0f69b7f7a72b0e5a6c86069fc46172a0ee22e54c1d80bbdd8cfaf704bR544-R565) [[3]](diffhunk://#diff-a3b484a0f69b7f7a72b0e5a6c86069fc46172a0ee22e54c1d80bbdd8cfaf704bR712) [[4]](diffhunk://#diff-a3b484a0f69b7f7a72b0e5a6c86069fc46172a0ee22e54c1d80bbdd8cfaf704bR736) [[5]](diffhunk://#diff-7c1dc40272484f25b0e4b71131aed062fb49f5dad62b1e62bca93763591d8dfaR378) [[6]](diffhunk://#diff-7c1dc40272484f25b0e4b71131aed062fb49f5dad62b1e62bca93763591d8dfaR411) [[7]](diffhunk://#diff-12fa44f4ca1a10294383d8e7cd1db43d9b4581d04da0f5a36ed72dd385f23b3aR662) [[8]](diffhunk://#diff-12fa44f4ca1a10294383d8e7cd1db43d9b4581d04da0f5a36ed72dd385f23b3aR712) [[9]](diffhunk://#diff-12fa44f4ca1a10294383d8e7cd1db43d9b4581d04da0f5a36ed72dd385f23b3aR1079-R1114)
* Updated internal model core creation functions to propagate FlowMap parameters through the model stack. [[1]](diffhunk://#diff-7c1dc40272484f25b0e4b71131aed062fb49f5dad62b1e62bca93763591d8dfaR346-R347) [[2]](diffhunk://#diff-7c1dc40272484f25b0e4b71131aed062fb49f5dad62b1e62bca93763591d8dfaR683-R684) [[3]](diffhunk://#diff-7c1dc40272484f25b0e4b71131aed062fb49f5dad62b1e62bca93763591d8dfaR700-R701) [[4]](diffhunk://#diff-12fa44f4ca1a10294383d8e7cd1db43d9b4581d04da0f5a36ed72dd385f23b3aR433-R434) [[5]](diffhunk://#diff-1e836d669cbd355cab74022e2eec2abb058e907223d6f5249d04739b0fb5a025R616-R617)

**Dependency and Import Adjustments:**

* Added imports for FlowMap utilities in all affected transformer files to support the new functionality. [[1]](diffhunk://#diff-a3b484a0f69b7f7a72b0e5a6c86069fc46172a0ee22e54c1d80bbdd8cfaf704bR32-R39) [[2]](diffhunk://#diff-12fa44f4ca1a10294383d8e7cd1db43d9b4581d04da0f5a36ed72dd385f23b3aR22-R28) [[3]](diffhunk://#diff-1e836d669cbd355cab74022e2eec2abb058e907223d6f5249d04739b0fb5a025R25-R31) [[4]](diffhunk://#diff-7c1dc40272484f25b0e4b71131aed062fb49f5dad62b1e62bca93763591d8dfaR24-R25)
* Refactored import of `CosmosTransformer3DModel` in `anima/transformer.py` for consistency. [[1]](diffhunk://#diff-7c1dc40272484f25b0e4b71131aed062fb49f5dad62b1e62bca93763591d8dfaL14-R14) [[2]](diffhunk://#diff-7c1dc40272484f25b0e4b71131aed062fb49f5dad62b1e62bca93763591d8dfaR24-R25)

These changes collectively make it possible to use FlowMap-based time conditioning in multiple transformer models, improving their flexibility for advanced temporal modeling tasks.