### PR TITLE
ideogram4 text embed size reduction with pre-projected cache

### DIFF
--- a/documentation/OPTIONS.es.md
+++ b/documentation/OPTIONS.es.md
@@ -80,6 +80,13 @@ Donde `foo` es tu entorno de configuración; o simplemente usa `config/config.js
   - En configuraciones multinodo, solo el rank local 0 en cada nodo realiza la eliminación. Los fallos de eliminación se ignoran silenciosamente para manejar condiciones de carrera en almacenamiento de red compartido.
   - Esto **no** afecta a los checkpoints de entrenamiento guardados; solo al caché del modelo base preentrenado.
 
+### `--text_embed_full_cache`
+
+- **Qué**: Guarda la salida raw completa del text encoder en el cache de text embeds.
+- **Predeterminado**: `False`
+- **Por qué**: El valor predeterminado permite layouts de cache compactos específicos del modelo. Por ejemplo, Ideogram 4 proyecta su pila Qwen de 13 capas mediante las capas congeladas `llm_cond_norm` y `llm_cond_proj` del transformer antes de escribir los archivos de cache; esas capas permanecen congeladas tanto en LoRA como en entrenamiento full del transformer.
+- **Cuándo usarlo**: Actívalo para depurar compatibilidad de cache, cuando necesites explícitamente features raw y sin proyección del text encoder, o al adaptar una arquitectura estilo Ideogram para entrenamiento desde cero donde la proyección de texto no sea un componente preentrenado fijo.
+
 ### `--trust_remote_code`
 
 - **Qué**: Permite que Transformers y los tokenizers ejecuten código Python personalizado del repositorio del modelo cuando el checkpoint depende de clases personalizadas upstream.
@@ -2236,6 +2243,11 @@ options:
   --cache_dir_text CACHE_DIR_TEXT
                         This is the path to a local directory that will
                         contain your text embed cache
+  --text_embed_full_cache [TEXT_EMBED_FULL_CACHE]
+                        Store full raw text encoder outputs in the text embed
+                        cache. This opts out of model-specific cache size
+                        optimisations, such as Ideogram 4's frozen text
+                        projection cache.
   --cache_dir_vae CACHE_DIR_VAE
                         This is the path to a local directory that will
                         contain your VAE outputs

--- a/documentation/OPTIONS.hi.md
+++ b/documentation/OPTIONS.hi.md
@@ -80,6 +80,13 @@ simpletuner configure config/foo/config.json
   - Multi‑node setups में, हर node पर केवल local‑rank 0 deletion करता है। Shared network storage पर race conditions संभालने के लिए deletion failures silently ignore की जाती हैं।
   - यह saved training checkpoints पर **प्रभाव नहीं** डालता — केवल pre‑trained base model cache पर लागू होता है।
 
+### `--text_embed_full_cache`
+
+- **What**: text embed cache में पूरा raw text encoder output store करता है।
+- **Default**: `False`
+- **Why**: default setting model-specific compact cache layouts को allow करती है। उदाहरण के लिए, Ideogram 4 cache files लिखने से पहले अपने 13-layer Qwen hidden-state stack को transformer की frozen `llm_cond_norm` और `llm_cond_proj` layers से project करता है; ये layers LoRA और full transformer training दोनों में frozen रहती हैं।
+- **When to use**: cache compatibility debugging के लिए, जब आपको raw unprojected text encoder features चाहिए हों, या जब आप Ideogram-style architecture को scratch training के लिए adapt कर रहे हों और text projection fixed pretrained component न हो।
+
 ### `--trust_remote_code`
 
 - **What**: जब checkpoint upstream custom classes पर निर्भर हो, तब Transformers और tokenizer को model repository से custom Python code चलाने की अनुमति देता है।
@@ -2234,6 +2241,11 @@ options:
   --cache_dir_text CACHE_DIR_TEXT
                         This is the path to a local directory that will
                         contain your text embed cache
+  --text_embed_full_cache [TEXT_EMBED_FULL_CACHE]
+                        Store full raw text encoder outputs in the text embed
+                        cache. This opts out of model-specific cache size
+                        optimisations, such as Ideogram 4's frozen text
+                        projection cache.
   --cache_dir_vae CACHE_DIR_VAE
                         This is the path to a local directory that will
                         contain your VAE outputs

--- a/documentation/OPTIONS.ja.md
+++ b/documentation/OPTIONS.ja.md
@@ -80,6 +80,13 @@ simpletuner configure config/foo/config.json
   - マルチノード構成では、各ノードの local-rank 0 のみが削除を実行します。共有ストレージでの競合を避けるため、削除失敗は無視されます。
   - 学習チェックポイントには影響せず、事前学習済みベースモデルのキャッシュのみが対象です。
 
+### `--text_embed_full_cache`
+
+- **内容**: text embed cache に text encoder の完全な raw 出力を保存します。
+- **既定値**: `False`
+- **理由**: 既定ではモデル固有の compact cache layout を使えます。たとえば Ideogram 4 は、cache file に書き込む前に 13 層の Qwen hidden-state stack を transformer の凍結された `llm_cond_norm` と `llm_cond_proj` で投影します。これらの layer は LoRA と full transformer training の両方で凍結されます。
+- **使用タイミング**: cache 互換性のデバッグ、raw で未投影の text encoder features が必要な場合、または text projection が固定済み pretrained component ではない Ideogram 風 architecture を scratch training に適用する場合に有効化します。
+
 ### `--trust_remote_code`
 
 - **内容**: チェックポイントが upstream の独自クラスに依存している場合に、Transformers と tokenizer がモデルリポジトリ内のカスタム Python コードを実行できるようにします。
@@ -2237,6 +2244,11 @@ options:
   --cache_dir_text CACHE_DIR_TEXT
                         This is the path to a local directory that will
                         contain your text embed cache
+  --text_embed_full_cache [TEXT_EMBED_FULL_CACHE]
+                        Store full raw text encoder outputs in the text embed
+                        cache. This opts out of model-specific cache size
+                        optimisations, such as Ideogram 4's frozen text
+                        projection cache.
   --cache_dir_vae CACHE_DIR_VAE
                         This is the path to a local directory that will
                         contain your VAE outputs

--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -80,6 +80,13 @@ Where `foo` is your config environment - or just use `config/config.json` if you
   - On multi-node setups, only local-rank 0 on each node performs the deletion. Deletion failures are silently ignored to handle race conditions on shared network storage.
   - This does **not** affect saved training checkpoints — only the pre-trained base model cache.
 
+### `--text_embed_full_cache`
+
+- **What**: Stores the full raw text encoder output in the text embed cache.
+- **Default**: `False`
+- **Why**: The default allows model-specific compact cache layouts. For example, Ideogram 4 projects its 13-layer Qwen hidden-state stack through the transformer's frozen `llm_cond_norm` and `llm_cond_proj` layers before writing cache files; those layers stay frozen for both LoRA and full transformer training.
+- **When to use**: Enable this for cache compatibility debugging, when you intentionally need raw unprojected text encoder features, or when adapting an Ideogram-style architecture for scratch training where the text projection is not a fixed pretrained component.
+
 ### `--trust_remote_code`
 
 - **What**: Allows Transformers and tokenizers to execute custom Python code from the model repository when a checkpoint depends on upstream custom classes.
@@ -2241,6 +2248,11 @@ options:
   --cache_dir_text CACHE_DIR_TEXT
                         This is the path to a local directory that will
                         contain your text embed cache
+  --text_embed_full_cache [TEXT_EMBED_FULL_CACHE]
+                        Store full raw text encoder outputs in the text embed
+                        cache. This opts out of model-specific cache size
+                        optimisations, such as Ideogram 4's frozen text
+                        projection cache.
   --cache_dir_vae CACHE_DIR_VAE
                         This is the path to a local directory that will
                         contain your VAE outputs

--- a/documentation/OPTIONS.pt-BR.md
+++ b/documentation/OPTIONS.pt-BR.md
@@ -80,6 +80,13 @@ Onde `foo` e seu ambiente de config — ou use `config/config.json` se nao estiv
   - Em setups multi-node, apenas local-rank 0 em cada node executa a delecao. Falhas sao ignoradas silenciosamente para lidar com race conditions em storage compartilhado.
   - Isso **nao** afeta checkpoints salvos — apenas o cache do modelo base pre-treinado.
 
+### `--text_embed_full_cache`
+
+- **O que**: Armazena a saída raw completa do text encoder no cache de text embeds.
+- **Padrão**: `False`
+- **Por que**: O padrão permite layouts de cache compactos específicos do modelo. Por exemplo, o Ideogram 4 projeta sua pilha Qwen de 13 camadas pelas camadas congeladas `llm_cond_norm` e `llm_cond_proj` do transformer antes de gravar os arquivos de cache; essas camadas ficam congeladas tanto em LoRA quanto em treinamento full do transformer.
+- **Quando usar**: Ative para depurar compatibilidade de cache, quando precisar explicitamente de features raw e não projetadas do text encoder, ou ao adaptar uma arquitetura estilo Ideogram para treinamento do zero em que a projeção de texto não seja um componente pretreinado fixo.
+
 ### `--trust_remote_code`
 
 - **O que**: Permite que Transformers e tokenizers executem codigo Python personalizado do repositorio do modelo quando o checkpoint depende de classes customizadas upstream.
@@ -2231,6 +2238,11 @@ options:
   --cache_dir_text CACHE_DIR_TEXT
                         This is the path to a local directory that will
                         contain your text embed cache
+  --text_embed_full_cache [TEXT_EMBED_FULL_CACHE]
+                        Store full raw text encoder outputs in the text embed
+                        cache. This opts out of model-specific cache size
+                        optimisations, such as Ideogram 4's frozen text
+                        projection cache.
   --cache_dir_vae CACHE_DIR_VAE
                         This is the path to a local directory that will
                         contain your VAE outputs

--- a/documentation/OPTIONS.zh.md
+++ b/documentation/OPTIONS.zh.md
@@ -80,6 +80,13 @@ simpletuner configure config/foo/config.json
   - 多节点环境下，仅每个节点的 local-rank 0 执行删除。为处理共享网络存储中的竞态，删除失败会被静默忽略。
   - 不影响训练检查点，仅影响预训练基础模型缓存。
 
+### `--text_embed_full_cache`
+
+- **内容**：在 text embed cache 中保存完整的 raw text encoder 输出。
+- **默认值**：`False`
+- **原因**：默认值允许按模型定制的紧凑 cache 布局。例如，Ideogram 4 会在写入 cache 文件前，通过 transformer 中冻结的 `llm_cond_norm` 和 `llm_cond_proj` 层投影 13 层 Qwen hidden-state 堆栈；这些层在 LoRA 和 full transformer 训练中都会保持冻结。
+- **何时使用**：用于调试缓存兼容性、确实需要 raw 未投影的 text encoder features，或在改造类似 Ideogram 的架构进行从零训练且 text projection 不是固定预训练组件时启用。
+
 ### `--trust_remote_code`
 
 - **内容**：当 checkpoint 依赖上游自定义类时，允许 Transformers 和 tokenizer 执行模型仓库中的自定义 Python 代码。
@@ -2239,6 +2246,11 @@ options:
   --cache_dir_text CACHE_DIR_TEXT
                         This is the path to a local directory that will
                         contain your text embed cache
+  --text_embed_full_cache [TEXT_EMBED_FULL_CACHE]
+                        Store full raw text encoder outputs in the text embed
+                        cache. This opts out of model-specific cache size
+                        optimisations, such as Ideogram 4's frozen text
+                        projection cache.
   --cache_dir_vae CACHE_DIR_VAE
                         This is the path to a local directory that will
                         contain your VAE outputs

--- a/documentation/quickstart/IDEOGRAM4.es.md
+++ b/documentation/quickstart/IDEOGRAM4.es.md
@@ -90,6 +90,26 @@ Para poca VRAM, usa NF4:
 }
 ```
 
