### PR TITLE
boogu-image: remove broken fp8 paths and use torchao on-the-fly quant instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04
 
 # Hardware Architecture
-ENV TORCH_CUDA_ARCH_LIST=8.9
+ENV TORCH_CUDA_ARCH_LIST=9.0
 ENV CUDA_HOME=/usr/local/cuda-12.8
 ENV LD_LIBRARY_PATH=$CUDA_HOME/lib64:$CUDA_HOME/targets/x86_64-linux/lib/stubs:$LD_LIBRARY_PATH
 
@@ -47,8 +47,8 @@ RUN python${PYTHON_VERSION} -m venv /opt/venv \
        "torchao>=0.17.0,<0.18.0"
 
 # 3. Install SimpleTuner
-# Using 'release' branch for stability. Change to 'main' for latest features.
-ARG SIMPLETUNER_BRANCH=release
+# Use main for current model integrations such as Boogu-Image.
+ARG SIMPLETUNER_BRANCH=main
 RUN git clone https://github.com/bghira/SimpleTuner --branch $SIMPLETUNER_BRANCH \
     && cd SimpleTuner \
     && pip install --no-cache-dir -e .[jxl] \

--- a/cog.yaml
+++ b/cog.yaml
@@ -6,8 +6,11 @@ build:
   system_packages:
     - git
   run:
+    - rm -rf SimpleTuner && git clone --depth 1 --branch main https://github.com/bghira/SimpleTuner.git SimpleTuner
     - pip install --upgrade pip
-    - pip install "simpletuner[cuda]"
+    - printf '%s\n' 'torch==2.11.0+cu128' 'torchvision==0.26.0+cu128' 'torchaudio==2.11.0+cu128' > /tmp/constraints-cuda128.txt
+    - pip install --index-url https://download.pytorch.org/whl/cu128 -c /tmp/constraints-cuda128.txt torch torchvision torchaudio
+    - pip install --extra-index-url https://download.pytorch.org/whl/cu128 -c /tmp/constraints-cuda128.txt -e "./SimpleTuner[cuda,jxl]"
     - python -c "from huggingface_hub import snapshot_download; models={'hf_falconsai':'Falconsai/nsfw_image_detection','hf_adamcodd':'AdamCodd/vit-base-nsfw-detector','hf_hoangtrung':'hoangtrung1801/nsfw-vit-model'}; [snapshot_download(repo_id=repo, allow_patterns=['*.json','*.safetensors','*.bin','*.txt'], local_dir=f'/opt/nsfw-classifier-comparison/{key}') for key, repo in models.items()]"
 
 predict: "predict.py:Predictor"

--- a/simpletuner/helpers/configuration/cmd_args.py
+++ b/simpletuner/helpers/configuration/cmd_args.py
@@ -746,6 +746,13 @@ def parse_cmdline_args(input_args=None, exit_on_error: bool = False):
     pipeline_quant_precisions = set(PIPELINE_QUANTIZATION_PRESETS)
     manual_only_precisions = manual_quant_precisions - pipeline_quant_precisions
     quantization_precisions = manual_quant_precisions | pipeline_quant_precisions
+    if (
+        getattr(args, "model_family", None) == "boogu_image"
+        and str(getattr(args, "model_flavour", "")).endswith("-fp8")
+        and getattr(args, "base_model_precision", "no_change") == "no_change"
+    ):
+        args.base_model_precision = "fp8-torchao"
+        args.quantize_via = "accelerator"
     base_precision = getattr(args, "base_model_precision", "no_change")
     model_path = str(getattr(args, "pretrained_model_name_or_path", "") or "")
     is_gguf_checkpoint = model_path.endswith(".gguf")

--- a/simpletuner/helpers/models/boogu_image/model.py
+++ b/simpletuner/helpers/models/boogu_image/model.py
@@ -55,11 +55,11 @@ class BooguImage(ImageModelFoundation):
     DEFAULT_MODEL_FLAVOUR = "v0.1-turbo"
     HUGGINGFACE_PATHS = {
         "v0.1-base": "SimpleTuner/Boogu-Image-0.1-Base",
-        "v0.1-base-fp8": "SimpleTuner/Boogu-Image-0.1-Base-fp8",
+        "v0.1-base-fp8": "SimpleTuner/Boogu-Image-0.1-Base",
         "v0.1-turbo": "SimpleTuner/Boogu-Image-0.1-Turbo",
-        "v0.1-turbo-fp8": "SimpleTuner/Boogu-Image-0.1-Turbo-fp8",
+        "v0.1-turbo-fp8": "SimpleTuner/Boogu-Image-0.1-Turbo",
         "v0.1-edit": "SimpleTuner/Boogu-Image-0.1-Edit",
-        "v0.1-edit-fp8": "SimpleTuner/Boogu-Image-0.1-Edit-fp8",
+        "v0.1-edit-fp8": "SimpleTuner/Boogu-Image-0.1-Edit",
     }
     MODEL_LICENSE = "apache-2.0"
 
