### PR TITLE
ideogram4: document apple-specific quant via int8-sdnq

### DIFF
--- a/documentation/quickstart/IDEOGRAM4.es.md
+++ b/documentation/quickstart/IDEOGRAM4.es.md
@@ -24,7 +24,7 @@ Medido en H100 80GB con FP8 nativo (`base_model_precision=fp8-torchao`, `quantiz
 | 2 | 20,095 MiB / 19.6 GiB |
 | 4 | 28,603 MiB / 27.9 GiB |
 
-La validación tiene un pico de generación separado, así que deja margen adicional con `ideogram_validation=true`. En GPUs más pequeñas, empieza con FP8 o NF4, rank 8-16, gradient checkpointing y offload. Las GPUs Apple no se recomiendan para entrenar Ideogram 4.
+La validación tiene un pico de generación separado, así que deja margen adicional con `ideogram_validation=true`. En GPUs más pequeñas, empieza con FP8 o NF4, rank 8-16, gradient checkpointing y offload. Apple Silicon (MPS) es compatible con el entrenamiento de Ideogram 4: el checkpoint FP8 se descuantiza a bf16 al cargar. Para reducir memoria, usa `base_model_precision=int8-sdnq` junto con `quantize_via=cpu` (FP8/NF4 son solo para CUDA).
 
 ### Torch compile
 
@@ -86,6 +86,15 @@ Para poca VRAM, usa NF4:
 {
   "base_model_precision": "nf4-bnb",
   "base_model_default_dtype": "bf16",
+  "quantize_via": "cpu"
+}
+```
+
+En Apple Silicon (MPS), usa SDNQ int8 en su lugar:
+
+```json
+{
+  "base_model_precision": "int8-sdnq",
   "quantize_via": "cpu"
 }
 ```

--- a/documentation/quickstart/IDEOGRAM4.hi.md
+++ b/documentation/quickstart/IDEOGRAM4.hi.md
@@ -24,7 +24,7 @@ H100 80GB पर measured values: native FP8 (`base_model_precision=fp8-torchao`
 | 2 | 20,095 MiB / 19.6 GiB |
 | 4 | 28,603 MiB / 27.9 GiB |
 
-Validation का अलग generation peak होता है, इसलिए `ideogram_validation=true` के साथ extra headroom रखें। छोटी GPUs पर FP8 या NF4, rank 8-16, gradient checkpointing और offload से शुरू करें। Apple GPUs Ideogram 4 training के लिए recommended नहीं हैं।
+Validation का अलग generation peak होता है, इसलिए `ideogram_validation=true` के साथ extra headroom रखें। छोटी GPUs पर FP8 या NF4, rank 8-16, gradient checkpointing और offload से शुरू करें। Apple Silicon (MPS) पर Ideogram 4 training समर्थित है: लोड करते समय FP8 checkpoint स्वतः bf16 में dequantize हो जाता है। memory कम करने के लिए `base_model_precision=int8-sdnq` को `quantize_via=cpu` के साथ सेट करें (FP8/NF4 केवल CUDA पर उपलब्ध हैं)।
 
 ### Torch compile
 
@@ -86,6 +86,15 @@ cp simpletuner/examples/multidatabackend-ideogram-dreambooth-1024px.json config/
 {
   "base_model_precision": "nf4-bnb",
   "base_model_default_dtype": "bf16",
+  "quantize_via": "cpu"
+}
+```
+
+Apple Silicon (MPS) पर इसके बजाय SDNQ int8 का उपयोग करें:
+
+```json
+{
+  "base_model_precision": "int8-sdnq",
   "quantize_via": "cpu"
 }
 ```

--- a/documentation/quickstart/IDEOGRAM4.ja.md
+++ b/documentation/quickstart/IDEOGRAM4.ja.md
@@ -24,7 +24,7 @@ H100 80GB での実測値です。native FP8（`base_model_precision=fp8-torchao
 | 2 | 20,095 MiB / 19.6 GiB |
 | 4 | 28,603 MiB / 27.9 GiB |
 
-Validation には別の生成ピークがあるため、`ideogram_validation=true` を使う場合は余裕を見てください。小さいGPUでは FP8 または NF4、rank 8-16、gradient checkpointing、offload から始めてください。Apple GPU は Ideogram 4 学習には推奨しません。
+Validation には別の生成ピークがあるため、`ideogram_validation=true` を使う場合は余裕を見てください。小さいGPUでは FP8 または NF4、rank 8-16、gradient checkpointing、offload から始めてください。Apple Silicon（MPS）でも Ideogram 4 を学習できます。FP8 チェックポイントは読み込み時に自動で bf16 へ逆量子化されます。メモリ削減には `base_model_precision=int8-sdnq` と `quantize_via=cpu` を指定してください（FP8/NF4 は CUDA 専用です）。
 
 ### Torch compile
 
@@ -86,6 +86,15 @@ FP8 が最初の推奨です:
 {
   "base_model_precision": "nf4-bnb",
   "base_model_default_dtype": "bf16",
+  "quantize_via": "cpu"
+}
+```
+
+Apple Silicon（MPS）では、代わりに SDNQ int8 を使用してください：
+
+```json
+{
+  "base_model_precision": "int8-sdnq",
   "quantize_via": "cpu"
 }
 ```

--- a/documentation/quickstart/IDEOGRAM4.md
+++ b/documentation/quickstart/IDEOGRAM4.md
@@ -28,7 +28,22 @@ Expected memory varies with rank, optimiser, resolution, validation, and offload
 
 Validation has a separate generation peak, so leave extra headroom when `ideogram_validation=true`. On smaller cards, start with FP8 or NF4, rank 8-16, gradient checkpointing, and offload.
 
-Apple GPUs are not recommended for Ideogram 4 training.
+### Apple Silicon (MPS)
+
+Ideogram 4 trains on Apple Silicon (M-series) GPUs through the Metal (MPS) backend. The public checkpoint ships as FP8, which MPS cannot store, so SimpleTuner dequantises it to bf16 automatically on load. A bf16 base is large (the transformer alone is roughly 18 GiB of unified memory), so for memory reduction set `base_model_precision=int8-sdnq`: SDNQ quantises the base transformer to int8 (Apple-compatible) and roughly halves its weight footprint.
+
+```bash
+pip install 'simpletuner[apple]'
+```
+
+```json
+{
+  "base_model_precision": "int8-sdnq",
+  "quantize_via": "cpu"
+}
+```
+
+Keep `quantize_via=cpu` so quantisation runs on the host before the model moves to the GPU. Native FP8 and NF4 are CUDA-only and unavailable on Apple; SDNQ is the supported low-memory path on MPS. Expect slower steps than CUDA: there is no fused FP8 matmul on MPS (weights run as SDNQ int8, or bf16 without quantisation), SDNQ uses its Triton-free eager path, and the `float64` schedule math runs on CPU. Budget a unified-memory machine accordingly.
 
 ### Memory offloading
 
@@ -74,6 +89,9 @@ pip install 'simpletuner[cuda]'
 
 # CUDA 13 / Blackwell users
 pip install 'simpletuner[cuda13]' --extra-index-url https://download.pytorch.org/whl/cu130
+
+# Apple Silicon (M-series, MPS) — see Apple Silicon notes above; use base_model_precision=int8-sdnq
+pip install 'simpletuner[apple]'
 ```
 
 For manual installation or development setup, see the [installation documentation](../INSTALL.md).
@@ -129,6 +147,15 @@ For lower VRAM systems, NF4 is the next recommendation:
 {
   "base_model_precision": "nf4-bnb",
   "base_model_default_dtype": "bf16",
+  "quantize_via": "cpu"
+}
+```
+
+On Apple Silicon (MPS), FP8 and NF4 are unavailable; use SDNQ int8 instead (see [Apple Silicon (MPS)](#apple-silicon-mps)):
+
+```json
+{
+  "base_model_precision": "int8-sdnq",
   "quantize_via": "cpu"
 }
 ```

--- a/documentation/quickstart/IDEOGRAM4.pt-BR.md
+++ b/documentation/quickstart/IDEOGRAM4.pt-BR.md
@@ -24,7 +24,7 @@ Medição em H100 80GB, FP8 nativo (`base_model_precision=fp8-torchao`, `quantiz
 | 2 | 20,095 MiB / 19.6 GiB |
 | 4 | 28,603 MiB / 27.9 GiB |
 
-A validação tem um pico de geração separado, então reserve margem extra com `ideogram_validation=true`. Em GPUs menores, comece com FP8 ou NF4, rank 8-16, gradient checkpointing e offload. GPUs Apple não são recomendadas para treinamento do Ideogram 4.
+A validação tem um pico de geração separado, então reserve margem extra com `ideogram_validation=true`. Em GPUs menores, comece com FP8 ou NF4, rank 8-16, gradient checkpointing e offload. O Apple Silicon (MPS) é compatível com o treinamento do Ideogram 4: o checkpoint FP8 é desquantizado para bf16 no carregamento. Para reduzir memória, use `base_model_precision=int8-sdnq` com `quantize_via=cpu` (FP8/NF4 são exclusivos de CUDA).
 
 ### Torch compile
 
@@ -86,6 +86,15 @@ Para pouca VRAM, use NF4:
 {
   "base_model_precision": "nf4-bnb",
   "base_model_default_dtype": "bf16",
+  "quantize_via": "cpu"
+}
+```
+
+No Apple Silicon (MPS), use SDNQ int8 no lugar:
+
+```json
+{
+  "base_model_precision": "int8-sdnq",
   "quantize_via": "cpu"
 }
 ```

--- a/documentation/quickstart/IDEOGRAM4.zh.md
+++ b/documentation/quickstart/IDEOGRAM4.zh.md
@@ -24,7 +24,7 @@ simpletuner/examples/ideogram-fp8.peft-lora/config.json
 | 2 | 20,095 MiB / 19.6 GiB |
 | 4 | 28,603 MiB / 27.9 GiB |
 
-Validation 会有单独的生成峰值，所以启用 `ideogram_validation=true` 时请预留额外显存。小显存机器建议使用 FP8 或 NF4、rank 8-16、梯度检查点和 offload。Apple GPU 不推荐用于 Ideogram 4 训练。
+Validation 会有单独的生成峰值，所以启用 `ideogram_validation=true` 时请预留额外显存。小显存机器建议使用 FP8 或 NF4、rank 8-16、梯度检查点和 offload。Apple Silicon（MPS）可用于 Ideogram 4 训练：加载时会自动将 FP8 checkpoint 反量化为 bf16。如需降低内存占用，请设置 `base_model_precision=int8-sdnq` 并配合 `quantize_via=cpu`（FP8/NF4 仅支持 CUDA）。
 
 ### Torch compile
 
@@ -86,6 +86,15 @@ FP8 是默认推荐：
 {
   "base_model_precision": "nf4-bnb",
   "base_model_default_dtype": "bf16",
+  "quantize_via": "cpu"
+}
+```
+
+在 Apple Silicon（MPS）上，请改用 SDNQ int8：
+
+```json
+{
+  "base_model_precision": "int8-sdnq",
   "quantize_via": "cpu"
 }
 ```


### PR DESCRIPTION
This pull request updates the quickstart documentation for Ideogram 4 in all supported languages to add official support and instructions for training on Apple Silicon (M-series) GPUs using the MPS backend. It clarifies that FP8/NF4 quantization is CUDA-only, and introduces SDNQ int8 as the recommended quantization method for Apple Silicon, with detailed configuration examples and installation notes.

**Apple Silicon (MPS) support and documentation:**

- Added detailed sections in the English quickstart (`IDEOGRAM4.md`) describing Apple Silicon (M-series) support, including installation instructions (`pip install 'simpletuner[apple]'`), limitations (no FP8/NF4, only SDNQ int8 supported), and configuration examples for memory-efficient training. [[1]](diffhunk://#diff-0d18797b07701e94da0d44c62670cc4598f7d6e28dafc62c227cd6cc00209bb9L31-R46) [[2]](diffhunk://#diff-0d18797b07701e94da0d44c62670cc4598f7d6e28dafc62c227cd6cc00209bb9R92-R94) [[3]](diffhunk://#diff-0d18797b07701e94da0d44c62670cc4598f7d6e28dafc62c227cd6cc00209bb9R154-R162)
- Updated the FP8/NF4 recommendations in all quickstart docs (Spanish, Portuguese, Hindi, Japanese, Chinese) to clarify that Apple Silicon is now supported for training, with FP8 checkpoints automatically dequantized to bf16, and to recommend using SDNQ int8 with `quantize_via=cpu` for memory reduction. [[1]](diffhunk://#diff-689b47a19fd059e937d0ef282f459ec7dcbadc61dac659d70f6743ce50a5c410L27-R27) [[2]](diffhunk://#diff-4c661981e84c1f09d34f5b2996ed68a4cbf9ef5c5535c84e7d14cbf0e1907f7dL27-R27) [[3]](diffhunk://#diff-9ac1a840b36d3db848a6cd6c5d7e9008e2a0f41c0cf350e3e61ee1cac36fcbbeL27-R27) [[4]](diffhunk://#diff-058c62dc320320cabc2fbfad8d1acf7900c41312643ec650abe9face5fcc8207L27-R27) [[5]](diffhunk://#diff-78900be6840cb62ef6ac835bb91f808ed6f05966a55decb5c98e5de7ca82f685L27-R27)
- Added explicit configuration examples for SDNQ int8 quantization on Apple Silicon (MPS) to all language variants, ensuring users know how to set `base_model_precision=int8-sdnq` and `quantize_via=cpu`. [[1]](diffhunk://#diff-689b47a19fd059e937d0ef282f459ec7dcbadc61dac659d70f6743ce50a5c410R93-R101) [[2]](diffhunk://#diff-4c661981e84c1f09d34f5b2996ed68a4cbf9ef5c5535c84e7d14cbf0e1907f7dR93-R101) [[3]](diffhunk://#diff-9ac1a840b36d3db848a6cd6c5d7e9008e2a0f41c0cf350e3e61ee1cac36fcbbeR93-R101) [[4]](diffhunk://#diff-058c62dc320320cabc2fbfad8d1acf7900c41312643ec650abe9face5fcc8207R93-R101) [[5]](diffhunk://#diff-78900be6840cb62ef6ac835bb91f808ed6f05966a55decb5c98e5de7ca82f685R93-R101)