### PR TITLE
scrub private information from simpletuner_config.json inside ckpt export

### DIFF
--- a/simpletuner/helpers/publishing/metadata.py
+++ b/simpletuner/helpers/publishing/metadata.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import os
+from enum import Enum
+from pathlib import Path
 from typing import Any, Optional, Union
 
 import numpy as np
@@ -108,6 +110,31 @@ allowed_licenses = [
     "other",
     "array",
 ]
+
+_EXCLUDED_TRAINING_CONFIG_KEYS = {
+    "publishing_config",
+    "webhook_config",
+}
+_SENSITIVE_TRAINING_CONFIG_KEY_PARTS = (
+    "secret",
+    "password",
+    "credential",
+    "access_key",
+    "api_key",
+    "private_key",
+)
+_SENSITIVE_TRAINING_CONFIG_KEYS = {
+    "token",
+    "access_token",
+    "api_token",
+    "auth_token",
+    "bearer_token",
+    "client_secret",
+    "hf_token",
+    "hub_token",
+    "session_token",
+    "upload_token",
+}
 for _model, _license in licenses.items():
     if _license not in allowed_licenses:
         licenses[_model] = "other"
@@ -772,27 +799,52 @@ The text encoder {'**was**' if train_text_encoder else '**was not**'} trained.
         f.write(yaml_content + model_card_content)
 
 
+def _normalise_training_config_key(key: Any) -> str:
+    return str(key).strip().lower().replace("-", "_")
+
+
+def _should_skip_training_config_key(key: Any) -> bool:
+    normalised_key = _normalise_training_config_key(key)
+    if normalised_key in _EXCLUDED_TRAINING_CONFIG_KEYS:
+        return True
+    if normalised_key in _SENSITIVE_TRAINING_CONFIG_KEYS:
+        return True
+    return any(part in normalised_key for part in _SENSITIVE_TRAINING_CONFIG_KEY_PARTS)
+
+
+def _make_training_config_serializable(obj: Any) -> Any:
+    if isinstance(obj, Enum):
+        return _make_training_config_serializable(obj.value)
+    if isinstance(obj, (str, int, float, bool)) or obj is None:
+        return obj
+    if isinstance(obj, Path):
+        return str(obj)
+    if isinstance(obj, torch.dtype):
+        return str(obj)
+    if isinstance(obj, torch.device):
+        return str(obj)
+    if isinstance(obj, np.generic):
+        return obj.item()
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, dict):
+        return {
+            str(key): _make_training_config_serializable(value)
+            for key, value in obj.items()
+            if not _should_skip_training_config_key(key)
+        }
+    if isinstance(obj, (list, tuple, set)):
+        return [_make_training_config_serializable(value) for value in obj]
+    if hasattr(obj, "__dict__"):
+        return _make_training_config_serializable(vars(obj))
+    return str(obj)
+
+
 def save_training_config(repo_folder: str = None, config: dict = None):
-    import types
-
-    def make_serializable(obj):
-        if isinstance(obj, dict):
-            return {k: make_serializable(v) for k, v in obj.items()}
-        elif isinstance(obj, (list, tuple)):
-            return [make_serializable(v) for v in obj]
-        elif hasattr(obj, "__dict__"):
-            return make_serializable(vars(obj))
-        elif isinstance(obj, types.SimpleNamespace):
-            return make_serializable(vars(obj))
-        elif isinstance(obj, (str, int, float, bool)) or obj is None:
-            return obj
-        else:
-            return str(obj)
-
     if repo_folder is None:
         raise ValueError("The repo_folder must be specified and not be None.")
     config_path = os.path.join(repo_folder, "simpletuner_config.json")
-    serializable_config = make_serializable(config)
+    serializable_config = _make_training_config_serializable(config)
     with open(config_path, "w", encoding="utf-8") as f:
         json.dump(serializable_config, f, indent=4)
     logger.debug(f"Saved model config to {config_path}")

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -1,6 +1,8 @@
 import json
 import os
+import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from simpletuner.helpers.publishing.metadata import *
@@ -13,6 +15,7 @@ from simpletuner.helpers.publishing.metadata import (
     _torch_device,
     _validation_resolution,
 )