@@ -153,6 +153,16 @@ class BooguImage(ImageModelFoundation):
 
     def requires_text_embed_image_context(self) -> bool:
         return self._is_edit_flavour()
+
+    def sample_flow_sigmas(self, batch: dict, state: dict) -> tuple[torch.Tensor, torch.Tensor]:
+        noise_sigmas, _ = super().sample_flow_sigmas(batch=batch, state=state)
+        boogu_timesteps = 1.0 - noise_sigmas
+        return noise_sigmas, boogu_timesteps
+
+    def get_prediction_target(self, prepared_batch: dict):
+        if prepared_batch.get("target") is not None:
+            return prepared_batch["target"]
+        return prepared_batch["latents"] - prepared_batch["noise"]
 
     def text_embed_cache_key(self):
         if self._is_edit_flavour():

--- a/simpletuner/helpers/training/quantisation/__init__.py
+++ b/simpletuner/helpers/training/quantisation/__init__.py
@@ -415,6 +415,10 @@ def _torchao_filter_fn(mod: torch.nn.Module, fqn: str):
     # Skip RamTorch-offloaded modules; TorchAO expects GPU-resident weights.
     if any(getattr(p, "is_ramtorch", False) for p in mod.parameters(recurse=False)):
         return False
+    # Boogu T2I sends empty tensors through reference-image modules; TorchAO fp8
+    # cannot dynamically scale empty activations.
+    if fqn.startswith("ref_image_"):
+        return False
     # don't convert the output module
     if fqn == "proj_out":
         return False

--- a/tests/test_boogu_image_model.py
+++ b/tests/test_boogu_image_model.py
@@ -9,6 +9,7 @@ from simpletuner.helpers.models.boogu_image.model import BooguImage
 from simpletuner.helpers.models.boogu_image.pipeline import BooguImagePipeline, retrieve_timesteps
 from simpletuner.helpers.models.flux.model import Flux
 from simpletuner.helpers.training.attention_backend import _DIFFUSERS_BACKEND_ALIASES
+from simpletuner.helpers.training.quantisation import _torchao_filter_fn
 
 
 class BooguImageModelTests(unittest.TestCase):
@@ -25,11 +26,11 @@ class BooguImageModelTests(unittest.TestCase):
 
     def test_flavour_paths_include_requested_variants(self):
         self.assertEqual(BooguImage.HUGGINGFACE_PATHS["v0.1-base"], "SimpleTuner/Boogu-Image-0.1-Base")
-        self.assertEqual(BooguImage.HUGGINGFACE_PATHS["v0.1-base-fp8"], "SimpleTuner/Boogu-Image-0.1-Base-fp8")
+        self.assertEqual(BooguImage.HUGGINGFACE_PATHS["v0.1-base-fp8"], "SimpleTuner/Boogu-Image-0.1-Base")
         self.assertEqual(BooguImage.HUGGINGFACE_PATHS["v0.1-turbo"], "SimpleTuner/Boogu-Image-0.1-Turbo")
-        self.assertEqual(BooguImage.HUGGINGFACE_PATHS["v0.1-turbo-fp8"], "SimpleTuner/Boogu-Image-0.1-Turbo-fp8")
+        self.assertEqual(BooguImage.HUGGINGFACE_PATHS["v0.1-turbo-fp8"], "SimpleTuner/Boogu-Image-0.1-Turbo")
         self.assertEqual(BooguImage.HUGGINGFACE_PATHS["v0.1-edit"], "SimpleTuner/Boogu-Image-0.1-Edit")
-        self.assertEqual(BooguImage.HUGGINGFACE_PATHS["v0.1-edit-fp8"], "SimpleTuner/Boogu-Image-0.1-Edit-fp8")
+        self.assertEqual(BooguImage.HUGGINGFACE_PATHS["v0.1-edit-fp8"], "SimpleTuner/Boogu-Image-0.1-Edit")
 
     def test_model_components_are_local_simpletuner_classes(self):
         self.assertEqual(BooguImage.MODEL_CLASS.__module__, "simpletuner.helpers.models.boogu_image.transformer")
