### PR TITLE
configure script needs to resolve config dir properly like webui does

### DIFF
--- a/simpletuner/configure.py
+++ b/simpletuner/configure.py
@@ -2651,7 +2651,14 @@ class SimpleTunerNCurses:
     def _save_config(self, stdscr, config_data: Dict[str, Any]) -> None:
         """Persist configuration to disk."""
 
-        default_path = self.state.loaded_config_path or "config/config.json"
+        # Default to the same directory the WebUI's config API resolves to
+        # (SIMPLETUNER_CONFIG_DIR -> onboarding configs_dir -> <root>/config) so a
+        # config saved here is visible to the WebUI, including Docker /workspace mounts.
+        # Imported lazily: config_store imports from this module at load time.
+        from simpletuner.simpletuner_sdk.server.services.config_store import ConfigStore
+
+        default_dir = ConfigStore(config_type="model").config_dir
+        default_path = self.state.loaded_config_path or str(default_dir / "config.json")
         path = self.get_input(stdscr, "Enter file path to save config:", default_path)
         if not path:
             self.show_error(stdscr, "Path cannot be empty.")


### PR DESCRIPTION
This pull request updates how the default configuration save path is determined in the `simpletuner/configure.py` file. The change ensures that configurations saved from the CLI are stored in the same directory as the WebUI expects, improving compatibility, especially when running in Docker or mounted environments.

Configuration path logic update:

* The `_save_config` method now determines the default configuration directory by using `ConfigStore(config_type="model").config_dir`, ensuring consistency with the WebUI's configuration API and Docker mount points.