### PR TITLE
qwen_image: remove deprecation notice

### DIFF
--- a/simpletuner/helpers/models/qwen_image/transformer.py
+++ b/simpletuner/helpers/models/qwen_image/transformer.py
@@ -31,7 +31,7 @@ from diffusers.models.embeddings import TimestepEmbedding, Timesteps
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 from diffusers.models.modeling_utils import ModelMixin
 from diffusers.models.normalization import AdaLayerNormContinuous, RMSNorm
-from diffusers.utils import USE_PEFT_BACKEND, deprecate, logging, scale_lora_layers, unscale_lora_layers
+from diffusers.utils import USE_PEFT_BACKEND, logging, scale_lora_layers, unscale_lora_layers
 from diffusers.utils.torch_utils import maybe_allow_in_graph
 
 from simpletuner.helpers.models.flowmap import (
@@ -1239,16 +1239,6 @@ class QwenImageTransformer2DModel(
             If `return_dict` is True, an [`~models.transformer_2d.Transformer2DModelOutput`] is returned, otherwise a
             `tuple` where the first element is the sample tensor.
         """
-        if txt_seq_lens is not None:
-            deprecate(
-                "txt_seq_lens",
-                "0.39.0",
-                "Passing `txt_seq_lens` is deprecated and will be removed in version 0.39.0. "
-                "Please use `txt_seq_len` instead (singular, not plural). "
-                "The new parameter accepts a single int or tensor value instead of a list.",
-                standard_warn=False,
-            )
-
         if attention_kwargs is not None:
             attention_kwargs = attention_kwargs.copy()
             lora_scale = attention_kwargs.pop("scale", 1.0)


### PR DESCRIPTION
This pull request makes a minor update to the `qwen_image/transformer.py` model helper by removing deprecated code and cleaning up imports. There are no functional changes to the model's behavior.

- **Deprecation Cleanup:**
  - Removed the deprecated handling and warning for the `txt_seq_lens` parameter in the `forward` method, as support for it is being phased out.

- **Import Cleanup:**
  - Removed the unused import of the `deprecate` utility from `diffusers.utils`.