@@ -106,6 +107,36 @@ class BooguImageModelTests(unittest.TestCase):
         self.assertEqual(dispatch_calls, [True])
         self.assertEqual(len(forward_calls), 1)
         self.assertEqual(forward_calls[0][0][3], "freqs")
+
+    def test_boogu_flow_target_points_from_noise_to_latents(self):
+        model = object.__new__(BooguImage)
+        latents = torch.tensor([1.0, 3.0])
+        noise = torch.tensor([4.0, -1.0])
+
+        target = model.get_prediction_target({"latents": latents, "noise": noise})
+
+        self.assertTrue(torch.equal(target, latents - noise))
+
+    def test_boogu_flow_timesteps_are_normalized_clean_progress(self):
+        model = object.__new__(BooguImage)
+
+        def sample_flow_sigmas(self, batch, state):
+            return torch.tensor([0.25, 0.75]), torch.tensor([250.0, 750.0])
+
+        parent = BooguImage.__mro__[1]
+        original = parent.sample_flow_sigmas
+        try:
+            parent.sample_flow_sigmas = sample_flow_sigmas
+            noise_sigmas, timesteps = model.sample_flow_sigmas(batch={}, state={})
+        finally:
+            parent.sample_flow_sigmas = original
+
+        self.assertTrue(torch.equal(noise_sigmas, torch.tensor([0.25, 0.75])))
+        self.assertTrue(torch.equal(timesteps, torch.tensor([0.75, 0.25])))
+
+    def test_torchao_filter_skips_boogu_reference_image_modules(self):
+        self.assertFalse(_torchao_filter_fn(torch.nn.Linear(16, 16), "ref_image_refiner.0.attn.to_q"))
+        self.assertTrue(_torchao_filter_fn(torch.nn.Linear(16, 16), "context_refiner.0.attn.to_q"))
 
     def test_validation_kwargs_are_mapped_to_boogu_pipeline_names(self):
         model = object.__new__(BooguImage)


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes for Boogu-Image model integration, quantization handling, and the build pipeline. The main focus is on ensuring correct model path resolution for FP8 variants, enhancing quantization compatibility, and updating the build process to use the latest SimpleTuner features. Additional tests have been added to verify the new behaviors.

**Boogu-Image Model Integration and Path Resolution:**

* Updated `BooguImage.HUGGINGFACE_PATHS` to map all FP8 model flavours (e.g., `"v0.1-base-fp8"`) to their base model paths, ensuring correct model loading and avoiding missing model errors.
* Adjusted tests to reflect the new path mapping logic for FP8 variants, verifying that FP8 flavours resolve to the correct base paths.

**Quantization and Precision Handling:**

* In `_normalize_input_args`, added logic to automatically set `base_model_precision` to `"fp8-torchao"` and `quantize_via` to `"accelerator"` for Boogu-Image models with FP8 flavours, improving quantization automation.
* Modified `_torchao_filter_fn` to skip quantization for modules starting with `"ref_image_"`, preventing TorchAO FP8 issues with empty activations in Boogu T2I reference-image modules.

**Boogu-Image Model Methods:**

* Added `sample_flow_sigmas` and `get_prediction_target` methods to `BooguImage` for correct flow noise/target calculations; corresponding unit tests were added to validate these behaviors. [[1]](diffhunk://#diff-7c9abfe3a5a4965d798529f374b5780ddd5557a103e738a30459758e436b1761R157-R166) [[2]](diffhunk://#diff-304243fe46b0f263fa8ab4adef2b6ef5676a00e1402099e661b0e92adc15e07fR111-R140)

**Build and Dependency Updates:**

* Updated the build process in `Dockerfile` and `cog.yaml` to always use the `main` branch of SimpleTuner for the latest model integrations, and improved the installation of PyTorch and SimpleTuner with CUDA 12.8 constraints for compatibility. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L50-R51) [[2]](diffhunk://#diff-3cfbd3558e4eb3136f364310be55f301cb9be46b65931d69a336e6c433d382b4R9-R13)
* Increased `TORCH_CUDA_ARCH_LIST` from 8.9 to 9.0 in the Dockerfile to support newer GPU architectures.