+## Cache de text embeds
+
+La salida del text encoder de Ideogram 4 concatena 13 capas hidden-state de Qwen. Por defecto, SimpleTuner proyecta esas features raw con las capas congeladas `llm_cond_norm` y `llm_cond_proj` del transformer antes de escribir los archivos de cache de text embeds. Esto reduce mucho el tamaño del cache y conserva el tensor de conditioning que consume el transformer.
+
+Las capas de proyección están congeladas tanto en LoRA como en entrenamiento full del transformer. Para entrenamiento del text encoder, LoRA no estándar, o targets LoRA que incluyan explícitamente `llm_cond_norm` o `llm_cond_proj`, SimpleTuner mantiene la salida raw del text encoder en el cache.
+
+El coste grande del cache viene del ancho de las features, no de padding guardado. El precompute de text embeds escribe un archivo por prompt con la longitud real de tokens de ese prompt; el padding de batch ocurre después en memoria. El tensor raw de 13 capas tiene `13 * 4096 = 53,248` valores float32 por token, unos 0.203 MiB por token antes del overhead de serialización. Una caption de 512 tokens ocupa alrededor de 104 MiB en raw, mientras que el cache proyectado en bf16 ocupa unos 4.5 MiB.
+
+Si adaptas esta ruta para entrenar desde cero un modelo comparable estilo Ideogram y la proyección de texto no es un componente preentrenado fijo, desactiva el cache proyectado y planifica el almacenamiento mucho mayor de text embeds raw.
+
+Usa el cache completo solo si necesitas explícitamente las features raw del text encoder o estás depurando compatibilidad de cache:
+
+```json
+{
+  "text_embed_full_cache": true
+}
+```
+
+Esto desactiva la optimización de cache proyectado de Ideogram 4 y guarda la salida completa de 13 capas del text encoder.
+
 ## Validación
 
 La validación de Ideogram está desactivada hasta que la habilites:

--- a/documentation/quickstart/IDEOGRAM4.hi.md
+++ b/documentation/quickstart/IDEOGRAM4.hi.md
@@ -90,6 +90,26 @@ cp simpletuner/examples/multidatabackend-ideogram-dreambooth-1024px.json config/
 }
 ```
 
+## Text embed cache
+
+Ideogram 4 का text encoder output Qwen की 13 hidden-state layers को concatenate करता है। डिफ़ॉल्ट रूप से SimpleTuner cache files लिखने से पहले इन raw features को transformer की frozen `llm_cond_norm` और `llm_cond_proj` layers से project करता है। इससे cache files काफी छोटी रहती हैं और transformer द्वारा consume किया जाने वाला conditioning tensor preserved रहता है।
+
+ये projection layers LoRA और full transformer training दोनों में frozen रहती हैं। Text encoder training, non-standard LoRA, या ऐसे LoRA targets जिनमें explicitly `llm_cond_norm` या `llm_cond_proj` शामिल हो, उनमें SimpleTuner cache में raw text encoder output रखता है।
+
+Cache का बड़ा cost saved padding से नहीं, feature width से आता है। Text embed precompute हर prompt के actual token length पर एक file लिखता है; batch padding बाद में memory में होती है। Raw 13-layer tensor `13 * 4096 = 53,248` float32 values per token है, यानी serialization overhead से पहले लगभग 0.203 MiB per token। 512-token caption raw में करीब 104 MiB होती है, जबकि projected bf16 cache करीब 4.5 MiB होती है।
+
+अगर आप इस path को Ideogram-जैसे comparable model को scratch से train करने के लिए adapt कर रहे हैं और text projection fixed pretrained component नहीं है, तो projected cache disable करें और raw text embed storage के काफी बड़े cost की planning करें।
+
+Full cache सिर्फ तब use करें जब आपको raw text encoder features चाहिए हों या cache compatibility debug कर रहे हों:
+
+```json
+{
+  "text_embed_full_cache": true
+}
+```
+
+यह Ideogram 4 की projected text embed cache optimisation बंद करता है और text encoder की पूरी 13-layer output save करता है।
+
 ## Validation
 
 Ideogram validation opt-in है:

--- a/documentation/quickstart/IDEOGRAM4.ja.md
+++ b/documentation/quickstart/IDEOGRAM4.ja.md
@@ -90,6 +90,26 @@ FP8 が最初の推奨です:
 }
 ```
 
