### PR TITLE
FSDP2 LoRA training (LTX 2.3 verified)

### DIFF
--- a/simpletuner/helpers/configuration/cmd_args.py
+++ b/simpletuner/helpers/configuration/cmd_args.py
@@ -1164,6 +1164,17 @@ def parse_cmdline_args(input_args=None, exit_on_error: bool = False):
             filtered_values = [entry for entry in values if entry]
             args.fsdp_transformer_layer_cls_to_wrap = filtered_values or None
             info_log(f"FSDP transformer layer classes to wrap: {args.fsdp_transformer_layer_cls_to_wrap}")
+
+        fsdp_quantized_precision_fields = ["base_model_precision"] + [f"text_encoder_{idx}_precision" for idx in range(1, 5)]
+        fsdp_quanto_fields = [
+            field for field in fsdp_quantized_precision_fields if "quanto" in str(getattr(args, field, "") or "").lower()
+        ]
+        if args.fsdp_version == 2 and fsdp_quanto_fields:
+            field_list = ", ".join(fsdp_quanto_fields)
+            raise ValueError(
+                "FSDP v2 uses DTensor-sharded parameters, but Quanto kernels do not register DTensor sharding "
+                f"strategies. Disable Quanto precision for FSDP v2 runs ({field_list}), or use non-FSDP LoRA training."
+            )
     else:
         # When FSDP is disabled, normalise auxiliary options so downstream logic can rely on None/False.
         args.fsdp_transformer_layer_cls_to_wrap = None

--- a/simpletuner/helpers/data_backend/runtime/context_parallel_sync.py
+++ b/simpletuner/helpers/data_backend/runtime/context_parallel_sync.py
@@ -1,18 +1,20 @@
 """Context-parallel batch synchronization for distributed training.
 
-When using context parallelism, all ranks within a CP group must receive the same
-batch data. This module provides utilities to synchronize batch sampling so that:
-- Rank 0 of each CP group samples the batch
-- Other ranks in the same CP group receive the sampled batch via broadcast
+When using context parallelism, all ranks within a model replica must receive the
+same batch data. This module provides utilities to synchronize batch sampling so
+that:
+- Rank 0 of each replicated data-parallel group samples the batch
+- Other ranks in the same model replica receive the sampled batch via broadcast
 
 This ensures that when the batch is later split along the sequence dimension by
-the model's _cp_plan, all ranks in the group have consistent data.
+the model's _cp_plan, all FSDP shard and CP ranks have consistent data.
 
 The synchronization addresses two key issues:
-1. Data sharding: The dataset is split by DP rank (not global rank), so all ranks
-   in a CP group see the same data pool.
-2. Batch sampling: Only the CP leader samples batches; other ranks receive via
-   broadcast. This keeps seen_images tracking consistent across the CP group.
+1. Data sharding: The dataset is split by replicated DP rank only, not by FSDP
+   shard rank or CP rank.
+2. Batch sampling: Only the model-replica leader samples batches; other ranks
+   receive via broadcast. This keeps seen_images tracking consistent across the
+   model-parallel ranks.
 """
 
 import logging
@@ -34,6 +36,16 @@ else:
 
 # Sentinel value for non-leader ranks that skip sampling
 CP_SKIP_SAMPLING_SENTINEL = "__CP_SKIP_SAMPLING__"
+
+
+def _normalize_parallel_size(value: Any, name: str) -> int:
+    if value is None:
+        return 1
+    if isinstance(value, torch.SymInt):
+        return int(value)
+    if isinstance(value, numbers.Integral):
+        return int(value)
+    raise TypeError(f"{name} must be an integer type, got {type(value).__name__}.")
 
 
 def get_cp_info(accelerator) -> Tuple[bool, Optional[Any], int, int]:
@@ -111,10 +123,9 @@ def sync_batch_for_context_parallel(
     """
     Synchronize batch data across ranks in a context-parallel group.
 
-    In context parallelism, all ranks within a CP group must receive the same
-    input data, which is then split along the sequence dimension. This function
-    ensures that rank 0 of each CP group broadcasts its sampled batch to all
-    other ranks in the group.
+    In FSDP2 + context parallelism, all ranks in the same model replica must
+    receive the same input data. FSDP shard ranks and CP ranks are
+    model-parallel, while only DP-replicate ranks represent unique data shards.
 
     Args:
         batch: The batch data (can be a tuple, dict, or any picklable object)
@@ -136,17 +147,58 @@ def sync_batch_for_context_parallel(
         logger.debug("CP enabled but no process group available, skipping sync")
         return batch
 
-    # Broadcast the batch from rank 0 of the CP group
-    # Use broadcast_object_list for arbitrary Python objects
-    batch_list = [batch if cp_rank == 0 else None]
-
     try:
-        # For ProcessGroup from device_mesh.get_group(), src=0 means rank 0 within that group
-        dist.broadcast_object_list(batch_list, src=0, group=cp_group)
-        return batch_list[0]
+        data_enabled, data_rank, data_local_rank, data_group_size, data_parallel_size = get_model_replica_data_info(
+            accelerator, cp_info
+        )
+        if not data_enabled:
+            return batch
+
+        replica_batch = None
+        for replica_rank in range(data_parallel_size):
+            leader_global_rank = replica_rank * data_group_size
+            batch_list = [batch if data_rank == replica_rank and data_local_rank == 0 else None]
+            dist.broadcast_object_list(batch_list, src=leader_global_rank)
+            if data_rank == replica_rank:
+                replica_batch = batch_list[0]
+        return replica_batch
     except Exception as e:
-        logger.error(f"Failed to broadcast batch in CP group: {e}")
+        logger.error(f"Failed to broadcast batch in CP/FSDP model replica: {e}")
         raise RuntimeError("Context-parallel batch broadcast failed.") from e
+
+
+def get_model_replica_data_info(
+    accelerator,
+    cp_info: Optional[Tuple[bool, Optional[Any], int, int]] = None,
+) -> Tuple[bool, int, int, int, int]:
+    if cp_info is None:
+        cp_enabled, _cp_group, _cp_rank, cp_size = get_cp_info(accelerator)
+    else:
+        cp_enabled, _cp_group, _cp_rank, cp_size = cp_info
+    if not cp_enabled:
+        return False, 0, 0, 1, 1
+
+    parallelism_config = getattr(accelerator, "parallelism_config", None)
+    if parallelism_config is None:
+        return False, 0, 0, 1, 1
+
+    dp_replicate_size = _normalize_parallel_size(getattr(parallelism_config, "dp_replicate_size", 1), "dp_replicate_size")
+    dp_shard_size = _normalize_parallel_size(getattr(parallelism_config, "dp_shard_size", 1), "dp_shard_size")
+    world_size = _normalize_parallel_size(getattr(accelerator, "num_processes", 1), "num_processes")
+    process_index = _normalize_parallel_size(getattr(accelerator, "process_index", 0), "process_index")
+
+    data_group_size = dp_shard_size * cp_size
+    expected_world_size = dp_replicate_size * data_group_size
+    if world_size != expected_world_size:
+        raise ValueError(
+            "Context parallel batch synchronization expected "
+            f"num_processes={expected_world_size} from dp_replicate_size={dp_replicate_size}, "
+            f"dp_shard_size={dp_shard_size}, cp_size={cp_size}; got {world_size}."
+        )
+
+    data_rank = process_index // data_group_size
+    data_local_rank = process_index % data_group_size
+    return True, data_rank, data_local_rank, data_group_size, dp_replicate_size
 
 
 class ContextParallelBatchSynchronizer:
@@ -174,7 +226,15 @@ class ContextParallelBatchSynchronizer:
 
             cp_enabled, cp_group, cp_rank, cp_size = self._cp_info
             if cp_enabled:
-                logger.info(f"Context parallel batch sync initialized: cp_rank={cp_rank}, cp_size={cp_size}")
+                _, data_rank, data_local_rank, data_group_size, data_parallel_size = get_model_replica_data_info(
+                    self.accelerator, self._cp_info
+                )
+                logger.info(
+                    "Context parallel batch sync initialized: "
+                    f"cp_rank={cp_rank}, cp_size={cp_size}, data_rank={data_rank}, "
+                    f"data_local_rank={data_local_rank}, data_group_size={data_group_size}, "
+                    f"data_parallel_size={data_parallel_size}"
+                )
 
     @property
     def is_cp_enabled(self) -> bool:
@@ -184,9 +244,11 @@ class ContextParallelBatchSynchronizer:
 
     @property
     def is_cp_leader(self) -> bool:
-        """Check if this rank is the leader (rank 0) of its CP group."""
+        """Check if this rank samples for its model replica."""
         self._ensure_initialized()
-        return self._cp_info[2] == 0
+        if not self._cp_info[0]:
+            return True
+        return get_model_replica_data_info(self.accelerator, self._cp_info)[2] == 0
 
     @property
     def cp_rank(self) -> int:
@@ -204,7 +266,7 @@ class ContextParallelBatchSynchronizer:
         """
         Synchronize batch across the CP group.
 
-        Only rank 0 of each CP group samples; other ranks receive the broadcast.
+        Only one rank per model replica samples; other ranks receive the broadcast.
 
         Args:
             batch: The batch data from the dataloader
@@ -220,9 +282,9 @@ class ContextParallelBatchSynchronizer:
         Fetch a batch with CP-aware sampling.
 
         When CP is enabled:
-        - CP leader (rank 0 of CP group) calls the iterator to sample a batch
-        - Non-leaders skip sampling and receive the batch via broadcast
-        - This ensures seen_images tracking is consistent across the CP group
+        - The model-replica leader calls the iterator to sample a batch
+        - Other ranks skip sampling and receive the batch via broadcast
+        - This ensures seen_images tracking is consistent across model-parallel ranks
 
         When CP is disabled:
         - All ranks call the iterator normally
@@ -242,12 +304,14 @@ class ContextParallelBatchSynchronizer:
             # No CP - just call the iterator normally
             return iterator_fn(step, *iterator_args)
 
-        if cp_rank == 0:
-            # CP leader: sample the batch normally
+        data_local_rank = get_model_replica_data_info(self.accelerator, self._cp_info)[2]
+
+        if data_local_rank == 0:
+            # Model-replica leader: sample the batch normally
             batch = iterator_fn(step, *iterator_args)
         else:
             # Non-leader: use sentinel (will be replaced by broadcast)
             batch = CP_SKIP_SAMPLING_SENTINEL
 
-        # Broadcast from leader to all ranks in CP group
+        # Broadcast from leader to all model-parallel ranks in the model replica
         return self.sync(batch)

--- a/simpletuner/helpers/metadata/backends/base.py
+++ b/simpletuner/helpers/metadata/backends/base.py
@@ -56,9 +56,9 @@ def get_cp_aware_dp_info(accelerator) -> Tuple[int, int, int]:
     """
     Get context-parallel-aware data parallelism information.
 
-    When context parallelism is enabled, the effective data parallelism degree
-    is reduced because multiple ranks share the same data (which is then split
-    along the sequence dimension).
+    With FSDP2 + context parallelism, only the replicated data-parallel axis
+    represents unique data shards. The FSDP shard axis and context-parallel axis
+    are model-parallel dimensions and must receive the same samples.
 
     Returns:
         Tuple of (effective_dp_size, dp_rank, cp_size):
@@ -78,18 +78,12 @@ def get_cp_aware_dp_info(accelerator) -> Tuple[int, int, int]:
         return world_size, global_rank, 1
 
     dp_replicate_size = _normalize_parallel_size(getattr(parallelism_config, "dp_replicate_size", 1), "dp_replicate_size")
-    dp_shard_size = _normalize_parallel_size(getattr(parallelism_config, "dp_shard_size", 1), "dp_shard_size")
-
     dp_replicate_rank = 0
     if dp_replicate_size > 1:
         dp_replicate_rank = _normalize_parallel_rank(accelerator.data_parallel_rank, "data_parallel_rank")
 
-    dp_shard_rank = 0
-    if dp_shard_size > 1:
-        dp_shard_rank = _normalize_parallel_rank(accelerator.data_parallel_shard_rank, "data_parallel_shard_rank")
-
-    effective_dp_size = dp_replicate_size * dp_shard_size
-    dp_rank = (dp_replicate_rank * dp_shard_size) + dp_shard_rank
+    effective_dp_size = dp_replicate_size
+    dp_rank = dp_replicate_rank
 
     logger.debug(
         f"Context parallel data splitting: world_size={world_size}, cp_size={cp_size}, "
@@ -752,8 +746,8 @@ class MetadataBackend:
         logger.debug(f"Count of items before split: {total_samples}")
 
         # Get context-parallel-aware data parallelism info
-        # When CP is enabled, multiple ranks share the same data shard, so we split
-        # by effective_dp_size (world_size / cp_size) instead of world_size
+        # When CP/FSDP model-parallel axes are enabled, multiple ranks share the
+        # same data shard, so only replicated DP groups split the dataset.
         effective_dp_size, dp_rank, cp_size = get_cp_aware_dp_info(self.accelerator)
         num_processes = effective_dp_size  # Use effective DP size for batch calculations
 

--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -2008,7 +2008,7 @@ class ModelFoundation(ABC):
         return self._single_file_component_cache
 
     def unwrap_model(self, model=None, keep_fp32_wrapper: bool = True):
-        if self.config.controlnet and model is None:
+        if getattr(self.config, "controlnet", False) and model is None:
             if self.controlnet is None:
                 return None
             return unwrap_model(self.accelerator, self.controlnet, keep_fp32_wrapper=keep_fp32_wrapper)

--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -3128,6 +3128,9 @@ class ModelFoundation(ABC):
         else:
             self.model = model
 
+    def before_accelerator_prepare(self):
+        pass
+
     def freeze_components(self):
         if self.vae is not None:
             self.vae.requires_grad_(False)

--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 import numpy as np
 import torch
 import torch.nn.functional as F
+from huggingface_hub import snapshot_download
 from PIL import Image
 from torch.distributions import Beta
 from torchvision import transforms
@@ -79,6 +80,10 @@ if should_log():
     logger.setLevel(os.environ.get("SIMPLETUNER_LOG_LEVEL", "INFO"))
 else:
     logger.setLevel("ERROR")
+
+
+def _is_hf_repo_id(path: str) -> bool:
+    return isinstance(path, str) and not os.path.exists(path) and "://" not in path
 
 
 flow_matching_model_families = [
@@ -2616,6 +2621,25 @@ class ModelFoundation(ABC):
                     "subfolder": text_encoder_config.get("subfolder", "text_encoder") or "",
                     **extra_kwargs,
                 }
+                accelerator = getattr(self, "accelerator", None)
+                if accelerator is not None and _is_hf_repo_id(text_encoder_path):
+                    subfolder = text_encoder_kwargs["subfolder"]
+                    if _get_rank() == 0:
+                        snapshot_download(
+                            repo_id=text_encoder_path,
+                            revision=self.config.revision,
+                            allow_patterns=[f"{subfolder}/*"] if subfolder else None,
+                        )
+                    if torch.distributed.is_available() and torch.distributed.is_initialized():
+                        torch.distributed.barrier()
+                    else:
+                        accelerator.wait_for_everyone()
+                    text_encoder_kwargs["pretrained_model_name_or_path"] = snapshot_download(
+                        repo_id=text_encoder_path,
+                        revision=self.config.revision,
+                        allow_patterns=[f"{subfolder}/*"] if subfolder else None,
+                        local_files_only=True,
+                    )
                 logger.debug(f"Text encoder {text_encoder_idx} load args: {text_encoder_kwargs}")
                 text_encoder = text_encoder_config["model"].from_pretrained(**text_encoder_kwargs)
                 is_bnb_quantized = self._is_bitsandbytes_model(text_encoder)

--- a/simpletuner/helpers/models/ltxvideo2/model.py
+++ b/simpletuner/helpers/models/ltxvideo2/model.py
@@ -587,6 +587,11 @@ class LTXVideo2(VideoModelFoundation):
         super().post_model_load_setup()
         self._load_connectors(move_to_device=True)
 
+    def before_accelerator_prepare(self):
+        super().before_accelerator_prepare()
+        if self.model is not None and getattr(self.model, "connectors", None) is self.connectors:
+            self.model.connectors = None
+
     def _load_video_vae_from_combined(self):
         if self.vae is not None:
             return

--- a/simpletuner/helpers/models/ltxvideo2/transformer.py
+++ b/simpletuner/helpers/models/ltxvideo2/transformer.py
@@ -579,7 +579,14 @@ class LTX2Attention(torch.nn.Module, AttentionModuleMixin):
                 f"attention_kwargs {unused_kwargs} are not expected by {self.processor.__class__.__name__} and will be ignored."
             )
         kwargs = {k: w for k, w in kwargs.items() if k in attn_parameters}
-        hidden_states = self.processor(
+        processor_call = self.processor.__call__
+        if (
+            torch.compiler.is_compiling()
+            and _ltx2_active_attention_backend(getattr(self.processor, "_attention_backend", None))
+            == AttentionBackendName._FLASH_3_VARLEN_HUB
+        ):
+            processor_call = torch.compiler.disable(processor_call)
+        hidden_states = processor_call(
             self, hidden_states, encoder_hidden_states, attention_mask, query_rotary_emb, key_rotary_emb, **kwargs
         )
         return hidden_states

--- a/simpletuner/helpers/models/ltxvideo2/transformer.py
+++ b/simpletuner/helpers/models/ltxvideo2/transformer.py
@@ -45,6 +45,7 @@ from simpletuner.helpers.models.flowmap import (
     validate_flowmap_deltatime_type,
 )
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
+from simpletuner.helpers.training.checkpointing import checkpoint as simpletuner_checkpoint
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
 from simpletuner.helpers.training.tread import TREADRouter
 
@@ -144,7 +145,7 @@ def _ltx2_flash3_varlen_hub_attention(
         value_packed = value.flatten(0, 1)
     else:
         seqlens_k = keep_mask.sum(dim=1, dtype=torch.int32)
-        if torch.any(seqlens_k == 0):
+        if not torch.compiler.is_compiling() and torch.any(seqlens_k == 0):
             raise ValueError("LTX-2 varlen attention received a mask with no valid key/value tokens.")
         key_packed = torch.cat([key[idx, keep_mask[idx]] for idx in range(batch_size)], dim=0)
         value_packed = torch.cat([value[idx, keep_mask[idx]] for idx in range(batch_size)], dim=0)
@@ -162,14 +163,17 @@ def _ltx2_flash3_varlen_hub_attention(
         v=value_packed,
         cu_seqlens_q=cu_seqlens_q,
         cu_seqlens_k=cu_seqlens_k,
-        max_seqlen_q=int(seqlens_q.max().item()),
-        max_seqlen_k=int(seqlens_k.max().item()),
+        max_seqlen_q=seq_len_q,
+        max_seqlen_k=seq_len_kv,
         softmax_scale=scale,
         causal=is_causal,
     )
     if isinstance(output, tuple):
         output = output[0]
     return output.unflatten(0, (batch_size, seq_len_q))
+
+
+_ltx2_flash3_varlen_hub_attention_eager = torch.compiler.disable(_ltx2_flash3_varlen_hub_attention)
 
 
 def _ltx2_dispatch_attention(
@@ -182,7 +186,10 @@ def _ltx2_dispatch_attention(
 ) -> torch.Tensor:
     backend_name = _ltx2_active_attention_backend(backend)
     if backend_name == AttentionBackendName._FLASH_3_VARLEN_HUB:
-        return _ltx2_flash3_varlen_hub_attention(
+        attention_fn = (
+            _ltx2_flash3_varlen_hub_attention_eager if torch.compiler.is_compiling() else _ltx2_flash3_varlen_hub_attention
+        )
+        return attention_fn(
             query=query,
             key=key,
             value=value,
@@ -1650,6 +1657,14 @@ class LTX2VideoTransformer3DModel(
             return tuple(_route_one(r) for r in rope)
         return _route_one(rope)
 
+    @staticmethod
+    def _rope_to_dtype(rope, dtype: torch.dtype):
+        if rope is None:
+            return None
+        if isinstance(rope, tuple):
+            return tuple(r.to(dtype=dtype) for r in rope)
+        return rope.to(dtype=dtype)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -1896,11 +1911,20 @@ class LTX2VideoTransformer3DModel(
         if audio_coords is None:
             audio_coords = self.audio_rope.prepare_audio_coords(batch_size, audio_num_frames, audio_hidden_states.device)
 
-        video_rotary_emb = self.rope(video_coords, fps=fps, device=hidden_states.device)
-        audio_rotary_emb = self.audio_rope(audio_coords, device=audio_hidden_states.device)
+        video_rotary_emb = self._rope_to_dtype(
+            self.rope(video_coords, fps=fps, device=hidden_states.device), hidden_states.dtype
+        )
+        audio_rotary_emb = self._rope_to_dtype(
+            self.audio_rope(audio_coords, device=audio_hidden_states.device), audio_hidden_states.dtype
+        )
 
-        video_cross_attn_rotary_emb = self.cross_attn_rope(video_coords[:, 0:1, :], device=hidden_states.device)
-        audio_cross_attn_rotary_emb = self.cross_attn_audio_rope(audio_coords[:, 0:1, :], device=audio_hidden_states.device)
+        video_cross_attn_rotary_emb = self._rope_to_dtype(
+            self.cross_attn_rope(video_coords[:, 0:1, :], device=hidden_states.device), hidden_states.dtype
+        )
+        audio_cross_attn_rotary_emb = self._rope_to_dtype(
+            self.cross_attn_audio_rope(audio_coords[:, 0:1, :], device=audio_hidden_states.device),
+            audio_hidden_states.dtype,
+        )
 
         # 2. Patchify input projections
         hidden_states = self.proj_in(hidden_states)
@@ -2096,10 +2120,9 @@ class LTX2VideoTransformer3DModel(
 
                     checkpoint_fn = offloaded_checkpoint
                 else:
-                    checkpoint_fn = torch.utils.checkpoint.checkpoint
+                    checkpoint_fn = simpletuner_checkpoint
 
-                hidden_states, audio_hidden_states = checkpoint_fn(
-                    block,
+                def _checkpoint_block(
                     hidden_states,
                     audio_hidden_states,
                     encoder_hidden_states,
@@ -2116,16 +2139,54 @@ class LTX2VideoTransformer3DModel(
                     audio_rotary_emb,
                     current_ca_video_rotary_emb,
                     audio_cross_attn_rotary_emb,
-                    encoder_attention_mask,
-                    audio_encoder_attention_mask,
-                    self_attention_mask,
-                    audio_self_attention_mask,
-                    a2v_cross_attention_mask,
-                    v2a_cross_attention_mask,
-                    True,
-                    True,
-                    None,
-                    None,
+                ):
+                    return block(
+                        hidden_states,
+                        audio_hidden_states,
+                        encoder_hidden_states,
+                        audio_encoder_hidden_states,
+                        temb,
+                        temb_audio,
+                        video_cross_attn_scale_shift,
+                        audio_cross_attn_scale_shift,
+                        video_cross_attn_a2v_gate,
+                        audio_cross_attn_v2a_gate,
+                        temb_prompt,
+                        temb_prompt_audio,
+                        current_video_rotary_emb,
+                        audio_rotary_emb,
+                        current_ca_video_rotary_emb,
+                        audio_cross_attn_rotary_emb,
+                        encoder_attention_mask,
+                        audio_encoder_attention_mask,
+                        self_attention_mask,
+                        audio_self_attention_mask,
+                        a2v_cross_attention_mask,
+                        v2a_cross_attention_mask,
+                        True,
+                        True,
+                        None,
+                        None,
+                    )
+
+                hidden_states, audio_hidden_states = checkpoint_fn(
+                    _checkpoint_block,
+                    hidden_states,
+                    audio_hidden_states,
+                    encoder_hidden_states,
+                    audio_encoder_hidden_states,
+                    temb,
+                    temb_audio,
+                    video_cross_attn_scale_shift,
+                    audio_cross_attn_scale_shift,
+                    video_cross_attn_a2v_gate,
+                    audio_cross_attn_v2a_gate,
+                    temb_prompt,
+                    temb_prompt_audio,
+                    current_video_rotary_emb,
+                    audio_rotary_emb,
+                    current_ca_video_rotary_emb,
+                    audio_cross_attn_rotary_emb,
                     use_reentrant=False,
                 )
             else:

--- a/simpletuner/helpers/training/checkpointing.py
+++ b/simpletuner/helpers/training/checkpointing.py
@@ -1,0 +1,16 @@
+import os
+from typing import Any, Callable
+
+import torch
+
+
+def _dynamo_backend_enabled() -> bool:
+    backend = os.environ.get("TRAINING_DYNAMO_BACKEND", "")
+    return backend.strip().lower() not in {"", "no", "none", "disabled"}
+
+
+def checkpoint(function: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    use_reentrant = kwargs.get("use_reentrant")
+    if use_reentrant is False and _dynamo_backend_enabled():
+        kwargs.setdefault("determinism_check", "none")
+    return torch.utils.checkpoint.checkpoint(function, *args, **kwargs)

--- a/simpletuner/helpers/training/checkpointing.py
+++ b/simpletuner/helpers/training/checkpointing.py
@@ -13,4 +13,7 @@ def checkpoint(function: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
     use_reentrant = kwargs.get("use_reentrant")
     if use_reentrant is False and _dynamo_backend_enabled():
         kwargs.setdefault("determinism_check", "none")
+        if torch.compiler.is_compiling():
+            checkpoint_eager = torch.compiler.disable(torch.utils.checkpoint.checkpoint)
+            return checkpoint_eager(function, *args, **kwargs)
     return torch.utils.checkpoint.checkpoint(function, *args, **kwargs)

--- a/simpletuner/helpers/training/collate.py
+++ b/simpletuner/helpers/training/collate.py
@@ -1234,6 +1234,8 @@ def collate_fn(batch):
     return {
         "latent_batch": latent_batch,
         "latent_metadata": latent_metadata,
+        "filepaths": filepaths,
+        "data_backend_id": batch_backend_id,
         "prompts": captions,
         "text_encoder_output": all_text_encoder_outputs,
         "prompt_embeds": all_text_encoder_outputs.get("prompt_embeds"),

--- a/simpletuner/helpers/training/dynamo.py
+++ b/simpletuner/helpers/training/dynamo.py
@@ -35,3 +35,11 @@ def run_with_dynamo_config(config: Any, fn: Callable[..., Any], *args: Any, **kw
     with dynamo_config_context(config):
         context = contextvars.copy_context()
         return context.run(fn, *args, **kwargs)
+
+
+def mark_cudagraph_step_begin(config: Any) -> None:
+    if not getattr(config, "dynamo_backend", None):
+        return
+    mark_step_begin = getattr(torch.compiler, "cudagraph_mark_step_begin", None)
+    if mark_step_begin is not None:
+        mark_step_begin()

--- a/simpletuner/helpers/training/dynamo.py
+++ b/simpletuner/helpers/training/dynamo.py
@@ -1,0 +1,37 @@
+import contextlib
+import contextvars
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import torch
+
+
+def _coerce_flag(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+    return bool(value)
+
+
+def dynamo_config_patches(config: Any) -> dict[str, Any]:
+    patches: dict[str, Any] = {}
+    if _coerce_flag(getattr(config, "dynamo_dynamic", None)):
+        patches["capture_dynamic_output_shape_ops"] = True
+        patches["force_parameter_static_shapes"] = False
+    return patches
+
+
+@contextlib.contextmanager
+def dynamo_config_context(config: Any) -> Iterator[None]:
+    patches = dynamo_config_patches(config)
+    if not patches:
+        yield
+        return
+
+    with torch._dynamo.config.patch(patches):
+        yield
+
+
+def run_with_dynamo_config(config: Any, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    with dynamo_config_context(config):
+        context = contextvars.copy_context()
+        return context.run(fn, *args, **kwargs)

--- a/simpletuner/helpers/training/optimizer_param.py
+++ b/simpletuner/helpers/training/optimizer_param.py
@@ -3,6 +3,7 @@ import importlib.util
 import inspect
 import logging
 import os
+import types
 from functools import lru_cache
 
 import accelerate
@@ -916,6 +917,13 @@ def optimizer_parameters(optimizer, args):
         optimizer_class = optimizer_choice_entry.get("class")
         optimizer_params = copy.deepcopy(optimizer_choice_entry.get("default_settings", {}))
         optimizer_params.update(convert_arg_to_parameters(args))
+        if optimizer == "prodigy" and _is_fsdp2_enabled(args) and optimizer_params.get("factored", False):
+            logger.warning(
+                "Disabling Prodigy factored second-moment state for FSDP2. "
+                "ProdigyPlus creates factored row/column buffers as local tensors, which cannot be updated with "
+                "DTensor gradients."
+            )
+            optimizer_params["factored"] = False
         if args.optimizer_release_gradients and "optimi-" in optimizer:
             optimizer_params["gradient_release"] = True
 
@@ -978,17 +986,96 @@ def _requires_fsdp2_safe_fallback(args, optimizer_name: str | None) -> bool:
     """
     if optimizer_name is None:
         return False
-    if not getattr(args, "use_fsdp", False):
+    if not _is_fsdp2_enabled(args):
+        return False
+
+    return _is_optimizer_fsdp2_incompatible(optimizer_name)
+
+
+def _is_fsdp2_enabled(args) -> bool:
+    if not (getattr(args, "use_fsdp", False) or getattr(args, "fsdp_enable", False)):
         return False
     fsdp_version_raw = getattr(args, "fsdp_version", 2)
     try:
         fsdp_version = int(fsdp_version_raw)
     except (TypeError, ValueError):
         fsdp_version = 2
-    if fsdp_version != 2:
-        return False
+    return fsdp_version == 2
 
-    return _is_optimizer_fsdp2_incompatible(optimizer_name)
+
+def patch_prodigy_for_fsdp2_dtensor(optimizer, args) -> None:
+    if getattr(args, "optimizer", None) != "prodigy" or not _is_fsdp2_enabled(args):
+        return
+
+    target_optimizer = getattr(optimizer, "optimizer", optimizer)
+    if getattr(target_optimizer, "_simpletuner_fsdp2_dtensor_patch", False):
+        return
+    if target_optimizer.__class__.__module__.split(".", 1)[0] != "prodigyplus":
+        return
+
+    def _local_scalar(value, like: torch.Tensor) -> torch.Tensor:
+        full_tensor = getattr(value, "full_tensor", None)
+        if callable(full_tensor):
+            value = full_tensor()
+        if not torch.is_tensor(value):
+            value = torch.as_tensor(value, device=like.device, dtype=like.dtype)
+        return value.detach().to(device=like.device, dtype=like.dtype)
+
+    def update_prodigy_fsdp2(self, state, group, grad, data):
+        k = group["k"]
+        prodigy_steps = group["prodigy_steps"]
+
+        if prodigy_steps <= 0 or k < prodigy_steps:
+            d_update = (group["d"] ** 2) / (group["d0"] ** 0.5)
+
+            sliced_grad = self.get_sliced_tensor(grad)
+            sliced_data = self.get_sliced_tensor(data)
+            running_d_numerator, running_d_denom = self.get_running_values_for_group(group)
+
+            x0_minus = state["p0"] - sliced_data
+            x0_dot = torch.dot(sliced_grad, x0_minus)
+
+            if group["use_speed"]:
+                beta = 1 - (k**-0.75)
+                previous_x0_dot = state.get("exp_avg_x0_dot", None)
+                if previous_x0_dot is not None:
+                    x0_dot = x0_dot * (1 - beta) + previous_x0_dot * beta
+
+                x0_minus_l1_norm = x0_minus.abs().sum()
+                x0_minus_l1_norm = _local_scalar(x0_minus_l1_norm, running_d_denom).clamp_min(
+                    state.get("max_x0_minus_l1_norm", 1e-8)
+                )
+                state["max_x0_minus_l1_norm"] = x0_minus_l1_norm.item()
+
+                x0_minus_l2_norm = x0_minus.norm()
+                x0_minus_l2_norm = _local_scalar(x0_minus_l2_norm, running_d_denom).clamp_min(
+                    state.get("max_x0_minus_l2_norm", 1e-8)
+                )
+                state["max_x0_minus_l2_norm"] = x0_minus_l2_norm.item()
+
+                d_update /= x0_minus_l2_norm.add(1).square()
+                running_d_denom.add_(x0_minus_l2_norm)
+                x0_dot = _local_scalar(x0_dot, running_d_numerator).div_(x0_minus_l1_norm)
+                state["exp_avg_x0_dot"] = x0_dot.item()
+            else:
+                _, _, beta3 = self.get_betas(group)
+                denom_update = state["s"].mul_(beta3).add_(sliced_grad, alpha=d_update).abs().sum()
+                running_d_denom.add_(_local_scalar(denom_update, running_d_denom))
+                x0_dot = _local_scalar(x0_dot, running_d_numerator)
+
+            running_d_numerator.add_(x0_dot, alpha=d_update)
+
+            del x0_minus
+        else:
+            if "s" in state:
+                s = state.pop("s")
+                del s
+            if "p0" in state:
+                p0 = state.pop("p0")
+                del p0
+
+    target_optimizer.update_prodigy = types.MethodType(update_prodigy_fsdp2, target_optimizer)
+    target_optimizer._simpletuner_fsdp2_dtensor_patch = True
 
 
 def _is_optimizer_fsdp2_incompatible(optimizer_name: str | None) -> bool:

--- a/simpletuner/helpers/training/save_hooks.py
+++ b/simpletuner/helpers/training/save_hooks.py
@@ -103,6 +103,16 @@ def _collect_wrapped_component_classes(accelerator, component):
     return classes
 
 
+def _materialize_tensor_for_save(tensor: torch.Tensor) -> torch.Tensor:
+    if type(tensor).__name__ == "DTensor" and hasattr(tensor, "full_tensor"):
+        tensor = tensor.full_tensor()
+    return tensor.detach().cpu().contiguous().clone()
+
+
+def _materialize_state_dict_for_save(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    return {name: _materialize_tensor_for_save(tensor) for name, tensor in state_dict.items()}
+
+
 class SaveHookManager:
     def __init__(
         self,
@@ -443,7 +453,7 @@ class SaveHookManager:
             except Exception as exc:
                 logger.warning("Failed to restore models after offload save: %s", exc)
 
-    def _save_lora(self, models, weights, output_dir):
+    def _save_lora(self, models, weights, output_dir, write: bool = True):
         # for SDXL/others, there are only two options here. Either are just the unet attn processor layers
         # or there are the unet and text encoder atten layers.
         model_lora_layers_to_save = None
@@ -469,7 +479,11 @@ class SaveHookManager:
             }
             ema_modules_to_save = {self.model.MODEL_SUBFOLDER: ema_trained_component}
             ema_metadata = _collate_lora_metadata(ema_modules_to_save)
-            self.model.save_lora_weights(os.path.join(output_dir, "ema"), **lora_save_parameters, **ema_metadata)
+            lora_save_parameters = {
+                key: _materialize_state_dict_for_save(value) for key, value in lora_save_parameters.items()
+            }
+            if write:
+                self.model.save_lora_weights(os.path.join(output_dir, "ema"), **lora_save_parameters, **ema_metadata)
             self.ema_model.restore(trainable_parameters)
 
         trained_component_classes = _collect_wrapped_component_classes(
@@ -531,6 +545,10 @@ class SaveHookManager:
             # make sure to pop weight so that corresponding model is not saved again
             if weights:
                 weights.pop()
+
+        lora_save_parameters = {key: _materialize_state_dict_for_save(value) for key, value in lora_save_parameters.items()}
+        if not write:
+            return
 
         metadata = _collate_lora_metadata(modules_to_save)
         self.model.save_lora_weights(output_dir, **lora_save_parameters, **metadata)
@@ -829,17 +847,20 @@ class SaveHookManager:
             ):
                 logger.info("Detected FSDP v2; skipping custom full-model save and relying on Accelerate shards.")
                 # LoRA/LyCORIS adapters are not part of the FSDP-wrapped module; save them explicitly.
-                if is_main_process and "lora" in self.args.model_type:
+                if "lora" in self.args.model_type:
                     if self.args.lora_type == "lycoris":
-                        logger.info("Saving LyCORIS adapter weights alongside FSDP v2 shards.")
-                        self._save_lycoris(models=models, weights=weights, output_dir=output_dir)
+                        if is_main_process:
+                            logger.info("Saving LyCORIS adapter weights alongside FSDP v2 shards.")
+                            self._save_lycoris(models=models, weights=weights, output_dir=output_dir)
                     elif self.args.lora_type == "standard":
-                        logger.info("Saving standard LoRA adapter weights alongside FSDP v2 shards.")
-                        self._save_lora(models=models, weights=weights, output_dir=output_dir)
-                        self._save_lyrics_embedder_state(
-                            output_dir=output_dir,
-                            is_main_process=is_main_process,
-                        )
+                        if is_main_process:
+                            logger.info("Saving standard LoRA adapter weights alongside FSDP v2 shards.")
+                        self._save_lora(models=models, weights=weights, output_dir=output_dir, write=is_main_process)
+                        if is_main_process:
+                            self._save_lyrics_embedder_state(
+                                output_dir=output_dir,
+                                is_main_process=is_main_process,
+                            )
                 if self.accelerator is not None and distributed_type != DistributedType.NO:
                     self.accelerator.wait_for_everyone()
                 return

--- a/simpletuner/helpers/training/save_hooks.py
+++ b/simpletuner/helpers/training/save_hooks.py
@@ -103,6 +103,15 @@ def _collect_wrapped_component_classes(accelerator, component):
     return classes
 
 
+def _get_trained_component_for_save(model, **kwargs):
+    try:
+        return model.get_trained_component(**kwargs)
+    except TypeError as exc:
+        if "unexpected keyword argument" not in str(exc):
+            raise
+        return model.get_trained_component()
+
+
 def _materialize_tensor_for_save(tensor: torch.Tensor) -> torch.Tensor:
     if type(tensor).__name__ == "DTensor" and hasattr(tensor, "full_tensor"):
         tensor = tensor.full_tensor()
@@ -493,7 +502,7 @@ class SaveHookManager:
         trained_component_classes.update(
             _collect_wrapped_component_classes(
                 self.accelerator,
-                self.model.get_trained_component(base_model=True, unwrap_model=False),
+                _get_trained_component_for_save(self.model, base_model=True, unwrap_model=False),
             )
         )
         text_encoder_0_cls = None

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -604,11 +604,51 @@ class Trainer:
                 "Torch Dynamo config lacks capture_dynamic_output_shape_ops; skipping dynamic output capture configuration."
             )
             return
-        if getattr(config_obj, "capture_dynamic_output_shape_ops", False):
+        if not getattr(config_obj, "capture_dynamic_output_shape_ops", False):
+            config_obj.capture_dynamic_output_shape_ops = True
+            logger.info("Torch Dynamo capture_dynamic_output_shape_ops enabled for dynamic output shape support.")
+
+        if hasattr(config_obj, "force_parameter_static_shapes") and getattr(
+            config_obj, "force_parameter_static_shapes", True
+        ):
+            config_obj.force_parameter_static_shapes = False
+            logger.info("Torch Dynamo force_parameter_static_shapes disabled for dynamic parameter shape support.")
+
+    def _disable_dynamo_lru_cache_for_checkpointing(self) -> None:
+        eval_frame = getattr(getattr(torch._C, "_dynamo", None), "eval_frame", None)
+        set_lru_cache = getattr(eval_frame, "_set_lru_cache", None)
+        if set_lru_cache is None:
+            logger.debug("Torch Dynamo eval_frame._set_lru_cache unavailable; skipping LRU cache configuration.")
             return
 
-        config_obj.capture_dynamic_output_shape_ops = True
-        logger.info("Torch Dynamo capture_dynamic_output_shape_ops enabled for bitsandbytes models.")
+        set_lru_cache(False)
+        logger.info("Torch Dynamo LRU cache disabled for compiled gradient checkpointing.")
+
+    def _configure_inductor_dynamic_training_passes(self, dynamo_backend: str) -> None:
+        if dynamo_backend != "inductor":
+            return
+
+        disabled_passes = [
+            candidate.strip()
+            for candidate in os.environ.get("TORCHINDUCTOR_DISABLED_PASSES", "").split(",")
+            if candidate.strip()
+        ]
+        if not any(candidate.upper() == "PASS_PATTERN_1" for candidate in disabled_passes):
+            disabled_passes.append("PASS_PATTERN_1")
+            os.environ["TORCHINDUCTOR_DISABLED_PASSES"] = ",".join(disabled_passes)
+
+        try:
+            import torch._inductor.config as inductor_config
+        except Exception as exc:
+            logger.warning("Unable to configure TorchInductor pass disables: %s", exc)
+            return
+
+        if getattr(inductor_config, "disabled_passes", "") != os.environ["TORCHINDUCTOR_DISABLED_PASSES"]:
+            inductor_config.disabled_passes = os.environ["TORCHINDUCTOR_DISABLED_PASSES"]
+        logger.info(
+            "TorchInductor disabled passes for compiled training: %s",
+            os.environ["TORCHINDUCTOR_DISABLED_PASSES"],
+        )
 
     def parse_arguments(self, args=None, disable_accelerator: bool = False, exit_on_error: bool = False):
         skip_config_fallback = False
@@ -728,6 +768,7 @@ class Trainer:
         elif isinstance(dynamo_backend_value, str) and dynamo_backend_value.strip():
             dynamo_backend_env = dynamo_backend_value.strip().lower()
         os.environ["TRAINING_DYNAMO_BACKEND"] = dynamo_backend_env
+        self._configure_inductor_dynamic_training_passes(dynamo_backend_env)
 
         report_to_value = getattr(self.config, "report_to", None)
         if isinstance(report_to_value, unittest_mock.Mock):
@@ -860,8 +901,12 @@ class Trainer:
 
             dynamo_plugin = None
             if will_create_dynamo_plugin:
-                if is_bitsandbytes_available and self._config_uses_bitsandbytes():
+                if (is_bitsandbytes_available and self._config_uses_bitsandbytes()) or _coerce_flag(
+                    getattr(self.config, "dynamo_dynamic", None)
+                ):
                     self._enable_dynamo_dynamic_output_capture()
+                if _coerce_flag(getattr(self.config, "gradient_checkpointing", None)):
+                    self._disable_dynamo_lru_cache_for_checkpointing()
 
                 plugin_kwargs: Dict[str, object] = {"backend": resolved_dynamo_backend}
 
@@ -3784,6 +3829,8 @@ class Trainer:
             )
         )
         primary_model = self.model.get_trained_component(unwrap_model=False)
