### PR TITLE
diffusers: fix sigma bounds after initialising scheduler to prevent double-shift

### DIFF
--- a/simpletuner/helpers/models/ace_step/schedulers/scheduling_flow_match_euler_discrete.py
+++ b/simpletuner/helpers/models/ace_step/schedulers/scheduling_flow_match_euler_discrete.py
@@ -79,6 +79,8 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         timesteps = torch.from_numpy(timesteps).to(dtype=torch.float32)
 
         sigmas = timesteps / num_train_timesteps
+        sigma_min = sigmas[-1].item()
+        sigma_max = sigmas[0].item()
         if not use_dynamic_shifting:
             # when use_dynamic_shifting is True, we apply the timestep shifting on the fly based on the image resolution
             sigmas = shift * sigmas / (1 + (shift - 1) * sigmas)
@@ -89,8 +91,8 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         self._begin_index = None
 
         self.sigmas = sigmas.to("cpu")  # to avoid too much CPU/GPU communication
-        self.sigma_min = self.sigmas[-1].item()
-        self.sigma_max = self.sigmas[0].item()
+        self.sigma_min = sigma_min
+        self.sigma_max = sigma_max
 
     @property
     def step_index(self):

--- a/simpletuner/helpers/models/anima/scheduler.py
+++ b/simpletuner/helpers/models/anima/scheduler.py
@@ -12,6 +12,8 @@ from typing import Any
 from diffusers import FlowMatchEulerDiscreteScheduler
 from diffusers import SchedulerMixin as SchedulerMixin  # noqa: F401
 
+from simpletuner.helpers.training.flow_match import fix_flow_match_euler_schedule_bounds
+
 from .constants import FORGE_BETA_ALPHA, FORGE_BETA_BETA
 
 SUPPORTED_ANIMA_SAMPLERS = (
@@ -103,6 +105,7 @@ class AnimaFlowMatchEulerDiscreteScheduler(FlowMatchEulerDiscreteScheduler):
             time_shift_type=time_shift_type,
             stochastic_sampling=stochastic_sampling,
         )