+## Text Embed Cache
+
+Ideogram 4 の text encoder 出力は、13 層の Qwen hidden-state を連結したものです。デフォルトでは、SimpleTuner は text embed cache ファイルへ書き込む前に、transformer の凍結された `llm_cond_norm` と `llm_cond_proj` で raw features を投影します。これにより cache file は大幅に小さくなり、transformer が実際に消費する conditioning tensor を保持できます。
+
+この projection layer は LoRA と full transformer training の両方で凍結されます。text encoder training、標準以外の LoRA、または `llm_cond_norm` / `llm_cond_proj` を明示的に含む LoRA target では、SimpleTuner は raw text encoder output を cache に保持します。
+
+cache の大きなコストは保存された padding ではなく feature 幅です。text embed precompute は prompt ごとの実際の token 長で 1 ファイルを書きます。batch padding は後でメモリ上だけで行われます。raw 13-layer tensor は `13 * 4096 = 53,248` 個の float32 値/token、serialization overhead 前で約 0.203 MiB/token です。512-token caption は raw で約 104 MiB、projected bf16 cache では約 4.5 MiB になります。
+
+この経路を使って Ideogram に似たモデルを scratch から学習し、text projection が固定済み pretrained component ではない場合は、projected cache を無効化し、raw text embed storage がかなり大きくなる前提で計画してください。
+
+raw text encoder features が必要な場合、または cache 互換性をデバッグする場合だけ full cache を使ってください:
+
+```json
+{
+  "text_embed_full_cache": true
+}
+```
+
+これは Ideogram 4 の projected text embed cache 最適化を無効化し、13 層すべての text encoder output を保存します。
+
 ## 検証
 
 Ideogram の検証は明示的に有効化するまで無効です:

--- a/documentation/quickstart/IDEOGRAM4.md
+++ b/documentation/quickstart/IDEOGRAM4.md
@@ -135,6 +135,26 @@ For lower VRAM systems, NF4 is the next recommendation:
 
 If startup is slow or memory-constrained, keep `quantize_via` on `cpu` so the model is prepared before moving to the GPU.
 
+### Text embed cache
+
+Ideogram 4's text encoder output is a concatenation of 13 Qwen hidden-state layers. By default, SimpleTuner projects those raw features through the transformer's frozen `llm_cond_norm` and `llm_cond_proj` layers before writing text embed cache files. This keeps cache files much smaller while preserving the conditioning tensor the transformer consumes.
+
+The projection layers are frozen for both LoRA and full transformer training. For text encoder training, non-standard LoRA, or LoRA targets that explicitly include `llm_cond_norm` or `llm_cond_proj`, SimpleTuner keeps the raw text encoder output in the cache.
+
+The large cache cost comes from feature width, not saved padding. Text embed precomputation writes one file per prompt at that prompt's actual token length; batch padding happens later in memory. The raw 13-layer tensor is `13 * 4096 = 53,248` float32 values per token, or about 0.203 MiB per token before serialization overhead. A 512-token caption is therefore about 104 MiB raw, while the projected bf16 cache is about 4.5 MiB.
+
+If you adapt this path to train a comparable Ideogram-style model from scratch and the text projection is not a fixed pretrained component, disable the projected cache and budget for the much larger raw text embed storage.
+
+Use the full cache only when you intentionally need raw text encoder features or are debugging cache compatibility:
+
+```json
+{
+  "text_embed_full_cache": true
+}
+```
+
+This disables the Ideogram 4 projected text embed cache optimisation and stores the full 13-layer text encoder output.
+
 ### Validation
 
 Ideogram validation is disabled unless you opt in:

--- a/documentation/quickstart/IDEOGRAM4.pt-BR.md
+++ b/documentation/quickstart/IDEOGRAM4.pt-BR.md
@@ -90,6 +90,26 @@ Para pouca VRAM, use NF4:
 }
 ```
 
+## Cache de text embeds
+
+A saída do text encoder do Ideogram 4 concatena 13 camadas hidden-state do Qwen. Por padrão, o SimpleTuner projeta essas features raw pelas camadas congeladas `llm_cond_norm` e `llm_cond_proj` do transformer antes de gravar os arquivos de cache de text embeds. Isso reduz bastante o tamanho do cache e preserva o tensor de conditioning consumido pelo transformer.
+
+As camadas de projeção ficam congeladas tanto em LoRA quanto em treinamento full do transformer. Para treinamento do text encoder, LoRA não padrão, ou targets LoRA que incluam explicitamente `llm_cond_norm` ou `llm_cond_proj`, o SimpleTuner mantém a saída raw do text encoder no cache.
+
+O maior custo do cache vem da largura das features, não de padding salvo. O precompute de text embeds grava um arquivo por prompt na quantidade real de tokens daquele prompt; o padding de batch acontece depois em memória. O tensor raw de 13 camadas tem `13 * 4096 = 53,248` valores float32 por token, cerca de 0.203 MiB por token antes do overhead de serialização. Uma caption de 512 tokens fica em torno de 104 MiB em raw, enquanto o cache projetado em bf16 fica em torno de 4.5 MiB.
+
+Se você adaptar este caminho para treinar do zero um modelo comparável no estilo Ideogram e a projeção de texto não for um componente pretreinado fixo, desative o cache projetado e planeje o armazenamento muito maior dos text embeds raw.
+
+Use o cache completo apenas quando precisar explicitamente das features raw do text encoder ou estiver depurando compatibilidade de cache:
+
+```json
+{
+  "text_embed_full_cache": true
+}
+```
+
+Isso desativa a otimização de cache projetado do Ideogram 4 e salva a saída completa de 13 camadas do text encoder.
+
 ## Validação
 
 A validação do Ideogram fica desativada até você optar por ela:

--- a/documentation/quickstart/IDEOGRAM4.zh.md
+++ b/documentation/quickstart/IDEOGRAM4.zh.md
@@ -90,6 +90,26 @@ FP8 是默认推荐：
 }
 ```
 
+## Text embed cache
+
+Ideogram 4 的 text encoder 输出会拼接 13 层 Qwen hidden-state。默认情况下，SimpleTuner 会在写入 text embed cache 文件前，先通过 transformer 中冻结的 `llm_cond_norm` 和 `llm_cond_proj` 层投影这些 raw features。这样 cache 文件会小得多，同时保留 transformer 实际消费的 conditioning tensor。
+
+这些 projection 层在 LoRA 和 full transformer 训练中都会被冻结。训练 text encoder、使用非标准 LoRA，或 LoRA target 显式包含 `llm_cond_norm` / `llm_cond_proj` 时，SimpleTuner 会在 cache 中保留 raw text encoder 输出。
+
+cache 的主要成本来自 feature 宽度，而不是保存了大量 padding。Text embed 预计算会按每个 prompt 的真实 token 长度写一个 cache 文件；batch padding 之后只在内存中发生。raw 13 层 tensor 是 `13 * 4096 = 53,248` 个 float32 值/每 token，序列化开销前约 0.203 MiB/token。因此 512-token caption 的 raw cache 约 104 MiB，而 projected bf16 cache 约 4.5 MiB。
+
+如果你基于这一路径从零训练一个类似 Ideogram 的模型，并且 text projection 不是固定的预训练组件，请关闭 projected cache，并为大得多的 raw text embed 存储做好预算。
+
+只有在确实需要 raw text encoder features，或调试 cache 兼容性时，才使用完整 cache：
+
+```json
+{
+  "text_embed_full_cache": true
+}
+```
+
+这会关闭 Ideogram 4 的 projected text embed cache 优化，并保存完整的 13 层 text encoder 输出。
+
 ## 验证
 
 Ideogram 验证默认关闭。要启用：

