### PR TITLE
Avoid complex Boogu rotary ops

### DIFF
--- a/simpletuner/helpers/models/boogu_image/embeddings.py
+++ b/simpletuner/helpers/models/boogu_image/embeddings.py
@@ -21,6 +21,19 @@ from diffusers.models.activations import get_activation
 from torch import nn
 
 
+def complex_rotary_to_real(
+    freqs_cis: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    if isinstance(freqs_cis, tuple):
+        return freqs_cis
+    if not torch.is_complex(freqs_cis):
+        return freqs_cis
+    return (
+        freqs_cis.real.repeat_interleave(2, dim=-1),
+        freqs_cis.imag.repeat_interleave(2, dim=-1),
+    )
+
+
 class TimestepEmbedding(nn.Module):
     def __init__(
         self,
@@ -79,7 +92,7 @@ class TimestepEmbedding(nn.Module):
 
 def apply_rotary_emb(
     x: torch.Tensor,
-    freqs_cis: Union[torch.Tensor, Tuple[torch.Tensor]],
+    freqs_cis: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
     use_real: bool = True,
     use_real_unbind_dim: int = -1,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -97,21 +110,32 @@ def apply_rotary_emb(
     Returns:
         Tuple[torch.Tensor, torch.Tensor]: Tuple of modified query tensor and key tensor with rotary embeddings.
     """
-    if use_real:
+    freqs_cis = complex_rotary_to_real(freqs_cis)
+
+    if use_real or isinstance(freqs_cis, tuple):
         cos, sin = freqs_cis  # [S, D]
-        cos = cos[None, None]
-        sin = sin[None, None]
-        cos, sin = cos.to(x.device), sin.to(x.device)
+        cos = cos.to(device=x.device, dtype=torch.float32)
+        sin = sin.to(device=x.device, dtype=torch.float32)
+        if cos.dim() == 2:
+            cos = cos[None, None]
+            sin = sin[None, None]
+        elif cos.dim() == 3:
+            cos = cos.unsqueeze(2)
+            sin = sin.unsqueeze(2)
+        else:
+            raise ValueError(
+                f"`freqs_cis` must have rank 2 or 3 after conversion to real tensors, got {cos.dim()}."
+            )
 
         if use_real_unbind_dim == -1:
             # Used for flux, cogvideox, hunyuan-dit
-            x_real, x_imag = x.reshape(*x.shape[:-1], -1, 2).unbind(
+            x_real, x_imag = x.reshape(*x.shape[:-1], x.shape[-1] // 2, 2).unbind(
                 -1
             )  # [B, S, H, D//2]
-            x_rotated = torch.stack([-x_imag, x_real], dim=-1).flatten(3)
+            x_rotated = torch.stack([-x_imag, x_real], dim=-1).flatten(-2)
         elif use_real_unbind_dim == -2:
             # Used for Stable Audio, Boogu and CogView4
-            x_real, x_imag = x.reshape(*x.shape[:-1], 2, -1).unbind(
+            x_real, x_imag = x.reshape(*x.shape[:-1], 2, x.shape[-1] // 2).unbind(
                 -2
             )  # [B, S, H, D//2]
             x_rotated = torch.cat([-x_imag, x_real], dim=-1)

--- a/simpletuner/helpers/models/boogu_image/rope.py
+++ b/simpletuner/helpers/models/boogu_image/rope.py
@@ -24,6 +24,8 @@ import torch.nn as nn
 from diffusers.models.embeddings import get_1d_rotary_pos_embed
 from einops import repeat
 
+from .embeddings import complex_rotary_to_real
+
 
 class BooguImageRotaryPosEmbed(nn.Module):
     def __init__(
@@ -211,10 +213,10 @@ class BooguImageRotaryPosEmbed(nn.Module):
             ]
 
         return (
-            cap_freqs_cis,
-            ref_img_freqs_cis,
-            img_freqs_cis,
-            freqs_cis,
+            complex_rotary_to_real(cap_freqs_cis),
+            complex_rotary_to_real(ref_img_freqs_cis),
+            complex_rotary_to_real(img_freqs_cis),
+            complex_rotary_to_real(freqs_cis),
             l_effective_cap_len,
             seq_lengths,
         )
@@ -437,13 +439,13 @@ class BooguImageDoubleStreamRotaryPosEmbed(nn.Module):
             )
 
         return (
-            cap_freqs_cis,
-            ref_img_freqs_cis,
-            img_freqs_cis,
-            freqs_cis,
+            complex_rotary_to_real(cap_freqs_cis),
+            complex_rotary_to_real(ref_img_freqs_cis),
+            complex_rotary_to_real(img_freqs_cis),
+            complex_rotary_to_real(freqs_cis),
             l_effective_cap_len,
             seq_lengths,
-            combined_img_freqs_cis,
+            complex_rotary_to_real(combined_img_freqs_cis),
             combined_img_seq_lengths,
         )
 
@@ -542,4 +544,4 @@ class BooguImagePromptTuningRotaryPosEmbed(nn.Module):
                 device=device,
             )  # [B, num_tokens]
 
-        return rotary_emb, attention_mask
+        return complex_rotary_to_real(rotary_emb), attention_mask

--- a/simpletuner/helpers/models/boogu_image/transformer.py
+++ b/simpletuner/helpers/models/boogu_image/transformer.py
@@ -39,6 +39,7 @@ from .attention_processor import (
     BooguImageAttnProcessor,
     BooguImageDoubleStreamSelfAttnProcessor,
 )
+from .embeddings import complex_rotary_to_real
 from .block_lumina2 import (
     Lumina2CombinedTimestepCaptionEmbedding,
     LuminaFeedForward,
@@ -64,6 +65,35 @@ from .taylorseer_utils import (
 logger = logging.get_logger(__name__)
 
 # Local runtime utilities.
+
+
+def _new_rotary_batch_like(hidden_states, rotary_emb, num_ref_images, max_ref_img_len):
+    rotary_emb = complex_rotary_to_real(rotary_emb)
+    if isinstance(rotary_emb, tuple):
+        return tuple(
+            hidden_states.new_zeros(
+                num_ref_images,
+                max_ref_img_len,
+                tensor.shape[-1],
+                dtype=tensor.dtype,
+            )
+            for tensor in rotary_emb
+        )
+    return hidden_states.new_zeros(
+        num_ref_images,
+        max_ref_img_len,
+        rotary_emb.shape[-1],
+        dtype=rotary_emb.dtype,
+    )
+
+
+def _copy_rotary_slice(rotary_batch, batch_index, target_slice, rotary_emb, source_slice):
+    rotary_emb = complex_rotary_to_real(rotary_emb)
+    if isinstance(rotary_batch, tuple):
+        for target, source in zip(rotary_batch, rotary_emb):
+            target[batch_index, target_slice] = source[source_slice]
+    else:
+        rotary_batch[batch_index, target_slice] = rotary_emb[source_slice]
 
 
 class PromptEmbedding(
@@ -1000,11 +1030,11 @@ class BooguImageTransformer2DModel(
         batch_ref_image_hidden_states = ref_image_hidden_states.new_zeros(
             num_ref_images, max_ref_img_len, self.config.hidden_size
         )
-        batch_ref_img_rotary_emb = hidden_states.new_zeros(
+        batch_ref_img_rotary_emb = _new_rotary_batch_like(
+            hidden_states,
+            ref_img_rotary_emb,
             num_ref_images,
             max_ref_img_len,
-            ref_img_rotary_emb.shape[-1],
-            dtype=ref_img_rotary_emb.dtype,
         )
         batch_temb = temb.new_zeros(num_ref_images, *temb.shape[1:], dtype=temb.dtype)
 
@@ -1017,9 +1047,13 @@ class BooguImageTransformer2DModel(
                 batch_ref_image_hidden_states[idx, :ref_img_len] = (
                     ref_image_hidden_states[i, shift : shift + ref_img_len]
                 )
-                batch_ref_img_rotary_emb[idx, :ref_img_len] = ref_img_rotary_emb[
-                    i, shift : shift + ref_img_len
-                ]
+                _copy_rotary_slice(
+                    batch_ref_img_rotary_emb,
+                    idx,
+                    slice(None, ref_img_len),
+                    ref_img_rotary_emb,
+                    (i, slice(shift, shift + ref_img_len)),
+                )
                 batch_temb[idx] = temb[i]
                 shift += ref_img_len
                 idx += 1

--- a/tests/test_boogu_image_model.py
+++ b/tests/test_boogu_image_model.py
@@ -6,8 +6,10 @@ from unittest.mock import patch
 import torch
 
 from simpletuner.helpers.models.boogu_image.lora_pipeline import BooguImageLoraLoaderMixin
+from simpletuner.helpers.models.boogu_image.embeddings import apply_rotary_emb
 from simpletuner.helpers.models.boogu_image.model import BooguImage
 from simpletuner.helpers.models.boogu_image.pipeline import BooguImagePipeline, retrieve_timesteps
+from simpletuner.helpers.models.boogu_image.rope import BooguImageDoubleStreamRotaryPosEmbed
 from simpletuner.helpers.models.common import PipelineTypes
 from simpletuner.helpers.models.flux.model import Flux
 from simpletuner.helpers.training.attention_backend import _DIFFUSERS_BACKEND_ALIASES
@@ -184,6 +186,46 @@ class BooguImageModelTests(unittest.TestCase):
     def test_torchao_filter_skips_boogu_reference_image_modules(self):
         self.assertFalse(_torchao_filter_fn(torch.nn.Linear(16, 16), "ref_image_refiner.0.attn.to_q"))
         self.assertTrue(_torchao_filter_fn(torch.nn.Linear(16, 16), "context_refiner.0.attn.to_q"))
+
+    def test_boogu_rotary_complex_inputs_use_real_valued_math(self):
+        x = torch.randn(2, 5, 3, 8, dtype=torch.bfloat16)
+        angles = torch.randn(2, 5, 4)
+        freqs_cis = torch.polar(torch.ones_like(angles), angles)
+
+        expected = torch.view_as_real(
+            torch.view_as_complex(x.float().reshape(*x.shape[:-1], x.shape[-1] // 2, 2))
+            * freqs_cis.unsqueeze(2)
+        ).flatten(-2).to(x.dtype)
+
+        with patch("torch.view_as_complex", side_effect=AssertionError("complex path used")):
+            actual = apply_rotary_emb(x, freqs_cis, use_real=False)
+
+        self.assertTrue(torch.allclose(actual.float(), expected.float(), atol=1e-2, rtol=1e-2))
+
+    def test_boogu_double_stream_rope_returns_real_rotary_tuples(self):
+        embedder = BooguImageDoubleStreamRotaryPosEmbed(
+            theta=10000,
+            axes_dim=(4, 4, 4),
+            axes_lens=(8, 8, 8),
+            patch_size=2,
+        )
+        freqs_cis = embedder.get_freqs_cis(embedder.axes_dim, embedder.axes_lens, embedder.theta)
+
+        output = embedder(
+            freqs_cis=freqs_cis,
+            attention_mask=torch.ones(1, 3, dtype=torch.bool),
+            l_effective_ref_img_len=[[4]],
+            l_effective_img_len=[4],
+            ref_img_sizes=[[(4, 4)]],
+            img_sizes=[(4, 4)],
+            device=torch.device("cpu"),
+        )
+
+        for rotary in (output[0], output[1], output[2], output[3], output[6]):
+            self.assertIsInstance(rotary, tuple)
+            self.assertEqual(len(rotary), 2)
+            self.assertFalse(torch.is_complex(rotary[0]))
+            self.assertFalse(torch.is_complex(rotary[1]))
 
     def test_validation_kwargs_are_mapped_to_boogu_pipeline_names(self):
         model = object.__new__(BooguImage)


### PR DESCRIPTION
## Summary
- convert Boogu rotary embeddings to real-valued cos/sin tuples before attention
- keep the ref-image rotary batching path compatible with tuple rotary embeddings
- add tests covering numerical equivalence with the previous complex path and tuple RoPE outputs

## Validation
- python3 -m compileall simpletuner/helpers/models/boogu_image tests/test_boogu_image_model.py
- cog exec python3 -m unittest tests.test_boogu_image_model