### PR TITLE
validation: eliminate network access requirement for scheduler config / pipeline build

### DIFF
--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -2330,6 +2330,88 @@ class Validation:
             should_validate = should_validate and self.accelerator.is_main_process
         return bool(should_validate)
 
+    def _loaded_scheduler_for_validation(self):
+        pipeline = getattr(self.model, "pipeline", None)
+        if pipeline is not None:
+            scheduler = getattr(pipeline, "scheduler", None)
+            if scheduler is not None and hasattr(scheduler, "config"):
+                return scheduler
+
+        scheduler = getattr(self.model, "noise_schedule", None)
+        if scheduler is not None and hasattr(scheduler, "config"):
+            return scheduler
+
+        return None
+
+    def _build_scheduler_from_loaded_config(self, scheduler_cls, scheduler_args: dict):
+        source_scheduler = self._loaded_scheduler_for_validation()
+        if source_scheduler is None:
+            return None
+
+        config_scheduler_cls = scheduler_cls
+        try:
+            if issubclass(source_scheduler.__class__, scheduler_cls):
+                config_scheduler_cls = source_scheduler.__class__
+        except TypeError:
+            pass
+
+        from_config = getattr(config_scheduler_cls, "from_config", None)
+        if not callable(from_config):
+            return None
+
+        scheduler_kwargs = dict(scheduler_args)
+        timestep_spacing = getattr(self.config, "inference_scheduler_timestep_spacing", None)
+        if timestep_spacing is not None:
+            scheduler_kwargs["timestep_spacing"] = timestep_spacing
+
+        rescale_betas_zero_snr = getattr(self.config, "rescale_betas_zero_snr", None)
+        if rescale_betas_zero_snr is not None:
+            scheduler_kwargs["rescale_betas_zero_snr"] = rescale_betas_zero_snr
+
+        try:
+            return from_config(source_scheduler.config, **scheduler_kwargs)
+        except (AttributeError, KeyError, TypeError, ValueError) as exc:
+            scheduler_name = getattr(config_scheduler_cls, "__name__", str(config_scheduler_cls))
+            logger.debug(
+                "Unable to build validation scheduler %s from loaded scheduler config: %s",
+                scheduler_name,
+                exc,
+            )
+            return None
+
+    def _validation_scheduler_pretrained_path(self):
+        model_config_path = getattr(self.model, "_model_config_path", None)
+        if callable(model_config_path):
+            return model_config_path()
+        return self.config.pretrained_model_name_or_path
+
+    def _scheduler_from_pretrained_kwargs(self, scheduler_args: dict) -> dict:
+        kwargs = {
+            "subfolder": "scheduler",
+            **scheduler_args,
+        }
+        revision = getattr(self.config, "revision", None)
+        if revision is not None:
+            kwargs["revision"] = revision
+
+        timestep_spacing = getattr(self.config, "inference_scheduler_timestep_spacing", None)
+        if timestep_spacing is not None:
+            kwargs["timestep_spacing"] = timestep_spacing
+
+        rescale_betas_zero_snr = getattr(self.config, "rescale_betas_zero_snr", None)
+        if rescale_betas_zero_snr is not None:
+            kwargs["rescale_betas_zero_snr"] = rescale_betas_zero_snr
+
+        cache_dir = getattr(self.config, "cache_dir", None)
+        if cache_dir is not None:
+            kwargs["cache_dir"] = cache_dir
+
+        local_files_only = getattr(self.config, "local_files_only", None)
+        if local_files_only is not None:
+            kwargs["local_files_only"] = local_files_only
+
+        return kwargs
+
     def setup_scheduler(self):
         if self.distiller is not None:
             distillation_scheduler = self.distiller.get_scheduler()
@@ -2391,8 +2473,9 @@ class Validation:
         if self.config.prediction_type is not None:
             scheduler_args["prediction_type"] = self.config.prediction_type
 
-        if self.model.pipeline is not None and "variance_type" in self.model.pipeline.scheduler.config:
-            variance_type = self.model.pipeline.scheduler.config.variance_type
+        loaded_scheduler = self._loaded_scheduler_for_validation()
+        if loaded_scheduler is not None and "variance_type" in loaded_scheduler.config:
+            variance_type = loaded_scheduler.config.variance_type
 
             if variance_type in ["learned", "learned_range"]:
                 variance_type = "fixed_small"
@@ -2413,14 +2496,12 @@ class Validation:
         elif scheduler_cls is TwinFlowScheduler:
             scheduler = scheduler_cls(**scheduler_args)
         else:
-            scheduler = scheduler_cls.from_pretrained(
-                self.config.pretrained_model_name_or_path,
-                subfolder="scheduler",
-                revision=self.config.revision,
-                timestep_spacing=self.config.inference_scheduler_timestep_spacing,
-                rescale_betas_zero_snr=self.config.rescale_betas_zero_snr,
-                **scheduler_args,
-            )
+            scheduler = self._build_scheduler_from_loaded_config(scheduler_cls, scheduler_args)
+            if scheduler is None:
+                scheduler = scheduler_cls.from_pretrained(
+                    self._validation_scheduler_pretrained_path(),
+                    **self._scheduler_from_pretrained_kwargs(scheduler_args),
+                )
         if self.model.pipeline is not None:
             self.model.pipeline.scheduler = scheduler
         return scheduler

--- a/tests/test_validation_scheduler_cache.py
+++ b/tests/test_validation_scheduler_cache.py
@@ -1,0 +1,165 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import simpletuner.helpers.training.validation as validation_module
+from simpletuner.helpers.training.validation import Validation
+
+
+class SchedulerConfig(dict):
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+
+class LoadedScheduler:
+    def __init__(self, **config):
+        self.config = SchedulerConfig(config)
+
+
+class ConfigBackedScheduler:
+    from_config_calls = []
+    from_pretrained_calls = []
+
+    def __init__(self, config, load_kwargs):
+        self.config = SchedulerConfig(config)
+        self.load_kwargs = load_kwargs
+
+    @classmethod
+    def reset(cls):
+        cls.from_config_calls = []
+        cls.from_pretrained_calls = []
+
+    @classmethod
+    def from_config(cls, config, **kwargs):
+        cls.from_config_calls.append((config, kwargs))
+        return cls(config=config, load_kwargs=kwargs)
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        cls.from_pretrained_calls.append((args, kwargs))
+        raise AssertionError("from_pretrained should not be called when a loaded scheduler config is available")
+
+
+class RequestedScheduler(ConfigBackedScheduler):
+    pass
+
+
+class LoadedSubclassScheduler(RequestedScheduler):
+    pass
+
+
+class PretrainedScheduler:
+    from_pretrained_calls = []
+
+    def __init__(self, path, load_kwargs):
+        self.config = SchedulerConfig()
+        self.path = path
+        self.load_kwargs = load_kwargs
+
+    @classmethod
+    def reset(cls):
+        cls.from_pretrained_calls = []
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        cls.from_pretrained_calls.append((args, kwargs))
+        return cls(path=args[0], load_kwargs=kwargs)
+
+
+class ValidationSchedulerCacheTests(unittest.TestCase):
+    def setUp(self):
+        ConfigBackedScheduler.reset()
+        RequestedScheduler.reset()
+        LoadedSubclassScheduler.reset()
+        PretrainedScheduler.reset()
+
+    def _validation(self, *, scheduler, scheduler_name="cached", model_path="repo/model"):
+        validation = Validation.__new__(Validation)
+        validation.distiller = None
+        validation.config = SimpleNamespace(
+            model_family="sdxl",
+            pretrained_model_name_or_path=model_path,
+            validation_noise_scheduler=scheduler_name,
+            prediction_type="epsilon",
+            inference_scheduler_timestep_spacing="trailing",
+            rescale_betas_zero_snr=True,
+            revision="main",
+            cache_dir="/tmp/hf-cache",
+            local_files_only=True,
+        )
+        validation.model = SimpleNamespace(
+            DEFAULT_NOISE_SCHEDULER=None,
+            PREDICTION_TYPE=SimpleNamespace(value="epsilon"),
+            pipeline=SimpleNamespace(scheduler=scheduler),
+            noise_schedule=None,
+            requires_special_scheduler_setup=lambda: False,
+        )
+        return validation
+
+    def test_setup_scheduler_clones_loaded_pipeline_scheduler_config(self):
+        loaded_scheduler = LoadedScheduler(variance_type="learned")
+        validation = self._validation(scheduler=loaded_scheduler)
+
+        with patch.dict(validation_module.SCHEDULER_NAME_MAP, {"cached": ConfigBackedScheduler}):
+            scheduler = validation.setup_scheduler()
+
+        self.assertIs(validation.model.pipeline.scheduler, scheduler)
+        self.assertEqual(ConfigBackedScheduler.from_pretrained_calls, [])
+        self.assertEqual(len(ConfigBackedScheduler.from_config_calls), 1)
+        _config, kwargs = ConfigBackedScheduler.from_config_calls[0]
+        self.assertEqual(kwargs["prediction_type"], "epsilon")
+        self.assertEqual(kwargs["variance_type"], "fixed_small")
+        self.assertEqual(kwargs["timestep_spacing"], "trailing")
+        self.assertTrue(kwargs["rescale_betas_zero_snr"])
+
+    def test_setup_scheduler_uses_loaded_noise_schedule_when_pipeline_is_absent(self):
+        validation = self._validation(scheduler=None)
+        validation.model.pipeline = None
+        validation.model.noise_schedule = LoadedScheduler(variance_type="fixed_small")
+
+        with patch.dict(validation_module.SCHEDULER_NAME_MAP, {"cached": ConfigBackedScheduler}):
+            scheduler = validation.setup_scheduler()
+
+        self.assertIsInstance(scheduler, ConfigBackedScheduler)
+        self.assertEqual(ConfigBackedScheduler.from_pretrained_calls, [])
+        self.assertEqual(len(ConfigBackedScheduler.from_config_calls), 1)
+
+    def test_setup_scheduler_preserves_loaded_scheduler_subclass(self):
+        loaded_scheduler = LoadedSubclassScheduler(config=SchedulerConfig(variance_type="fixed_small"), load_kwargs={})
+        validation = self._validation(scheduler=loaded_scheduler, scheduler_name="requested")
+
+        with patch.dict(validation_module.SCHEDULER_NAME_MAP, {"requested": RequestedScheduler}):
+            scheduler = validation.setup_scheduler()
+
+        self.assertIsInstance(scheduler, LoadedSubclassScheduler)
+        self.assertEqual(RequestedScheduler.from_pretrained_calls, [])
+        self.assertEqual(len(RequestedScheduler.from_config_calls), 0)
+        self.assertEqual(len(LoadedSubclassScheduler.from_config_calls), 1)
+
+    def test_fallback_from_pretrained_uses_resolved_path_and_cache_flags(self):
+        validation = self._validation(scheduler=None, scheduler_name="pretrained", model_path="repo/model.safetensors")
+        validation.model.pipeline = None
+        validation.model._model_config_path = MagicMock(return_value="/tmp/model-cache/snapshot")
+
+        with patch.dict(validation_module.SCHEDULER_NAME_MAP, {"pretrained": PretrainedScheduler}):
+            scheduler = validation.setup_scheduler()
+
+        self.assertIsInstance(scheduler, PretrainedScheduler)
+        validation.model._model_config_path.assert_called_once_with()
+        self.assertEqual(len(PretrainedScheduler.from_pretrained_calls), 1)
+        args, kwargs = PretrainedScheduler.from_pretrained_calls[0]
+        self.assertEqual(args, ("/tmp/model-cache/snapshot",))
+        self.assertEqual(kwargs["subfolder"], "scheduler")
+        self.assertEqual(kwargs["revision"], "main")
+        self.assertEqual(kwargs["timestep_spacing"], "trailing")
+        self.assertTrue(kwargs["rescale_betas_zero_snr"])
+        self.assertEqual(kwargs["cache_dir"], "/tmp/hf-cache")
+        self.assertTrue(kwargs["local_files_only"])
+        self.assertEqual(kwargs["prediction_type"], "epsilon")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request enhances the scheduler setup logic in the `Validation` class to more robustly handle loading and configuring schedulers for validation, and adds comprehensive tests for these changes. The main improvements include extracting and reusing scheduler configuration from already loaded models, gracefully falling back to loading from pretrained checkpoints when necessary, and ensuring all relevant configuration parameters are respected. Comprehensive unit tests are added to validate these behaviors.

**Enhancements to scheduler setup and configuration:**

* Added helper methods (`_loaded_scheduler_for_validation`, `_build_scheduler_from_loaded_config`, `_validation_scheduler_pretrained_path`, `_scheduler_from_pretrained_kwargs`) to extract scheduler configuration from loaded models or pipelines, and to build or load schedulers with all necessary configuration parameters.
* Modified `setup_scheduler` to first attempt building a scheduler from the loaded scheduler's config, preserving any subclassing, and only fall back to `from_pretrained` if necessary. This ensures consistency and correctness when reusing loaded schedulers.
* Updated logic to extract `variance_type` and other parameters from the loaded scheduler, not just from the pipeline, making the process more robust for different model structures.

**Testing improvements:**

* Added a new test suite (`tests/test_validation_scheduler_cache.py`) that covers scheduler setup scenarios, including cloning from loaded configs, handling absent pipelines, preserving scheduler subclasses, and verifying correct fallback to pretrained loading with all config options.