### PR TITLE
ideogram: fixes for torch compile, doc updates to recommend regional compile

### DIFF
--- a/documentation/quickstart/IDEOGRAM4.es.md
+++ b/documentation/quickstart/IDEOGRAM4.es.md
@@ -26,6 +26,19 @@ Medido en H100 80GB con FP8 nativo (`base_model_precision=fp8-torchao`, `quantiz
 
 La validación tiene un pico de generación separado, así que deja margen adicional con `ideogram_validation=true`. En GPUs más pequeñas, empieza con FP8 o NF4, rank 8-16, gradient checkpointing y offload. Las GPUs Apple no se recomiendan para entrenar Ideogram 4.
 
+### Torch compile
+
+Para `torch.compile`, prefiere regional compilation con pesos FP8 nativos:
+
+```json
+{
+  "dynamo_backend": "inductor",
+  "dynamo_use_regional_compilation": true
+}
+```
+
+`dynamo_backend="inductor"` puro también funciona, pero el compile del primer step del modelo completo es lento. Por ahora, evita `dynamo_mode="reduce-overhead"` y `dynamo_fullgraph=true` para Ideogram 4 LoRA; las capas PEFT LoRA pueden activar CUDA graph output reuse en la segunda invocación compilada.
+
 ## Configuración
 
 Copia la configuración y el dataloader de ejemplo:

--- a/documentation/quickstart/IDEOGRAM4.hi.md
+++ b/documentation/quickstart/IDEOGRAM4.hi.md
@@ -26,6 +26,19 @@ H100 80GB पर measured values: native FP8 (`base_model_precision=fp8-torchao`
 
 Validation का अलग generation peak होता है, इसलिए `ideogram_validation=true` के साथ extra headroom रखें। छोटी GPUs पर FP8 या NF4, rank 8-16, gradient checkpointing और offload से शुरू करें। Apple GPUs Ideogram 4 training के लिए recommended नहीं हैं।
 
+### Torch compile
+
+For `torch.compile`, prefer regional compilation with native FP8 weights:
+
+```json
+{
+  "dynamo_backend": "inductor",
+  "dynamo_use_regional_compilation": true
+}
+```
+
+Plain `dynamo_backend="inductor"` also works, but the whole-model first-step compile is slow. Avoid `dynamo_mode="reduce-overhead"` and `dynamo_fullgraph=true` for Ideogram 4 LoRA for now; PEFT LoRA layers can trip CUDA graph output reuse during the second compiled invocation.
+
 ## कॉन्फ़िगरेशन
 
 example config और dataloader कॉपी करें:

--- a/documentation/quickstart/IDEOGRAM4.ja.md
+++ b/documentation/quickstart/IDEOGRAM4.ja.md
@@ -26,6 +26,19 @@ H100 80GB での実測値です。native FP8（`base_model_precision=fp8-torchao
 
 Validation には別の生成ピークがあるため、`ideogram_validation=true` を使う場合は余裕を見てください。小さいGPUでは FP8 または NF4、rank 8-16、gradient checkpointing、offload から始めてください。Apple GPU は Ideogram 4 学習には推奨しません。
 
+### Torch compile
+
+`torch.compile` では、native FP8 重みに regional compilation を使う設定を推奨します:
+
+```json
+{
+  "dynamo_backend": "inductor",
+  "dynamo_use_regional_compilation": true
+}
+```
+
+通常の `dynamo_backend="inductor"` も動作しますが、モデル全体の初回 step コンパイルは遅くなります。現時点では Ideogram 4 LoRA で `dynamo_mode="reduce-overhead"` や `dynamo_fullgraph=true` は避けてください。PEFT LoRA レイヤーが 2 回目の compiled invocation で CUDA graph output reuse を踏むことがあります。
+
 ## 設定
 
 設定と dataloader をコピーします:

--- a/documentation/quickstart/IDEOGRAM4.md
+++ b/documentation/quickstart/IDEOGRAM4.md
@@ -52,6 +52,19 @@ Optional disk offload:
 - Group offload is not compatible with Quanto quantisation.
 - Prefer fast local NVMe when offloading to disk.
 
+### Torch compile
+
+For `torch.compile`, prefer regional compilation with native FP8 weights:
+
+```json
+{
+  "dynamo_backend": "inductor",
+  "dynamo_use_regional_compilation": true
+}
+```
+
+Plain `dynamo_backend="inductor"` also works, but the whole-model first-step compile is slow. Avoid `dynamo_mode="reduce-overhead"` and `dynamo_fullgraph=true` for Ideogram 4 LoRA for now; PEFT LoRA layers can trip CUDA graph output reuse during the second compiled invocation.
+
 ## Installation
 
 Install SimpleTuner via pip:

--- a/documentation/quickstart/IDEOGRAM4.pt-BR.md
+++ b/documentation/quickstart/IDEOGRAM4.pt-BR.md
@@ -26,6 +26,19 @@ Medição em H100 80GB, FP8 nativo (`base_model_precision=fp8-torchao`, `quantiz
 
 A validação tem um pico de geração separado, então reserve margem extra com `ideogram_validation=true`. Em GPUs menores, comece com FP8 ou NF4, rank 8-16, gradient checkpointing e offload. GPUs Apple não são recomendadas para treinamento do Ideogram 4.
 
+### Torch compile
+
+Para `torch.compile`, prefira regional compilation com pesos FP8 nativos:
+
+```json
+{
+  "dynamo_backend": "inductor",
+  "dynamo_use_regional_compilation": true
+}
+```
+
+`dynamo_backend="inductor"` puro também funciona, mas o compile do primeiro step do modelo inteiro é lento. Por enquanto, evite `dynamo_mode="reduce-overhead"` e `dynamo_fullgraph=true` para Ideogram 4 LoRA; camadas PEFT LoRA podem acionar CUDA graph output reuse na segunda invocação compilada.
+
 ## Configuração
 
 Copie a configuração e o dataloader de exemplo:

--- a/documentation/quickstart/IDEOGRAM4.zh.md
+++ b/documentation/quickstart/IDEOGRAM4.zh.md
@@ -26,6 +26,19 @@ simpletuner/examples/ideogram-fp8.peft-lora/config.json
 
 Validation 会有单独的生成峰值，所以启用 `ideogram_validation=true` 时请预留额外显存。小显存机器建议使用 FP8 或 NF4、rank 8-16、梯度检查点和 offload。Apple GPU 不推荐用于 Ideogram 4 训练。
 
+### Torch compile
+
+使用 `torch.compile` 时，建议对原生 FP8 权重启用 regional compilation：
+
+```json
+{
+  "dynamo_backend": "inductor",
+  "dynamo_use_regional_compilation": true
+}
+```
+
+普通 `dynamo_backend="inductor"` 也可用，但整模型第一次 step 的编译很慢。暂时不要为 Ideogram 4 LoRA 使用 `dynamo_mode="reduce-overhead"` 或 `dynamo_fullgraph=true`；PEFT LoRA 层可能在第二次 compiled invocation 时触发 CUDA graph output reuse。
+
 ## 配置
 
 复制示例配置和 dataloader：

--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -1978,7 +1978,8 @@ class ModelFoundation(ABC):
             return unwrap_model(self.accelerator, self.controlnet, keep_fp32_wrapper=keep_fp32_wrapper)
         if self.model is None:
             return None
-        return unwrap_model(self.accelerator, model or self.model, keep_fp32_wrapper=keep_fp32_wrapper)
+        target_model = model if model is not None else self.model
+        return unwrap_model(self.accelerator, target_model, keep_fp32_wrapper=keep_fp32_wrapper)
 
     @staticmethod
     def _module_has_meta_tensors(module: Optional[torch.nn.Module]) -> bool:

--- a/tests/test_model_foundation_compile.py
+++ b/tests/test_model_foundation_compile.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from simpletuner.helpers.models.common import ModelFoundation
+
+
+class _LenHostileModule:
+    def __len__(self):
+        raise TypeError("_LenHostileModule does not support len()")
+
+
+class _ConcreteModelFoundation(ModelFoundation):
+    def _encode_prompts(self, prompts, is_negative_prompt=False):
+        raise NotImplementedError
+
+    def convert_text_embed_for_pipeline(self, prompt_embeds):
+        raise NotImplementedError
+
+    def convert_negative_text_embed_for_pipeline(self, prompt_embeds):
+        raise NotImplementedError
+
+    def model_predict(self, prepared_batch, custom_timesteps=None):
+        raise NotImplementedError
+
+
+class ModelFoundationCompileTests(TestCase):
+    def test_unwrap_model_does_not_truth_test_explicit_model(self):
+        foundation = _ConcreteModelFoundation.__new__(_ConcreteModelFoundation)
+        foundation.config = SimpleNamespace(controlnet=False)
+        foundation.accelerator = object()
+        foundation.model = object()
+        foundation.controlnet = None
+
+        compiled_like_model = _LenHostileModule()
+
+        with patch("simpletuner.helpers.models.common.unwrap_model", side_effect=lambda _accel, model, **_: model):
+            self.assertIs(foundation.unwrap_model(model=compiled_like_model), compiled_like_model)


### PR DESCRIPTION
This pull request adds improved guidance for using `torch.compile` with native FP8 weights to all IDEOGRAM4 quickstart documentation files in multiple languages. Additionally, it fixes a subtle bug in the `ModelFoundation.unwrap_model` method to ensure the correct model object is passed, and introduces a new test to prevent regressions in this logic.

**Documentation updates:**

* Added a section on recommended `torch.compile` settings for native FP8 weights to the quickstart guides in English, Spanish, Hindi, Japanese, Portuguese, and Chinese. The guidance explains using regional compilation with the `inductor` backend, and warns against certain options that can cause slowdowns or CUDA graph output issues with LoRA layers. [[1]](diffhunk://#diff-0d18797b07701e94da0d44c62670cc4598f7d6e28dafc62c227cd6cc00209bb9R55-R67) [[2]](diffhunk://#diff-689b47a19fd059e937d0ef282f459ec7dcbadc61dac659d70f6743ce50a5c410R29-R41) [[3]](diffhunk://#diff-9ac1a840b36d3db848a6cd6c5d7e9008e2a0f41c0cf350e3e61ee1cac36fcbbeR29-R41) [[4]](diffhunk://#diff-058c62dc320320cabc2fbfad8d1acf7900c41312643ec650abe9face5fcc8207R29-R41) [[5]](diffhunk://#diff-4c661981e84c1f09d34f5b2996ed68a4cbf9ef5c5535c84e7d14cbf0e1907f7dR29-R41) [[6]](diffhunk://#diff-78900be6840cb62ef6ac835bb91f808ed6f05966a55decb5c98e5de7ca82f685R29-R41)

**Bug fix:**

* Updated `ModelFoundation.unwrap_model` to avoid using a truthy check on the `model` argument, which could cause errors with objects that do not support `__len__` or boolean evaluation. Now, the code explicitly checks for `None` to determine which model object to unwrap.

**Testing:**

* Added a new test in `tests/test_model_foundation_compile.py` to verify that `unwrap_model` does not perform a truth test on the `model` argument, preventing regressions for models with non-standard truthiness behavior.