### PR TITLE
ideogram4 doc updates for vram usage

### DIFF
--- a/documentation/quickstart/IDEOGRAM4.es.md
+++ b/documentation/quickstart/IDEOGRAM4.es.md
@@ -16,7 +16,15 @@ Puntos de partida recomendados:
 - **Baja VRAM:** NF4 para el modelo base.
 - **Alta VRAM:** pesos bf16-upcast si tienes suficiente VRAM y quieres evitar la carga cuantizada.
 
-En GPUs NVIDIA de 80G, el entrenamiento LoRA FP8 o bf16-upcast a 1024px con batch size 1 debería caber normalmente. En GPUs más pequeñas, empieza con FP8 o NF4, rank 8-16, gradient checkpointing y offload. Las GPUs Apple no se recomiendan para entrenar Ideogram 4.
+Medido en H100 80GB con FP8 nativo (`base_model_precision=fp8-torchao`, `quantize_via=pipeline`), LoRA rank 32, mixed precision bf16, gradient checkpointing activado, entrenamiento square 1024px y validación desactivada:
+
+| Batch size | Pico de VRAM |
+| --- | ---: |
+| 1 | 15,999 MiB / 15.6 GiB |
+| 2 | 20,095 MiB / 19.6 GiB |
+| 4 | 28,603 MiB / 27.9 GiB |
+
+La validación tiene un pico de generación separado, así que deja margen adicional con `ideogram_validation=true`. En GPUs más pequeñas, empieza con FP8 o NF4, rank 8-16, gradient checkpointing y offload. Las GPUs Apple no se recomiendan para entrenar Ideogram 4.
 
 ## Configuración
 

--- a/documentation/quickstart/IDEOGRAM4.hi.md
+++ b/documentation/quickstart/IDEOGRAM4.hi.md
@@ -16,7 +16,15 @@ simpletuner/examples/ideogram-fp8.peft-lora/config.json
 - **कम VRAM:** base model के लिए NF4।
 - **अधिक VRAM:** पर्याप्त VRAM होने पर bf16-upcast weights, ताकि quantized loading से बचा जा सके।
 
-80G NVIDIA GPU पर 1024px, batch size 1 के साथ FP8 या bf16-upcast LoRA training सामान्यतः फिट होनी चाहिए। छोटी GPUs पर FP8 या NF4, rank 8-16, gradient checkpointing और offload से शुरू करें। Apple GPUs Ideogram 4 training के लिए recommended नहीं हैं।
+H100 80GB पर measured values: native FP8 (`base_model_precision=fp8-torchao`, `quantize_via=pipeline`), rank 32 LoRA, bf16 mixed precision, gradient checkpointing enabled, 1024px square training, validation disabled:
+
+| Batch size | Peak VRAM |
+| --- | ---: |
+| 1 | 15,999 MiB / 15.6 GiB |
+| 2 | 20,095 MiB / 19.6 GiB |
+| 4 | 28,603 MiB / 27.9 GiB |
+
+Validation का अलग generation peak होता है, इसलिए `ideogram_validation=true` के साथ extra headroom रखें। छोटी GPUs पर FP8 या NF4, rank 8-16, gradient checkpointing और offload से शुरू करें। Apple GPUs Ideogram 4 training के लिए recommended नहीं हैं।
 
 ## कॉन्फ़िगरेशन
 

--- a/documentation/quickstart/IDEOGRAM4.ja.md
+++ b/documentation/quickstart/IDEOGRAM4.ja.md
@@ -16,7 +16,15 @@ simpletuner/examples/ideogram-fp8.peft-lora/config.json
 - **低VRAM:** ベースモデルに NF4 を使う。
 - **高VRAM:** 十分なVRAMがある場合は bf16-upcast 重みで量子化ロードを避ける。
 
-80G NVIDIA GPU では、1024px、batch size 1 の FP8 または bf16-upcast LoRA 学習は通常収まります。小さいGPUでは FP8 または NF4、rank 8-16、gradient checkpointing、offload から始めてください。Apple GPU は Ideogram 4 学習には推奨しません。
+H100 80GB での実測値です。native FP8（`base_model_precision=fp8-torchao`、`quantize_via=pipeline`）、rank 32 LoRA、bf16 mixed precision、gradient checkpointing 有効、1024px square、validation 無効のトレーニングピーク:
+
+| Batch size | Peak VRAM |
+| --- | ---: |
+| 1 | 15,999 MiB / 15.6 GiB |
+| 2 | 20,095 MiB / 19.6 GiB |
+| 4 | 28,603 MiB / 27.9 GiB |
+
+Validation には別の生成ピークがあるため、`ideogram_validation=true` を使う場合は余裕を見てください。小さいGPUでは FP8 または NF4、rank 8-16、gradient checkpointing、offload から始めてください。Apple GPU は Ideogram 4 学習には推奨しません。
 
 ## 設定
 