+        if hasattr(self.model, "before_accelerator_prepare"):
+            self.model.before_accelerator_prepare()
         attach_shared_ramtorch_parameters = None
         if self._ramtorch_distributed() and primary_model is not None:
             ramtorch_utils.ensure_available()
@@ -6494,22 +6541,26 @@ class Trainer:
             if self.model.get_trained_component() is not None:
                 self.model.model = unwrap_model(self.accelerator, self.model.model)
             if "lora" in self.config.model_type and "standard" == self.config.lora_type.lower():
+                from simpletuner.helpers.training.save_hooks import _materialize_state_dict_for_save
+
                 trained_component = unwrap_model(self.accelerator, self.model.get_trained_component(unwrap_model=False))
                 lora_save_kwargs = {
                     "save_directory": self.config.output_dir,
-                    f"{self.model.MODEL_TYPE.value}_lora_layers": get_peft_model_state_dict(trained_component),
+                    f"{self.model.MODEL_TYPE.value}_lora_layers": _materialize_state_dict_for_save(
+                        get_peft_model_state_dict(trained_component)
+                    ),
                 }
 
                 if self.config.train_text_encoder:
                     if self.model.get_text_encoder(0) is not None:
                         self.text_encoder_1 = self.accelerator.unwrap_model(self.model.get_text_encoder(0))
