### PR TITLE
filter secrets from runtime cmd arg log line

### DIFF
--- a/simpletuner/helpers/configuration/sanitization.py
+++ b/simpletuner/helpers/configuration/sanitization.py
@@ -1,0 +1,114 @@
+"""Sanitizers for public config exports and log messages."""
+
+from __future__ import annotations
+
+import json
+from enum import Enum
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import torch
+
+PUBLIC_CONFIG_EXCLUDED_KEYS = {
+    "publishing_config",
+    "webhook_config",
+}
+SENSITIVE_CONFIG_KEY_PARTS = (
+    "secret",
+    "password",
+    "credential",
+    "access_key",
+    "api_key",
+    "private_key",
+)
+SENSITIVE_CONFIG_KEYS = {
+    "token",
+    "access_token",
+    "api_token",
+    "auth_token",
+    "bearer_token",
+    "client_secret",
+    "hf_token",
+    "hub_token",
+    "session_token",
+    "upload_token",
+}
+
+
+def normalise_config_key(key: Any) -> str:
+    return str(key).strip().lower().replace("-", "_").lstrip("_")
+
+
+def should_skip_public_config_key(key: Any) -> bool:
+    normalised_key = normalise_config_key(key)
+    if normalised_key in PUBLIC_CONFIG_EXCLUDED_KEYS:
+        return True
+    if normalised_key in SENSITIVE_CONFIG_KEYS:
+        return True
+    return any(part in normalised_key for part in SENSITIVE_CONFIG_KEY_PARTS)
+
+
+def make_public_config_serializable(obj: Any) -> Any:
+    if isinstance(obj, Enum):
+        return make_public_config_serializable(obj.value)
+    if isinstance(obj, (str, int, float, bool)) or obj is None:
+        return obj
+    if isinstance(obj, Path):
+        return str(obj)
+    if isinstance(obj, torch.dtype):
+        return str(obj)
+    if isinstance(obj, torch.device):
+        return str(obj)
+    if isinstance(obj, np.generic):
+        return obj.item()
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, dict):
+        return {
+            str(key): make_public_config_serializable(value)
+            for key, value in obj.items()
+            if not should_skip_public_config_key(key)
+        }
+    if isinstance(obj, (list, tuple, set)):
+        return [make_public_config_serializable(value) for value in obj]
+    if hasattr(obj, "__dict__"):
+        return make_public_config_serializable(vars(obj))
+    return str(obj)
+
+
+def _sanitize_cli_value_for_logging(value: str) -> str:
+    stripped = value.strip()
+    if not stripped or stripped[0] not in "[{":
+        return value
+    try:
+        payload = json.loads(stripped)
+    except json.JSONDecodeError:
+        return value
+    return json.dumps(make_public_config_serializable(payload), sort_keys=True)
+
+
+def sanitize_cli_args_for_public_logging(args: Sequence[str]) -> list[str]:
+    sanitized: list[str] = []
+    index = 0
+    while index < len(args):
+        arg = str(args[index])
+        if not arg.startswith("--") or arg == "--":
+            sanitized.append(arg)
+            index += 1
+            continue
+
+        option, separator, value = arg.partition("=")
+        key = option.lstrip("-")
+        if should_skip_public_config_key(key):
+            index += 1
+            if not separator and index < len(args) and not str(args[index]).startswith("--"):
+                index += 1
+            continue
+
+        if separator:
+            sanitized.append(f"{option}={_sanitize_cli_value_for_logging(value)}")
+        else:
+            sanitized.append(arg)
+        index += 1
+    return sanitized

--- a/simpletuner/helpers/publishing/metadata.py
+++ b/simpletuner/helpers/publishing/metadata.py
@@ -1,8 +1,6 @@
 import json
 import logging
 import os
-from enum import Enum
-from pathlib import Path
 from typing import Any, Optional, Union
 
 import numpy as np
@@ -10,6 +8,7 @@ import torch
 from diffusers.utils.export_utils import export_to_gif
 from PIL import Image
 