+from simpletuner.helpers.training.attention_backend import AttentionBackendMode
 
 
 class TestMetadataFunctions(unittest.TestCase):
@@ -246,6 +249,41 @@ class TestMetadataFunctions(unittest.TestCase):
                                     "w",
                                     encoding="utf-8",
                                 )
+
+    def test_save_training_config_sanitizes_public_export(self):
+        config = SimpleNamespace(
+            output_dir="output/test",
+            sageattention_usage=AttentionBackendMode.INFERENCE,
+            publishing_config=[
+                {
+                    "provider": "s3",
+                    "bucket": "training",
+                    "access_key": "dummy-access-key",
+                    "secret_key": "dummy-secret-key",
+                }
+            ],
+            webhook_config={"url": "https://example.invalid/webhook", "auth_token": "dummy-token"},
+            nested={
+                "safe": "keep",
+                "tokenizer_max_length": 77,
+                "access_key": "nested-access-key",
+                "aws_secret_access_key": "nested-secret-key",
+                "token": "nested-token",
+            },
+            dtype=torch.bfloat16,
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            save_training_config(repo_folder=temp_dir, config=config)
+            with open(os.path.join(temp_dir, "simpletuner_config.json"), "r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+
+        self.assertEqual(payload["sageattention_usage"], "inference")
+        self.assertNotIsInstance(payload["sageattention_usage"], dict)
+        self.assertNotIn("publishing_config", payload)
+        self.assertNotIn("webhook_config", payload)
+        self.assertEqual(payload["nested"], {"safe": "keep", "tokenizer_max_length": 77})
+        self.assertEqual(payload["dtype"], "torch.bfloat16")
 
     def test_adapter_download_fn(self):
         with patch("huggingface_hub.hf_hub_download", return_value="path/to/adapter"):


### PR DESCRIPTION
This pull request enhances the handling and sanitization of training configuration data before exporting it, particularly focusing on excluding sensitive information and improving serialization. It introduces new helper functions for key normalization and sensitive key detection, updates the serialization logic to handle more data types, and adds comprehensive tests to ensure sensitive fields are excluded from exported configs.

Improvements to configuration sanitization and serialization:

* Added sets and tuples (`_EXCLUDED_TRAINING_CONFIG_KEYS`, `_SENSITIVE_TRAINING_CONFIG_KEY_PARTS`, `_SENSITIVE_TRAINING_CONFIG_KEYS`) to define which config keys should be excluded or treated as sensitive, and implemented logic to skip these keys when serializing training configs (`simpletuner/helpers/publishing/metadata.py`).
* Introduced `_normalise_training_config_key` and `_should_skip_training_config_key` helper functions to consistently identify and filter out sensitive or excluded keys during config export (`simpletuner/helpers/publishing/metadata.py`).
* Refactored and expanded `_make_training_config_serializable` to handle additional data types (such as `Enum`, `Path`, `torch.dtype`, `torch.device`, `np.generic`, and `np.ndarray`) and to recursively sanitize nested structures, ensuring all exported config data is safe and JSON-serializable (`simpletuner/helpers/publishing/metadata.py`).

Testing and validation:

* Added a new test, `test_save_training_config_sanitizes_public_export`, to verify that sensitive fields are excluded and allowed fields are correctly serialized when saving training configs (`tests/test_model_card.py`).

General code improvements:

* Updated imports to support new serialization logic and testing, including importing `Enum`, `Path`, `SimpleNamespace`, and `tempfile` (`simpletuner/helpers/publishing/metadata.py`, `tests/test_model_card.py`) [[1]](diffhunk://#diff-7e7621e1980ba1e0fb5c65b8dbf4491a028a6c471df661daf7019fadd3dd0b59R4-R5) [[2]](diffhunk://#diff-f3749f5c53ea2dc628ee9f0e6295d100144586bda2abd6853b69198d44b6434bR3-R5) [[3]](diffhunk://#diff-f3749f5c53ea2dc628ee9f0e6295d100144586bda2abd6853b69198d44b6434bR18).