--- a/scripts/extract_ideogram_text_projection.py
+++ b/scripts/extract_ideogram_text_projection.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python
+"""Extract Ideogram 4 text projection weights into a standalone component."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import struct
+from pathlib import Path
+from posixpath import dirname as posix_dirname
+from posixpath import join as posix_join
+
+import requests
+from huggingface_hub import hf_hub_download, hf_hub_url
+from huggingface_hub.errors import EntryNotFoundError
+from huggingface_hub.utils import build_hf_headers
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+from simpletuner.helpers.models.ideogram.quantized_loading import FP8_SCALE_SUFFIX
+from simpletuner.helpers.models.ideogram.text_projection import TEXT_PROJECTION_KEY_PREFIXES, Ideogram4TextProjectionConfig
+
+
+def _resolve_index(source_repo: str, index_filename: str, revision: str | None) -> Path:
+    local_index = Path(source_repo) / index_filename
+    if local_index.is_file():
+        return local_index
+    return Path(hf_hub_download(repo_id=source_repo, filename=index_filename, revision=revision))
+
+
+def _resolve_file(source_repo: str, filename: str, revision: str | None) -> Path:
+    local_file = Path(source_repo) / filename
+    if local_file.is_file():
+        return local_file
+    return Path(hf_hub_download(repo_id=source_repo, filename=filename, revision=revision))
+
+
+def _resolve_shard(
+    source_repo: str,
+    index_path: Path,
+    index_filename: str,
+    shard_name: str,
+    revision: str | None,
+) -> Path:
+    local_source = Path(source_repo)
+    if local_source.exists():
+        local_shard = index_path.parent / shard_name
+        if local_shard.is_file():
+            return local_shard
+
+    shard_dir = posix_dirname(index_filename)
+    shard_repo_path = posix_join(shard_dir, shard_name) if shard_dir else shard_name
+    return Path(hf_hub_download(repo_id=source_repo, filename=shard_repo_path, revision=revision))
+
+
+def _load_projection_from_safetensors(weights_path: Path) -> dict:
+    state_dict = {}
+    with safe_open(weights_path, framework="pt", device="cpu") as handle:
+        selected_keys = [
+            key for key in handle.keys() if any(key.startswith(prefix) for prefix in TEXT_PROJECTION_KEY_PREFIXES)
+        ]
+        if not selected_keys:
+            raise ValueError(f"No Ideogram text projection keys were found in {weights_path}.")
+        for key in selected_keys:
+            state_dict[key] = handle.get_tensor(key)
+    return state_dict
+
+
+def _read_remote_range(url: str, headers: dict[str, str], start: int, end: int) -> bytes:
+    response_headers = {**headers, "Range": f"bytes={start}-{end}"}
+    with requests.get(
+        url,
+        headers=response_headers,
+        stream=True,
+        timeout=(10, 600),
+    ) as response:
+        if response.status_code != 206:
+            raise RuntimeError(f"Expected HTTP 206 for range {start}-{end} from {url}, got {response.status_code}.")
+        data = b"".join(response.iter_content(chunk_size=1024 * 1024))
+
+    expected_size = end - start + 1
+    if len(data) != expected_size:
+        raise RuntimeError(f"Expected {expected_size} bytes for range {start}-{end} from {url}, got {len(data)}.")
+    return data
+
+
+def _read_remote_safetensors_header(source_repo: str, filename: str, revision: str | None) -> tuple[dict, int]:
+    url = hf_hub_url(repo_id=source_repo, filename=filename, revision=revision)
+    headers = build_hf_headers(token=None)
+    header_size_bytes = _read_remote_range(url, headers, 0, 7)
+    header_size = struct.unpack("<Q", header_size_bytes)[0]
+    header_bytes = _read_remote_range(url, headers, 8, 8 + header_size - 1)
+    header = json.loads(header_bytes.decode("utf-8"))
+    return header, header_size
+
+
+def _read_remote_safetensors_tensors(
+    source_repo: str,
+    filename: str,
+    selected_keys: list[str] | None,
+    revision: str | None,
+) -> list[tuple[str, dict, bytes]]:
+    url = hf_hub_url(repo_id=source_repo, filename=filename, revision=revision)
+    headers = build_hf_headers(token=None)
+    header, header_size = _read_remote_safetensors_header(source_repo, filename, revision)
+    if selected_keys is None:
+        selected_keys = [key for key in header if any(key.startswith(prefix) for prefix in TEXT_PROJECTION_KEY_PREFIXES)]
+    missing = [key for key in selected_keys if key not in header]
+    if missing:
+        raise KeyError(f"Expected keys missing from {filename}: {missing[:10]}")
+    if not selected_keys:
+        raise ValueError(f"No Ideogram text projection keys were found in {filename}.")
+
+    data_start = 8 + header_size
+    tensors = []
+    for key in selected_keys:
+        tensor_info = header[key]
+        start, end = tensor_info["data_offsets"]
+        tensor_bytes = _read_remote_range(url, headers, data_start + start, data_start + end - 1)
+        tensors.append((key, tensor_info, tensor_bytes))
+    return tensors
+
+
+def _write_safetensors_subset(output_path: Path, tensors: list[tuple[str, dict, bytes]]) -> list[str]:
+    header = {}
+    data_blocks = []
+    offset = 0
+    for key, tensor_info, tensor_bytes in tensors:
+        end = offset + len(tensor_bytes)
+        header[key] = {
+            "dtype": tensor_info["dtype"],
+            "shape": tensor_info["shape"],
+            "data_offsets": [offset, end],
+        }
+        data_blocks.append(tensor_bytes)
+        offset = end
+
+    header_bytes = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    with open(output_path, "wb") as handle:
+        handle.write(struct.pack("<Q", len(header_bytes)))
+        handle.write(header_bytes)
+        for data_block in data_blocks:
+            handle.write(data_block)
+    return list(header)
+
+
+def _load_projection_state_dict(
+    source_repo: str,
+    index_filename: str,
+    weights_filename: str,
+    revision: str | None,
+) -> dict:
+    try:
+        index_path = _resolve_index(source_repo, index_filename, revision)
+    except EntryNotFoundError:
+        weights_path = _resolve_file(source_repo, weights_filename, revision)
+        return _load_projection_from_safetensors(weights_path)
+
+    with open(index_path, "r", encoding="utf-8") as handle:
+        index = json.load(handle)
+
+    weight_map = index.get("weight_map")
+    if not isinstance(weight_map, dict):
+        raise ValueError(f"Index file {index_path} does not contain a weight_map object.")
+
+    selected_keys = [key for key in weight_map if any(key.startswith(prefix) for prefix in TEXT_PROJECTION_KEY_PREFIXES)]
+    if not selected_keys:
+        raise ValueError(f"No Ideogram text projection keys were found in {index_path}.")
+
+    state_dict = {}
+    keys_by_shard: dict[str, list[str]] = {}
+    for key in selected_keys:
+        keys_by_shard.setdefault(weight_map[key], []).append(key)
+
+    for shard_name, keys in keys_by_shard.items():
+        shard_path = _resolve_shard(source_repo, index_path, index_filename, shard_name, revision)
+        with safe_open(shard_path, framework="pt", device="cpu") as handle:
+            present = set(handle.keys())
+            for key in keys:
+                if key not in present:
+                    raise KeyError(f"Expected key {key} in shard {shard_path}.")
+                state_dict[key] = handle.get_tensor(key)
+    return state_dict
+
+
+def _extract_remote_projection_state_dict(
+    source_repo: str,
+    index_filename: str,
+    weights_filename: str,
+    revision: str | None,
+    output_path: Path,
+) -> list[str]:
+    try:
+        index_path = _resolve_index(source_repo, index_filename, revision)
+    except EntryNotFoundError:
+        tensors = _read_remote_safetensors_tensors(source_repo, weights_filename, None, revision)
+        return _write_safetensors_subset(output_path, tensors)
+
+    with open(index_path, "r", encoding="utf-8") as handle:
+        index = json.load(handle)
+
+    weight_map = index.get("weight_map")
+    if not isinstance(weight_map, dict):
+        raise ValueError(f"Index file {index_path} does not contain a weight_map object.")
+
+    selected_keys = [key for key in weight_map if any(key.startswith(prefix) for prefix in TEXT_PROJECTION_KEY_PREFIXES)]
+    if not selected_keys:
+        raise ValueError(f"No Ideogram text projection keys were found in {index_path}.")
+
+    keys_by_shard: dict[str, list[str]] = {}
+    for key in selected_keys:
+        keys_by_shard.setdefault(weight_map[key], []).append(key)
+
+    shard_dir = posix_dirname(index_filename)
+    tensors = []
+    for shard_name, keys in keys_by_shard.items():
+        shard_repo_path = posix_join(shard_dir, shard_name) if shard_dir else shard_name
+        tensors.extend(_read_remote_safetensors_tensors(source_repo, shard_repo_path, keys, revision))
+    return _write_safetensors_subset(output_path, tensors)
+
+
+def _extract_projection_state_dict(
+    source_repo: str,
+    index_filename: str,
+    weights_filename: str,
+    revision: str | None,
+    output_path: Path,
+) -> list[str]:
+    if Path(source_repo).exists():
+        state_dict = _load_projection_state_dict(source_repo, index_filename, weights_filename, revision)
+        save_file(state_dict, output_path)
+        return list(state_dict)
+    return _extract_remote_projection_state_dict(
+        source_repo,
+        index_filename,
+        weights_filename,
+        revision,
+        output_path,
+    )
+
+
+def _detect_quantization_from_keys(keys: list[str]) -> str:
+    if any(".quant_state.bitsandbytes__" in key for key in keys):
+        return "nf4"
+    if any(key.endswith(FP8_SCALE_SUFFIX) for key in keys):
+        return "fp8"
+    return "none"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source_repo", help="Ideogram 4 model repo or local snapshot directory.")
+    parser.add_argument("output_dir", help="Directory where the component files will be written.")
+    parser.add_argument(
+        "--index_filename",
+        default="transformer/diffusion_pytorch_model.safetensors.index.json",
+        help="Transformer safetensors index path inside source_repo. Falls back to --weights_filename when missing.",
+    )
+    parser.add_argument(
+        "--weights_filename",
+        default="transformer/diffusion_pytorch_model.safetensors",
+        help="Single transformer safetensors path inside source_repo.",
+    )
+    parser.add_argument("--revision", default=None, help="Optional Hugging Face revision for source_repo.")
+    parser.add_argument("--source_revision", default=None, help="Revision value to record in component config.")
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    keys = _extract_projection_state_dict(
+        args.source_repo,
+        args.index_filename,
+        args.weights_filename,
+        args.revision,
+        output_dir / "model.safetensors",
+    )
+    quantization = _detect_quantization_from_keys(keys)
+    config = Ideogram4TextProjectionConfig(
+        source_repo=args.source_repo,
+        source_revision=args.source_revision or args.revision,
+        quantization=quantization,
+    )
+
+    with open(output_dir / "config.json", "w", encoding="utf-8") as handle:
+        json.dump(config.to_dict(), handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    with open(output_dir / "README.md", "w", encoding="utf-8") as handle:
+        handle.write(
+            "# Ideogram 4 Text Projection Component\n\n"
+            "This repository contains only `llm_cond_norm` and `llm_cond_proj` "
+            "from an Ideogram 4 transformer checkpoint. SimpleTuner uses it to "
+            "project Qwen hidden-state stacks before writing text embed cache files.\n"
+        )
+
+    print(f"Wrote {len(keys)} tensors to {output_dir} ({quantization}).")
+
+
+if __name__ == "__main__":
+    main()

--- a/simpletuner/helpers/models/ideogram/model.py
+++ b/simpletuner/helpers/models/ideogram/model.py
@@ -22,6 +22,7 @@ from simpletuner.helpers.models.ideogram.pipeline import (
 from simpletuner.helpers.models.ideogram.prompt_enhancer import Ideogram4PromptEnhancerHead
 from simpletuner.helpers.models.ideogram.prompting import maybe_convert_prompt_to_ideogram_json
 from simpletuner.helpers.models.ideogram.scheduler import get_schedule_for_resolution
+from simpletuner.helpers.models.ideogram.text_projection import Ideogram4TextProjection, Ideogram4TextProjectionConfig
 from simpletuner.helpers.models.registry import ModelRegistry
 
 logger = logging.getLogger(__name__)
@@ -50,6 +51,11 @@ class Ideogram4(ImageModelFoundation):
     SUPPORTS_LORA = True
     DEFAULT_LORA_TARGET = ["qkv", "o", "w1", "w2", "w3"]
     DEFAULT_PROMPT_ENHANCER_HEAD = "diffusers/qwen3-vl-8b-instruct-lm-head"
+    TEXT_PROJECTION_COMPONENTS = {
+        "fp8": "bghira/ideogram4-component-text-projection-fp8",
+        "nf4": "bghira/ideogram4-component-text-projection-nf4",
+    }
+    TEXT_PROJECTION_MODULE_NAMES = ("llm_cond_norm", "llm_cond_proj")
     PATCH_SIZE = 2
     AE_SCALE_FACTOR = 8
 
@@ -82,6 +88,7 @@ class Ideogram4(ImageModelFoundation):
         )
         if move_to_device:
             self.model.to(self.accelerator.device)
+        self.apply_model_specific_freeze()
         return self.model
 
     def load_vae(self, move_to_device: bool = True):
@@ -288,6 +295,140 @@ class Ideogram4(ImageModelFoundation):
 
     def _format_text_embedding(self, text_embedding: dict):
         return text_embedding
+
+    def _text_projection_transformer(self, transformer=None):
+        transformer = transformer if transformer is not None else getattr(self, "model", None)
+        if transformer is None:
+            return None
+        if (
+            getattr(self, "model", None) is not None
+            and hasattr(self, "accelerator")
+            and hasattr(self, "config")
+            and hasattr(self.config, "controlnet")
+        ):
+            return self.unwrap_model(model=transformer)
+        if hasattr(transformer, "module"):
+            return transformer.module
+        return transformer
+
+    def freeze_text_projection_layers(self, transformer=None) -> list[str]:
+        transformer = self._text_projection_transformer(transformer)
+        if transformer is None:
+            return []
+
+        frozen = []
+        for module_name in self.TEXT_PROJECTION_MODULE_NAMES:
+            module = getattr(transformer, module_name, None)
+            if module is None:
+                continue
+            module.requires_grad_(False)
+            module.eval()
+            frozen.append(module_name)
+        return frozen
+
+    def apply_model_specific_freeze(self):
+        self.freeze_text_projection_layers()
+
+    def freeze_components(self):
+        super().freeze_components()
+        self.apply_model_specific_freeze()
+
+    def add_lora_adapter(self):
+        result = super().add_lora_adapter()
+        self.apply_model_specific_freeze()
+        return result
+
+    def _text_projection_flavour(self) -> str:
+        flavour = getattr(self.config, "model_flavour", None)
+        if flavour not in (None, "", "None"):
+            flavour = str(flavour).lower()
+            if flavour in self.TEXT_PROJECTION_COMPONENTS:
+                return flavour
+        repo_id = self._repo_id()
+        for known_flavour, known_repo in self.HUGGINGFACE_PATHS.items():
+            if repo_id == known_repo:
+                return known_flavour
+        return self.DEFAULT_MODEL_FLAVOUR
+
+    def _text_projection_component_id(self) -> str:
+        override = getattr(self.config, "pretrained_text_projection_model_name_or_path", None) or getattr(
+            self.config, "ideogram_text_projection_component", None
+        )
+        if override not in (None, "", "None"):
+            return str(override)
+        flavour = self._text_projection_flavour()
+        return self.TEXT_PROJECTION_COMPONENTS[flavour]
+
+    def _should_project_text_cache(self) -> bool:
+        if getattr(self.config, "text_embed_full_cache", False):
+            return False
+        if getattr(self.config, "train_text_encoder", False):
+            return False
+        model_type = str(getattr(self.config, "model_type", "full")).lower()
+        if "lora" not in model_type:
+            return True
+        if str(getattr(self.config, "lora_type", "standard")).lower() != "standard":
+            return False
+        targets = self.get_lora_target_layers()
+        return not any("llm_cond_norm" in target or "llm_cond_proj" in target for target in targets)
+
+    def _get_text_projection_component(
+        self,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> Ideogram4TextProjection:
+        component_id = self._text_projection_component_id()
+        cache_key = (component_id, str(device), dtype)
+        if getattr(self, "_text_projection_component_cache_key", None) == cache_key:
+            return self._text_projection_component
+
+        logger.info("Loading Ideogram text projection component for text embed cache: %s", component_id)
+        self._text_projection_component = Ideogram4TextProjection.from_pretrained(
+            component_id,
+            device=device,
+            dtype=dtype,
+            revision=getattr(self.config, "revision", None),
+        )
+        self._text_projection_component_cache_key = cache_key
+        return self._text_projection_component
+
+    @torch.no_grad()
+    def pack_text_embeddings_for_cache(self, embeddings):
+        if not self._should_project_text_cache():
+            return embeddings
+        if not isinstance(embeddings, dict):
+            embeddings = self._format_text_embedding(embeddings)
+
+        prompt_embeds = embeddings.get("prompt_embeds")
+        if not torch.is_tensor(prompt_embeds):
+            return embeddings
+
+        default_projection_config = Ideogram4TextProjectionConfig()
+        if prompt_embeds.shape[-1] == default_projection_config.emb_dim:
+            return embeddings
+
+        attention_mask = embeddings.get("attention_mask")
+        if attention_mask is None:
+            attention_mask = embeddings.get("attention_masks")
+
+        projector = self._get_text_projection_component(
+            device=prompt_embeds.device,
+            dtype=getattr(self.config, "weight_dtype", torch.bfloat16),
+        )
+        if prompt_embeds.shape[-1] == projector.config.emb_dim:
+            return embeddings
+        if prompt_embeds.shape[-1] != projector.config.llm_features_dim:
+            raise ValueError(
+                "Ideogram text embed cache projection expected raw Qwen features with last dimension "
+                f"{projector.config.llm_features_dim} or projected features with last dimension "
+                f"{projector.config.emb_dim}, got {prompt_embeds.shape[-1]}."
+            )
+
+        projected = projector(prompt_embeds, attention_mask=attention_mask)
+        packed = dict(embeddings)
+        packed["prompt_embeds"] = projected
+        return packed
 
     def convert_text_embed_for_pipeline(self, text_embedding: dict) -> dict:
         prompt_embeds = text_embedding["prompt_embeds"]

--- a/simpletuner/helpers/models/ideogram/text_projection.py
+++ b/simpletuner/helpers/models/ideogram/text_projection.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+from huggingface_hub import hf_hub_download
+from safetensors.torch import load_file
+
+from simpletuner.helpers.models.ideogram.constants import QWEN3_VL_ACTIVATION_LAYERS
+from simpletuner.helpers.models.ideogram.quantized_loading import (
+    is_bnb4bit_state_dict,
+    is_fp8_state_dict,
+    load_bnb4bit_state_dict,
+    load_fp8_state_dict,
+    swap_linears_to_bnb4bit,
+    swap_linears_to_fp8,
+)
+from simpletuner.helpers.models.ideogram.transformer import Ideogram4RMSNorm
+
+TEXT_PROJECTION_KEY_PREFIXES = ("llm_cond_norm.", "llm_cond_proj.")
+DEFAULT_LLM_FEATURES_DIM = 4096 * len(QWEN3_VL_ACTIVATION_LAYERS)
+DEFAULT_EMB_DIM = 4608
+DEFAULT_NORM_EPS = 1e-6
+
+
+@dataclass
+class Ideogram4TextProjectionConfig:
+    llm_features_dim: int = DEFAULT_LLM_FEATURES_DIM
+    emb_dim: int = DEFAULT_EMB_DIM
+    norm_eps: float = DEFAULT_NORM_EPS
+    activation_layers: tuple[int, ...] = QWEN3_VL_ACTIVATION_LAYERS
+    source_repo: str | None = None
+    source_revision: str | None = None
+    quantization: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Ideogram4TextProjectionConfig":
+        activation_layers = data.get("activation_layers", QWEN3_VL_ACTIVATION_LAYERS)
+        return cls(
+            llm_features_dim=int(data.get("llm_features_dim", DEFAULT_LLM_FEATURES_DIM)),
+            emb_dim=int(data.get("emb_dim", DEFAULT_EMB_DIM)),
+            norm_eps=float(data.get("norm_eps", DEFAULT_NORM_EPS)),
+            activation_layers=tuple(int(layer) for layer in activation_layers),
+            source_repo=data.get("source_repo"),
+            source_revision=data.get("source_revision"),
+            quantization=data.get("quantization"),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "llm_features_dim": self.llm_features_dim,
+            "emb_dim": self.emb_dim,
+            "norm_eps": self.norm_eps,
+            "activation_layers": list(self.activation_layers),
+            "source_repo": self.source_repo,
+            "source_revision": self.source_revision,
+            "quantization": self.quantization,
+        }
+
+
+class Ideogram4TextProjection(nn.Module):
+    """Ideogram text-conditioning projection used to shrink cached text embeds."""
+
+    def __init__(self, config: Ideogram4TextProjectionConfig | None = None) -> None:
+        super().__init__()
+        self.config = config or Ideogram4TextProjectionConfig()
+        self.llm_cond_norm = Ideogram4RMSNorm(self.config.llm_features_dim, eps=self.config.norm_eps)
+        self.llm_cond_proj = nn.Linear(self.config.llm_features_dim, self.config.emb_dim, bias=True)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        repo_id: str,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+        revision: str | None = None,
+    ) -> "Ideogram4TextProjection":
+        config_path = cls._resolve_component_file(repo_id, "config.json", revision=revision)
+        with open(config_path, "r", encoding="utf-8") as handle:
+            config = Ideogram4TextProjectionConfig.from_dict(json.load(handle))
+
+        model = cls(config)
+        state_dict = load_file(cls._resolve_component_file(repo_id, "model.safetensors", revision=revision))
+        model.load_component_state_dict(state_dict, device=device, dtype=dtype)
+        model.eval()
+        return model
+
+    @staticmethod
+    def _resolve_component_file(repo_id: str, filename: str, revision: str | None = None) -> str:
+        local_path = Path(repo_id) / filename
+        if local_path.is_file():
+            return str(local_path)
+        return hf_hub_download(repo_id=repo_id, filename=filename, revision=revision)
+
+    def load_component_state_dict(
+        self,
+        state_dict: dict[str, torch.Tensor],
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> None:
+        if is_fp8_state_dict(state_dict):
+            swap_linears_to_fp8(self, state_dict, compute_dtype=dtype)
+            load_fp8_state_dict(self, state_dict, device=device, dtype=dtype)
+        elif is_bnb4bit_state_dict(state_dict):
+            swap_linears_to_bnb4bit(self, compute_dtype=dtype)
+            load_bnb4bit_state_dict(self, state_dict, device=device, dtype=dtype)
+        else:
+            self.load_state_dict(state_dict)
+            self.to(device=device, dtype=dtype)
+
+    def forward(self, prompt_embeds: torch.Tensor, attention_mask: torch.Tensor | None = None) -> torch.Tensor:
+        param_dtype = getattr(self.llm_cond_proj, "compute_dtype", None) or self.llm_cond_proj.weight.dtype
+        prompt_embeds = prompt_embeds.to(device=self.device, dtype=param_dtype)
+        if attention_mask is not None:
+            attention_mask = attention_mask.to(device=prompt_embeds.device, dtype=torch.bool)
+            prompt_embeds = prompt_embeds * attention_mask.to(prompt_embeds.dtype).unsqueeze(-1)
+        projected = self.llm_cond_proj(self.llm_cond_norm(prompt_embeds))
+        if attention_mask is not None:
+            projected = projected * attention_mask.to(projected.dtype).unsqueeze(-1)
+        return projected
+
+    @property
+    def device(self) -> torch.device:
+        try:
+            return next(self.parameters()).device
+        except StopIteration:
+            return next(self.buffers()).device

--- a/simpletuner/helpers/models/ideogram/transformer.py
+++ b/simpletuner/helpers/models/ideogram/transformer.py
@@ -370,7 +370,9 @@ class Ideogram4Transformer(nn.Module, PeftAdapterMixin):
         """Velocity prediction.
 
         Args:
-          llm_features: (B, L, llm_features_dim) Qwen3-VL conditioning features.
+          llm_features: (B, L, llm_features_dim) Qwen3-VL conditioning features,
+            or (B, L, emb_dim) features already passed through llm_cond_norm
+            and llm_cond_proj.
           x: (B, L, in_channels) noise tokens.
           t: (B,) or (B, L) flow-matching time in [0, 1].
           r_timestep: optional AnyFlow/FlowMap interval endpoint in the same
@@ -397,6 +399,15 @@ class Ideogram4Transformer(nn.Module, PeftAdapterMixin):
         llm_token_mask = (indicator == LLM_TOKEN_INDICATOR).to(x.dtype).unsqueeze(-1)
         output_image_mask = (indicator == OUTPUT_IMAGE_INDICATOR).to(x.dtype).unsqueeze(-1)
 
+        llm_features_dim = llm_features.shape[-1]
+        llm_features_projected = llm_features_dim == self.config.emb_dim
+        if not llm_features_projected and llm_features_dim != self.config.llm_features_dim:
+            raise ValueError(
+                "Ideogram llm_features last dimension must be either "
+                f"{self.config.llm_features_dim} (raw Qwen features) or "
+                f"{self.config.emb_dim} (projected features), got {llm_features_dim}."
+            )
+
         llm_features = llm_features * llm_token_mask
         x = x * output_image_mask
 