+from simpletuner.helpers.configuration.sanitization import make_public_config_serializable
 from simpletuner.helpers.data_backend.dataset_types import DatasetType, ensure_dataset_type
 from simpletuner.helpers.models.common import AudioModelFoundation, ModelFoundation
 from simpletuner.helpers.training.state_tracker import StateTracker
@@ -111,30 +110,6 @@ allowed_licenses = [
     "array",
 ]
 
-_EXCLUDED_TRAINING_CONFIG_KEYS = {
-    "publishing_config",
-    "webhook_config",
-}
-_SENSITIVE_TRAINING_CONFIG_KEY_PARTS = (
-    "secret",
-    "password",
-    "credential",
-    "access_key",
-    "api_key",
-    "private_key",
-)
-_SENSITIVE_TRAINING_CONFIG_KEYS = {
-    "token",
-    "access_token",
-    "api_token",
-    "auth_token",
-    "bearer_token",
-    "client_secret",
-    "hf_token",
-    "hub_token",
-    "session_token",
-    "upload_token",
-}
 for _model, _license in licenses.items():
     if _license not in allowed_licenses:
         licenses[_model] = "other"
@@ -799,52 +774,11 @@ The text encoder {'**was**' if train_text_encoder else '**was not**'} trained.
         f.write(yaml_content + model_card_content)
 
 
-def _normalise_training_config_key(key: Any) -> str:
-    return str(key).strip().lower().replace("-", "_")
-
-
-def _should_skip_training_config_key(key: Any) -> bool:
-    normalised_key = _normalise_training_config_key(key)
-    if normalised_key in _EXCLUDED_TRAINING_CONFIG_KEYS:
-        return True
-    if normalised_key in _SENSITIVE_TRAINING_CONFIG_KEYS:
-        return True
-    return any(part in normalised_key for part in _SENSITIVE_TRAINING_CONFIG_KEY_PARTS)
-
-
-def _make_training_config_serializable(obj: Any) -> Any:
-    if isinstance(obj, Enum):
-        return _make_training_config_serializable(obj.value)
-    if isinstance(obj, (str, int, float, bool)) or obj is None:
-        return obj
-    if isinstance(obj, Path):
-        return str(obj)
-    if isinstance(obj, torch.dtype):
-        return str(obj)
-    if isinstance(obj, torch.device):
-        return str(obj)
-    if isinstance(obj, np.generic):
-        return obj.item()
-    if isinstance(obj, np.ndarray):
-        return obj.tolist()
-    if isinstance(obj, dict):
-        return {
-            str(key): _make_training_config_serializable(value)
-            for key, value in obj.items()
-            if not _should_skip_training_config_key(key)
-        }
-    if isinstance(obj, (list, tuple, set)):
-        return [_make_training_config_serializable(value) for value in obj]
-    if hasattr(obj, "__dict__"):
-        return _make_training_config_serializable(vars(obj))
-    return str(obj)
-
-
 def save_training_config(repo_folder: str = None, config: dict = None):
     if repo_folder is None:
         raise ValueError("The repo_folder must be specified and not be None.")
     config_path = os.path.join(repo_folder, "simpletuner_config.json")
