### PR TITLE
webui: when SaveAs is used to clone a config, use common helper and update project-specific paths

### DIFF
--- a/simpletuner/templates/trainer_htmx.html
+++ b/simpletuner/templates/trainer_htmx.html
@@ -6824,7 +6824,10 @@ function trainerComponent() {
                      },
 
                      async saveAsNew() {
-                         const name = prompt('Enter name for new configuration:');
+                         // Sanitize to match the backend's _validate_config_name (trim + strip
+                         // trailing .json). Otherwise the config is created under the sanitized
+                         // name while the UI tries to switch to the raw one (e.g. "foo.json").
+                         const name = sanitizeConfigName(prompt('Enter name for new configuration:'));
                          if (!name) return;
 
                          const formElement = document.getElementById('trainer-form');
@@ -6834,7 +6837,7 @@ function trainerComponent() {
                          }
 
                          const trainerStore = Alpine.store('trainer');
-                         const sourceName = trainerStore?.activeEnvironment || this.activeConfig || null;
+                         const sourceName = sanitizeConfigName(trainerStore?.activeEnvironment || this.activeConfig || '') || null;
 
                          // Capture the COMPLETE loaded config, not just the inputs currently in
                          // the DOM. A bare FormData omits fields on inactive tabs, which is why

--- a/simpletuner/templates/trainer_htmx.html
+++ b/simpletuner/templates/trainer_htmx.html
@@ -6827,12 +6827,52 @@ function trainerComponent() {
                          const name = prompt('Enter name for new configuration:');
                          if (!name) return;
 
-                         const formData = new FormData(document.getElementById('trainer-form'));
-                         const config = {};
+                         const formElement = document.getElementById('trainer-form');
+                         if (!formElement) {
+                             window.showToast('Trainer form not found', 'error');
+                             return;
+                         }
 
+                         const trainerStore = Alpine.store('trainer');
+                         const sourceName = trainerStore?.activeEnvironment || this.activeConfig || null;
+
+                         // Capture the COMPLETE loaded config, not just the inputs currently in
+                         // the DOM. A bare FormData omits fields on inactive tabs, which is why
+                         // Save As previously reverted every untouched field to its default. This
+                         // mirrors the regular save path: form values win, with the active config
+                         // filling in anything not materialized in the DOM.
+                         const formData = new FormData(formElement);
+                         if (trainerStore) {
+                             trainerStore.normalizeCheckboxFormData?.(formData);
+                             trainerStore.ensureCompleteFormData?.(formData);
+                             trainerStore.appendConfigValuesToFormData?.(formData, trainerStore.activeEnvironmentConfig || {});
+                             trainerStore.normalizeCheckboxFormData?.(formData);
+                         }
+
+                         const config = {};
                          for (const [key, value] of formData.entries()) {
-                             if (key.startsWith('--')) {
+                             if (!key.startsWith('--')) continue;
+                             if (Object.prototype.hasOwnProperty.call(config, key)) {
+                                 const existing = config[key];
+                                 config[key] = Array.isArray(existing) ? [...existing, value] : [existing, value];
+                             } else {
                                  config[key] = value;
+                             }
+                         }
+
+                         // The new project must train into its own location and report under its
+                         // own name, so identity fields that embed the source name are repointed.
+                         // The dataloader reference is intentionally left shared so the variant
+                         // trains on the same dataset.
+                         if (sourceName && name !== sourceName) {
+                             const repoint = (value) =>
+                                 (typeof value === 'string' && value.includes(sourceName))
+                                     ? value.split(sourceName).join(name)
+                                     : value;
+                             for (const key of ['--output_dir', '--tracker_run_name', '--tracker_project_name']) {
+                                 if (typeof config[key] === 'string') {
+                                     config[key] = repoint(config[key]);
+                                 }
                              }
                          }
 
@@ -6853,6 +6893,15 @@ function trainerComponent() {
                                  // Use the main component's switchEnvironment method
                                 await Alpine.store('trainer').switchEnvironment(name);
                                  window.showToast(`Created new configuration: ${name}`, 'success');
+                             } else {
+                                 let detail = '';
+                                 try {
+                                     const error = await response.json();
+                                     detail = error?.detail ? `: ${error.detail}` : '';
+                                 } catch (parseError) {
+                                     console.debug('Could not parse error response', parseError);
+                                 }
+                                 window.showToast(`Failed to create configuration${detail}`, 'error');
                              }
                          } catch (error) {
                              console.error('Failed to create config:', error);

--- a/tests/test_webui_e2e.py
+++ b/tests/test_webui_e2e.py
@@ -2098,5 +2098,114 @@ class EasyModeOptimizerSyncTestCase(_TrainerPageMixin, WebUITestCase):
         self.for_each_browser("test_full_form_optimizer_presets_button_applies_preset", scenario)
 
 
+class SaveAsNewConfigurationTestCase(_TrainerPageMixin, WebUITestCase):
+    """Regression coverage for the top-bar "Save As..." config cloning flow.
+
+    Previously Save As captured only the inputs materialized in the DOM, so any
+    field on an unvisited tab was dropped and the new config came back as mostly
+    defaults. It must now clone the complete loaded config (including a live
+    edit) and repoint name-derived identity fields to the new name.
+    """
+
+    MAX_BROWSERS = 1
+
+    def _seed_source_config(self) -> None:
+        env_dir = self.config_dir / "rank32-src"
+        env_dir.mkdir(parents=True, exist_ok=True)
+        config_payload = {
+            "--model_family": "flux",
+            "--model_type": "lora",
+            "--model_flavour": "libreflux",
+            "--pretrained_model_name_or_path": "jimmycarter/LibreFlux-SimpleTuner",
+            "--lora_rank": "32",
+            "--output_dir": "output/rank32-src",
+            "--tracker_run_name": "rank32-src-run",
+            "--data_backend_config": str(env_dir / "multidatabackend.json"),
+            "--job_id": "rank32-src",
+            "--report_to": "none",
+        }
+        (env_dir / "config.json").write_text(json.dumps(config_payload), encoding="utf-8")
+        (env_dir / "multidatabackend.json").write_text("[]", encoding="utf-8")
+        self.seed_defaults(active_config="rank32-src", output_dir="output/rank32-src")
+
+    def test_save_as_preserves_config_and_repoints_identity(self) -> None:
+        self._seed_source_config()
+
+        def scenario(driver, _browser):
+            trainer_page = self._trainer_page(driver)
+
+            trainer_page.navigate_to_trainer()
+            self.dismiss_onboarding(driver)
+            trainer_page.wait_for_tab("basic")
+
+            # Confirm the source config loaded before we edit it.
+            trainer_page.switch_to_model_tab()
+            trainer_page.wait_for_tab("model")
+            WebDriverWait(driver, 10).until(
+                lambda d: d.find_element(By.ID, "lora_rank").get_attribute("value") in ("32", "32.0"),
+                message="lora_rank did not populate from the loaded config",
+            )
+
+            # The user's scenario: bump rank 32 -> 64 in the form.
+            driver.execute_script(
+                "const el = document.getElementById('lora_rank');"
+                "el.value = arguments[0];"
+                "el.dispatchEvent(new Event('input', { bubbles: true }));"
+                "el.dispatchEvent(new Event('change', { bubbles: true }));",
+                "64",
+            )
+
+            # Trigger Save As through the real header dropdown. window.prompt is
+            # overridden because Selenium cannot interact with the native dialog.
+            driver.execute_script("window.prompt = function () { return 'rank64-clone'; };")
+            toggle = WebDriverWait(driver, 10).until(
+                EC.element_to_be_clickable((By.CSS_SELECTOR, ".config-selector__toggle-wrapper button")),
+                message="config selector toggle not clickable",
+            )
+            toggle.click()
+            save_as = WebDriverWait(driver, 10).until(
+                EC.element_to_be_clickable(
+                    (By.XPATH, "//div[contains(@class, 'config-selector')]//a[contains(normalize-space(.), 'Save As')]")
+                ),
+                message="Save As menu item not clickable",
+            )
+            save_as.click()
+
+            def _config_created(_driver):
+                response = requests.get(f"{self.base_url}/api/configs/rank64-clone", timeout=5)
+                return response if response.status_code == 200 else False
+
+            config_response = WebDriverWait(driver, 10).until(
+                _config_created,
+                message="Save As did not create the new configuration",
+            )
+            body = config_response.json().get("config") or {}
+
+            # Live edit captured.
+            self.assertIn(body.get("--lora_rank"), ("64", "64.0"))
+            # Untouched fields preserved (would be absent/default under the old bug).
+            self.assertEqual(body.get("--model_flavour"), "libreflux")
+            self.assertEqual(
+                body.get("--pretrained_model_name_or_path"),
+                "jimmycarter/LibreFlux-SimpleTuner",
+            )
+            # Identity fields repointed to the new name, not the source's.
+            output_dir = body.get("--output_dir") or ""
+            self.assertIn("rank64-clone", output_dir)
+            self.assertNotIn("rank32-src", output_dir)
+            tracker_run = body.get("--tracker_run_name") or ""
+            self.assertIn("rank64-clone", tracker_run)
+            self.assertNotIn("rank32-src", tracker_run)
+
+            # The original config is untouched.
+            source_response = requests.get(f"{self.base_url}/api/configs/rank32-src", timeout=5)
+            source_response.raise_for_status()
+            source_body = source_response.json().get("config") or {}
+            self.assertIn(source_body.get("--lora_rank"), ("32", "32.0"))
+            self.assertEqual(source_body.get("--output_dir"), "output/rank32-src")
+
+        self.for_each_browser("test_save_as_preserves_config_and_repoints_identity", scenario)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_webui_e2e.py
+++ b/tests/test_webui_e2e.py
@@ -2156,8 +2156,10 @@ class SaveAsNewConfigurationTestCase(_TrainerPageMixin, WebUITestCase):
             )
 
             # Trigger Save As through the real header dropdown. window.prompt is
-            # overridden because Selenium cannot interact with the native dialog.
-            driver.execute_script("window.prompt = function () { return 'rank64-clone'; };")
+            # overridden because Selenium cannot interact with the native dialog. The
+            # ".json" suffix exercises name sanitization: the backend strips it, so the
+            # UI must switch to the sanitized "rank64-clone", not "rank64-clone.json".
+            driver.execute_script("window.prompt = function () { return 'rank64-clone.json'; };")
             toggle = WebDriverWait(driver, 10).until(
                 EC.element_to_be_clickable((By.CSS_SELECTOR, ".config-selector__toggle-wrapper button")),
                 message="config selector toggle not clickable",
@@ -2180,6 +2182,13 @@ class SaveAsNewConfigurationTestCase(_TrainerPageMixin, WebUITestCase):
                 message="Save As did not create the new configuration",
             )
             body = config_response.json().get("config") or {}
+
+            # The UI must switch to the sanitized name, not the raw "rank64-clone.json".
+            active_env = driver.execute_script(
+                "const store = window.Alpine && Alpine.store ? Alpine.store('trainer') : null;"
+                "return store ? store.activeEnvironment : null;"
+            )
+            self.assertEqual(active_env, "rank64-clone")
 
             # Live edit captured.
             self.assertIn(body.get("--lora_rank"), ("64", "64.0"))


### PR DESCRIPTION
This pull request addresses a regression in the "Save As..." configuration cloning flow in the SimpleTuner web UI, ensuring that when users clone a configuration, all fields—including those not currently visible in the DOM—are preserved, and identity fields are properly repointed to the new configuration name. It also adds robust error handling and comprehensive regression tests to prevent similar issues in the future.

**Improvements to the "Save As..." configuration cloning flow:**

* The JavaScript logic for the "Save As..." action in `trainer_htmx.html` was updated to ensure the complete loaded configuration is cloned, not just the form fields present in the DOM, preventing loss of fields from inactive tabs. Identity fields (such as `--output_dir` and `--tracker_run_name`) are now automatically updated to reflect the new configuration name, while the data loader reference remains shared.
* Enhanced error handling for failed configuration creation, providing detailed feedback to the user if the operation fails.

**Testing and regression coverage:**

* Added a new end-to-end test case, `SaveAsNewConfigurationTestCase`, in `test_webui_e2e.py` to verify that the "Save As..." feature correctly clones the complete configuration, applies live edits, repoints identity fields, and leaves the source configuration unchanged. This test ensures the regression is covered and prevents future breakage.