### PR TITLE
Fix single-file SD/SDXL export with flattened CLIPTextModel (transformers >=5.6)

### DIFF
--- a/scripts/format_conversion/convert_sd_checkpoint.py
+++ b/scripts/format_conversion/convert_sd_checkpoint.py
@@ -266,6 +266,17 @@ def convert_text_enc_state_dict(text_enc_dict):
     return text_enc_dict
 
 
+def restore_clip_text_model_prefix(text_enc_dict):
+    # transformers >=5.6 flattened CLIPTextModel: the `text_model.` submodule wrapper was
+    # removed, so on-disk keys are `embeddings.*` / `encoder.*` / `final_layer_norm.*`.
+    # The SD single-file format (and everything below) still expects the nested
+    # `text_model.` layout, so re-add the prefix when it's missing. Nested checkpoints
+    # (older transformers, or CLIPTextModelWithProjection) already have it and pass through.
+    if any(k.startswith("text_model.") for k in text_enc_dict):
+        return text_enc_dict
+    return {f"text_model.{k}": v for k, v in text_enc_dict.items()}
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
@@ -319,6 +330,10 @@ if __name__ == "__main__":
     else:
         text_enc_path = osp.join(args.model_path, "text_encoder", "pytorch_model.bin")
         text_enc_dict = torch.load(text_enc_path, map_location="cpu")
+
+    # transformers >=5.6 flattened CLIPTextModel; restore the `text_model.` prefix so the
+    # v2.0 probe and conversion tables below keep working on both old and new checkpoints.
+    text_enc_dict = restore_clip_text_model_prefix(text_enc_dict)
 
     # Convert the UNet model
     unet_state_dict = convert_unet_state_dict(unet_state_dict)

--- a/scripts/format_conversion/convert_sdxl_checkpoint.py
+++ b/scripts/format_conversion/convert_sdxl_checkpoint.py
@@ -270,12 +270,15 @@ def convert_openai_text_enc_state_dict(text_enc_dict):
 def restore_clip_text_model_prefix(text_enc_dict):
     # transformers >=5.6 flattened CLIPTextModel: the `text_model.` submodule wrapper was
     # removed, so on-disk keys are `embeddings.*` / `encoder.*` / `final_layer_norm.*`.
-    # The SDXL single-file format still expects the nested `text_model.` layout, so re-add
-    # the prefix when it's missing. text_encoder_2 (CLIPTextModelWithProjection) was NOT
-    # flattened and already carries `text_model.`, so it passes through unchanged.
+    # The SDXL single-file format still expects the nested `text_model.` layout.
     if any(k.startswith("text_model.") for k in text_enc_dict):
         return text_enc_dict
-    return {f"text_model.{k}": v for k, v in text_enc_dict.items()}
+
+    flat_prefixes = ("embeddings.", "encoder.", "final_layer_norm.")
+    if not any(k.startswith(flat_prefixes) for k in text_enc_dict):
+        return text_enc_dict
+
+    return {("text_model." + k if k.startswith(flat_prefixes) else k): v for k, v in text_enc_dict.items()}
 
 
 if __name__ == "__main__":

--- a/scripts/format_conversion/convert_sdxl_checkpoint.py
+++ b/scripts/format_conversion/convert_sdxl_checkpoint.py
@@ -267,6 +267,17 @@ def convert_openai_text_enc_state_dict(text_enc_dict):
     return text_enc_dict
 
 
+def restore_clip_text_model_prefix(text_enc_dict):
+    # transformers >=5.6 flattened CLIPTextModel: the `text_model.` submodule wrapper was
+    # removed, so on-disk keys are `embeddings.*` / `encoder.*` / `final_layer_norm.*`.
+    # The SDXL single-file format still expects the nested `text_model.` layout, so re-add
+    # the prefix when it's missing. text_encoder_2 (CLIPTextModelWithProjection) was NOT
+    # flattened and already carries `text_model.`, so it passes through unchanged.
+    if any(k.startswith("text_model.") for k in text_enc_dict):
+        return text_enc_dict
+    return {f"text_model.{k}": v for k, v in text_enc_dict.items()}
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
@@ -327,6 +338,12 @@ if __name__ == "__main__":
     else:
         text_enc_2_path = osp.join(args.model_path, "text_encoder_2", "pytorch_model.bin")
         text_enc_2_dict = torch.load(text_enc_2_path, map_location="cpu")
+
+    # transformers >=5.6 flattened CLIPTextModel; restore the `text_model.` prefix on the
+    # flat text_encoder (TE1). text_encoder_2 is CLIPTextModelWithProjection (still nested)
+    # and is returned unchanged by the guard.
+    text_enc_dict = restore_clip_text_model_prefix(text_enc_dict)
+    text_enc_2_dict = restore_clip_text_model_prefix(text_enc_2_dict)
 
     # Convert the UNet model
     unet_state_dict = convert_unet_state_dict(unet_state_dict)


### PR DESCRIPTION
transformers 5.6 (huggingface/transformers#44431) flattened `CLIPTextModel`, dropping the `text_model.` wrapper. The `convert_sd`/`convert_sdxl` export tables and the SD v2.0 probe still expect nested keys, so single-file export from a 5.6+ checkpoint produced broken files.

This restores the `text_model.` prefix on flat text-encoder state dicts right after load; nested checkpoints and `CLIPTextModelWithProjection` (not flattened) pass through unchanged. Affects only the export scripts, not the training path.

Verified: flat input restores to the exact pre-flatten layout, v2.0 detection works again, nested/WithProjection dicts untouched. Draft — AI-assisted, pending human validation.