### PR TITLE
disable colours when logging via coglet

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from cog import BasePredictor, Input, Path, Secret
 
+os.environ.setdefault("SIMPLETUNER_DISABLE_COLORS", "1")
 os.environ["HF_ENDPOINT"] = "https://huggingface.co"
 os.environ["HUGGINGFACE_HUB_ENDPOINT"] = "https://huggingface.co"
 


### PR DESCRIPTION
This pull request introduces a small environment configuration change to the `predict.py` file. The update sets a default value for the `SIMPLETUNER_DISABLE_COLORS` environment variable, which may help ensure consistent output formatting by disabling colorization.

* Environment configuration:
  * Added `os.environ.setdefault("SIMPLETUNER_DISABLE_COLORS", "1")` to set a default value for disabling colored output in `predict.py`.