-                        lora_save_kwargs["text_encoder_lora_layers"] = convert_state_dict_to_diffusers(
-                            get_peft_model_state_dict(self.text_encoder_1)
+                        lora_save_kwargs["text_encoder_lora_layers"] = _materialize_state_dict_for_save(
+                            convert_state_dict_to_diffusers(get_peft_model_state_dict(self.text_encoder_1))
                         )
                     if self.model.get_text_encoder(1) is not None:
                         self.text_encoder_2 = self.accelerator.unwrap_model(self.model.get_text_encoder(1))
-                        lora_save_kwargs["text_encoder_2_lora_layers"] = convert_state_dict_to_diffusers(
-                            get_peft_model_state_dict(self.text_encoder_2)
+                        lora_save_kwargs["text_encoder_2_lora_layers"] = _materialize_state_dict_for_save(
+                            convert_state_dict_to_diffusers(get_peft_model_state_dict(self.text_encoder_2))
                         )
                         if self.model.get_text_encoder(2) is not None:
                             self.text_encoder_3 = self.accelerator.unwrap_model(self.model.get_text_encoder(2))
@@ -6517,9 +6568,12 @@ class Trainer:
                     text_encoder_lora_layers = None
                     text_encoder_2_lora_layers = None
 
-                self.model.save_lora_weights(
-                    **lora_save_kwargs,
-                )
+                if self.accelerator.is_main_process or self.config.use_deepspeed_optimizer:
+                    self.model.save_lora_weights(
+                        **lora_save_kwargs,
+                    )
+                if self.config.fsdp_enable:
+                    self.accelerator.wait_for_everyone()
                 del text_encoder_lora_layers
                 del text_encoder_2_lora_layers
                 reclaim_memory()

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -62,6 +62,7 @@ from simpletuner.helpers.training.deepspeed import prepare_model_for_deepspeed
 from simpletuner.helpers.training.deepspeed_optimizers import DEFAULT_OPTIMIZER as DS_DEFAULT_OPTIMIZER
 from simpletuner.helpers.training.deepspeed_optimizers import sanitize_optimizer_block
 from simpletuner.helpers.training.default_settings.safety_check import safety_check
+from simpletuner.helpers.training.dynamo import mark_cudagraph_step_begin
 from simpletuner.helpers.training.evaluation import ModelEvaluator
 from simpletuner.helpers.training.exceptions import GPUHealthError
 from simpletuner.helpers.training.gpu_circuit_breaker import get_current_gpu_index, get_gpu_circuit_breaker, is_cuda_error
@@ -77,6 +78,7 @@ from simpletuner.helpers.training.optimizer_param import (
     is_bitsandbytes_available,
     is_lr_schedulefree,
     is_lr_scheduler_disabled,
+    patch_prodigy_for_fsdp2_dtensor,
 )
 from simpletuner.helpers.training.optimizers.adamw_bfloat16 import AdamWBF16
 from simpletuner.helpers.training.peft_init import init_lokr_network_with_perturbed_normal
@@ -979,14 +981,44 @@ class Trainer:
                     )
                 setattr(self.config, "context_parallel_comm_strategy", context_parallel_strategy)
 
+                world_size = None
+                for world_size_candidate in (
+                    os.environ.get("WORLD_SIZE"),
+                    os.environ.get("TRAINING_NUM_PROCESSES"),
+                    getattr(self.config, "num_processes", None),
+                ):
+                    if world_size_candidate in (None, "", "None"):
+                        continue
+                    try:
+                        world_size = int(world_size_candidate)
+                    except (TypeError, ValueError) as exc:
+                        raise ValueError(
+                            f"Context parallelism requires an integer process count, got {world_size_candidate!r}."
+                        ) from exc
+                    break
+                if world_size is None:
+                    raise ValueError("Context parallelism requires a known process count before Accelerator setup.")
+                if world_size < context_parallel_size:
+                    raise ValueError(
+                        f"Context parallel size ({context_parallel_size}) cannot exceed process count ({world_size})."
+                    )
+                if world_size % context_parallel_size != 0:
+                    raise ValueError(
+                        f"Context parallel size ({context_parallel_size}) must evenly divide process count ({world_size})."
+                    )
+                dp_shard_size = world_size // context_parallel_size
+
                 accelerator_kwargs["parallelism_config"] = ParallelismConfig(
+                    dp_shard_size=dp_shard_size,
                     cp_size=context_parallel_size,
+                    cp_backend="torch",
                     cp_handler=TorchContextParallelConfig(cp_comm_strategy=context_parallel_strategy),
                 )
                 logger.info(
-                    "Context parallelism enabled (size=%s, rotation=%s).",
+                    "Context parallelism enabled (size=%s, rotation=%s, dp_shard_size=%s).",
                     context_parallel_size,
                     context_parallel_strategy,
+                    dp_shard_size,
                 )
             elif context_parallel_size is not None:
                 # Normalise stored value when users explicitly set 1 to disable sharding
@@ -3603,6 +3635,7 @@ class Trainer:
                 offload_mechanism=self.config.optimizer_cpu_offload_method,
             )
 