--- a/documentation/quickstart/IDEOGRAM4.md
+++ b/documentation/quickstart/IDEOGRAM4.md
@@ -18,7 +18,15 @@ Recommended starting points:
 - **Low VRAM fallback:** NF4 quantisation for the base model.
 - **High VRAM / fastest iteration:** bf16-upcast transformer weights if you have enough VRAM and want to avoid quantised base loading.
 
-Expected memory varies with rank, optimiser, resolution, and offload strategy. On 80G NVIDIA cards, FP8 and bf16-upcast LoRA training should fit comfortably at 1024px with batch size 1. On smaller cards, start with FP8 or NF4, rank 8-16, gradient checkpointing, and offload.
+Expected memory varies with rank, optimiser, resolution, validation, and offload strategy. Measured on an H100 80GB with native FP8 (`base_model_precision=fp8-torchao`, `quantize_via=pipeline`), rank 32 LoRA, bf16 mixed precision, gradient checkpointing enabled, 1024px square training, and validation disabled:
+
+| Batch size | Peak VRAM |
+| --- | ---: |
+| 1 | 15,999 MiB / 15.6 GiB |
+| 2 | 20,095 MiB / 19.6 GiB |
+| 4 | 28,603 MiB / 27.9 GiB |
+
+Validation has a separate generation peak, so leave extra headroom when `ideogram_validation=true`. On smaller cards, start with FP8 or NF4, rank 8-16, gradient checkpointing, and offload.
 
 Apple GPUs are not recommended for Ideogram 4 training.
 

--- a/documentation/quickstart/IDEOGRAM4.pt-BR.md
+++ b/documentation/quickstart/IDEOGRAM4.pt-BR.md
@@ -16,7 +16,15 @@ Pontos de partida recomendados:
 - **Baixa VRAM:** NF4 para o modelo base.
 - **Alta VRAM:** pesos bf16-upcast se houver VRAM suficiente e você quiser evitar carregamento quantizado.
 
-Em GPUs NVIDIA de 80G, LoRA FP8 ou bf16-upcast em 1024px com batch size 1 deve caber normalmente. Em GPUs menores, comece com FP8 ou NF4, rank 8-16, gradient checkpointing e offload. GPUs Apple não são recomendadas para treinamento do Ideogram 4.
+Medição em H100 80GB, FP8 nativo (`base_model_precision=fp8-torchao`, `quantize_via=pipeline`), LoRA rank 32, mixed precision bf16, gradient checkpointing ligado, treino square 1024px e validação desligada:
+
+| Batch size | Pico de VRAM |
+| --- | ---: |
+| 1 | 15,999 MiB / 15.6 GiB |
+| 2 | 20,095 MiB / 19.6 GiB |
+| 4 | 28,603 MiB / 27.9 GiB |
+
+A validação tem um pico de geração separado, então reserve margem extra com `ideogram_validation=true`. Em GPUs menores, comece com FP8 ou NF4, rank 8-16, gradient checkpointing e offload. GPUs Apple não são recomendadas para treinamento do Ideogram 4.
 
 ## Configuração
 

--- a/documentation/quickstart/IDEOGRAM4.zh.md
+++ b/documentation/quickstart/IDEOGRAM4.zh.md
@@ -16,7 +16,15 @@ simpletuner/examples/ideogram-fp8.peft-lora/config.json
 - **低显存：** 基础模型使用 NF4。
 - **高显存：** 如果显存充足，可以使用 bf16-upcast 权重以避免量化加载开销。
 
-80G NVIDIA GPU 上，1024px、batch size 1 的 FP8 或 bf16-upcast LoRA 训练通常可以正常运行。小显存机器建议使用 FP8 或 NF4、rank 8-16、梯度检查点和 offload。Apple GPU 不推荐用于 Ideogram 4 训练。
+在 H100 80GB 上实测，原生 FP8（`base_model_precision=fp8-torchao`、`quantize_via=pipeline`）、rank 32 LoRA、bf16 mixed precision、启用梯度检查点、1024px 方图、关闭 validation 时的训练峰值显存为：
+
+| Batch size | 峰值 VRAM |
+| --- | ---: |
+| 1 | 15,999 MiB / 15.6 GiB |
+| 2 | 20,095 MiB / 19.6 GiB |
+| 4 | 28,603 MiB / 27.9 GiB |
+
+Validation 会有单独的生成峰值，所以启用 `ideogram_validation=true` 时请预留额外显存。小显存机器建议使用 FP8 或 NF4、rank 8-16、梯度检查点和 offload。Apple GPU 不推荐用于 Ideogram 4 训练。
 
 ## 配置
 


