### PR TITLE
ideogram: use _scaled_mm for fp8 matmul, sorry non-Ada-or-newer owners

### DIFF
--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -1051,7 +1051,16 @@ class ModelFoundation(ABC):
             for i, text_encoder in enumerate(self.text_encoders):
                 if text_encoder is None:
                     continue
-                logger.debug(f"Text encoder {i} device: {text_encoder.device}")
+                device = getattr(text_encoder, "device", None)
+                if device is None:
+                    try:
+                        device = next(text_encoder.parameters()).device
+                    except StopIteration:
+                        try:
+                            device = next(text_encoder.buffers()).device
+                        except StopIteration:
+                            device = "unknown"
+                logger.debug(f"Text encoder {i} device: {device}")
 
     def setup_model_flavour(self):
         """

--- a/simpletuner/helpers/models/ideogram/model.py
+++ b/simpletuner/helpers/models/ideogram/model.py
@@ -204,6 +204,8 @@ class Ideogram4(ImageModelFoundation):
     def _maybe_upsample_prompt(self, prompt: str, encoder_shell: Ideogram4Pipeline) -> str:
         if not getattr(self.config, "ideogram_prompt_upsample", False):
             return prompt
+        if getattr(self, "prompt_enhancer_head", None) is not None and hasattr(self.prompt_enhancer_head, "to"):
+            self.prompt_enhancer_head.to(device=self.accelerator.device, dtype=self.config.weight_dtype)
         upsample_prompt = getattr(encoder_shell, "upsample_prompt", None)
         if upsample_prompt is None:
             raise ValueError("--ideogram_prompt_upsample requires an Ideogram pipeline with upsample_prompt().")
@@ -220,6 +222,33 @@ class Ideogram4(ImageModelFoundation):
             self.load_prompt_enhancer_head(move_to_device=True)
 
         tokenizer = self.tokenizers[0]
+        if not getattr(self, "_logged_text_encoder_devices", False):
+            text_encoder = self.text_encoders[0]
+            text_encoder_device = getattr(text_encoder, "device", None)
+            if text_encoder_device is None and hasattr(text_encoder, "parameters"):
+                try:
+                    text_encoder_device = next(text_encoder.parameters()).device
+                except StopIteration:
+                    text_encoder_device = "unknown"
+            if text_encoder_device is None:
+                text_encoder_device = "unknown"
+            logger.info(
+                "Ideogram text encoder device: %s; prompt upsample: %s",
+                text_encoder_device,
+                bool(getattr(self.config, "ideogram_prompt_upsample", False)),
+            )
+            head = getattr(self, "prompt_enhancer_head", None)
+            if head is not None:
+                head_device = getattr(head, "device", None)
+                if head_device is None and hasattr(head, "parameters"):
+                    try:
+                        head_device = next(head.parameters()).device
+                    except StopIteration:
+                        head_device = "unknown"
+                if head_device is None:
+                    head_device = "unknown"
+                logger.info("Ideogram prompt enhancer head device: %s", head_device)
+            self._logged_text_encoder_devices = True
         encoder_shell = Ideogram4Pipeline(
             conditional_transformer=None,
             unconditional_transformer=None,
@@ -507,6 +536,16 @@ class Ideogram4(ImageModelFoundation):
     def check_user_config(self):
         super().check_user_config()
         self.config.prediction_type = "flow_matching"
+
+    def log_model_devices(self):
+        super().log_model_devices()
+        head = getattr(self, "prompt_enhancer_head", None)
+        if head is not None:
+            try:
+                device = next(head.parameters()).device
+            except StopIteration:
+                device = "unknown"
+            logger.debug(f"Prompt enhancer head device: {device}")
 
 
 ModelRegistry.register("ideogram", Ideogram4)

--- a/simpletuner/helpers/models/ideogram/quantized_loading.py
+++ b/simpletuner/helpers/models/ideogram/quantized_loading.py
@@ -272,7 +272,24 @@ class Fp8Linear(nn.Module):
     else:
       self.bias = None
 
+  def _apply(self, fn, recurse: bool = True):
+    weight = self._buffers.pop("weight")
+    weight_scale = self._buffers.pop("weight_scale")
+    try:
+      super()._apply(fn, recurse=recurse)
+      device_probe = fn(torch.empty(0, device=weight.device, dtype=torch.uint8))
+    finally:
+      self._buffers["weight"] = weight
+      self._buffers["weight_scale"] = weight_scale
+    self._buffers["weight"] = weight.to(device=device_probe.device)
+    self._buffers["weight_scale"] = weight_scale.to(device=device_probe.device)
+    return self
+
   def forward(self, x: torch.Tensor) -> torch.Tensor:
+    if self.weight.dtype != FP8_WEIGHT_DTYPE:
+      raise RuntimeError(f"Fp8Linear weight must be {FP8_WEIGHT_DTYPE}, got {self.weight.dtype}.")
+    if self.weight_scale.dtype != torch.float32:
+      raise RuntimeError(f"Fp8Linear weight_scale must be torch.float32, got {self.weight_scale.dtype}.")
     if _scaled_mm_supported(x):
       return _Fp8LinearScaledMm.apply(
         x,

--- a/simpletuner/helpers/models/ideogram/quantized_loading.py
+++ b/simpletuner/helpers/models/ideogram/quantized_loading.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import warnings
 
 import torch
@@ -18,10 +19,78 @@ _BNB_SIBLING_SUFFIXES = (
 # scales map each row's max abs value onto this so we use the full range.
 FP8_E4M3_MAX = 448.0
 FP8_WEIGHT_DTYPE = torch.float8_e4m3fn
+FP8_INPUT_DTYPE = torch.float8_e5m2
 FP8_SCALE_SUFFIX = ".weight_scale"
 # Marker written into the text encoder's config.json so the loader knows to take
 # the custom weight-only FP8 path instead of transformers' from_pretrained.
 FP8_TEXT_ENCODER_CONFIG_FLAG = "ideogram_fp8_weight_only"
+
+
+def _scaled_mm_supported(x: torch.Tensor) -> bool:
+  if not x.is_cuda or not hasattr(torch, "_scaled_mm"):
+    return False
+  mode = os.environ.get("SIMPLETUNER_IDEOGRAM_FP8_SCALED_MM", "auto").strip().lower()
+  if mode in {"0", "false", "off", "no"}:
+    return False
+  if mode in {"1", "true", "on", "yes"}:
+    return True
+  try:
+    # Ada (L40S/4090) benefits most from scaled FP8 matmul. Hopper's bf16 path is
+    # competitive enough that we leave it on the dequantized fallback by default.
+    return torch.cuda.get_device_capability(x.device) == (8, 9)
+  except Exception:
+    return False
+
+
+class _Fp8LinearScaledMm(torch.autograd.Function):
+  @staticmethod
+  def forward(
+    ctx,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None,
+    out_features: int,
+  ) -> torch.Tensor:
+    input_shape = x.shape
+    x_2d = x.reshape(-1, x.shape[-1])
+    input_max = torch.finfo(FP8_INPUT_DTYPE).max
+    input_scale = (input_max / x_2d.detach().abs().amax().clamp(min=1e-12)).clamp(
+      max=input_max,
+    )
+    x_fp8 = (x_2d * input_scale).clamp(-input_max, input_max).to(FP8_INPUT_DTYPE)
+
+    bias_arg = bias.to(x.dtype) if bias is not None else None
+    scale_a = input_scale.reciprocal().to(torch.float32).expand(x_2d.shape[0], 1).contiguous()
+    scale_b = weight_scale.to(torch.float32).reshape(1, -1).contiguous()
+    out = torch._scaled_mm(
+      x_fp8,
+      weight.T,
+      scale_a=scale_a,
+      scale_b=scale_b,
+      bias=bias_arg,
+      out_dtype=x.dtype,
+      use_fast_accum=True,
+    )
+    if isinstance(out, tuple):
+      out = out[0]
+
+    ctx.save_for_backward(weight, weight_scale)
+    ctx.input_shape = input_shape
+    ctx.out_features = out_features
+    return out.reshape(*input_shape[:-1], out_features)
+
+  @staticmethod
+  def backward(ctx, grad_output: torch.Tensor):
+    weight, weight_scale = ctx.saved_tensors
+    grad_x = None
+    if ctx.needs_input_grad[0]:
+      grad_2d = grad_output.reshape(-1, ctx.out_features)
+      dequant_weight = weight.to(grad_output.dtype) * weight_scale.to(
+        grad_output.dtype,
+      ).unsqueeze(1)
+      grad_x = grad_2d.matmul(dequant_weight).reshape(ctx.input_shape)
+    return grad_x, None, None, None, None
 
 
 def _require_bitsandbytes():
@@ -204,6 +273,14 @@ class Fp8Linear(nn.Module):
       self.bias = None
 
   def forward(self, x: torch.Tensor) -> torch.Tensor:
+    if _scaled_mm_supported(x):
+      return _Fp8LinearScaledMm.apply(
+        x,
+        self.weight,
+        self.weight_scale,
+        self.bias,
+        self.out_features,
+      )
     w = self.weight.to(x.dtype) * self.weight_scale.to(x.dtype).unsqueeze(1)
     bias = self.bias.to(x.dtype) if self.bias is not None else None
     return F.linear(x, w, bias)

--- a/simpletuner/helpers/models/ideogram/quantized_loading.py
+++ b/simpletuner/helpers/models/ideogram/quantized_loading.py
@@ -60,7 +60,7 @@ class _Fp8LinearScaledMm(torch.autograd.Function):
     )
     x_fp8 = (x_2d * input_scale).clamp(-input_max, input_max).to(FP8_INPUT_DTYPE)
 
-    bias_arg = bias.to(x.dtype) if bias is not None else None
+    bias_arg = bias.to(x.dtype) if bias is not None and x.dtype != torch.float32 else None
     scale_a = input_scale.reciprocal().to(torch.float32).expand(x_2d.shape[0], 1).contiguous()
     scale_b = weight_scale.to(torch.float32).reshape(1, -1).contiguous()
     out = torch._scaled_mm(
@@ -74,6 +74,8 @@ class _Fp8LinearScaledMm(torch.autograd.Function):
     )
     if isinstance(out, tuple):
       out = out[0]
+    if bias is not None and bias_arg is None:
+      out = out + bias.to(out.dtype)
 
     ctx.save_for_backward(weight, weight_scale)
     ctx.input_shape = input_shape

--- a/simpletuner/helpers/models/ideogram/quantized_loading.py
+++ b/simpletuner/helpers/models/ideogram/quantized_loading.py
@@ -44,6 +44,19 @@ def _scaled_mm_supported(x: torch.Tensor) -> bool:
 
 class _Fp8LinearScaledMm(torch.autograd.Function):
   @staticmethod
+  def _dequantized_forward(
+    x_2d: torch.Tensor,
+    input_shape: torch.Size,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None,
+    out_features: int,
+  ) -> torch.Tensor:
+    w = weight.to(x_2d.dtype) * weight_scale.to(x_2d.dtype).unsqueeze(1)
+    bias_arg = bias.to(x_2d.dtype) if bias is not None else None
+    return F.linear(x_2d, w, bias_arg).reshape(*input_shape[:-1], out_features)
+
+  @staticmethod
   def forward(
     ctx,
     x: torch.Tensor,
@@ -62,17 +75,38 @@ class _Fp8LinearScaledMm(torch.autograd.Function):
 
     kernel_out_dtype = x.dtype if x.dtype in {torch.bfloat16, torch.float16} else torch.bfloat16
     bias_arg = bias.to(kernel_out_dtype) if bias is not None else None
-    scale_a = input_scale.reciprocal().to(torch.float32).expand(x_2d.shape[0], 1).contiguous()
-    scale_b = weight_scale.to(torch.float32).reshape(1, -1).contiguous()
-    out = torch._scaled_mm(
-      x_fp8,
-      weight.T,
-      scale_a=scale_a,
-      scale_b=scale_b,
-      bias=bias_arg,
-      out_dtype=kernel_out_dtype,
-      use_fast_accum=True,
+    scale_a = torch.empty(
+      (x_2d.shape[0], 1),
+      device=x_2d.device,
+      dtype=torch.float32,
     )
+    scale_a.copy_(input_scale.reciprocal().to(torch.float32).expand_as(scale_a))
+    scale_b = weight_scale.to(torch.float32).reshape(1, -1).contiguous()
+    try:
+      out = torch._scaled_mm(
+        x_fp8,
+        weight.T,
+        scale_a=scale_a,
+        scale_b=scale_b,
+        bias=bias_arg,
+        out_dtype=kernel_out_dtype,
+        use_fast_accum=True,
+      )
+    except RuntimeError as exc:
+      if "scale_a" not in str(exc) and "Invalid scaling configuration" not in str(exc):
+        raise
+      out = _Fp8LinearScaledMm._dequantized_forward(
+        x_2d,
+        input_shape,
+        weight,
+        weight_scale,
+        bias,
+        out_features,
+      )
+      ctx.save_for_backward(weight, weight_scale)
+      ctx.input_shape = input_shape
+      ctx.out_features = out_features
+      return out
     if isinstance(out, tuple):
       out = out[0]
     if out.dtype != x.dtype:

--- a/simpletuner/helpers/models/ideogram/quantized_loading.py
+++ b/simpletuner/helpers/models/ideogram/quantized_loading.py
@@ -60,7 +60,8 @@ class _Fp8LinearScaledMm(torch.autograd.Function):
     )
     x_fp8 = (x_2d * input_scale).clamp(-input_max, input_max).to(FP8_INPUT_DTYPE)
 
-    bias_arg = bias.to(x.dtype) if bias is not None and x.dtype != torch.float32 else None
+    kernel_out_dtype = x.dtype if x.dtype in {torch.bfloat16, torch.float16} else torch.bfloat16
+    bias_arg = bias.to(kernel_out_dtype) if bias is not None else None
     scale_a = input_scale.reciprocal().to(torch.float32).expand(x_2d.shape[0], 1).contiguous()
     scale_b = weight_scale.to(torch.float32).reshape(1, -1).contiguous()
     out = torch._scaled_mm(
@@ -69,13 +70,13 @@ class _Fp8LinearScaledMm(torch.autograd.Function):
       scale_a=scale_a,
       scale_b=scale_b,
       bias=bias_arg,
-      out_dtype=x.dtype,
+      out_dtype=kernel_out_dtype,
       use_fast_accum=True,
     )
     if isinstance(out, tuple):
       out = out[0]
-    if bias is not None and bias_arg is None:
-      out = out + bias.to(out.dtype)
+    if out.dtype != x.dtype:
+      out = out.to(x.dtype)
 
     ctx.save_for_backward(weight, weight_scale)
     ctx.input_shape = input_shape

--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -737,7 +737,9 @@ def prepare_validation_prompt_list(args, embed_cache, model):
         negative_prompt = StateTracker.get_args().validation_negative_prompt
         logger.info(f"Precomputing the negative prompt embed for validations: {negative_prompt}")
         model.log_model_devices()
-        if model.should_precompute_validation_negative_prompt():
+        if getattr(args, "model_family", None) == "ideogram":
+            embed_cache.encode_validation_negative_prompt(negative_prompt)
+        elif model.should_precompute_validation_negative_prompt():
             embed_cache.compute_embeddings_for_prompts(
                 [negative_prompt],
                 is_validation=True,

--- a/tests/test_ideogram4_prompting.py
+++ b/tests/test_ideogram4_prompting.py
@@ -14,6 +14,7 @@ from simpletuner.helpers.models.ideogram.pipeline import Ideogram4Pipeline
 from simpletuner.helpers.models.ideogram.prompting import maybe_convert_prompt_to_ideogram_json
 from simpletuner.helpers.models.ideogram.scheduler import get_schedule_for_resolution
 from simpletuner.helpers.models.ideogram.transformer import Ideogram4Config, Ideogram4Transformer
+from simpletuner.helpers.training.validation import prepare_validation_prompt_list
 
 
 class Ideogram4PromptingTests(unittest.TestCase):
@@ -327,6 +328,52 @@ class Ideogram4PromptingTests(unittest.TestCase):
 
         self.assertIs(loaded, model.prompt_enhancer_head)
         self.assertEqual(DummyHead.loaded_repo, "example/head")
+
+    def test_validation_negative_prompt_uses_ideogram_negative_encoder(self):
+        class DummyEmbedCache:
+            model_type = "ideogram"
+            _requires_path_based_keys = False
+
+            def __init__(self):
+                self.generic_calls = []
+                self.negative_calls = []
+
+            def compute_embeddings_for_prompts(self, prompts, **kwargs):
+                self.generic_calls.append((prompts, kwargs))
+
+            def encode_validation_negative_prompt(self, prompt):
+                self.negative_calls.append(prompt)
+
+        class DummyModel:
+            def requires_conditioning_validation_inputs(self):
+                return False
+
+            def should_precompute_validation_negative_prompt(self):
+                return True
+
+            def log_model_devices(self):
+                pass
+
+        args = types.SimpleNamespace(
+            model_family="ideogram",
+            model_flavour="fp8",
+            controlnet=False,
+            control=False,
+            validation_using_datasets=False,
+            validation_prompt_library=False,
+            user_prompt_library=None,
+            validation_prompt="a domokun plush",
+            validation_negative_prompt="bad",
+            validation_disable_unconditional=True,
+        )
+        embed_cache = DummyEmbedCache()
+
+        with mock.patch("simpletuner.helpers.training.validation.StateTracker.get_args", return_value=args):
+            prepare_validation_prompt_list(args, embed_cache, DummyModel())
+
+        self.assertEqual(embed_cache.negative_calls, ["bad"])
+        self.assertTrue(any(call[0][0]["prompt"] == "a domokun plush" for call in embed_cache.generic_calls))
+        self.assertFalse(any(call[0] == ["bad"] for call in embed_cache.generic_calls))
 
     def test_pipeline_saves_lora_weights_with_transformer_prefix(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_ideogram_fp8_linear.py
+++ b/tests/test_ideogram_fp8_linear.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest import mock
+
+import torch
+
+from simpletuner.helpers.models.ideogram import quantized_loading
+from simpletuner.helpers.models.ideogram.quantized_loading import (
+  FP8_WEIGHT_DTYPE,
+  Fp8Linear,
+)
+
+
+class IdeogramFp8LinearTests(unittest.TestCase):
+  def test_to_dtype_preserves_fp8_weight_and_float_scale(self):
+    layer = Fp8Linear(4, 3, bias=True, compute_dtype=torch.bfloat16)
+    weight = layer.weight
+    weight_scale = layer.weight_scale
+
+    layer.to(dtype=torch.bfloat16)
+
+    self.assertEqual(layer.weight.dtype, FP8_WEIGHT_DTYPE)
+    self.assertEqual(layer.weight_scale.dtype, torch.float32)
+    self.assertEqual(layer.bias.dtype, torch.bfloat16)
+    self.assertIs(layer.weight, weight)
+    self.assertIs(layer.weight_scale, weight_scale)
+
+  def test_forward_requires_fp8_weight(self):
+    layer = Fp8Linear(4, 3, bias=False, compute_dtype=torch.bfloat16)
+    layer.weight = layer.weight.to(dtype=torch.bfloat16)
+    x = torch.randn(2, 4, dtype=torch.bfloat16)
+
+    with mock.patch.object(quantized_loading, "_scaled_mm_supported", return_value=True):
+      with mock.patch.object(quantized_loading._Fp8LinearScaledMm, "apply") as scaled_mm:
+        with self.assertRaisesRegex(RuntimeError, "Fp8Linear weight must be"):
+          layer(x)
+
+    scaled_mm.assert_not_called()
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/test_ideogram_fp8_linear.py
+++ b/tests/test_ideogram_fp8_linear.py
@@ -7,6 +7,7 @@ from simpletuner.helpers.models.ideogram import quantized_loading
 from simpletuner.helpers.models.ideogram.quantized_loading import (
   FP8_WEIGHT_DTYPE,
   Fp8Linear,
+  _Fp8LinearScaledMm,
 )
 
 
@@ -35,6 +36,24 @@ class IdeogramFp8LinearTests(unittest.TestCase):
           layer(x)
 
     scaled_mm.assert_not_called()
+
+  def test_scaled_mm_adds_float32_bias_outside_kernel(self):
+    x = torch.randn(2, 4, dtype=torch.float32)
+    weight = torch.zeros(3, 4, dtype=FP8_WEIGHT_DTYPE)
+    weight_scale = torch.ones(3, dtype=torch.float32)
+    bias = torch.tensor([1.0, 2.0, 3.0], dtype=torch.bfloat16)
+    calls = []
+
+    def fake_scaled_mm(*args, **kwargs):
+      calls.append(kwargs)
+      return torch.zeros(2, 3, dtype=torch.float32)
+
+    with mock.patch.object(torch, "_scaled_mm", side_effect=fake_scaled_mm):
+      out = _Fp8LinearScaledMm.apply(x, weight, weight_scale, bias, 3)
+
+    self.assertIsNone(calls[0]["bias"])
+    self.assertEqual(calls[0]["out_dtype"], torch.float32)
+    torch.testing.assert_close(out, bias.to(torch.float32).expand_as(out))
 
 
 if __name__ == "__main__":

--- a/tests/test_ideogram_fp8_linear.py
+++ b/tests/test_ideogram_fp8_linear.py
@@ -53,7 +53,21 @@ class IdeogramFp8LinearTests(unittest.TestCase):
 
     self.assertEqual(calls[0]["bias"].dtype, torch.bfloat16)
     self.assertEqual(calls[0]["out_dtype"], torch.bfloat16)
+    self.assertEqual(calls[0]["scale_a"].shape, (2, 1))
+    self.assertEqual(calls[0]["scale_a"].stride(0), 1)
+    self.assertTrue(calls[0]["scale_a"].is_contiguous())
     self.assertEqual(out.dtype, torch.float32)
+
+  def test_scaled_mm_layout_error_falls_back_to_dequantized_linear(self):
+    x = torch.randn(2, 4, dtype=torch.bfloat16)
+    weight = torch.zeros(3, 4, dtype=FP8_WEIGHT_DTYPE)
+    weight_scale = torch.ones(3, dtype=torch.float32)
+
+    with mock.patch.object(torch, "_scaled_mm", side_effect=RuntimeError("Expected scale_a.stride(0) == 1")):
+      out = quantized_loading._Fp8LinearScaledMm.apply(x, weight, weight_scale, None, 3)
+
+    self.assertEqual(out.shape, (2, 3))
+    self.assertEqual(out.dtype, torch.bfloat16)
 
   @unittest.skipUnless(torch.cuda.is_available() and hasattr(torch, "_scaled_mm"), "CUDA _scaled_mm required")
   def test_scaled_mm_cuda_forward_supports_float32_input_with_bias(self):

--- a/tests/test_ideogram_fp8_linear.py
+++ b/tests/test_ideogram_fp8_linear.py
@@ -7,7 +7,7 @@ from simpletuner.helpers.models.ideogram import quantized_loading
 from simpletuner.helpers.models.ideogram.quantized_loading import (
   FP8_WEIGHT_DTYPE,
   Fp8Linear,
-  _Fp8LinearScaledMm,
+  quantize_weight_to_fp8,
 )
 
 
@@ -37,7 +37,7 @@ class IdeogramFp8LinearTests(unittest.TestCase):
 
     scaled_mm.assert_not_called()
 
-  def test_scaled_mm_adds_float32_bias_outside_kernel(self):
+  def test_scaled_mm_uses_supported_kernel_dtype_for_float32_input(self):
     x = torch.randn(2, 4, dtype=torch.float32)
     weight = torch.zeros(3, 4, dtype=FP8_WEIGHT_DTYPE)
     weight_scale = torch.ones(3, dtype=torch.float32)
@@ -46,14 +46,32 @@ class IdeogramFp8LinearTests(unittest.TestCase):
 
     def fake_scaled_mm(*args, **kwargs):
       calls.append(kwargs)
-      return torch.zeros(2, 3, dtype=torch.float32)
+      return torch.zeros(2, 3, dtype=kwargs["out_dtype"])
 
     with mock.patch.object(torch, "_scaled_mm", side_effect=fake_scaled_mm):
-      out = _Fp8LinearScaledMm.apply(x, weight, weight_scale, bias, 3)
+      out = quantized_loading._Fp8LinearScaledMm.apply(x, weight, weight_scale, bias, 3)
 
-    self.assertIsNone(calls[0]["bias"])
-    self.assertEqual(calls[0]["out_dtype"], torch.float32)
-    torch.testing.assert_close(out, bias.to(torch.float32).expand_as(out))
+    self.assertEqual(calls[0]["bias"].dtype, torch.bfloat16)
+    self.assertEqual(calls[0]["out_dtype"], torch.bfloat16)
+    self.assertEqual(out.dtype, torch.float32)
+
+  @unittest.skipUnless(torch.cuda.is_available() and hasattr(torch, "_scaled_mm"), "CUDA _scaled_mm required")
+  def test_scaled_mm_cuda_forward_supports_float32_input_with_bias(self):
+    layer = Fp8Linear(16, 16, bias=True, compute_dtype=torch.float32).cuda()
+    weight = torch.randn(16, 16, dtype=torch.bfloat16)
+    quantized_weight, weight_scale = quantize_weight_to_fp8(weight)
+    layer.weight = quantized_weight.cuda()
+    layer.weight_scale = weight_scale.cuda()
+    layer.bias = torch.randn(16, device="cuda", dtype=torch.float32)
+    x = torch.randn(8, 16, device="cuda", dtype=torch.float32, requires_grad=True)
+
+    with mock.patch.object(quantized_loading, "_scaled_mm_supported", return_value=True):
+      out = layer(x)
+      out.sum().backward()
+
+    self.assertEqual(out.shape, (8, 16))
+    self.assertEqual(out.dtype, torch.float32)
+    self.assertEqual(x.grad.shape, x.shape)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces support for efficient FP8 matrix multiplication using scaled matmul on compatible CUDA devices in the `ideogram` quantized loading helpers. The most significant change is the addition of a custom autograd function to accelerate FP8 linear layers when supported hardware and software conditions are met.

**FP8 Scaled Matmul Support:**

* Added a function `_scaled_mm_supported` to check if the current environment and tensor are suitable for using the optimized FP8 scaled matrix multiplication, with an environment variable override for manual control.
* Introduced the `_Fp8LinearScaledMm` custom autograd function to perform forward and backward passes using `torch._scaled_mm` for FP8 inputs, including dynamic input scaling and proper handling of gradients.
* Updated the `forward` method in the quantized linear class to use the new scaled FP8 path when supported, falling back to the previous dequantized path otherwise.

**General Improvements:**

* Added import of the `os` module to support environment variable checks.
* Defined `FP8_INPUT_DTYPE` for clarity and consistency in FP8 input handling.