@@ -422,8 +433,11 @@ class Ideogram4Transformer(nn.Module, PeftAdapterMixin):
             t_cond = t_cond.unsqueeze(1)
         adaln_input = F.silu(self.adaln_proj(t_cond))
 
-        llm_features = self.llm_cond_norm(llm_features)
-        llm_features = self.llm_cond_proj(llm_features) * llm_token_mask
+        if llm_features_projected:
+            llm_features = llm_features * llm_token_mask
+        else:
+            llm_features = self.llm_cond_norm(llm_features)
+            llm_features = self.llm_cond_proj(llm_features) * llm_token_mask
 
         h = x + llm_features
 

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -2950,6 +2950,9 @@ class Trainer:
             if self.model.get_trained_component() is not None:
                 logger.info(f"Applying BitFit freezing strategy to the {self.model.MODEL_TYPE.value}.")
                 self.model.model = apply_bitfit_freezing(unwrap_model(self.accelerator, self.model.model), self.config)
+        model_specific_freeze = getattr(self.model, "apply_model_specific_freeze", None)
+        if callable(model_specific_freeze):
+            model_specific_freeze()
         self.enable_gradient_checkpointing()
 
     def _resolve_distiller_profile(self) -> DistillerRequirementProfile:

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/advanced.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/advanced.py
@@ -1430,6 +1430,25 @@ def register_advanced_fields(registry: "FieldRegistry") -> None:
         )
     )
 