-    serializable_config = _make_training_config_serializable(config)
+    serializable_config = make_public_config_serializable(config)
     with open(config_path, "w", encoding="utf-8") as f:
         json.dump(serializable_config, f, indent=4)
     logger.debug(f"Saved model config to {config_path}")

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -167,6 +167,7 @@ from accelerate.utils import (
 from torch.distributions import Beta
 
 from simpletuner.configure import model_classes, model_labels
+from simpletuner.helpers.configuration.sanitization import sanitize_cli_args_for_public_logging
 
 try:
     from lycoris import LycorisNetwork
@@ -7174,7 +7175,10 @@ def run_trainer_job(config):
             launch_env.setdefault("CONFIG_BACKEND", "cmd")
             cmd.extend(cli_args)
 
-        launch_logger.info("Launching training via accelerate: %s", " ".join(cmd))
+        launch_logger.info(
+            "Launching training via accelerate: %s",
+            shlex.join(sanitize_cli_args_for_public_logging(cmd)),
+        )
 
         popen_kwargs = {
             "env": launch_env,

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -953,6 +953,46 @@ class TestTrainer(unittest.TestCase):
         self.assertNotIn("--multi_gpu", captured["cmd"])
         self.assertIn("--use_fsdp", captured["cmd"])
 
+    def test_run_trainer_job_sanitizes_accelerate_launch_log(self):
+        payload = {
+            "accelerate_visible_devices": [0],
+            "accelerate_extra_args": "--api_key dummy-api-key --use_fsdp",
+            "model_type": "lora",
+            "publishing_config": [
+                {
+                    "provider": "s3",
+                    "bucket": "training",
+                    "access_key": "dummy-access-key",
+                    "secret_key": "dummy-secret-key",
+                }
+            ],
+            "webhook_config": {
+                "url": "https://example.invalid/webhook",
+                "auth_token": "dummy-auth-token",
+            },
+        }
+
+        with self.assertLogs("SimpleTuner", level="INFO") as captured_logs:
+            result, captured = self._run_trainer_job_with_captured_popen(payload)
+
+        self.assertEqual(result, 0)
+        actual_command = " ".join(captured["cmd"])
+        self.assertIn("--publishing_config=", actual_command)
+        self.assertIn("dummy-access-key", actual_command)
+        self.assertIn("dummy-secret-key", actual_command)
+        self.assertIn("dummy-api-key", actual_command)
+
+        launch_lines = [line for line in captured_logs.output if "Launching training via accelerate:" in line]
+        self.assertEqual(len(launch_lines), 1)
+        launch_line = launch_lines[0]
+        self.assertIn("--use_fsdp", launch_line)
+        self.assertNotIn("publishing_config", launch_line)
+        self.assertNotIn("webhook_config", launch_line)
+        self.assertNotIn("dummy-access-key", launch_line)
+        self.assertNotIn("dummy-secret-key", launch_line)
+        self.assertNotIn("dummy-auth-token", launch_line)
+        self.assertNotIn("dummy-api-key", launch_line)
+
     def test_accelerate_manual_triggers_are_relayed(self):
         from simpletuner.helpers.training import trainer as trainer_module
 


### PR DESCRIPTION
This pull request introduces a new configuration sanitization utility to centralize and standardize the removal of sensitive information from configuration data and command-line arguments. The sanitization logic is now reused in both configuration export and logging, improving security and maintainability. The changes also include updates to logging in the training launch process to ensure that sensitive data is never logged, and adds a test to verify this behavior.

**Centralization and reuse of sanitization logic:**

* Added `simpletuner/helpers/configuration/sanitization.py`, which provides functions to sanitize configuration data and command-line arguments, ensuring sensitive information is excluded from public logs and exports.
* Updated `simpletuner/helpers/publishing/metadata.py` to import and use the new `make_public_config_serializable` function, removing the old, duplicate sanitization logic from this file. [[1]](diffhunk://#diff-7e7621e1980ba1e0fb5c65b8dbf4491a028a6c471df661daf7019fadd3dd0b59L4-R11) [[2]](diffhunk://#diff-7e7621e1980ba1e0fb5c65b8dbf4491a028a6c471df661daf7019fadd3dd0b59L114-L137) [[3]](diffhunk://#diff-7e7621e1980ba1e0fb5c65b8dbf4491a028a6c471df661daf7019fadd3dd0b59L802-R781)

**Improvements to logging security:**

* Updated `simpletuner/helpers/training/trainer.py` to use `sanitize_cli_args_for_public_logging` when logging the accelerate launch command, ensuring sensitive CLI arguments are sanitized before being logged. [[1]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R170) [[2]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27L7177-R7181)

**Testing:**

* Added a test (`test_run_trainer_job_sanitizes_accelerate_launch_log`) to `tests/test_trainer.py` to verify that sensitive information is not present in the logged accelerate launch command.