### PR DESCRIPTION
This pull request updates the quickstart documentation for Ideogram 4 across multiple languages to provide more detailed and practical VRAM usage benchmarks. The new guidance includes measured peak VRAM values for different batch sizes on H100 80GB GPUs, clarifies the impact of validation on memory requirements, and maintains recommendations for users with smaller GPUs.

**Documentation improvements:**

* Added a table of measured peak VRAM usage for batch sizes 1, 2, and 4 on H100 80GB GPUs using native FP8, LoRA rank 32, bf16 mixed precision, and gradient checkpointing, with validation disabled. This helps users better estimate hardware requirements. [[1]](diffhunk://#diff-0d18797b07701e94da0d44c62670cc4598f7d6e28dafc62c227cd6cc00209bb9L21-R29) [[2]](diffhunk://#diff-689b47a19fd059e937d0ef282f459ec7dcbadc61dac659d70f6743ce50a5c410L19-R27) [[3]](diffhunk://#diff-4c661981e84c1f09d34f5b2996ed68a4cbf9ef5c5535c84e7d14cbf0e1907f7dL19-R27) [[4]](diffhunk://#diff-9ac1a840b36d3db848a6cd6c5d7e9008e2a0f41c0cf350e3e61ee1cac36fcbbeL19-R27) [[5]](diffhunk://#diff-058c62dc320320cabc2fbfad8d1acf7900c41312643ec650abe9face5fcc8207L19-R27) [[6]](diffhunk://#diff-78900be6840cb62ef6ac835bb91f808ed6f05966a55decb5c98e5de7ca82f685L19-R27)
* Clarified that validation introduces a separate memory peak and advised users to leave extra headroom if `ideogram_validation=true` is enabled. [[1]](diffhunk://#diff-0d18797b07701e94da0d44c62670cc4598f7d6e28dafc62c227cd6cc00209bb9L21-R29) [[2]](diffhunk://#diff-689b47a19fd059e937d0ef282f459ec7dcbadc61dac659d70f6743ce50a5c410L19-R27) [[3]](diffhunk://#diff-4c661981e84c1f09d34f5b2996ed68a4cbf9ef5c5535c84e7d14cbf0e1907f7dL19-R27) [[4]](diffhunk://#diff-9ac1a840b36d3db848a6cd6c5d7e9008e2a0f41c0cf350e3e61ee1cac36fcbbeL19-R27) [[5]](diffhunk://#diff-058c62dc320320cabc2fbfad8d1acf7900c41312643ec650abe9face5fcc8207L19-R27) [[6]](diffhunk://#diff-78900be6840cb62ef6ac835bb91f808ed6f05966a55decb5c98e5de7ca82f685L19-R27)
* Retained and reiterated recommendations for users with smaller GPUs: start with FP8 or NF4, rank 8-16, gradient checkpointing, and offload strategies. [[1]](diffhunk://#diff-0d18797b07701e94da0d44c62670cc4598f7d6e28dafc62c227cd6cc00209bb9L21-R29) [[2]](diffhunk://#diff-689b47a19fd059e937d0ef282f459ec7dcbadc61dac659d70f6743ce50a5c410L19-R27) [[3]](diffhunk://#diff-4c661981e84c1f09d34f5b2996ed68a4cbf9ef5c5535c84e7d14cbf0e1907f7dL19-R27) [[4]](diffhunk://#diff-9ac1a840b36d3db848a6cd6c5d7e9008e2a0f41c0cf350e3e61ee1cac36fcbbeL19-R27) [[5]](diffhunk://#diff-058c62dc320320cabc2fbfad8d1acf7900c41312643ec650abe9face5fcc8207L19-R27) [[6]](diffhunk://#diff-78900be6840cb62ef6ac835bb91f808ed6f05966a55decb5c98e5de7ca82f685L19-R27)
* Maintained the recommendation against using Apple GPUs for Ideogram 4 training. [[1]](diffhunk://#diff-0d18797b07701e94da0d44c62670cc4598f7d6e28dafc62c227cd6cc00209bb9L21-R29) [[2]](diffhunk://#diff-689b47a19fd059e937d0ef282f459ec7dcbadc61dac659d70f6743ce50a5c410L19-R27) [[3]](diffhunk://#diff-4c661981e84c1f09d34f5b2996ed68a4cbf9ef5c5535c84e7d14cbf0e1907f7dL19-R27) [[4]](diffhunk://#diff-9ac1a840b36d3db848a6cd6c5d7e9008e2a0f41c0cf350e3e61ee1cac36fcbbeL19-R27) [[5]](diffhunk://#diff-058c62dc320320cabc2fbfad8d1acf7900c41312643ec650abe9face5fcc8207L19-R27) [[6]](diffhunk://#diff-78900be6840cb62ef6ac835bb91f808ed6f05966a55decb5c98e5de7ca82f685L19-R27)