+    # Text Embed Full Cache
+    registry._add_field(
+        ConfigField(
+            name="text_embed_full_cache",
+            arg_name="--text_embed_full_cache",
+            ui_label="Text Embed Full Cache",
+            field_type=FieldType.CHECKBOX,
+            tab="basic",
+            section="caching",
+            subsection="advanced",
+            default_value=False,
+            help_text="Store full raw text encoder outputs in the text embed cache. This opts out of model-specific cache size optimisations, such as Ideogram 4's frozen text projection cache.",
+            tooltip="Use this only when you need raw, unprojected text encoder features, are debugging cache compatibility, or are adapting a comparable architecture for scratch training.",
+            importance=ImportanceLevel.ADVANCED,
+            order=50.5,
+            documentation="OPTIONS.md#--text_embed_full_cache",
+        )
+    )
+
     # Cache Directory VAE
     registry._add_field(
         ConfigField(

--- a/tests/test_ideogram4_prompting.py
+++ b/tests/test_ideogram4_prompting.py
@@ -7,12 +7,14 @@ from unittest import mock
 
 import torch
 import torch.nn as nn
-from safetensors.torch import load_file
+from safetensors.torch import load_file, save_file
 
+from simpletuner.helpers.models.ideogram.constants import LLM_TOKEN_INDICATOR, OUTPUT_IMAGE_INDICATOR
 from simpletuner.helpers.models.ideogram.model import Ideogram4
 from simpletuner.helpers.models.ideogram.pipeline import Ideogram4Pipeline
 from simpletuner.helpers.models.ideogram.prompting import maybe_convert_prompt_to_ideogram_json
 from simpletuner.helpers.models.ideogram.scheduler import get_schedule_for_resolution
+from simpletuner.helpers.models.ideogram.text_projection import Ideogram4TextProjection, Ideogram4TextProjectionConfig
 from simpletuner.helpers.models.ideogram.transformer import Ideogram4Config, Ideogram4Transformer
 from simpletuner.helpers.training.validation import prepare_validation_prompt_list
 
@@ -89,6 +91,147 @@ class Ideogram4PromptingTests(unittest.TestCase):
         negative = model.convert_negative_text_embed_for_pipeline(first)
         self.assertEqual(converted["prompt_embeds"].shape, (1, 2, 4))
         self.assertEqual(negative["negative_prompt_embeds"].shape, (1, 2, 4))
+
+    def test_text_embed_cache_projection_uses_projection_component(self):
+        model = Ideogram4.__new__(Ideogram4)
+        model.config = types.SimpleNamespace(
+            text_embed_full_cache=False,
+            model_type="lora",
+            lora_type="standard",
+            train_text_encoder=False,
+            weight_dtype=torch.float32,
+        )
+        model.get_lora_target_layers = lambda: ["qkv"]
+
+        projector = Ideogram4TextProjection(Ideogram4TextProjectionConfig(llm_features_dim=4, emb_dim=2))
+        with torch.no_grad():
+            projector.llm_cond_norm.weight.fill_(1.0)
+            projector.llm_cond_proj.weight.copy_(torch.tensor([[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]]))
+            projector.llm_cond_proj.bias.zero_()
+        model._get_text_projection_component = lambda **_: projector
+
+        prompt_embeds = torch.randn(1, 3, 4)
+        attention_mask = torch.tensor([[True, True, False]])
+        packed = model.pack_text_embeddings_for_cache({"prompt_embeds": prompt_embeds, "attention_mask": attention_mask})
+
+        expected = projector(prompt_embeds, attention_mask=attention_mask)
+        self.assertEqual(packed["prompt_embeds"].shape, (1, 3, 2))
+        self.assertTrue(torch.allclose(packed["prompt_embeds"], expected))
+        self.assertTrue(torch.equal(packed["attention_mask"], attention_mask))
+
+    def test_text_embed_cache_projection_applies_to_full_training(self):
+        model = Ideogram4.__new__(Ideogram4)
+        model.config = types.SimpleNamespace(
+            text_embed_full_cache=False,
+            model_type="full",
+            train_text_encoder=False,
+            weight_dtype=torch.float32,
+        )
+        model.get_lora_target_layers = lambda: (_ for _ in ()).throw(AssertionError("should not inspect LoRA targets"))
+
+        projector = Ideogram4TextProjection(Ideogram4TextProjectionConfig(llm_features_dim=4, emb_dim=2))
+        model._get_text_projection_component = lambda **_: projector
+
+        packed = model.pack_text_embeddings_for_cache(
+            {"prompt_embeds": torch.randn(1, 3, 4), "attention_mask": torch.ones(1, 3, dtype=torch.bool)}
+        )
+
+        self.assertEqual(packed["prompt_embeds"].shape, (1, 3, 2))
+
+    def test_text_projection_component_loads_local_layout(self):
+        projector = Ideogram4TextProjection(Ideogram4TextProjectionConfig(llm_features_dim=4, emb_dim=2))
+        with torch.no_grad():
+            projector.llm_cond_norm.weight.fill_(1.0)
+            projector.llm_cond_proj.weight.copy_(torch.tensor([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]))
+            projector.llm_cond_proj.bias.zero_()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            save_file(projector.state_dict(), os.path.join(tmp_dir, "model.safetensors"))
+            with open(os.path.join(tmp_dir, "config.json"), "w", encoding="utf-8") as handle:
+                json.dump(projector.config.to_dict(), handle)
+            loaded = Ideogram4TextProjection.from_pretrained(
+                tmp_dir,
+                device=torch.device("cpu"),
+                dtype=torch.float32,
+            )
+
+        prompt_embeds = torch.randn(1, 3, 4)
+        attention_mask = torch.tensor([[True, False, True]])
+        expected = projector(prompt_embeds, attention_mask=attention_mask)
+        self.assertTrue(torch.allclose(loaded(prompt_embeds, attention_mask=attention_mask), expected))
+        self.assertEqual(loaded.config.llm_features_dim, 4)
+        self.assertEqual(loaded.config.emb_dim, 2)
+
+    def test_text_embed_full_cache_skips_ideogram_projection(self):
+        model = Ideogram4.__new__(Ideogram4)
+        model.config = types.SimpleNamespace(
+            text_embed_full_cache=True,
+            model_type="lora",
+            lora_type="standard",
+            train_text_encoder=False,
+            weight_dtype=torch.float32,
+        )
+        model.get_lora_target_layers = lambda: ["qkv"]
+        model._get_text_projection_component = lambda **_: (_ for _ in ()).throw(AssertionError("should not load"))
+
+        embeddings = {"prompt_embeds": torch.randn(1, 3, 4), "attention_mask": torch.ones(1, 3, dtype=torch.bool)}
+        self.assertIs(model.pack_text_embeddings_for_cache(embeddings), embeddings)
+
+    def test_text_projection_component_follows_explicit_known_repo(self):
+        model = Ideogram4.__new__(Ideogram4)
+        model.config = types.SimpleNamespace(
+            model_flavour=None,
+            pretrained_model_name_or_path=Ideogram4.HUGGINGFACE_PATHS["nf4"],
+            pretrained_transformer_model_name_or_path=None,
+        )
+
+        self.assertEqual(model._text_projection_component_id(), Ideogram4.TEXT_PROJECTION_COMPONENTS["nf4"])
+
+    def test_full_training_freezes_text_projection_layers(self):
+        model = Ideogram4.__new__(Ideogram4)
+        model.config = types.SimpleNamespace(controlnet=False, model_type="full")
+        model.vae = None
+        model.text_encoders = None
+        model.controlnet = None
+        model.model = Ideogram4Transformer(
+            Ideogram4Config(
+                emb_dim=16,
+                num_layers=1,
+                num_heads=1,
+                intermediate_size=32,
+                adanln_dim=8,
+                llm_features_dim=4,
+                mrope_section=(1, 1, 1),
+            )
+        )
+
+        model.freeze_components()
+
+        self.assertFalse(any(param.requires_grad for param in model.model.llm_cond_norm.parameters()))
+        self.assertFalse(any(param.requires_grad for param in model.model.llm_cond_proj.parameters()))
+        self.assertTrue(model.model.input_proj.weight.requires_grad)
+
+    def test_model_specific_freeze_reapplies_text_projection_freeze(self):
+        model = Ideogram4.__new__(Ideogram4)
+        model.config = types.SimpleNamespace(controlnet=False)
+        model.model = Ideogram4Transformer(
+            Ideogram4Config(
+                emb_dim=16,
+                num_layers=1,
+                num_heads=1,
+                intermediate_size=32,
+                adanln_dim=8,
+                llm_features_dim=4,
+                mrope_section=(1, 1, 1),
+            )
+        )
+        model.model.llm_cond_norm.requires_grad_(True)
+        model.model.llm_cond_proj.requires_grad_(True)
+
+        model.apply_model_specific_freeze()
+
+        self.assertFalse(any(param.requires_grad for param in model.model.llm_cond_norm.parameters()))
+        self.assertFalse(any(param.requires_grad for param in model.model.llm_cond_proj.parameters()))
 
     def test_pipeline_cfg_fallback_uses_negative_prompt_with_conditional_transformer(self):
         class DummyTransformer:
@@ -423,6 +566,42 @@ class Ideogram4PromptingTests(unittest.TestCase):
 
         self.assertEqual(out.shape, (1, 6, 128))
         self.assertIsNotNone(x.grad)
+
+    def test_transformer_accepts_preprojected_text_features(self):
+        torch.manual_seed(789)
+        model = Ideogram4Transformer(
+            Ideogram4Config(
+                emb_dim=16,
+                num_layers=1,
+                num_heads=1,
+                intermediate_size=32,
+                adanln_dim=8,
+                llm_features_dim=4,
+                mrope_section=(1, 1, 1),
+            )
+        )
+        model.eval()
+
+        indicator = torch.tensor(
+            [[LLM_TOKEN_INDICATOR, LLM_TOKEN_INDICATOR, OUTPUT_IMAGE_INDICATOR, OUTPUT_IMAGE_INDICATOR]],
+            dtype=torch.long,
+        )
+        raw_features = torch.randn(1, 4, 4)
+        raw_features[:, 2:] = 0
+        llm_mask = (indicator == LLM_TOKEN_INDICATOR).to(raw_features.dtype).unsqueeze(-1)
+        with torch.no_grad():
+            projected_features = model.llm_cond_proj(model.llm_cond_norm(raw_features * llm_mask)) * llm_mask
+            common = {
+                "x": torch.randn(1, 4, 128),
+                "t": torch.tensor([0.25], dtype=torch.float32),
+                "position_ids": torch.zeros(1, 4, 3, dtype=torch.long),
+                "segment_ids": torch.ones(1, 4, dtype=torch.long),
+                "indicator": indicator,
+            }
+            raw_out = model(llm_features=raw_features, **common)
+            projected_out = model(llm_features=projected_features, **common)
+
+        self.assertTrue(torch.allclose(raw_out, projected_out, atol=1e-6))
 
     def test_transformer_flowmap_requires_enable_for_r_timestep(self):
         model = Ideogram4Transformer(


### PR DESCRIPTION
This pull request adds comprehensive documentation for the new `--text_embed_full_cache` option across all supported languages and enhances the quickstart guides with detailed explanations of text embed cache behavior in Ideogram 4. The changes clarify when and why to use full raw text encoder outputs versus the default projected cache, and provide practical guidance on storage implications and configuration.

**Documentation for the new `--text_embed_full_cache` option:**

* Added detailed descriptions for the `--text_embed_full_cache` CLI/config option in English, Spanish, Hindi, Japanese, Portuguese (Brazil), and Chinese documentation files, explaining its purpose, default behavior, and recommended use cases. [[1]](diffhunk://#diff-45e063db3ebcffb55dde68f083e92399a74f4cefbb464e8cd36911971c50933fR83-R89) [[2]](diffhunk://#diff-3f0cd39e3a7f176d81408ae40dc4f8c6271347f75b1cee5cf71c4e701d7db561R83-R89) [[3]](diffhunk://#diff-39b5789a705b2e70400106934436b619d10413ca5e37bd7a2b5fa7aa0c0fb8cfR83-R89) [[4]](diffhunk://#diff-fd629904ab3e1ecdd5b568c3ef6ac61e71e3d7741700e360820849938158a1d9R83-R89) [[5]](diffhunk://#diff-2c007ae9176f9f69b3ae16558be55b46d524f460a626f4e5c31e1e9a1d1b14b8R83-R89) [[6]](diffhunk://#diff-cddcc50c252e719be92644d65ea8542cc51d08f15e67d918bfae737904142b1fR83-R89)
* Updated the `options:` sections in all language variants to include the `--text_embed_full_cache` flag and its description. [[1]](diffhunk://#diff-45e063db3ebcffb55dde68f083e92399a74f4cefbb464e8cd36911971c50933fR2251-R2255) [[2]](diffhunk://#diff-3f0cd39e3a7f176d81408ae40dc4f8c6271347f75b1cee5cf71c4e701d7db561R2246-R2250) [[3]](diffhunk://#diff-39b5789a705b2e70400106934436b619d10413ca5e37bd7a2b5fa7aa0c0fb8cfR2244-R2248) [[4]](diffhunk://#diff-fd629904ab3e1ecdd5b568c3ef6ac61e71e3d7741700e360820849938158a1d9R2247-R2251) [[5]](diffhunk://#diff-2c007ae9176f9f69b3ae16558be55b46d524f460a626f4e5c31e1e9a1d1b14b8R2241-R2245) [[6]](diffhunk://#diff-cddcc50c252e719be92644d65ea8542cc51d08f15e67d918bfae737904142b1fR2249-R2253)

**Enhancements to quickstart guides:**

* Expanded the quickstart guides for Ideogram 4 in English, Spanish, Hindi, Japanese, and Portuguese (Brazil) to include a new section about text embed cache mechanics, the impact of raw vs. projected cache, memory/storage requirements, and when to enable full cache. Each guide now includes a configuration example for enabling the full cache. [[1]](diffhunk://#diff-0d18797b07701e94da0d44c62670cc4598f7d6e28dafc62c227cd6cc00209bb9R138-R157) [[2]](diffhunk://#diff-689b47a19fd059e937d0ef282f459ec7dcbadc61dac659d70f6743ce50a5c410R93-R112) [[3]](diffhunk://#diff-9ac1a840b36d3db848a6cd6c5d7e9008e2a0f41c0cf350e3e61ee1cac36fcbbeR93-R112) [[4]](diffhunk://#diff-058c62dc320320cabc2fbfad8d1acf7900c41312643ec650abe9face5fcc8207R93-R112) [[5]](diffhunk://#diff-4c661981e84c1f09d34f5b2996ed68a4cbf9ef5c5535c84e7d14cbf0e1907f7dR93-R112)

These updates ensure that users understand the trade-offs of the `--text_embed_full_cache` option and can make informed decisions about cache configuration, especially when adapting or debugging Ideogram-style models.