+        patch_prodigy_for_fsdp2_dtensor(self.optimizer, self.config)
         self._register_optimizer_attention_params(self.optimizer)
         AttentionBackendController.bind_optimizer(self.optimizer)
         if is_optimi_available and self.config.optimizer_release_gradients and "optimi" in self.config.optimizer:
@@ -3637,6 +3670,7 @@ class Trainer:
                 offload_gradients=self.config.optimizer_offload_gradients,
                 offload_mechanism=self.config.optimizer_cpu_offload_method,
             )
+            patch_prodigy_for_fsdp2_dtensor(self.sidecar_optimizer, lyrics_config)
             self.sidecar_is_schedulefree = is_lr_schedulefree(lyrics_optimizer_name)
             logger.info(
                 "Configured lyrics embedder optimizer with %s parameters",
@@ -5239,6 +5273,7 @@ class Trainer:
 
         try:
             if not self.config.disable_accelerator:
+                mark_cudagraph_step_begin(self.config)
                 if self.config.controlnet:
                     model_pred = self.model.controlnet_predict(
                         prepared_batch=prepared_batch,
@@ -6010,6 +6045,15 @@ class Trainer:
                     parent_loss = None
                     if is_regularisation_data:
                         parent_loss = loss
+                    if not torch.isfinite(loss.detach()).all():
+                        batch_filepaths = prepared_batch.get("filepaths")
+                        batch_backend_id = prepared_batch.get("data_backend_id")
+                        loss_logs_context = {k: v for k, v in (loss_logs or {}).items()}
+                        raise RuntimeError(
+                            "Non-finite training loss detected "
+                            f"(loss={loss.detach().item()}, data_backend_id={batch_backend_id}, "
+                            f"filepaths={batch_filepaths}, loss_logs={loss_logs_context})."
+                        )
 
                     # Gather the losses across all processes for logging (if using distributed training)
                     avg_loss = self.accelerator.gather(loss.repeat(self.config.train_batch_size)).mean()
@@ -6499,6 +6543,35 @@ class Trainer:
         # Create the pipeline using the trained modules and save it.
         self.accelerator.wait_for_everyone()
         validation_images = None
+        final_lora_save_kwargs = None
+        if "lora" in self.config.model_type and "standard" == self.config.lora_type.lower():
+            from simpletuner.helpers.training.save_hooks import _materialize_state_dict_for_save
+
+            trained_component = unwrap_model(self.accelerator, self.model.get_trained_component(unwrap_model=False))
+            final_lora_save_kwargs = {
+                "save_directory": self.config.output_dir,
+                f"{self.model.MODEL_TYPE.value}_lora_layers": _materialize_state_dict_for_save(
+                    get_peft_model_state_dict(trained_component)
+                ),
+            }
+
+            if self.config.train_text_encoder:
+                if self.model.get_text_encoder(0) is not None:
+                    self.text_encoder_1 = self.accelerator.unwrap_model(self.model.get_text_encoder(0))
+                    final_lora_save_kwargs["text_encoder_lora_layers"] = _materialize_state_dict_for_save(
+                        convert_state_dict_to_diffusers(get_peft_model_state_dict(self.text_encoder_1))
+                    )
+                if self.model.get_text_encoder(1) is not None:
+                    self.text_encoder_2 = self.accelerator.unwrap_model(self.model.get_text_encoder(1))
+                    final_lora_save_kwargs["text_encoder_2_lora_layers"] = _materialize_state_dict_for_save(
+                        convert_state_dict_to_diffusers(get_peft_model_state_dict(self.text_encoder_2))
+                    )
+                    if self.model.get_text_encoder(2) is not None:
+                        self.text_encoder_3 = self.accelerator.unwrap_model(self.model.get_text_encoder(2))
+
+            if self.config.fsdp_enable:
+                self.accelerator.wait_for_everyone()
+
         if self.accelerator.is_main_process:
             event = lifecycle_stage_event(
                 key="model_save",
@@ -6541,41 +6614,12 @@ class Trainer:
             if self.model.get_trained_component() is not None:
                 self.model.model = unwrap_model(self.accelerator, self.model.model)
             if "lora" in self.config.model_type and "standard" == self.config.lora_type.lower():
-                from simpletuner.helpers.training.save_hooks import _materialize_state_dict_for_save
-
-                trained_component = unwrap_model(self.accelerator, self.model.get_trained_component(unwrap_model=False))
-                lora_save_kwargs = {
-                    "save_directory": self.config.output_dir,
-                    f"{self.model.MODEL_TYPE.value}_lora_layers": _materialize_state_dict_for_save(
-                        get_peft_model_state_dict(trained_component)
-                    ),
-                }
-
-                if self.config.train_text_encoder:
-                    if self.model.get_text_encoder(0) is not None:
-                        self.text_encoder_1 = self.accelerator.unwrap_model(self.model.get_text_encoder(0))
-                        lora_save_kwargs["text_encoder_lora_layers"] = _materialize_state_dict_for_save(
-                            convert_state_dict_to_diffusers(get_peft_model_state_dict(self.text_encoder_1))
-                        )
-                    if self.model.get_text_encoder(1) is not None:
-                        self.text_encoder_2 = self.accelerator.unwrap_model(self.model.get_text_encoder(1))
-                        lora_save_kwargs["text_encoder_2_lora_layers"] = _materialize_state_dict_for_save(
-                            convert_state_dict_to_diffusers(get_peft_model_state_dict(self.text_encoder_2))
-                        )
-                        if self.model.get_text_encoder(2) is not None:
-                            self.text_encoder_3 = self.accelerator.unwrap_model(self.model.get_text_encoder(2))
-                else:
-                    text_encoder_lora_layers = None
-                    text_encoder_2_lora_layers = None
-
-                if self.accelerator.is_main_process or self.config.use_deepspeed_optimizer:
-                    self.model.save_lora_weights(
-                        **lora_save_kwargs,
-                    )
-                if self.config.fsdp_enable:
-                    self.accelerator.wait_for_everyone()
-                del text_encoder_lora_layers
-                del text_encoder_2_lora_layers
+                if final_lora_save_kwargs is None:
+                    raise RuntimeError("Final LoRA save kwargs were not materialized before the main-process save.")
+                self.model.save_lora_weights(
+                    **final_lora_save_kwargs,
+                )
+                del final_lora_save_kwargs
                 reclaim_memory()
             elif "lora" in self.config.model_type and "lycoris" == self.config.lora_type.lower():
                 if self.accelerator.is_main_process or self.config.use_deepspeed_optimizer:

--- a/simpletuner/train.py
+++ b/simpletuner/train.py
@@ -1,4 +1,5 @@
 import atexit
+import contextvars
 import json
 import logging
 from os import environ
@@ -25,6 +26,7 @@ environ["ACCELERATE_LOG_LEVEL"] = "WARNING"
 
 from simpletuner.helpers import log_format
 from simpletuner.helpers.training.attention_backend import AttentionBackendController, AttentionPhase
+from simpletuner.helpers.training.dynamo import dynamo_config_context
 from simpletuner.helpers.training.gpu_circuit_breaker import get_current_gpu_index, get_gpu_circuit_breaker, is_cuda_error
 from simpletuner.helpers.training.multi_process import _get_rank
 from simpletuner.helpers.training.state_tracker import StateTracker
@@ -35,6 +37,52 @@ if hasattr(log_format, "configure_third_party_loggers"):
     log_format.configure_third_party_loggers()
 
 logger = get_logger("SimpleTuner")
+
+
+def _run_training(trainer: Trainer) -> None:
+    signal_file = environ.get("SIMPLETUNER_ACCELERATE_SIGNAL_FILE")
+    validation_consumer = _build_signal_consumer(signal_file, "manual_validation")
+    checkpoint_consumer = _build_signal_consumer(signal_file, "manual_checkpoint")
+    if callable(validation_consumer):
+        trainer.register_manual_validation_trigger(validation_consumer)
+    if callable(checkpoint_consumer):
+        trainer.register_manual_checkpoint_trigger(checkpoint_consumer)
+    trainer.configure_webhook()
+    trainer.init_noise_schedule()
+    trainer.init_seed()
+
+    trainer.init_huggingface_hub()
+
+    trainer.init_preprocessing_models()
+    trainer.init_precision(preprocessing_models_only=True)
+    trainer.init_data_backend()
+    # trainer.init_validation_prompts()
+    trainer.init_unload_text_encoder()
+    trainer.init_unload_vae()
+
+    trainer.init_load_base_model()
+    trainer.init_delete_model_caches()
+
+    trainer.init_controlnet_model()
+    trainer.init_tread_model()
+    trainer.init_precision()
+    trainer.init_freeze_models()
+    trainer.init_trainable_peft_adapter()
+    trainer.init_ema_model()
+    # EMA must be quantised if the base model is as well.
+    trainer.init_precision(ema_only=True)
+
+    trainer.move_models(destination="accelerator")
+    trainer.init_distillation()
+    trainer.init_validations()
+    AttentionBackendController.apply(trainer.config, AttentionPhase.EVAL)
+    trainer.init_benchmark_base_model()
+    AttentionBackendController.apply(trainer.config, AttentionPhase.TRAIN)
+
+    trainer.resume_and_prepare()
+
+    trainer.init_trackers()
+    trainer.train()
 
 
 def _build_signal_consumer(signal_path_text: str | None, key: str):
@@ -180,49 +228,8 @@ if __name__ == "__main__":
         trainer = Trainer(
             exit_on_error=True,
         )
-        signal_file = environ.get("SIMPLETUNER_ACCELERATE_SIGNAL_FILE")
-        validation_consumer = _build_signal_consumer(signal_file, "manual_validation")
-        checkpoint_consumer = _build_signal_consumer(signal_file, "manual_checkpoint")
-        if callable(validation_consumer):
-            trainer.register_manual_validation_trigger(validation_consumer)
-        if callable(checkpoint_consumer):
-            trainer.register_manual_checkpoint_trigger(checkpoint_consumer)
-        trainer.configure_webhook()
-        trainer.init_noise_schedule()
-        trainer.init_seed()
-
-        trainer.init_huggingface_hub()
-
-        trainer.init_preprocessing_models()
-        trainer.init_precision(preprocessing_models_only=True)
-        trainer.init_data_backend()
-        # trainer.init_validation_prompts()
-        trainer.init_unload_text_encoder()
-        trainer.init_unload_vae()
-
-        trainer.init_load_base_model()
-        trainer.init_delete_model_caches()
-
-        trainer.init_controlnet_model()
-        trainer.init_tread_model()
-        trainer.init_precision()
-        trainer.init_freeze_models()
-        trainer.init_trainable_peft_adapter()
-        trainer.init_ema_model()
-        # EMA must be quantised if the base model is as well.
-        trainer.init_precision(ema_only=True)
-
-        trainer.move_models(destination="accelerator")
-        trainer.init_distillation()
-        trainer.init_validations()
-        AttentionBackendController.apply(trainer.config, AttentionPhase.EVAL)
-        trainer.init_benchmark_base_model()
-        AttentionBackendController.apply(trainer.config, AttentionPhase.TRAIN)
-
-        trainer.resume_and_prepare()
-
-        trainer.init_trackers()
-        trainer.train()
+        with dynamo_config_context(trainer.config):
+            contextvars.copy_context().run(_run_training, trainer)
     except KeyboardInterrupt:
         if StateTracker.get_webhook_handler() is not None:
             StateTracker.get_webhook_handler().send(

--- a/tests/test_fsdp_cmd_args.py
+++ b/tests/test_fsdp_cmd_args.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 import types
 import unittest
+from importlib.machinery import ModuleSpec
 
 
 def _ensure_torchao_stub():
@@ -10,17 +11,46 @@ def _ensure_torchao_stub():
         return
     torchao_module = types.ModuleType("torchao")
     optim_module = types.ModuleType("torchao.optim")
+    quantization_module = types.ModuleType("torchao.quantization")
+    prototype_module = types.ModuleType("torchao.prototype")
+    safetensors_module = types.ModuleType("torchao.prototype.safetensors")
+    safetensors_support_module = types.ModuleType("torchao.prototype.safetensors.safetensors_support")
+    torchao_module.__spec__ = ModuleSpec("torchao", loader=None)
+    optim_module.__spec__ = ModuleSpec("torchao.optim", loader=None)
+    quantization_module.__spec__ = ModuleSpec("torchao.quantization", loader=None)
+    prototype_module.__spec__ = ModuleSpec("torchao.prototype", loader=None)
+    safetensors_module.__spec__ = ModuleSpec("torchao.prototype.safetensors", loader=None)
+    safetensors_support_module.__spec__ = ModuleSpec("torchao.prototype.safetensors.safetensors_support", loader=None)
+    torchao_module.__path__ = []
+    prototype_module.__path__ = []
+    safetensors_module.__path__ = []
     dummy_class = type("DummyOptimizer", (), {})
+
+    def _flatten_tensor_state_dict(state_dict):
+        return state_dict
+
+    def _quantize_(*_args, **_kwargs):
+        return None
 
     optim_module.AdamFp8 = dummy_class
     optim_module.AdamW4bit = dummy_class
     optim_module.AdamW8bit = dummy_class
     optim_module.AdamWFp8 = dummy_class
     optim_module.CPUOffloadOptimizer = dummy_class
+    quantization_module.quantize_ = _quantize_
+    safetensors_support_module.flatten_tensor_state_dict = _flatten_tensor_state_dict
 
     torchao_module.optim = optim_module
+    torchao_module.quantization = quantization_module
+    torchao_module.prototype = prototype_module
+    prototype_module.safetensors = safetensors_module
+    safetensors_module.safetensors_support = safetensors_support_module
     sys.modules["torchao"] = torchao_module
     sys.modules["torchao.optim"] = optim_module
+    sys.modules["torchao.quantization"] = quantization_module
+    sys.modules["torchao.prototype"] = prototype_module
+    sys.modules["torchao.prototype.safetensors"] = safetensors_module
+    sys.modules["torchao.prototype.safetensors.safetensors_support"] = safetensors_support_module
 
 
 _ensure_torchao_stub()
@@ -30,6 +60,7 @@ def _ensure_optimi_stub():
     if "optimi" in sys.modules:
         return
     optimi_module = types.ModuleType("optimi")
+    optimi_module.__spec__ = ModuleSpec("optimi", loader=None)
     for cls_name in [
         "StableAdamW",
         "AdamW",
@@ -159,6 +190,27 @@ class TestFSDPCmdArgs(unittest.TestCase):
                 + [
                     "--fsdp_enable",
                     '--deepspeed_config={"zero_optimization": {"stage": 2}}',
+                ],
+                exit_on_error=False,
+            )
+
+    def test_fsdp2_rejects_quanto_precision(self):
+        tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(tmp_dir, ignore_errors=True))
+        base_args = [
+            "--model_family=sdxl",
+            "--model_type=lora",
+            f"--output_dir={tmp_dir}",
+            "--optimizer=adamw_bf16",
+            "--data_backend_config=dummy",
+        ]
+        with self.assertRaisesRegex(ValueError, "Quanto kernels do not register DTensor"):
+            parse_cmdline_args(
+                input_args=base_args
+                + [
+                    "--fsdp_enable",
+                    "--fsdp_version=2",
+                    "--base_model_precision=int8-quanto",
                 ],
                 exit_on_error=False,
             )

--- a/tests/test_lora_metadata.py
+++ b/tests/test_lora_metadata.py
@@ -10,7 +10,7 @@ from safetensors import safe_open
 from safetensors.torch import save_file
 
 from simpletuner.helpers.models.common import ModelFoundation, PipelineTypes
-from simpletuner.helpers.training.save_hooks import MODEL_SPEC_VERSION, SaveHookManager
+from simpletuner.helpers.training.save_hooks import MODEL_SPEC_VERSION, SaveHookManager, _materialize_state_dict_for_save
 
 
 class _DummyAccelerator:
@@ -54,7 +54,7 @@ class _DummyModel:
         self._text_encoders = {0: text_encoder} if text_encoder is not None else {}
         self.save_lora_weights = MagicMock()
 
-    def get_trained_component(self, unwrap_model=False):
+    def get_trained_component(self, unwrap_model=False, base_model=False):
         return self._trained_component
 
     def get_text_encoder(self, index: int):
@@ -143,6 +143,26 @@ class SaveHookMetadataTests(unittest.TestCase):
             use_deepspeed_optimizer=False,
         )
         return manager, model, trained_component
+
+    def test_materialize_state_dict_for_save_expands_dtensor_like_values(self):
+        class DTensor:
+            def __init__(self):
+                self.full_tensor_called = False
+
+            def full_tensor(self):
+                self.full_tensor_called = True
+                return torch.tensor([[1.0, 2.0]], device="cpu")
+
+        dtensor = DTensor()
+        regular = torch.tensor([3.0], requires_grad=True)
+
+        materialized = _materialize_state_dict_for_save({"dtensor": dtensor, "regular": regular})
+
+        self.assertTrue(dtensor.full_tensor_called)
+        self.assertEqual(materialized["dtensor"].device.type, "cpu")
+        self.assertFalse(materialized["regular"].requires_grad)
+        self.assertTrue(materialized["regular"].is_contiguous())
+        self.assertIsNot(materialized["regular"], regular)
 
     def test_save_hook_collects_metadata_for_transformer_and_text_encoder(self):
         text_encoder = _DummyTextEncoder("text_encoder")

--- a/tests/test_ltxvideo2_attention.py
+++ b/tests/test_ltxvideo2_attention.py
@@ -1,0 +1,44 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+from diffusers.models.attention_dispatch import AttentionBackendName
+
+from simpletuner.helpers.models.ltxvideo2 import transformer as ltx2_transformer
+
+
+class TestLTX2AttentionDispatch(unittest.TestCase):
+    def test_flash3_varlen_uses_eager_helper_while_compiling(self):
+        query = torch.randn(1, 2, 1, 4)
+        key = torch.randn(1, 3, 1, 4)
+        value = torch.randn(1, 3, 1, 4)
+        expected = torch.randn(1, 2, 1, 4)
+
+        with (
+            patch.object(ltx2_transformer.torch.compiler, "is_compiling", return_value=True),
+            patch.object(
+                ltx2_transformer,
+                "_ltx2_flash3_varlen_hub_attention_eager",
+                return_value=expected,
+            ) as eager_attention,
+            patch.object(
+                ltx2_transformer,
+                "_ltx2_flash3_varlen_hub_attention",
+            ) as compiled_attention,
+        ):
+            result = ltx2_transformer._ltx2_dispatch_attention(
+                query=query,
+                key=key,
+                value=value,
+                attention_mask=torch.ones(1, 3, dtype=torch.bool),
+                backend=AttentionBackendName._FLASH_3_VARLEN_HUB,
+                parallel_config=None,
+            )
+
+        self.assertIs(result, expected)
+        eager_attention.assert_called_once()
+        compiled_attention.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lumina2_model.py
+++ b/tests/test_lumina2_model.py
@@ -7,6 +7,20 @@ import torch
 from simpletuner.helpers.models.lumina2.model import Lumina2
 
 
+class _DummyTransformer:
+    def __init__(self, output=None, forward=None):
+        self.config = SimpleNamespace(patch_size=2)
+        self.output = output
+        self.forward = forward
+        self.call_args = None
+
+    def __call__(self, **kwargs):
+        self.call_args = SimpleNamespace(kwargs=kwargs)
+        if self.forward is not None:
+            return self.forward(**kwargs)
+        return self.output
+
+
 class Lumina2ModelTests(unittest.TestCase):
     def setUp(self):
         self.model = Lumina2.__new__(Lumina2)
@@ -17,8 +31,7 @@ class Lumina2ModelTests(unittest.TestCase):
         self.model.noise_schedule = SimpleNamespace(config=SimpleNamespace(num_train_timesteps=1000))
         self.model._new_hidden_state_buffer = MagicMock(return_value={})
         self.model.crepa_regularizer = SimpleNamespace(enabled=True, block_index=2)
-        self.model.model = MagicMock()
-        self.model.model.config = SimpleNamespace(patch_size=2)
+        self.model.model = _DummyTransformer()
 
     def test_model_predict_uses_crepa_capture_block_override(self):
         hidden_states_buffer = {}
@@ -29,7 +42,7 @@ class Lumina2ModelTests(unittest.TestCase):
             kwargs["hidden_states_buffer"]["layer_6"] = torch.full((1, 4, 8), 6.0)
             return (torch.ones(1, 16, 4, 4),)
 
-        self.model.model = MagicMock(side_effect=_forward)
+        self.model.model = _DummyTransformer(forward=_forward)
 
         prepared_batch = {
             "noisy_latents": torch.randn(1, 16, 4, 4),
@@ -48,7 +61,7 @@ class Lumina2ModelTests(unittest.TestCase):
         self.assertTrue(torch.equal(result["model_prediction"], -torch.ones(1, 16, 4, 4)))
 
     def test_model_predict_accepts_tokenwise_timesteps(self):
-        self.model.model = MagicMock(return_value=(torch.ones(1, 16, 4, 4),))
+        self.model.model = _DummyTransformer(output=(torch.ones(1, 16, 4, 4),))
 
         prepared_batch = {
             "noisy_latents": torch.randn(1, 16, 4, 4),

--- a/tests/test_pipelines/test_ltxvideo2_pipeline.py
+++ b/tests/test_pipelines/test_ltxvideo2_pipeline.py
@@ -181,20 +181,6 @@ class TestLTXVideo2Pipeline(unittest.TestCase):
         self.assertTrue(torch.equal(scaled[:, 2], ref_coords[:, 2] * 2))
         self.assertTrue(torch.equal(scaled[:, 0], torch.clamp(ref_coords[:, 0] - 0.25, min=0)))
 
-    def test_masked_video_loss_ignores_intrinsic_condition_tokens(self):
-        self.model.model = SimpleNamespace(config=SimpleNamespace(patch_size=1, patch_size_t=1))
-        self.model.config.loss_type = "l2"
-        prepared_batch = {
-            "latents": torch.zeros(1, 1, 1, 1, 2),
-            "noise": torch.ones(1, 1, 1, 1, 2),
-            "video_loss_mask": torch.tensor([[False, True]]),
-        }
-        model_output = {"model_prediction": torch.tensor([[[[[99.0, 1.0]]]]])}
-
-        loss = self.model._compute_ltx2_masked_video_loss(prepared_batch, model_output)
-
-        self.assertEqual(loss.item(), 0.0)
-
 
 class TestLTXVideo2Metadata(unittest.TestCase):
     def test_model_metadata_exposes_only_named_ltx23_flavours(self):
@@ -206,6 +192,23 @@ class TestLTXVideo2Metadata(unittest.TestCase):
             metadata["ltxvideo2"]["flavour_choices"],
             ["dev", "dev-fp4", "dev-fp8", "2.3-dev", "2.3-distilled"],
         )
+
+
+class TestLTXVideo2Loss(unittest.TestCase):
+    def test_masked_video_loss_ignores_intrinsic_condition_tokens(self):
+        model = LTXVideo2.__new__(LTXVideo2)
+        model.model = SimpleNamespace(config=SimpleNamespace(patch_size=1, patch_size_t=1))
+        model.config = SimpleNamespace(loss_type="l2")
+        prepared_batch = {
+            "latents": torch.zeros(1, 1, 1, 1, 2),
+            "noise": torch.ones(1, 1, 1, 1, 2),
+            "video_loss_mask": torch.tensor([[False, True]]),
+        }
+        model_output = {"model_prediction": torch.tensor([[[[[99.0, 1.0]]]]])}
+
+        loss = model._compute_ltx2_masked_video_loss(prepared_batch, model_output)
+
+        self.assertEqual(loss.item(), 0.0)
 
 
 class TestLTXVideo2TransformerLoading(unittest.TestCase):

--- a/tests/test_qwen_image_model.py
+++ b/tests/test_qwen_image_model.py
@@ -9,6 +9,20 @@ from simpletuner.helpers.models.common import PipelineTypes
 from simpletuner.helpers.models.qwen_image.model import QwenImage
 
 
+class _DummyTransformer:
+    def __init__(self, output=None, forward=None):
+        self.config = SimpleNamespace(patch_size=2)
+        self.output = output
+        self.forward = forward
+        self.call_args = None
+
+    def __call__(self, **kwargs):
+        self.call_args = SimpleNamespace(kwargs=kwargs)
+        if self.forward is not None:
+            return self.forward(**kwargs)
+        return self.output
+
+
 class QwenImageModelTests(unittest.TestCase):
     def setUp(self):
         self.model = QwenImage.__new__(QwenImage)
@@ -21,8 +35,7 @@ class QwenImageModelTests(unittest.TestCase):
         self.model._is_edit_v2_flavour = lambda: False
         self.model._is_edit_v2_plus_flavour = lambda: False
         self.model.crepa_regularizer = SimpleNamespace(enabled=True, block_index=3)
-        self.model.model = MagicMock()
-        self.model.model.config = SimpleNamespace(patch_size=2)
+        self.model.model = _DummyTransformer()
 
         class _Pipeline:
             @staticmethod
@@ -48,7 +61,7 @@ class QwenImageModelTests(unittest.TestCase):
             kwargs["hidden_states_buffer"]["layer_7"] = torch.full((1, 4, 8), 7.0)
             return (torch.randn(1, 4, 64),)
 
-        self.model.model = MagicMock(side_effect=_forward)
+        self.model.model = _DummyTransformer(forward=_forward)
 
         prepared_batch = {
             "noisy_latents": torch.randn(1, 16, 4, 4),
@@ -65,7 +78,7 @@ class QwenImageModelTests(unittest.TestCase):
         self.assertTrue(torch.equal(transformer_kwargs["timestep"], torch.tensor([0.5], dtype=torch.float32)))
 
     def test_model_predict_accepts_tokenwise_timesteps(self):
-        self.model.model = MagicMock(return_value=(torch.randn(1, 4, 64),))
+        self.model.model = _DummyTransformer(output=(torch.randn(1, 4, 64),))
 
         prepared_batch = {
             "noisy_latents": torch.randn(1, 16, 4, 4),

--- a/tests/test_runtime_components.py
+++ b/tests/test_runtime_components.py
@@ -767,6 +767,8 @@ class TestContextParallelBatchSynchronizer(unittest.TestCase):
         mock_parallelism_config = MagicMock()
         mock_parallelism_config.cp_size = 2
         mock_parallelism_config.cp_enabled = True
+        mock_parallelism_config.dp_replicate_size = 1
+        mock_parallelism_config.dp_shard_size = 1
 
         mock_mesh = MagicMock()
         mock_mesh.get_group.return_value = MagicMock()
@@ -800,6 +802,8 @@ class TestContextParallelBatchSynchronizer(unittest.TestCase):
         mock_parallelism_config = MagicMock()
         mock_parallelism_config.cp_size = 2
         mock_parallelism_config.cp_enabled = True
+        mock_parallelism_config.dp_replicate_size = 1
+        mock_parallelism_config.dp_shard_size = 1
 
         mock_mesh = MagicMock()
         mock_mesh.get_group.return_value = MagicMock()
@@ -825,6 +829,41 @@ class TestContextParallelBatchSynchronizer(unittest.TestCase):
             result = synchronizer.fetch_batch(mock_iterator, 10)
             mock_iterator.assert_not_called()
             self.assertEqual(result, {"broadcasted": True})
+
+    def test_fetch_batch_fsdp_shard_rank_skips_iterator(self):
+        """FSDP shard ranks are model-parallel ranks, not independent samplers."""
+        from simpletuner.helpers.data_backend.runtime.context_parallel_sync import ContextParallelBatchSynchronizer
+
+        mock_parallelism_config = MagicMock()
+        mock_parallelism_config.cp_size = 2
+        mock_parallelism_config.cp_enabled = True
+        mock_parallelism_config.dp_replicate_size = 1
+        mock_parallelism_config.dp_shard_size = 4
+
+        mock_mesh = MagicMock()
+        mock_mesh.get_group.return_value = MagicMock()
+        mock_mesh.get_local_rank.return_value = 0
+
+        mock_accelerator = MagicMock()
+        mock_accelerator.parallelism_config = mock_parallelism_config
+        mock_accelerator.torch_device_mesh = mock_mesh
+        mock_accelerator.num_processes = 8
+        mock_accelerator.process_index = 2
+
+        synchronizer = ContextParallelBatchSynchronizer(mock_accelerator)
+        mock_iterator = MagicMock(return_value={"data": [1, 2, 3]})
+
+        with patch("simpletuner.helpers.data_backend.runtime.context_parallel_sync.dist") as mock_dist:
+
+            def mock_broadcast(batch_list, **kwargs):
+                self.assertEqual(kwargs["src"], 0)
+                batch_list[0] = {"broadcasted": True}
+
+            mock_dist.broadcast_object_list = mock_broadcast
+            result = synchronizer.fetch_batch(mock_iterator, 10)
+
+        mock_iterator.assert_not_called()
+        self.assertEqual(result, {"broadcasted": True})
 
 
 class TestContextParallelDataParallelInfo(unittest.TestCase):
@@ -854,8 +893,8 @@ class TestContextParallelDataParallelInfo(unittest.TestCase):
 
         effective_dp_size, dp_rank, cp_size = get_cp_aware_dp_info(mock_accelerator)
 
-        self.assertEqual(effective_dp_size, 4)
-        self.assertEqual(dp_rank, 2)
+        self.assertEqual(effective_dp_size, 2)
+        self.assertEqual(dp_rank, 1)
         self.assertEqual(cp_size, 2)
 
     def test_get_cp_aware_dp_info_disables_without_mesh(self):

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -2279,6 +2279,66 @@ class TestTrainer(unittest.TestCase):
             },
         )
 
+    def test_disable_dynamo_lru_cache_for_checkpointing_calls_private_api(self):
+        from simpletuner.helpers.training import trainer as trainer_module
+
+        trainer = object.__new__(Trainer)
+        set_lru_cache = Mock()
+
+        with patch.object(
+            trainer_module.torch,
+            "_C",
+            SimpleNamespace(_dynamo=SimpleNamespace(eval_frame=SimpleNamespace(_set_lru_cache=set_lru_cache))),
+        ):
+            trainer._disable_dynamo_lru_cache_for_checkpointing()
+
+        set_lru_cache.assert_called_once_with(False)
+
+    def test_enable_dynamo_dynamic_output_capture_updates_config(self):
+        import torch._dynamo as torch_dynamo
+
+        trainer = object.__new__(Trainer)
+        original_dynamic_output = torch_dynamo.config.capture_dynamic_output_shape_ops
+        original_parameter_static_shapes = torch_dynamo.config.force_parameter_static_shapes
+
+        try:
+            torch_dynamo.config.capture_dynamic_output_shape_ops = False
+            torch_dynamo.config.force_parameter_static_shapes = True
+
+            trainer._enable_dynamo_dynamic_output_capture()
+
+            self.assertTrue(torch_dynamo.config.capture_dynamic_output_shape_ops)
+            self.assertFalse(torch_dynamo.config.force_parameter_static_shapes)
+        finally:
+            torch_dynamo.config.capture_dynamic_output_shape_ops = original_dynamic_output
+            torch_dynamo.config.force_parameter_static_shapes = original_parameter_static_shapes
+
+    def test_configure_inductor_dynamic_training_passes_preserves_existing_disables(self):
+        import torch._inductor.config as inductor_config
+
+        trainer = object.__new__(Trainer)
+        original_env = os.environ.get("TORCHINDUCTOR_DISABLED_PASSES")
+        original_config = inductor_config.disabled_passes
+
+        try:
+            os.environ["TORCHINDUCTOR_DISABLED_PASSES"] = "EXISTING_PASS"
+            inductor_config.disabled_passes = "EXISTING_PASS"
+
+            trainer._configure_inductor_dynamic_training_passes("inductor")
+
+            self.assertEqual(os.environ["TORCHINDUCTOR_DISABLED_PASSES"], "EXISTING_PASS,PASS_PATTERN_1")
+            self.assertEqual(inductor_config.disabled_passes, "EXISTING_PASS,PASS_PATTERN_1")
+
+            trainer._configure_inductor_dynamic_training_passes("no")
+
+            self.assertEqual(os.environ["TORCHINDUCTOR_DISABLED_PASSES"], "EXISTING_PASS,PASS_PATTERN_1")
+        finally:
+            if original_env is None:
+                os.environ.pop("TORCHINDUCTOR_DISABLED_PASSES", None)
+            else:
+                os.environ["TORCHINDUCTOR_DISABLED_PASSES"] = original_env
+            inductor_config.disabled_passes = original_config
+
     @patch("simpletuner.helpers.training.trainer.TorchDynamoPlugin")
     @patch("simpletuner.helpers.training.trainer.Accelerator")
     def test_dynamo_plugin_created_when_advanced_options_enabled(self, mock_accelerator, mock_dynamo_plugin):

--- a/tests/test_training_checkpointing.py
+++ b/tests/test_training_checkpointing.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from simpletuner.helpers.training import checkpointing
+
+
+class TrainingCheckpointingTests(unittest.TestCase):
+    def test_compiled_non_reentrant_checkpoint_disables_determinism_check(self):
+        function = Mock()
+
+        with (
+            patch.dict("os.environ", {"TRAINING_DYNAMO_BACKEND": "inductor"}, clear=False),
+            patch("simpletuner.helpers.training.checkpointing.torch.utils.checkpoint.checkpoint") as mock_checkpoint,
+        ):
+            checkpointing.checkpoint(function, "input", use_reentrant=False)
+
+        mock_checkpoint.assert_called_once_with(function, "input", use_reentrant=False, determinism_check="none")
+
+    def test_eager_non_reentrant_checkpoint_keeps_default_determinism_check(self):
+        function = Mock()
+
+        with (
+            patch.dict("os.environ", {"TRAINING_DYNAMO_BACKEND": "no"}, clear=False),
+            patch("simpletuner.helpers.training.checkpointing.torch.utils.checkpoint.checkpoint") as mock_checkpoint,
+        ):
+            checkpointing.checkpoint(function, "input", use_reentrant=False)
+
+        mock_checkpoint.assert_called_once_with(function, "input", use_reentrant=False)
+
+    def test_explicit_determinism_check_is_preserved(self):
+        function = Mock()
+
+        with (
+            patch.dict("os.environ", {"TRAINING_DYNAMO_BACKEND": "inductor"}, clear=False),
+            patch("simpletuner.helpers.training.checkpointing.torch.utils.checkpoint.checkpoint") as mock_checkpoint,
+        ):
+            checkpointing.checkpoint(function, "input", use_reentrant=False, determinism_check="default")
+
+        mock_checkpoint.assert_called_once_with(function, "input", use_reentrant=False, determinism_check="default")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces significant improvements to distributed training support, especially for FSDP v2 and context parallelism, along with a few utility and robustness enhancements. The most important changes are grouped below:

**Distributed Training and Context Parallelism Overhaul**

* Refactored context-parallel batch synchronization logic to support FSDP v2 model replicas, ensuring only replicated data-parallel ranks represent unique data shards, and all model-parallel (FSDP shard and CP) ranks receive the same batch. Added new functions such as `get_model_replica_data_info` and `_normalize_parallel_size` to robustly handle parallelism dimensions. Updated synchronization and logging accordingly. [[1]](diffhunk://#diff-886fe02c954235002591969548d1a9c54ec9ca0239d21950d1f44e22d6ad916dL3-R17) [[2]](diffhunk://#diff-886fe02c954235002591969548d1a9c54ec9ca0239d21950d1f44e22d6ad916dR41-R50) [[3]](diffhunk://#diff-886fe02c954235002591969548d1a9c54ec9ca0239d21950d1f44e22d6ad916dL114-R128) [[4]](diffhunk://#diff-886fe02c954235002591969548d1a9c54ec9ca0239d21950d1f44e22d6ad916dL139-R203) [[5]](diffhunk://#diff-886fe02c954235002591969548d1a9c54ec9ca0239d21950d1f44e22d6ad916dL177-R237) [[6]](diffhunk://#diff-886fe02c954235002591969548d1a9c54ec9ca0239d21950d1f44e22d6ad916dL187-R251) [[7]](diffhunk://#diff-886fe02c954235002591969548d1a9c54ec9ca0239d21950d1f44e22d6ad916dL207-R269) [[8]](diffhunk://#diff-886fe02c954235002591969548d1a9c54ec9ca0239d21950d1f44e22d6ad916dL223-R287) [[9]](diffhunk://#diff-886fe02c954235002591969548d1a9c54ec9ca0239d21950d1f44e22d6ad916dL245-R316) [[10]](diffhunk://#diff-05a1e3df70530b5a9bbf255a7a84fb8d7cd4c979c8b6a74b8180af877e387ff5L59-R61) [[11]](diffhunk://#diff-05a1e3df70530b5a9bbf255a7a84fb8d7cd4c979c8b6a74b8180af877e387ff5L81-R86) [[12]](diffhunk://#diff-05a1e3df70530b5a9bbf255a7a84fb8d7cd4c979c8b6a74b8180af877e387ff5L755-R750)
* Added a check in `_normalize_input_args` to prevent incompatible use of Quanto quantized precision with FSDP v2, raising a clear error if detected.

**Model Loading and Initialization Improvements**

* Improved text encoder loading: when a HuggingFace repo ID is specified, the main process downloads the weights and synchronizes across distributed ranks to ensure consistent local files before loading. [[1]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR85-R88) [[2]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR2624-R2642)
* Added a `before_accelerator_prepare` hook to model classes for pre-accelerator initialization logic, and implemented it in the LTXVideo2 model to handle connector detachment. [[1]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR3155-R3157) [[2]](diffhunk://#diff-64820a284b076801c442da19649e63dc4a2e00e645d7f92abbc5754b3dbae22fR590-R594)

**Transformer and Attention Robustness**

* Updated LTXVideo2 varlen attention to avoid raising errors for empty key/value masks during Torch compilation, and fixed the computation of max sequence lengths for FlashAttention calls. [[1]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3L147-R148) [[2]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3L165-R167) [[3]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3R176-R178)

**General Utility**

* Added import for `snapshot_download` from `huggingface_hub` and improved model unwrapping logic to handle missing attributes safely. [[1]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR22) [[2]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbL2006-R2011)
* Added missing import for `simpletuner_checkpoint` in LTXVideo2 transformer.