+        fix_flow_match_euler_schedule_bounds(self)
         self.set_sampling_config(
             sampler=sampler,
             sigma_schedule=sigma_schedule,

--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -48,6 +48,7 @@ from simpletuner.helpers.training.custom_schedule import (
     segmented_timestep_selection,
 )
 from simpletuner.helpers.training.deepspeed import deepspeed_zero_init_disabled_context_manager, prepare_model_for_deepspeed
+from simpletuner.helpers.training.flow_match import fix_flow_match_euler_schedule_bounds
 from simpletuner.helpers.training.layersync import LayerSyncRegularizer
 from simpletuner.helpers.training.lora_format import (
     PEFTLoRAFormat,
@@ -3875,6 +3876,7 @@ class ModelFoundation(ABC):
                 subfolder="scheduler",
                 shift=self.config.flow_schedule_shift,
             )
+            fix_flow_match_euler_schedule_bounds(self.noise_schedule)
             flow_matching = True
         elif self.PREDICTION_TYPE in [
             PredictionTypes.EPSILON,

--- a/simpletuner/helpers/models/hunyuanvideo/model.py
+++ b/simpletuner/helpers/models/hunyuanvideo/model.py
@@ -35,6 +35,7 @@ from simpletuner.helpers.models.hunyuanvideo.pipeline_i2v import HunyuanVideo15I
 from simpletuner.helpers.models.hunyuanvideo.transformer import HunyuanVideo15Transformer3DModel
 from simpletuner.helpers.models.registry import ModelRegistry
 from simpletuner.helpers.musubi_block_swap import apply_musubi_pretrained_defaults
+from simpletuner.helpers.training.flow_match import fix_flow_match_euler_schedule_bounds
 from simpletuner.helpers.training.multi_process import should_log
 
 logger = logging.getLogger(__name__)
@@ -268,9 +269,11 @@ class HunyuanVideo(VideoModelFoundation):
         return self._is_i2v_like_flavour() or super().requires_validation_i2v_samples()
 
     def setup_training_noise_schedule(self):
-        self.noise_schedule = FlowMatchEulerDiscreteScheduler(
-            num_train_timesteps=1000,
-            shift=self.config.flow_schedule_shift,
+        self.noise_schedule = fix_flow_match_euler_schedule_bounds(
+            FlowMatchEulerDiscreteScheduler(
+                num_train_timesteps=1000,
+                shift=self.config.flow_schedule_shift,
+            )
         )
         return self.config, self.noise_schedule
 
@@ -463,7 +466,9 @@ class HunyuanVideo(VideoModelFoundation):
         flow_shift = getattr(self.config, "flow_schedule_shift", 7.0)
         guidance_scale = getattr(self.config, "validation_guidance", 6.0)
 
-        scheduler = FlowMatchEulerDiscreteScheduler(num_train_timesteps=1000, shift=flow_shift)
+        scheduler = fix_flow_match_euler_schedule_bounds(
+            FlowMatchEulerDiscreteScheduler(num_train_timesteps=1000, shift=flow_shift)
+        )
         guider = ClassifierFreeGuidance(guidance_scale=guidance_scale)
 
         transformer = self.unwrap_model(self.model) if load_base_model and self.model is not None else None

--- a/simpletuner/helpers/models/ideogram/model.py
+++ b/simpletuner/helpers/models/ideogram/model.py
@@ -24,6 +24,7 @@ from simpletuner.helpers.models.ideogram.prompting import maybe_convert_prompt_t
 from simpletuner.helpers.models.ideogram.scheduler import get_schedule_for_resolution
 from simpletuner.helpers.models.ideogram.text_projection import Ideogram4TextProjection, Ideogram4TextProjectionConfig
 from simpletuner.helpers.models.registry import ModelRegistry
+from simpletuner.helpers.training.flow_match import fix_flow_match_euler_schedule_bounds
 
 logger = logging.getLogger(__name__)
 
@@ -683,9 +684,11 @@ class Ideogram4(ImageModelFoundation):
     def setup_training_noise_schedule(self):
         from diffusers import FlowMatchEulerDiscreteScheduler
 
-        self.noise_schedule = FlowMatchEulerDiscreteScheduler(
-            num_train_timesteps=1000,
-            shift=getattr(self.config, "flow_schedule_shift", 1.0) or 1.0,
+        self.noise_schedule = fix_flow_match_euler_schedule_bounds(
+            FlowMatchEulerDiscreteScheduler(
+                num_train_timesteps=1000,
+                shift=getattr(self.config, "flow_schedule_shift", 1.0) or 1.0,
+            )
         )
         self.config.prediction_type = "flow_matching"
         return self.config, self.noise_schedule

--- a/simpletuner/helpers/models/longcat_video/model.py
+++ b/simpletuner/helpers/models/longcat_video/model.py
@@ -27,6 +27,7 @@ from simpletuner.helpers.models.longcat_video.pipeline import LongCatVideoPipeli
 from simpletuner.helpers.models.longcat_video.transformer import LongCatVideoTransformer3DModel
 from simpletuner.helpers.models.registry import ModelRegistry
 from simpletuner.helpers.musubi_block_swap import apply_musubi_pretrained_defaults
+from simpletuner.helpers.training.flow_match import fix_flow_match_euler_schedule_bounds
 from simpletuner.helpers.training.multi_process import should_log
 from simpletuner.helpers.utils.hidden_state_buffer import HiddenStateBuffer
 
@@ -375,9 +376,11 @@ class LongCatVideo(VideoModelFoundation):
         return TextEmbedCacheKey.CAPTION
 
     def setup_training_noise_schedule(self):
-        self.noise_schedule = FlowMatchEulerDiscreteScheduler(
-            num_train_timesteps=1000,
-            shift=self.config.flow_schedule_shift,
+        self.noise_schedule = fix_flow_match_euler_schedule_bounds(
+            FlowMatchEulerDiscreteScheduler(
+                num_train_timesteps=1000,
+                shift=self.config.flow_schedule_shift,
+            )
         )
         return self.config, self.noise_schedule
 

--- a/simpletuner/helpers/models/ltxvideo2/model.py
+++ b/simpletuner/helpers/models/ltxvideo2/model.py
@@ -36,6 +36,7 @@ from simpletuner.helpers.models.ltxvideo2.pipeline_ltx2_image2video import LTX2I
 from simpletuner.helpers.models.ltxvideo2.transformer import LTX2VideoTransformer3DModel
 from simpletuner.helpers.models.ltxvideo2.vocoder import LTX2Vocoder, LTX2VocoderWithBWE
 from simpletuner.helpers.musubi_block_swap import apply_musubi_pretrained_defaults
+from simpletuner.helpers.training.flow_match import fix_flow_match_euler_schedule_bounds
 from simpletuner.helpers.training.multi_process import _get_rank, should_log
 from simpletuner.helpers.training.state_tracker import StateTracker
 
@@ -454,15 +455,17 @@ class LTXVideo2(VideoModelFoundation):
             shift = 1.0
         flavour_value = str(getattr(self.config, "model_flavour", "") or "").strip().lower()
         is_distilled = "distilled" in flavour_value
-        return FlowMatchEulerDiscreteScheduler(
-            num_train_timesteps=1000,
-            shift=float(shift),
-            use_dynamic_shifting=not is_distilled,
-            base_shift=0.95,
-            max_shift=2.05,
-            base_image_seq_len=1024,
-            max_image_seq_len=4096,
-            shift_terminal=None if is_distilled else 0.1,
+        return fix_flow_match_euler_schedule_bounds(
+            FlowMatchEulerDiscreteScheduler(
+                num_train_timesteps=1000,
+                shift=float(shift),
+                use_dynamic_shifting=not is_distilled,
+                base_shift=0.95,
+                max_shift=2.05,
+                base_image_seq_len=1024,
+                max_image_seq_len=4096,
+                shift_terminal=None if is_distilled else 0.1,
+            )
         )
 
     def _load_audio_vae(self, move_to_device: bool = True):

--- a/simpletuner/helpers/models/sana/model.py
+++ b/simpletuner/helpers/models/sana/model.py
@@ -26,6 +26,7 @@ from simpletuner.helpers.models.common import (
 )
 from simpletuner.helpers.models.sana.pipeline import SanaImg2ImgPipeline
 from simpletuner.helpers.models.sana.transformer import SanaTransformer2DModel
+from simpletuner.helpers.training.flow_match import fix_flow_match_euler_schedule_bounds
 
 logger = logging.getLogger(__name__)
 from simpletuner.helpers.training.multi_process import should_log
@@ -291,6 +292,7 @@ class Sana(ImageModelFoundation):
             get_model_config_path(self.config.model_family, self.config.pretrained_model_name_or_path),
             subfolder="scheduler",
         )
+        fix_flow_match_euler_schedule_bounds(self.noise_schedule)
         # Lock Sana to the scheduler's built-in shift and distributions; ignore user overrides.
         self.config.flow_schedule_shift = None
         self.config.flow_schedule_auto_shift = False

--- a/simpletuner/helpers/models/sanavideo/model.py
+++ b/simpletuner/helpers/models/sanavideo/model.py
@@ -26,6 +26,7 @@ from simpletuner.helpers.models.common import (
 )
 from simpletuner.helpers.models.sanavideo.pipeline import SanaVideoPipeline
 from simpletuner.helpers.models.sanavideo.transformer import SanaVideoTransformer3DModel
+from simpletuner.helpers.training.flow_match import fix_flow_match_euler_schedule_bounds
 from simpletuner.helpers.training.multi_process import should_log
 
 logger = logging.getLogger(__name__)
@@ -472,6 +473,7 @@ class SanaVideo(VideoModelFoundation):
             get_model_config_path(self.config.model_family, self.config.pretrained_model_name_or_path),
             subfolder="scheduler",
         )
+        fix_flow_match_euler_schedule_bounds(self.noise_schedule)
         # Lock Sana to the scheduler's built-in shift and distributions; ignore user overrides.
         self.config.flow_schedule_shift = None
         self.config.flow_schedule_auto_shift = False

--- a/simpletuner/helpers/models/zlab_i1/model.py
+++ b/simpletuner/helpers/models/zlab_i1/model.py
@@ -26,6 +26,7 @@ from simpletuner.helpers.models.zlab_i1.latent_utils import (
 from simpletuner.helpers.models.registry import ModelRegistry
 from simpletuner.helpers.models.zlab_i1.pipeline import ZlabI1Pipeline
 from simpletuner.helpers.models.zlab_i1.transformer import ZlabI1Transformer2DModel
+from simpletuner.helpers.training.flow_match import fix_flow_match_euler_schedule_bounds
 
 logger = logging.getLogger(__name__)
 
@@ -357,6 +358,7 @@ class ZLabI1(ImageModelFoundation):
             subfolder="scheduler",
             shift=self.config.flow_schedule_shift,
         )
+        fix_flow_match_euler_schedule_bounds(self.noise_schedule)
         self.config.training_scheduler_timestep_spacing = self.noise_schedule.config.get("timestep_spacing")
         self.config.prediction_type = self.PREDICTION_TYPE.value
         self.config.rescale_betas_zero_snr = False

--- a/simpletuner/helpers/training/flow_match.py
+++ b/simpletuner/helpers/training/flow_match.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import TypeVar
+
+
+TScheduler = TypeVar("TScheduler")
+
+
+def fix_flow_match_euler_schedule_bounds(scheduler: TScheduler) -> TScheduler:
+    config = getattr(scheduler, "config", None)
+    if config is None or getattr(config, "use_dynamic_shifting", False):
+        return scheduler
+
+    num_train_timesteps = getattr(config, "num_train_timesteps", None)
+    if num_train_timesteps is None:
+        return scheduler
+
+    scheduler.sigma_max = float(getattr(config, "sigma_max", 1.0) or 1.0)
+    scheduler.sigma_min = 1.0 / float(num_train_timesteps)
+    return scheduler

--- a/tests/test_flow_match_scheduler_bounds.py
+++ b/tests/test_flow_match_scheduler_bounds.py
@@ -10,6 +10,15 @@ from simpletuner.helpers.training.flow_match import fix_flow_match_euler_schedul
 
 
 class TestFlowMatchSchedulerBounds(unittest.TestCase):
+    def test_000_diffusers_static_shift_still_has_duplicate_shift_regression(self):
+        scheduler = DiffusersFlowMatchEulerDiscreteScheduler(num_train_timesteps=10, shift=3.0)
+
+        initial_sigmas = scheduler.sigmas.clone()
+        scheduler.set_timesteps(num_inference_steps=10)
+
+        self.assertFalse(torch.allclose(scheduler.sigmas[:-1].cpu(), initial_sigmas, atol=1e-6))
+        self.assertGreater(scheduler.sigmas[-2].item(), initial_sigmas[-1].item())
+
     def test_diffusers_static_shift_bounds_are_unshifted_for_set_timesteps(self):
         scheduler = DiffusersFlowMatchEulerDiscreteScheduler(num_train_timesteps=10, shift=3.0)
         fix_flow_match_euler_schedule_bounds(scheduler)

--- a/tests/test_flow_match_scheduler_bounds.py
+++ b/tests/test_flow_match_scheduler_bounds.py
@@ -1,0 +1,36 @@
+import unittest
+
+import torch
+from diffusers import FlowMatchEulerDiscreteScheduler as DiffusersFlowMatchEulerDiscreteScheduler
+
+from simpletuner.helpers.models.ace_step.schedulers.scheduling_flow_match_euler_discrete import (
+    FlowMatchEulerDiscreteScheduler as ACEStepFlowMatchEulerDiscreteScheduler,
+)
+from simpletuner.helpers.training.flow_match import fix_flow_match_euler_schedule_bounds
+
+
+class TestFlowMatchSchedulerBounds(unittest.TestCase):
+    def test_diffusers_static_shift_bounds_are_unshifted_for_set_timesteps(self):
+        scheduler = DiffusersFlowMatchEulerDiscreteScheduler(num_train_timesteps=10, shift=3.0)
+        fix_flow_match_euler_schedule_bounds(scheduler)
+
+        initial_sigmas = scheduler.sigmas.clone()
+        scheduler.set_timesteps(num_inference_steps=10)
+
+        self.assertAlmostEqual(scheduler.sigma_min, 0.1, places=6)
+        self.assertAlmostEqual(scheduler.sigma_max, 1.0, places=6)
+        self.assertTrue(torch.allclose(scheduler.sigmas[:-1].cpu(), initial_sigmas, atol=1e-6))
+
+    def test_ace_step_static_shift_bounds_are_unshifted_for_set_timesteps(self):
+        scheduler = ACEStepFlowMatchEulerDiscreteScheduler(num_train_timesteps=10, shift=3.0)
+
+        initial_sigmas = scheduler.sigmas.clone()
+        scheduler.set_timesteps(num_inference_steps=10)
+
+        self.assertAlmostEqual(scheduler.sigma_min, 0.1, places=6)
+        self.assertAlmostEqual(scheduler.sigma_max, 1.0, places=6)
+        self.assertTrue(torch.allclose(scheduler.sigmas[:-1].cpu(), initial_sigmas, atol=1e-6))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces a new helper function, `fix_flow_match_euler_schedule_bounds`, to ensure consistent and correct `sigma_min` and `sigma_max` bounds for FlowMatch Euler schedulers across multiple model implementations. The function is applied throughout the codebase wherever these schedulers are instantiated or configured, improving reliability and consistency. Additionally, a new test is added to verify correct scheduler behavior.

**Key changes:**

Scheduler bounds consistency:

* Added the `fix_flow_match_euler_schedule_bounds` helper in `simpletuner/helpers/training/flow_match.py` to set `sigma_min` and `sigma_max` based on scheduler configuration, unless dynamic shifting is used.
* Updated all model classes that instantiate or configure a `FlowMatchEulerDiscreteScheduler` to use this helper, ensuring consistent scheduler bounds in `anima`, `common`, `hunyuanvideo`, `ideogram`, `longcat_video`, `ltxvideo2`, `sana`, `sanavideo`, and `zlab_i1` modules. [[1]](diffhunk://#diff-80521d688bbe3b6f02adddc3e9f8ba54647adfd6d282d26cf8c7cc9b1cf622f1R15-R16) [[2]](diffhunk://#diff-80521d688bbe3b6f02adddc3e9f8ba54647adfd6d282d26cf8c7cc9b1cf622f1R108) [[3]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR51) [[4]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR3879) [[5]](diffhunk://#diff-7415b0e19fb3d9edd0f57963ccdbfc2ea8946e23297f845a1f4948b75bead27bR38) [[6]](diffhunk://#diff-7415b0e19fb3d9edd0f57963ccdbfc2ea8946e23297f845a1f4948b75bead27bL271-R277) [[7]](diffhunk://#diff-7415b0e19fb3d9edd0f57963ccdbfc2ea8946e23297f845a1f4948b75bead27bL466-R471) [[8]](diffhunk://#diff-a70985a349876d8de26ed564c8501c876f9de35222dba4b9f44d2338fd423643R27) [[9]](diffhunk://#diff-a70985a349876d8de26ed564c8501c876f9de35222dba4b9f44d2338fd423643L686-R692) [[10]](diffhunk://#diff-035c3b65c204f1bfbde1b88ca07e0d537e119d009ba012a6c430ac360e4ff07dR30) [[11]](diffhunk://#diff-035c3b65c204f1bfbde1b88ca07e0d537e119d009ba012a6c430ac360e4ff07dL378-R384) [[12]](diffhunk://#diff-64820a284b076801c442da19649e63dc4a2e00e645d7f92abbc5754b3dbae22fR39) [[13]](diffhunk://#diff-64820a284b076801c442da19649e63dc4a2e00e645d7f92abbc5754b3dbae22fL457-R459) [[14]](diffhunk://#diff-64820a284b076801c442da19649e63dc4a2e00e645d7f92abbc5754b3dbae22fR469) [[15]](diffhunk://#diff-e454af392519beae8e37cac551a5faffed88f240b93bb85633a5819432267502R29) [[16]](diffhunk://#diff-e454af392519beae8e37cac551a5faffed88f240b93bb85633a5819432267502R295) [[17]](diffhunk://#diff-ed0e7e251ddd8fc817f9b86ec8832f1d7e0e6350a65479f0f2cb6bef9b5526b4R29) [[18]](diffhunk://#diff-ed0e7e251ddd8fc817f9b86ec8832f1d7e0e6350a65479f0f2cb6bef9b5526b4R476) [[19]](diffhunk://#diff-b9975bb8753b0c5c79106a6d91f50c716e8984bc9e8e818377227027e8e23b01R29) [[20]](diffhunk://#diff-b9975bb8753b0c5c79106a6d91f50c716e8984bc9e8e818377227027e8e23b01R361)

Internal scheduler implementation:

* Refactored the ACE Step scheduler (`scheduling_flow_match_euler_discrete.py`) to compute `sigma_min` and `sigma_max` before possible sigma shifting, ensuring accurate assignment. [[1]](diffhunk://#diff-82fcb29fd70d4b108cdef7dee6de352ac4f649b253713651db33af070cec0700R82-R83) [[2]](diffhunk://#diff-82fcb29fd70d4b108cdef7dee6de352ac4f649b253713651db33af070cec0700L92-R95)

Testing:

* Added `tests/test_flow_match_scheduler_bounds.py` to verify that both the diffusers and ACE Step schedulers set `sigma_min` and `sigma_max` correctly and maintain expected sigma values after applying the fix.