### PR TITLE
support fused projections across more models

### DIFF
--- a/simpletuner/helpers/models/auraflow/transformer.py
+++ b/simpletuner/helpers/models/auraflow/transformer.py
@@ -6,12 +6,7 @@ import torch.nn.functional as F
 from diffusers.configuration_utils import ConfigMixin
 from diffusers.loaders import FromOriginalModelMixin, PeftAdapterMixin
 from diffusers.models._modeling_parallel import ContextParallelInput, ContextParallelOutput
-from diffusers.models.attention_processor import (
-    Attention,
-    AttentionProcessor,
-    AuraFlowAttnProcessor2_0,
-    FusedAuraFlowAttnProcessor2_0,
-)
+from diffusers.models.attention_processor import Attention, AttentionProcessor, AuraFlowAttnProcessor2_0
 from diffusers.models.embeddings import TimestepEmbedding, Timesteps
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 from diffusers.models.modeling_utils import ModelMixin
@@ -29,6 +24,7 @@ from simpletuner.helpers.models.flowmap import (
 )
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
+from simpletuner.helpers.training.packed_attention_processors import PackedAuraFlowAttnProcessor2_0
 from simpletuner.helpers.training.tread import TREADRouter
 from simpletuner.helpers.utils.patching import CallableDict, MutableModuleList, PatchableModule
 
@@ -631,7 +627,7 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
         for name, module in self.named_children():
             fn_recursive_attn_processor(name, module, processor)
 
-    def fuse_qkv_projections(self):
+    def fuse_qkv_projections(self, preferred_backend: Optional[str] = None):
         self.original_attn_processors = None
 
         for _, attn_processor in self.attn_processors.items():
@@ -644,11 +640,14 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
             if isinstance(module, Attention):
                 module.fuse_projections(fuse=True)
 
-        self.set_attn_processor(FusedAuraFlowAttnProcessor2_0())
+        self.set_attn_processor(PackedAuraFlowAttnProcessor2_0(preferred_backend=preferred_backend))
 
     def unfuse_qkv_projections(self):
         if self.original_attn_processors is not None:
             self.set_attn_processor(self.original_attn_processors)
+        for module in self.modules():
+            if isinstance(module, Attention):
+                module.unfuse_projections()
 
     def forward(
         self,

--- a/simpletuner/helpers/models/chroma/transformer.py
+++ b/simpletuner/helpers/models/chroma/transformer.py
@@ -28,6 +28,7 @@ from simpletuner.helpers.models.flowmap import (
     set_flowmap_gate,
     validate_flowmap_deltatime_type,
 )
+from simpletuner.helpers.models.flux.attention import FluxFusedFlashAttnProcessor3
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.attention_backend import AttentionBackendController
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
@@ -687,6 +688,19 @@ class ChromaTransformer2DModel(
             swap_device=musubi_block_swap_device,
             logger=logger,
         )
+
+    def fuse_qkv_projections(self, preferred_backend: Optional[str] = None):
+        processor = FluxFusedFlashAttnProcessor3(preferred_backend=preferred_backend)
+        for module in self.modules():
+            if isinstance(module, FluxAttention):
+                module.fuse_projections()
+                module.set_processor(processor)
+
+    def unfuse_qkv_projections(self):
+        for module in self.modules():
+            if isinstance(module, FluxAttention):
+                module.unfuse_projections()
+                module.set_processor(FluxAttnProcessor())
 
     def set_gradient_checkpointing_interval(self, interval: int):
         """

--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -3128,10 +3128,18 @@ class ModelFoundation(ABC):
         self._init_layersync_regularizer()
 
     def fuse_qkv_projections(self):
-        if self.config.fuse_qkv_projections:
-            logger.warning(
-                f"{self.__class__.__name__} does not support fused QKV projection yet, please open a feature request on the issue tracker."
-            )
+        if not self.config.fuse_qkv_projections or self._qkv_projections_fused:
+            return
+        if self.model is not None:
+            model = self.unwrap_model(model=self.model)
+            fuse = getattr(model, "fuse_qkv_projections", None)
+            if callable(fuse):
+                fuse(preferred_backend=getattr(self.config, "attention_mechanism", None))
+                self._qkv_projections_fused = True
+                return
+        logger.warning(
+            f"{self.__class__.__name__} does not support fused QKV projection yet, please open a feature request on the issue tracker."
+        )
 
     def unfuse_qkv_projections(self):
         """
@@ -3144,7 +3152,14 @@ class ModelFoundation(ABC):
         - Saving full model checkpoints
         - Any operation that expects separate Q, K, V projections
         """
-        pass
+        if not self.config.fuse_qkv_projections or not self._qkv_projections_fused:
+            return
+        self._qkv_projections_fused = False
+        if self.model is not None:
+            model = self.unwrap_model(model=self.model)
+            unfuse = getattr(model, "unfuse_qkv_projections", None)
+            if callable(unfuse):
+                unfuse()
 
     def set_prepared_model(self, model, base_model: bool = False):
         if self.config.controlnet and not base_model:

--- a/simpletuner/helpers/models/flux/attention.py
+++ b/simpletuner/helpers/models/flux/attention.py
@@ -5,6 +5,8 @@ from einops import rearrange
 from torch import FloatTensor, Tensor
 from torch.nn import functional as F
 
+from simpletuner.helpers.training.attention_backend import get_packed_attention_backend
+
 try:
     from flash_attn_interface import flash_attn_func, flash_attn_qkvpacked_func
 except:
@@ -192,17 +194,18 @@ class FluxFusedFlashAttnProcessor3(object):
     Keeps QKV tensors packed through the entire attention computation.
     """
 
-    def __init__(self):
-        self.flash_attn_qkvpacked_func = None
-        try:
-            from flash_attn_interface import flash_attn_qkvpacked_func
-
-            self.flash_attn_qkvpacked_func = flash_attn_qkvpacked_func
-        except ImportError:
-            raise ImportError(
-                "FluxFusedFlashAttnProcessor3 requires flash-attn library. "
-                "Please see this link for Hopper and Blackwell instructions: https://github.com/bghira/SimpleTuner/blob/main/INSTALL.md#nvidia-hopper--blackwell-follow-up-steps"
+    def __init__(self, preferred_backend: str | None = None):
+        self.preferred_backend = preferred_backend
+        self.packed_backend = get_packed_attention_backend(preferred_backend)
+        if not self.packed_backend.capabilities.fixed_qkvpacked:
+            raise RuntimeError(
+                f"Packed attention backend '{self.packed_backend.name}' does not support fixed qkvpacked attention."
             )
+
+    def _get_backend(self, attention_mask: FloatTensor = None):
+        if attention_mask is None:
+            return self.packed_backend
+        return get_packed_attention_backend(self.preferred_backend, require_varlen_qkvpacked=True)
 
     def __call__(
         self,
@@ -296,13 +299,13 @@ class FluxFusedFlashAttnProcessor3(object):
             # Transpose back and repack
             qkv = torch.stack([q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)], dim=2)
 
-        # Flash Attention 3 with packed QKV
+        # Flash Attention with packed QKV.
         # Input shape: (batch, seq_len, 3, heads, head_dim)
         # Output shape: (batch, seq_len, heads, head_dim)
-        hidden_states = self.flash_attn_qkvpacked_func(
+        hidden_states = self._get_backend(attention_mask).qkvpacked(
             qkv,
+            attention_mask=attention_mask,
             causal=False,
-            # Don't pass num_heads_q for standard MHA
         )
 
         # Reshape output: (batch, seq_len, heads, head_dim) -> (batch, seq_len, heads * head_dim)

--- a/simpletuner/helpers/models/flux/model.py
+++ b/simpletuner/helpers/models/flux/model.py
@@ -339,14 +339,11 @@ class Flux(ImageModelFoundation):
         if not self.config.fuse_qkv_projections or self._qkv_projections_fused:
             return
 
-        try:
-            from simpletuner.helpers.models.flux.attention import FluxFusedFlashAttnProcessor3
+        from simpletuner.helpers.models.flux.attention import FluxFusedFlashAttnProcessor3
 
-            attn_processor = FluxFusedFlashAttnProcessor3()
-        except:
-            from simpletuner.helpers.models.flux.attention import FluxFusedSDPAProcessor
-
-            attn_processor = FluxFusedSDPAProcessor()
+        attn_processor = FluxFusedFlashAttnProcessor3(
+            preferred_backend=getattr(self.config, "attention_mechanism", None),
+        )
 
         if self.model is not None:
             logger.debug("Fusing QKV projections in the model..")
@@ -380,12 +377,12 @@ class Flux(ImageModelFoundation):
             logger.debug("Temporarily unfusing QKV projections in the model..")
             for module in self.model.modules():
                 if isinstance(module, Attention):
-                    module.fuse_projections(fuse=False)
+                    module.unfuse_projections()
             if self.controlnet is not None:
                 logger.debug("Tempoarily unfusing QKV projections in the ControlNet..")
                 for module in self.controlnet.modules():
                     if isinstance(module, Attention):
-                        module.fuse_projections(fuse=False)
+                        module.unfuse_projections()
 
     def requires_conditioning_latents(self) -> bool:
         # Flux ControlNet requires latent inputs instead of pixels.
@@ -1033,8 +1030,9 @@ class Flux(ImageModelFoundation):
                 logger.warning("LibreFlux requires attention masking. Enabling it.")
                 self.config.flux_attention_masked_training = True
             if self.config.fuse_qkv_projections:
-                logger.warning("LibreFlux does not support fused QKV projections. Disabling it.")
-                self.config.fuse_qkv_projections = False
+                logger.info(
+                    "LibreFlux fused QKV projections require a packed attention backend with varlen qkvpacked mask support."
+                )
         if self.config.model_flavour == "fluxbooru":
             # FluxBooru requires some special settings, we'll just override them here.
             if self.config.validation_num_inference_steps < 28:

--- a/simpletuner/helpers/models/flux2/autoencoder.py
+++ b/simpletuner/helpers/models/flux2/autoencoder.py
@@ -546,7 +546,7 @@ class AutoencoderKLFlux2(AutoencoderMixin, ModelMixin, ConfigMixin, FromOriginal
         return DecoderOutput(sample=dec)
 
     # Copied from diffusers.models.unets.unet_2d_condition.UNet2DConditionModel.fuse_qkv_projections
-    def fuse_qkv_projections(self):
+    def fuse_qkv_projections(self, preferred_backend=None):
         """
         Enables fused QKV projections. For self-attention modules, all projection matrices (i.e., query, key, value)
         are fused. For cross-attention modules, key and value projection matrices are fused.

--- a/simpletuner/helpers/models/flux2/model.py
+++ b/simpletuner/helpers/models/flux2/model.py
@@ -153,6 +153,27 @@ class Flux2(ImageModelFoundation):
     def supports_crepa_self_flow(self) -> bool:
         return True
 
+    def fuse_qkv_projections(self):
+        if not self.config.fuse_qkv_projections or self._qkv_projections_fused:
+            return
+        if self.model is None:
+            logger.warning("Model does not support QKV projection fusing. Skipping.")
+            return
+        logger.debug("Fusing QKV projections in the Flux2 double-stream attention blocks..")
+        self.unwrap_model(model=self.model).fuse_qkv_projections(
+            preferred_backend=getattr(self.config, "attention_mechanism", None),
+        )
+        self._qkv_projections_fused = True
+
+    def unfuse_qkv_projections(self):
+        if not self.config.fuse_qkv_projections or not self._qkv_projections_fused:
+            return
+        self._qkv_projections_fused = False
+        if self.model is None:
+            return
+        logger.debug("Temporarily unfusing QKV projections in the Flux2 double-stream attention blocks..")
+        self.unwrap_model(model=self.model).unfuse_qkv_projections()
+
     def _prepare_crepa_self_flow_batch(self, batch: dict, state: dict) -> dict:
         latents = batch["latents"]
         input_noise = batch["input_noise"]

--- a/simpletuner/helpers/models/flux2/transformer.py
+++ b/simpletuner/helpers/models/flux2/transformer.py
@@ -39,6 +39,7 @@ from simpletuner.helpers.models.flowmap import (
     validate_flowmap_deltatime_type,
 )
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
+from simpletuner.helpers.training.attention_backend import get_packed_attention_backend
 from simpletuner.helpers.training.qk_clip_logging import publish_attention_max_logits
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -128,6 +129,12 @@ def _get_qkv_projections(attn: "Flux2Attention", hidden_states, encoder_hidden_s
     return _get_projections(attn, hidden_states, encoder_hidden_states)
 
 
+def _run_packed_qkv_attention(query, key, value, attention_mask, preferred_backend):
+    backend = get_packed_attention_backend(preferred_backend, require_varlen_qkvpacked=attention_mask is not None)
+    qkv = torch.stack([query, key, value], dim=2).contiguous()
+    return backend.qkvpacked(qkv, attention_mask=attention_mask, causal=False)
+
+
 class Flux2SwiGLU(nn.Module):
     """
     Flux 2 uses a SwiGLU-style activation in the transformer feedforward sub-blocks, but with the linear projection
@@ -172,6 +179,7 @@ class Flux2FeedForward(nn.Module):
 
 class Flux2AttnProcessor:
     _attention_backend = None
+    _packed_attention_backend = None
     _parallel_config = None
 
     def __init__(self):
@@ -221,14 +229,17 @@ class Flux2AttnProcessor:
             getattr(attn, "to_k", None) and getattr(attn, "to_k", None).weight,
         )
 
-        hidden_states = dispatch_attention_fn(
-            query,
-            key,
-            value,
-            attn_mask=attention_mask,
-            backend=self._attention_backend,
-            # parallel_config=self._parallel_config,
-        )
+        if self._packed_attention_backend is not None:
+            hidden_states = _run_packed_qkv_attention(query, key, value, attention_mask, self._packed_attention_backend)
+        else:
+            hidden_states = dispatch_attention_fn(
+                query,
+                key,
+                value,
+                attn_mask=attention_mask,
+                backend=self._attention_backend,
+                # parallel_config=self._parallel_config,
+            )
         hidden_states = hidden_states.flatten(2, 3)
         hidden_states = hidden_states.to(query.dtype)
 
@@ -324,6 +335,7 @@ class Flux2Attention(torch.nn.Module, AttentionModuleMixin):
 
 class Flux2ParallelSelfAttnProcessor:
     _attention_backend = None
+    _packed_attention_backend = None
     _parallel_config = None
 
     def __init__(self):
@@ -365,14 +377,17 @@ class Flux2ParallelSelfAttnProcessor:
             getattr(attn, "to_qkv_mlp_proj", None) and attn.to_qkv_mlp_proj.weight,
         )
 
-        hidden_states = dispatch_attention_fn(
-            query,
-            key,
-            value,
-            attn_mask=attention_mask,
-            backend=self._attention_backend,
-            # parallel_config=self._parallel_config,
-        )
+        if self._packed_attention_backend is not None:
+            hidden_states = _run_packed_qkv_attention(query, key, value, attention_mask, self._packed_attention_backend)
+        else:
+            hidden_states = dispatch_attention_fn(
+                query,
+                key,
+                value,
+                attn_mask=attention_mask,
+                backend=self._attention_backend,
+                # parallel_config=self._parallel_config,
+            )
         hidden_states = hidden_states.flatten(2, 3)
         hidden_states = hidden_states.to(query.dtype)
 
@@ -929,6 +944,22 @@ class Flux2Transformer2DModel(
         # TREAD router for efficient training
         self._tread_router = None
         self._tread_routes = None
+
+    def fuse_qkv_projections(self, preferred_backend: Optional[str] = None):
+        for module in self.modules():
+            if isinstance(module, Flux2Attention):
+                module.fuse_projections()
+            processor = getattr(module, "processor", None)
+            if processor is not None and hasattr(processor, "_packed_attention_backend"):
+                processor._packed_attention_backend = preferred_backend
+
+    def unfuse_qkv_projections(self):
+        for module in self.modules():
+            if isinstance(module, Flux2Attention):
+                module.unfuse_projections()
+            processor = getattr(module, "processor", None)
+            if processor is not None and hasattr(processor, "_packed_attention_backend"):
+                processor._packed_attention_backend = None
 
     def set_gradient_checkpointing_backend(self, backend: str):
         self.gradient_checkpointing_backend = backend

--- a/simpletuner/helpers/models/ltxvideo2/transformer.py
+++ b/simpletuner/helpers/models/ltxvideo2/transformer.py
@@ -47,6 +47,7 @@ from simpletuner.helpers.models.flowmap import (
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.checkpointing import checkpoint as simpletuner_checkpoint
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
+from simpletuner.helpers.training.packed_attention_processors import run_packed_qkv_attention
 from simpletuner.helpers.training.tread import TREADRouter
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -332,6 +333,7 @@ class LTX2AudioVideoAttnProcessor:
     """
 
     _attention_backend = None
+    _packed_attention_backend = None
     _parallel_config = None
 
     def __init__(self):
@@ -393,14 +395,23 @@ class LTX2AudioVideoAttnProcessor:
         value = value.unflatten(2, (attn.heads, -1))
         query, key, value = _ltx2_cast_attention_inputs(query, key, value, hidden_states, attn)
 
-        hidden_states = _ltx2_dispatch_attention(
-            query,
-            key,
-            value,
-            attention_mask=attention_mask,
-            backend=self._attention_backend,
-            parallel_config=self._parallel_config,
-        )
+        if self._packed_attention_backend is not None and encoder_hidden_states is hidden_states:
+            hidden_states = run_packed_qkv_attention(
+                query,
+                key,
+                value,
+                attention_mask,
+                self._packed_attention_backend,
+            )
+        else:
+            hidden_states = _ltx2_dispatch_attention(
+                query,
+                key,
+                value,
+                attention_mask=attention_mask,
+                backend=self._attention_backend,
+                parallel_config=self._parallel_config,
+            )
         hidden_states = self._flatten_attention_output(hidden_states, batch_size, attn)
         hidden_states = hidden_states.to(query.dtype)
 
@@ -417,6 +428,7 @@ class LTX2AudioVideoAttnProcessor:
 
 class LTX2PerturbedAttnProcessor:
     _attention_backend = None
+    _packed_attention_backend = None
     _parallel_config = None
 
     def __init__(self):
@@ -478,14 +490,23 @@ class LTX2PerturbedAttnProcessor:
             value = value.unflatten(2, (attn.heads, -1))
             query, key, value = _ltx2_cast_attention_inputs(query, key, value, hidden_states, attn)
 
-            hidden_states = _ltx2_dispatch_attention(
-                query,
-                key,
-                value,
-                attention_mask=attention_mask,
-                backend=self._attention_backend,
-                parallel_config=self._parallel_config,
-            )
+            if self._packed_attention_backend is not None and encoder_hidden_states is hidden_states:
+                hidden_states = run_packed_qkv_attention(
+                    query,
+                    key,
+                    value,
+                    attention_mask,
+                    self._packed_attention_backend,
+                )
+            else:
+                hidden_states = _ltx2_dispatch_attention(
+                    query,
+                    key,
+                    value,
+                    attention_mask=attention_mask,
+                    backend=self._attention_backend,
+                    parallel_config=self._parallel_config,
+                )
             hidden_states = self._flatten_attention_output(hidden_states, batch_size, attn)
             hidden_states = hidden_states.to(query.dtype)
 
@@ -1583,6 +1604,22 @@ class LTX2VideoTransformer3DModel(
             swap_device=musubi_block_swap_device,
             logger=logger,
         )
+
+    def fuse_qkv_projections(self, preferred_backend: Optional[str] = None):
+        for module in self.modules():
+            if isinstance(module, LTX2Attention):
+                module.fuse_projections()
+            processor = getattr(module, "processor", None)
+            if processor is not None and hasattr(processor, "_packed_attention_backend"):
+                processor._packed_attention_backend = preferred_backend
+
+    def unfuse_qkv_projections(self):
+        for module in self.modules():
+            if isinstance(module, LTX2Attention):
+                module.unfuse_projections()
+            processor = getattr(module, "processor", None)
+            if processor is not None and hasattr(processor, "_packed_attention_backend"):
+                processor._packed_attention_backend = None
 
     def set_gradient_checkpointing_backend(self, backend: str):
         self.gradient_checkpointing_backend = backend

--- a/simpletuner/helpers/models/lumina2/model.py
+++ b/simpletuner/helpers/models/lumina2/model.py
@@ -3,7 +3,6 @@ import os
 
 import torch
 from diffusers import AutoencoderKL, Lumina2Pipeline
-from diffusers.models.attention_processor import Attention
 from transformers import Gemma2Model, PreTrainedTokenizerFast
 
 from simpletuner.helpers.acceleration import (
@@ -71,41 +70,26 @@ class Lumina2(ImageModelFoundation):
     SYSTEM_PROMPT = "You are an assistant designed to generate superior images with the superior degree of image-text alignment based on textual prompts or user prompts."
 
     def fuse_qkv_projections(self):
-        """Lumina2 may support QKV fusion similar to Flux"""
         if not self.config.fuse_qkv_projections or self._qkv_projections_fused:
-            return
-
-        try:
-            # Try to use fused attention if available
-            from diffusers.models.attention_processor import FusedAttnProcessor2_0
-
-            attn_processor = FusedAttnProcessor2_0()
-        except:
-            logger.debug("Fused attention not available for Lumina2, using default")
             return
 
         if self.model is not None:
             logger.debug("Fusing QKV projections in the model..")
-            for module in self.model.modules():
-                if isinstance(module, Attention):
-                    module.fuse_projections(fuse=True)
+            self.unwrap_model(model=self.model).fuse_qkv_projections(
+                preferred_backend=getattr(self.config, "attention_mechanism", None)
+            )
+            self._qkv_projections_fused = True
         else:
             logger.warning("Model does not support QKV projection fusing. Skipping.")
 
-        self.unwrap_model(model=self.model).set_attn_processor(attn_processor)
-        self._qkv_projections_fused = True
-
     def unfuse_qkv_projections(self):
-        """Unfuse QKV projections if they were fused."""
         if not self.config.fuse_qkv_projections or not self._qkv_projections_fused:
             return
         self._qkv_projections_fused = False
 
         if self.model is not None:
             logger.debug("Temporarily unfusing QKV projections in the model..")
-            for module in self.model.modules():
-                if isinstance(module, Attention):
-                    module.fuse_projections(fuse=False)
+            self.unwrap_model(model=self.model).unfuse_qkv_projections()
 
     def _format_text_embedding(self, text_embedding: torch.Tensor):
         """

--- a/simpletuner/helpers/models/lumina2/transformer.py
+++ b/simpletuner/helpers/models/lumina2/transformer.py
@@ -49,6 +49,7 @@ from simpletuner.helpers.models.flowmap import (
     validate_flowmap_deltatime_type,
 )
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
+from simpletuner.helpers.training.packed_attention_processors import run_packed_qkv_attention
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
@@ -203,6 +204,71 @@ class Lumina2AttnProcessor2_0:
         hidden_states = hidden_states.type_as(query)
 
         # linear proj
+        hidden_states = attn.to_out[0](hidden_states)
+        hidden_states = attn.to_out[1](hidden_states)
+        return hidden_states
+
+
+class Lumina2PackedAttnProcessor2_0:
+    def __init__(self, preferred_backend: Optional[str] = None):
+        self.preferred_backend = preferred_backend
+
+    def __call__(
+        self,
+        attn: Attention,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        image_rotary_emb: Optional[torch.Tensor] = None,
+        base_sequence_length: Optional[int] = None,
+    ) -> torch.Tensor:
+        if encoder_hidden_states is not hidden_states:
+            raise ValueError("Lumina2 packed QKV attention only supports self-attention inputs.")
+
+        batch_size, sequence_length, _ = hidden_states.shape
+        qkv = attn.to_qkv(hidden_states)
+        query_dim = attn.inner_dim
+        kv_dim = attn.inner_kv_dim
+        query, key, value = torch.split(qkv, (query_dim, kv_dim, kv_dim), dim=-1)
+        head_dim = query_dim // attn.heads
+        kv_heads = kv_dim // head_dim
+        if attn.heads % kv_heads != 0:
+            raise ValueError(f"Lumina2 GQA head layout requires heads divisible by kv_heads, got {attn.heads}/{kv_heads}.")
+        dtype = query.dtype
+
+        query = query.view(batch_size, -1, attn.heads, head_dim)
+        key = key.view(batch_size, -1, kv_heads, head_dim)
+        value = value.view(batch_size, -1, kv_heads, head_dim)
+
+        if attn.norm_q is not None:
+            query = attn.norm_q(query)
+        if attn.norm_k is not None:
+            key = attn.norm_k(key)
+
+        if image_rotary_emb is not None:
+            query = apply_rotary_emb(query, image_rotary_emb, use_real=False)
+            key = apply_rotary_emb(key, image_rotary_emb, use_real=False)
+
+        query, key = query.to(dtype), key.to(dtype)
+        if base_sequence_length is not None:
+            softmax_scale = math.sqrt(math.log(sequence_length, base_sequence_length)) * attn.scale
+        else:
+            softmax_scale = attn.scale
+
+        n_rep = attn.heads // kv_heads
+        if n_rep >= 1:
+            key = key.unsqueeze(3).repeat(1, 1, 1, n_rep, 1).flatten(2, 3)
+            value = value.unsqueeze(3).repeat(1, 1, 1, n_rep, 1).flatten(2, 3)
+
+        hidden_states = run_packed_qkv_attention(
+            query,
+            key,
+            value,
+            attention_mask,
+            self.preferred_backend,
+            softmax_scale=softmax_scale,
+        )
+        hidden_states = hidden_states.reshape(batch_size, -1, attn.heads * head_dim).type_as(query)
         hidden_states = attn.to_out[0](hidden_states)
         hidden_states = attn.to_out[1](hidden_states)
         return hidden_states
@@ -546,6 +612,18 @@ class Lumina2Transformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromO
             swap_device=musubi_block_swap_device,
             logger=logger,
         )
+
+    def fuse_qkv_projections(self, preferred_backend: Optional[str] = None):
+        for module in self.modules():
+            if isinstance(module, Attention):
+                module.fuse_projections(fuse=True)
+                module.set_processor(Lumina2PackedAttnProcessor2_0(preferred_backend=preferred_backend))
+
+    def unfuse_qkv_projections(self):
+        for module in self.modules():
+            if isinstance(module, Attention):
+                module.unfuse_projections()
+                module.set_processor(Lumina2AttnProcessor2_0())
 
     def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
         self.time_caption_embed.enable_flowmap_time_conditioning(gate_value=gate_value, deltatime_type=deltatime_type)

--- a/simpletuner/helpers/models/pixart/transformer.py
+++ b/simpletuner/helpers/models/pixart/transformer.py
@@ -19,7 +19,7 @@ from diffusers.configuration_utils import ConfigMixin
 from diffusers.loaders import PeftAdapterMixin
 from diffusers.models._modeling_parallel import ContextParallelInput, ContextParallelOutput
 from diffusers.models.attention import BasicTransformerBlock
-from diffusers.models.attention_processor import Attention, AttentionProcessor, AttnProcessor, FusedAttnProcessor2_0
+from diffusers.models.attention_processor import Attention, AttentionProcessor, AttnProcessor
 from diffusers.models.embeddings import PatchEmbed, PixArtAlphaTextProjection
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 from diffusers.models.modeling_utils import ModelMixin
@@ -36,6 +36,7 @@ from simpletuner.helpers.models.flowmap import (
     validate_flowmap_deltatime_type,
 )
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
+from simpletuner.helpers.training.packed_attention_processors import PackedFusedAttnProcessor2_0
 from simpletuner.helpers.training.tread import TREADRouter
 from simpletuner.helpers.utils.patching import CallableDict, MutableModuleList, PatchableModule
 
@@ -427,7 +428,7 @@ class PixArtTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAda
         self.set_attn_processor(AttnProcessor())
 
     # Copied from diffusers.models.unets.unet_2d_condition.UNet2DConditionModel.fuse_qkv_projections
-    def fuse_qkv_projections(self):
+    def fuse_qkv_projections(self, preferred_backend: Optional[str] = None):
         """
         Enables fused QKV projections. For self-attention modules, all projection matrices (i.e., query, key, value)
         are fused. For cross-attention modules, key and value projection matrices are fused.
@@ -450,7 +451,7 @@ class PixArtTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAda
             if isinstance(module, Attention):
                 module.fuse_projections(fuse=True)
 
-        self.set_attn_processor(FusedAttnProcessor2_0())
+        self.set_attn_processor(PackedFusedAttnProcessor2_0(preferred_backend=preferred_backend))
 
     # Copied from diffusers.models.unets.unet_2d_condition.UNet2DConditionModel.unfuse_qkv_projections
     def unfuse_qkv_projections(self):
@@ -465,6 +466,9 @@ class PixArtTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAda
         """
         if self.original_attn_processors is not None:
             self.set_attn_processor(self.original_attn_processors)
+        for module in self.modules():
+            if isinstance(module, Attention):
+                module.unfuse_projections()
 
     def set_router(self, router: TREADRouter, routes: List[Dict[str, Any]]):
         """Set the TREAD router and routing configuration."""

--- a/simpletuner/helpers/models/sd3/expanded.py
+++ b/simpletuner/helpers/models/sd3/expanded.py
@@ -367,7 +367,7 @@ class SD3TransformerQKNorm2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fro
             fn_recursive_attn_processor(name, module, processor)
 
     # Copied from diffusers.models.unets.unet_2d_condition.UNet2DConditionModel.fuse_qkv_projections
-    def fuse_qkv_projections(self):
+    def fuse_qkv_projections(self, preferred_backend=None):
         """
         Enables fused QKV projections. For self-attention modules, all projection matrices (i.e., query, key, value)
         are fused. For cross-attention modules, key and value projection matrices are fused.

--- a/simpletuner/helpers/models/sd3/transformer.py
+++ b/simpletuner/helpers/models/sd3/transformer.py
@@ -21,7 +21,7 @@ from diffusers.configuration_utils import ConfigMixin
 from diffusers.loaders import FromOriginalModelMixin, PeftAdapterMixin
 from diffusers.models._modeling_parallel import ContextParallelInput, ContextParallelOutput
 from diffusers.models.attention import JointTransformerBlock, _chunked_feed_forward
-from diffusers.models.attention_processor import Attention, AttentionProcessor, FusedJointAttnProcessor2_0
+from diffusers.models.attention_processor import Attention, AttentionProcessor
 from diffusers.models.embeddings import CombinedTimestepTextProjEmbeddings, PatchEmbed
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 from diffusers.models.modeling_utils import ModelMixin
@@ -39,6 +39,7 @@ from simpletuner.helpers.models.flowmap import (
 )
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
+from simpletuner.helpers.training.packed_attention_processors import PackedJointAttnProcessor2_0
 from simpletuner.helpers.training.tread import TREADRouter
 from simpletuner.helpers.utils.patching import CallableDict, MutableModuleList, PatchableModule
 
@@ -507,7 +508,7 @@ class SD3Transformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapte
             fn_recursive_attn_processor(name, module, processor)
 
     # Copied from diffusers.models.unets.unet_2d_condition.UNet2DConditionModel.fuse_qkv_projections with FusedAttnProcessor2_0->FusedJointAttnProcessor2_0
-    def fuse_qkv_projections(self):
+    def fuse_qkv_projections(self, preferred_backend: Optional[str] = None):
         """
         Enables fused QKV projections. For self-attention modules, all projection matrices (i.e., query, key, value)
         are fused. For cross-attention modules, key and value projection matrices are fused.
@@ -530,7 +531,7 @@ class SD3Transformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapte
             if isinstance(module, Attention):
                 module.fuse_projections(fuse=True)
 
-        self.set_attn_processor(FusedJointAttnProcessor2_0())
+        self.set_attn_processor(PackedJointAttnProcessor2_0(preferred_backend=preferred_backend))
 
     # Copied from diffusers.models.unets.unet_2d_condition.UNet2DConditionModel.unfuse_qkv_projections
     def unfuse_qkv_projections(self):
@@ -545,6 +546,9 @@ class SD3Transformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapte
         """
         if self.original_attn_processors is not None:
             self.set_attn_processor(self.original_attn_processors)
+        for module in self.modules():
+            if isinstance(module, Attention):
+                module.unfuse_projections()
 
     def forward(
         self,

--- a/simpletuner/helpers/training/attention_backend.py
+++ b/simpletuner/helpers/training/attention_backend.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import os
 import sys
+from dataclasses import dataclass
 from enum import Enum
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple
 
 import torch
@@ -106,6 +108,236 @@ class AttentionBackendMode(str, Enum):
 class AttentionPhase(Enum):
     TRAIN = "train"
     EVAL = "eval"
+
+
+@dataclass(frozen=True)
+class PackedAttentionCapabilities:
+    fixed_qkvpacked: bool
+    varlen_qkvpacked: bool
+    varlen_unpacked: bool
+
+
+class PackedAttentionBackend:
+    """
+    Dispatch QKV-packed attention through direct FlashAttention or Hugging Face Kernels providers.
+
+    The model processors own projection, normalization, and RoPE ordering. This class only owns kernel
+    selection, bool-mask unpadding, and padding the visible-token output back to batch-major layout.
+    """
+
+    def __init__(self, name: str, module: Any):
+        self.name = name
+        self.module = module
+        self.fixed_qkvpacked_func = getattr(module, "flash_attn_qkvpacked_func", None)
+        self.varlen_qkvpacked_func = getattr(module, "flash_attn_varlen_qkvpacked_func", None)
+        self.varlen_unpacked_func = getattr(module, "flash_attn_varlen_func", None)
+        self.capabilities = PackedAttentionCapabilities(
+            fixed_qkvpacked=self.fixed_qkvpacked_func is not None,
+            varlen_qkvpacked=self.varlen_qkvpacked_func is not None,
+            varlen_unpacked=self.varlen_unpacked_func is not None,
+        )
+
+    def qkvpacked(
+        self,
+        qkv: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        *,
+        causal: bool = False,
+        dropout_p: float = 0.0,
+        softmax_scale: Optional[float] = None,
+    ) -> torch.Tensor:
+        if attention_mask is None:
+            if self.fixed_qkvpacked_func is None:
+                raise RuntimeError(f"Packed attention backend '{self.name}' does not provide fixed qkvpacked attention.")
+            return _call_qkvpacked_kernel(
+                self.fixed_qkvpacked_func,
+                qkv,
+                causal=causal,
+                dropout_p=dropout_p,
+                softmax_scale=softmax_scale,
+            )
+
+        if self.varlen_qkvpacked_func is None:
+            raise RuntimeError(
+                f"Packed attention backend '{self.name}' does not provide varlen qkvpacked attention for masked inputs."
+            )
+
+        qkv_unpad, indices, cu_seqlens, max_seqlen, batch_size, padded_seqlen = _unpad_qkv(qkv, attention_mask)
+        output_unpad = _call_varlen_qkvpacked_kernel(
+            self.varlen_qkvpacked_func,
+            qkv_unpad,
+            cu_seqlens,
+            max_seqlen,
+            causal=causal,
+            dropout_p=dropout_p,
+            softmax_scale=softmax_scale,
+        )
+        return _pad_varlen_output(output_unpad, indices, batch_size, padded_seqlen)
+
+
+_PACKED_BACKEND_ALIASES = {
+    "flash-attn-2": ("direct-fa2", "flash_attn"),
+    "flash_attn_2": ("direct-fa2", "flash_attn"),
+    "flash2": ("direct-fa2", "flash_attn"),
+    "flash-attn-2-hub": ("hub-fa2", "kernels-community/flash-attn2"),
+    "flash_attn_2_hub": ("hub-fa2", "kernels-community/flash-attn2"),
+    "flash2-hub": ("hub-fa2", "kernels-community/flash-attn2"),
+    "flash-attn-3": ("direct-fa3", "flash_attn_interface"),
+    "flash_attn_3": ("direct-fa3", "flash_attn_interface"),
+    "flash3": ("direct-fa3", "flash_attn_interface"),
+    "flash-attn-3-hub": ("hub-fa3", "kernels-community/flash-attn3"),
+    "flash_attn_3_hub": ("hub-fa3", "kernels-community/flash-attn3"),
+    "flash3-hub": ("hub-fa3", "kernels-community/flash-attn3"),
+    "flash-attn-3-varlen": ("direct-fa3", "flash_attn_interface"),
+    "flash_attn_3_varlen": ("direct-fa3", "flash_attn_interface"),
+    "flash3-varlen": ("direct-fa3", "flash_attn_interface"),
+    "flash-attn-3-varlen-hub": ("hub-fa3", "kernels-community/flash-attn3"),
+    "flash_attn_3_varlen_hub": ("hub-fa3", "kernels-community/flash-attn3"),
+    "flash3-varlen-hub": ("hub-fa3", "kernels-community/flash-attn3"),
+    "flash-attn-4": ("direct-fa4", "flash_attn.cute"),
+    "flash_attn_4": ("direct-fa4", "flash_attn.cute"),
+    "flash4": ("direct-fa4", "flash_attn.cute"),
+    "flash-attn-4-hub": ("hub-fa4", "kernels-community/flash-attn4"),
+    "flash_attn_4_hub": ("hub-fa4", "kernels-community/flash-attn4"),
+    "flash4-hub": ("hub-fa4", "kernels-community/flash-attn4"),
+}
+
+
+def _normalize_backend_key(value: str) -> str:
+    return value.replace("_", "-")
+
+
+@lru_cache(maxsize=32)
+def get_packed_attention_backend(
+    preferred_backend: Optional[str] = None,
+    require_varlen_qkvpacked: bool = False,
+) -> PackedAttentionBackend:
+    backend_key = _select_packed_backend(preferred_backend, require_varlen_qkvpacked=require_varlen_qkvpacked)
+    provider, target = _PACKED_BACKEND_ALIASES[backend_key]
+    if provider.startswith("hub-"):
+        try:
+            from kernels import get_kernel
+        except ImportError as exc:
+            raise RuntimeError("The 'kernels' package is required for Hugging Face Hub attention kernels.") from exc
+
+        module = get_kernel(target)
+        return PackedAttentionBackend(backend_key, module)
+
+    import importlib
+
+    try:
+        module = importlib.import_module(target)
+    except ImportError as exc:
+        raise RuntimeError(f"Could not import packed attention backend '{target}'.") from exc
+    return PackedAttentionBackend(backend_key, module)
+
+
+def _select_packed_backend(preferred_backend: Optional[str], *, require_varlen_qkvpacked: bool = False) -> str:
+    if preferred_backend:
+        normalized = _normalize_backend_key(preferred_backend.strip().lower())
+        raw = preferred_backend.strip().lower()
+        if raw in _PACKED_BACKEND_ALIASES:
+            return raw
+        if normalized in _PACKED_BACKEND_ALIASES:
+            return normalized
+        if normalized in ("auto", "automatic"):
+            return _auto_packed_backend(require_varlen_qkvpacked=require_varlen_qkvpacked)
+        raise ValueError(f"Unsupported packed attention backend '{preferred_backend}'.")
+    return _auto_packed_backend(require_varlen_qkvpacked=require_varlen_qkvpacked)
+
+
+def _auto_packed_backend(*, require_varlen_qkvpacked: bool = False) -> str:
+    if not torch.cuda.is_available():
+        raise RuntimeError("Packed FlashAttention backends require CUDA.")
+    major, minor = torch.cuda.get_device_capability()
+    if require_varlen_qkvpacked and major >= 8:
+        return "flash2-hub"
+    if major >= 10:
+        return "flash4-hub"
+    if major >= 9:
+        return "flash3-hub"
+    if major == 8:
+        return "flash2-hub"
+    raise RuntimeError(f"No packed FlashAttention backend is configured for CUDA capability {major}.{minor}.")
+
+
+def _normalize_bool_mask(attention_mask: torch.Tensor, batch_size: int, seqlen: int) -> torch.Tensor:
+    if attention_mask.ndim != 2:
+        raise ValueError(
+            f"Packed varlen attention expects a [batch, sequence] bool-compatible mask, got {tuple(attention_mask.shape)}."
+        )
+    if attention_mask.shape != (batch_size, seqlen):
+        raise ValueError(
+            f"Packed varlen attention mask shape {tuple(attention_mask.shape)} does not match qkv shape "
+            f"{(batch_size, seqlen)}."
+        )
+    return attention_mask.to(dtype=torch.bool)
+
+
+def _unpad_qkv(qkv: torch.Tensor, attention_mask: torch.Tensor):
+    if qkv.ndim != 5 or qkv.shape[2] != 3:
+        raise ValueError(f"Expected qkv shape [batch, sequence, 3, heads, head_dim], got {tuple(qkv.shape)}.")
+    batch_size, seqlen = qkv.shape[:2]
+    mask = _normalize_bool_mask(attention_mask, batch_size, seqlen).to(device=qkv.device)
+    lengths = mask.sum(dim=1, dtype=torch.int32)
+    if torch.any(lengths == 0):
+        raise ValueError("Packed varlen attention received an empty sequence in the attention mask.")
+
+    indices = torch.nonzero(mask.flatten(), as_tuple=False).flatten()
+    qkv_unpad = qkv.reshape(batch_size * seqlen, *qkv.shape[2:]).index_select(0, indices)
+    cu_seqlens = torch.zeros(batch_size + 1, device=qkv.device, dtype=torch.int32)
+    cu_seqlens[1:] = torch.cumsum(lengths, dim=0)
+    max_seqlen = int(lengths.max().item())
+    return qkv_unpad.contiguous(), indices, cu_seqlens, max_seqlen, batch_size, seqlen
+
+
+def _pad_varlen_output(output_unpad: torch.Tensor, indices: torch.Tensor, batch_size: int, seqlen: int) -> torch.Tensor:
+    output = output_unpad.new_zeros((batch_size * seqlen, *output_unpad.shape[1:]))
+    output.index_copy_(0, indices, output_unpad)
+    return output.view(batch_size, seqlen, *output_unpad.shape[1:])
+
+
+def _call_qkvpacked_kernel(func, qkv: torch.Tensor, *, causal: bool, dropout_p: float, softmax_scale: Optional[float]):
+    try:
+        output = func(qkv, dropout_p=dropout_p, softmax_scale=softmax_scale, causal=causal)
+    except TypeError:
+        output = func(qkv, causal=causal)
+    if isinstance(output, tuple):
+        return output[0]
+    return output
+
+
+def _call_varlen_qkvpacked_kernel(
+    func,
+    qkv_unpad: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    max_seqlen: int,
+    *,
+    causal: bool,
+    dropout_p: float,
+    softmax_scale: Optional[float],
+):
+    try:
+        output = func(
+            qkv_unpad,
+            cu_seqlens,
+            max_seqlen,
+            dropout_p,
+            softmax_scale=softmax_scale,
+            causal=causal,
+        )
+    except TypeError:
+        output = func(
+            qkv_unpad,
+            cu_seqlens,
+            max_seqlen,
+            dropout_p=dropout_p,
+            softmax_scale=softmax_scale,
+            causal=causal,
+        )
+    if isinstance(output, tuple):
+        return output[0]
+    return output
 
 
 def is_sageattention_available() -> bool:

--- a/simpletuner/helpers/training/packed_attention_processors.py
+++ b/simpletuner/helpers/training/packed_attention_processors.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from diffusers.models.attention_processor import Attention, FusedAttnProcessor2_0
+
+from simpletuner.helpers.training.attention_backend import get_packed_attention_backend
+
+
+def attention_mask_to_keep_mask(
+    attention_mask: Optional[torch.Tensor],
+    batch_size: int,
+    sequence_length: int,
+) -> Optional[torch.Tensor]:
+    if attention_mask is None:
+        return None
+    if attention_mask.dtype == torch.bool:
+        keep_mask = attention_mask
+    else:
+        keep_mask = attention_mask >= -9000.0
+
+    if keep_mask.ndim == 1:
+        keep_mask = keep_mask.unsqueeze(0).expand(batch_size, sequence_length)
+    elif keep_mask.ndim == 2:
+        pass
+    elif keep_mask.ndim == 3:
+        keep_mask = keep_mask.any(dim=1)
+    elif keep_mask.ndim == 4:
+        keep_mask = keep_mask.any(dim=(1, 2))
+    else:
+        raise ValueError(f"Unsupported packed attention mask shape: {tuple(attention_mask.shape)}")
+
+    if keep_mask.shape != (batch_size, sequence_length):
+        raise ValueError(
+            f"Packed attention mask shape {tuple(keep_mask.shape)} does not match " f"({batch_size}, {sequence_length})."
+        )
+    return keep_mask
+
+
+def run_packed_qkv_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: Optional[torch.Tensor],
+    preferred_backend: Optional[str],
+    *,
+    softmax_scale: Optional[float] = None,
+) -> torch.Tensor:
+    if query.shape != key.shape or query.shape != value.shape:
+        raise ValueError(
+            "Packed qkv attention requires query, key, and value to share shape; "
+            f"got {tuple(query.shape)}, {tuple(key.shape)}, {tuple(value.shape)}."
+        )
+    keep_mask = attention_mask_to_keep_mask(attention_mask, query.shape[0], query.shape[1])
+    backend = get_packed_attention_backend(preferred_backend, require_varlen_qkvpacked=keep_mask is not None)
+    qkv = torch.stack([query, key, value], dim=2).contiguous()
+    return backend.qkvpacked(qkv, attention_mask=keep_mask, causal=False, softmax_scale=softmax_scale)
+
+
+class PackedFusedAttnProcessor2_0:
+    def __init__(self, preferred_backend: Optional[str] = None):
+        if not hasattr(F, "scaled_dot_product_attention"):
+            raise ImportError("PackedFusedAttnProcessor2_0 requires PyTorch 2.0 or newer.")
+        self.preferred_backend = preferred_backend
+        self.cross_attention_processor = FusedAttnProcessor2_0()
+
+    def __call__(
+        self,
+        attn: Attention,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        temb: Optional[torch.Tensor] = None,
+        *args,
+        **kwargs,
+    ) -> torch.Tensor:
+        if encoder_hidden_states is not None:
+            return self.cross_attention_processor(
+                attn, hidden_states, encoder_hidden_states, attention_mask, temb, *args, **kwargs
+            )
+
+        residual = hidden_states
+        if attn.spatial_norm is not None:
+            hidden_states = attn.spatial_norm(hidden_states, temb)
+
+        input_ndim = hidden_states.ndim
+        if input_ndim == 4:
+            batch_size, channel, height, width = hidden_states.shape
+            hidden_states = hidden_states.view(batch_size, channel, height * width).transpose(1, 2)
+
+        batch_size, sequence_length, _ = hidden_states.shape
+        if attention_mask is not None:
+            attention_mask = attn.prepare_attention_mask(attention_mask, sequence_length, batch_size)
+            attention_mask = attention_mask.view(batch_size, attn.heads, -1, attention_mask.shape[-1])
+
+        if attn.group_norm is not None:
+            hidden_states = attn.group_norm(hidden_states.transpose(1, 2)).transpose(1, 2)
+
+        qkv = attn.to_qkv(hidden_states)
+        query, key, value = torch.chunk(qkv, 3, dim=-1)
+        inner_dim = key.shape[-1]
+        head_dim = inner_dim // attn.heads
+        query = query.view(batch_size, -1, attn.heads, head_dim)
+        key = key.view(batch_size, -1, attn.heads, head_dim)
+        value = value.view(batch_size, -1, attn.heads, head_dim)
+
+        if attn.norm_q is not None:
+            query = attn.norm_q(query)
+        if attn.norm_k is not None:
+            key = attn.norm_k(key)
+
+        hidden_states = run_packed_qkv_attention(query, key, value, attention_mask, self.preferred_backend)
+        hidden_states = hidden_states.reshape(batch_size, -1, attn.heads * head_dim).to(query.dtype)
+        hidden_states = attn.to_out[0](hidden_states)
+        hidden_states = attn.to_out[1](hidden_states)
+
+        if input_ndim == 4:
+            hidden_states = hidden_states.transpose(-1, -2).reshape(batch_size, channel, height, width)
+        if attn.residual_connection:
+            hidden_states = hidden_states + residual
+        return hidden_states / attn.rescale_output_factor
+
+
+class PackedJointAttnProcessor2_0:
+    def __init__(self, preferred_backend: Optional[str] = None):
+        self.preferred_backend = preferred_backend
+
+    def __call__(
+        self,
+        attn: Attention,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        *args,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        residual = hidden_states
+        input_ndim = hidden_states.ndim
+        if input_ndim == 4:
+            batch_size, channel, height, width = hidden_states.shape
+            hidden_states = hidden_states.view(batch_size, channel, height * width).transpose(1, 2)
+        context_input_ndim = encoder_hidden_states.ndim
+        if context_input_ndim == 4:
+            batch_size, channel, height, width = encoder_hidden_states.shape
+            encoder_hidden_states = encoder_hidden_states.view(batch_size, channel, height * width).transpose(1, 2)
+
+        batch_size = encoder_hidden_states.shape[0]
+        qkv = attn.to_qkv(hidden_states)
+        query, key, value = torch.chunk(qkv, 3, dim=-1)
+        encoder_qkv = attn.to_added_qkv(encoder_hidden_states)
+        encoder_query, encoder_key, encoder_value = torch.chunk(encoder_qkv, 3, dim=-1)
+
+        query = torch.cat([query, encoder_query], dim=1)
+        key = torch.cat([key, encoder_key], dim=1)
+        value = torch.cat([value, encoder_value], dim=1)
+        inner_dim = key.shape[-1]
+        head_dim = inner_dim // attn.heads
+        query = query.view(batch_size, -1, attn.heads, head_dim)
+        key = key.view(batch_size, -1, attn.heads, head_dim)
+        value = value.view(batch_size, -1, attn.heads, head_dim)
+
+        hidden_states = run_packed_qkv_attention(query, key, value, attention_mask, self.preferred_backend)
+        hidden_states = hidden_states.reshape(batch_size, -1, attn.heads * head_dim).to(query.dtype)
+        hidden_states, encoder_hidden_states = (
+            hidden_states[:, : residual.shape[1]],
+            hidden_states[:, residual.shape[1] :],
+        )
+
+        hidden_states = attn.to_out[0](hidden_states)
+        hidden_states = attn.to_out[1](hidden_states)
+        if not attn.context_pre_only:
+            encoder_hidden_states = attn.to_add_out(encoder_hidden_states)
+
+        if input_ndim == 4:
+            hidden_states = hidden_states.transpose(-1, -2).reshape(batch_size, channel, height, width)
+        if context_input_ndim == 4:
+            encoder_hidden_states = encoder_hidden_states.transpose(-1, -2).reshape(batch_size, channel, height, width)
+        return hidden_states, encoder_hidden_states
+
+
+class PackedAuraFlowAttnProcessor2_0:
+    def __init__(self, preferred_backend: Optional[str] = None):
+        self.preferred_backend = preferred_backend
+
+    def __call__(
+        self,
+        attn: Attention,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        *args,
+        **kwargs,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        batch_size = hidden_states.shape[0]
+        qkv = attn.to_qkv(hidden_states)
+        query, key, value = torch.chunk(qkv, 3, dim=-1)
+        inner_dim = key.shape[-1]
+        head_dim = inner_dim // attn.heads
+        query = query.view(batch_size, -1, attn.heads, head_dim)
+        key = key.view(batch_size, -1, attn.heads, head_dim)
+        value = value.view(batch_size, -1, attn.heads, head_dim)
+
+        if attn.norm_q is not None:
+            query = attn.norm_q(query)
+        if attn.norm_k is not None:
+            key = attn.norm_k(key)
+
+        if encoder_hidden_states is not None:
+            encoder_qkv = attn.to_added_qkv(encoder_hidden_states)
+            encoder_query, encoder_key, encoder_value = torch.chunk(encoder_qkv, 3, dim=-1)
+            encoder_query = encoder_query.view(batch_size, -1, attn.heads, head_dim)
+            encoder_key = encoder_key.view(batch_size, -1, attn.heads, head_dim)
+            encoder_value = encoder_value.view(batch_size, -1, attn.heads, head_dim)
+            if attn.norm_added_q is not None:
+                encoder_query = attn.norm_added_q(encoder_query)
+            if attn.norm_added_k is not None:
+                encoder_key = attn.norm_added_k(encoder_key)
+            query = torch.cat([encoder_query, query], dim=1)
+            key = torch.cat([encoder_key, key], dim=1)
+            value = torch.cat([encoder_value, value], dim=1)
+
+        hidden_states = run_packed_qkv_attention(
+            query,
+            key,
+            value,
+            None,
+            self.preferred_backend,
+            softmax_scale=attn.scale,
+        )
+        hidden_states = hidden_states.reshape(batch_size, -1, attn.heads * head_dim).to(query.dtype)
+
+        if encoder_hidden_states is not None:
+            hidden_states, encoder_hidden_states = (
+                hidden_states[:, encoder_hidden_states.shape[1] :],
+                hidden_states[:, : encoder_hidden_states.shape[1]],
+            )
+
+        hidden_states = attn.to_out[0](hidden_states)
+        hidden_states = attn.to_out[1](hidden_states)
+        if encoder_hidden_states is not None:
+            encoder_hidden_states = attn.to_add_out(encoder_hidden_states)
+            return hidden_states, encoder_hidden_states
+        return hidden_states

--- a/simpletuner/helpers/training/packed_attention_processors.py
+++ b/simpletuner/helpers/training/packed_attention_processors.py
@@ -136,17 +136,21 @@ class PackedJointAttnProcessor2_0:
         *args,
         **kwargs,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        residual = hidden_states
+        sample_input_shape = hidden_states.shape
+        context_input_shape = encoder_hidden_states.shape
         input_ndim = hidden_states.ndim
         if input_ndim == 4:
-            batch_size, channel, height, width = hidden_states.shape
-            hidden_states = hidden_states.view(batch_size, channel, height * width).transpose(1, 2)
+            batch_size, sample_channel, sample_height, sample_width = sample_input_shape
+            hidden_states = hidden_states.view(batch_size, sample_channel, sample_height * sample_width).transpose(1, 2)
         context_input_ndim = encoder_hidden_states.ndim
         if context_input_ndim == 4:
-            batch_size, channel, height, width = encoder_hidden_states.shape
-            encoder_hidden_states = encoder_hidden_states.view(batch_size, channel, height * width).transpose(1, 2)
+            batch_size, context_channel, context_height, context_width = context_input_shape
+            encoder_hidden_states = encoder_hidden_states.view(
+                batch_size, context_channel, context_height * context_width
+            ).transpose(1, 2)
 
         batch_size = encoder_hidden_states.shape[0]
+        context_sequence_length = encoder_hidden_states.shape[1]
         qkv = attn.to_qkv(hidden_states)
         query, key, value = torch.chunk(qkv, 3, dim=-1)
         encoder_qkv = attn.to_added_qkv(encoder_hidden_states)
@@ -163,9 +167,10 @@ class PackedJointAttnProcessor2_0:
 
         hidden_states = run_packed_qkv_attention(query, key, value, attention_mask, self.preferred_backend)
         hidden_states = hidden_states.reshape(batch_size, -1, attn.heads * head_dim).to(query.dtype)
+        sample_sequence_length = hidden_states.shape[1] - context_sequence_length
         hidden_states, encoder_hidden_states = (
-            hidden_states[:, : residual.shape[1]],
-            hidden_states[:, residual.shape[1] :],
+            hidden_states[:, :sample_sequence_length],
+            hidden_states[:, sample_sequence_length:],
         )
 
         hidden_states = attn.to_out[0](hidden_states)
@@ -174,9 +179,11 @@ class PackedJointAttnProcessor2_0:
             encoder_hidden_states = attn.to_add_out(encoder_hidden_states)
 
         if input_ndim == 4:
-            hidden_states = hidden_states.transpose(-1, -2).reshape(batch_size, channel, height, width)
+            hidden_states = hidden_states.transpose(-1, -2).reshape(batch_size, sample_channel, sample_height, sample_width)
         if context_input_ndim == 4:
-            encoder_hidden_states = encoder_hidden_states.transpose(-1, -2).reshape(batch_size, channel, height, width)
+            encoder_hidden_states = encoder_hidden_states.transpose(-1, -2).reshape(
+                batch_size, context_channel, context_height, context_width
+            )
         return hidden_states, encoder_hidden_states
 
 

--- a/tests/test_attention_backend.py
+++ b/tests/test_attention_backend.py
@@ -2,11 +2,12 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest.mock import patch
 
 import torch
 
 from simpletuner.helpers.training import attention_backend as attention_backend_module
-from simpletuner.helpers.training.attention_backend import AttentionBackendController, AttentionPhase
+from simpletuner.helpers.training.attention_backend import AttentionBackendController, AttentionPhase, PackedAttentionBackend
 
 
 class TestAttentionBackendPersistence(unittest.TestCase):
@@ -30,6 +31,7 @@ class TestAttentionBackendPersistence(unittest.TestCase):
         AttentionBackendController._sla_state_store = {}
         AttentionBackendController._diffusers_backend_context = None
         AttentionBackendController._diffusers_backend_name = None
+        attention_backend_module.get_packed_attention_backend.cache_clear()
 
     def test_save_checkpoint_no_state(self):
         AttentionBackendController._active_backend = "sla"
@@ -89,3 +91,57 @@ class TestAttentionBackendPersistence(unittest.TestCase):
         self.assertEqual(AttentionBackendController._diffusers_backend_name, "native-math")
         AttentionBackendController.restore_default()
         self.assertIsNone(AttentionBackendController._diffusers_backend_name)
+
+    def test_packed_backend_dispatches_fixed_qkvpacked(self):
+        class DummyKernel:
+            @staticmethod
+            def flash_attn_qkvpacked_func(qkv, dropout_p=0.0, softmax_scale=None, causal=False):
+                return qkv[:, :, 0]
+
+        backend = PackedAttentionBackend("dummy", DummyKernel())
+        qkv = torch.randn(2, 4, 3, 2, 8)
+
+        output = backend.qkvpacked(qkv)
+
+        self.assertTrue(torch.equal(output, qkv[:, :, 0]))
+
+    def test_packed_backend_dispatches_varlen_qkvpacked_with_bool_mask(self):
+        calls = {}
+
+        class DummyKernel:
+            @staticmethod
+            def flash_attn_qkvpacked_func(qkv, dropout_p=0.0, softmax_scale=None, causal=False):
+                return qkv[:, :, 0]
+
+            @staticmethod
+            def flash_attn_varlen_qkvpacked_func(
+                qkv, cu_seqlens, max_seqlen, dropout_p=0.0, softmax_scale=None, causal=False
+            ):
+                calls["qkv"] = qkv
+                calls["cu_seqlens"] = cu_seqlens
+                calls["max_seqlen"] = max_seqlen
+                return qkv[:, 0]
+
+        backend = PackedAttentionBackend("dummy", DummyKernel())
+        qkv = torch.arange(2 * 4 * 3 * 1 * 2, dtype=torch.float32).view(2, 4, 3, 1, 2)
+        mask = torch.tensor([[1, 1, 0, 1], [0, 1, 1, 0]], dtype=torch.bool)
+
+        output = backend.qkvpacked(qkv, attention_mask=mask)
+
+        expected = torch.zeros(2, 4, 1, 2)
+        expected[mask] = qkv[:, :, 0][mask]
+        self.assertTrue(torch.equal(output, expected))
+        self.assertTrue(torch.equal(calls["cu_seqlens"].cpu(), torch.tensor([0, 3, 5], dtype=torch.int32)))
+        self.assertEqual(calls["max_seqlen"], 3)
+        self.assertEqual(calls["qkv"].shape, (5, 3, 1, 2))
+
+    def test_auto_packed_backend_prefers_fa2_hub_for_varlen_qkvpacked(self):
+        with (
+            patch.object(torch.cuda, "is_available", return_value=True),
+            patch.object(torch.cuda, "get_device_capability", return_value=(9, 0)),
+        ):
+            self.assertEqual(
+                attention_backend_module._select_packed_backend(None, require_varlen_qkvpacked=True),
+                "flash2-hub",
+            )
+            self.assertEqual(attention_backend_module._select_packed_backend(None), "flash3-hub")

--- a/tests/test_flux_model.py
+++ b/tests/test_flux_model.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import torch
+from diffusers.models.attention_processor import Attention
 
 from simpletuner.helpers.models.flux.model import Flux
 
@@ -21,6 +22,7 @@ class FluxModelTests(unittest.TestCase):
             tread_config=None,
             model_flavour="kontext",
             crepa_self_flow_mask_ratio=0.0,
+            fuse_qkv_projections=False,
         )
         self.model.noise_schedule = SimpleNamespace(config=SimpleNamespace(num_train_timesteps=1000))
         self.model.get_trained_component = MagicMock(
@@ -131,6 +133,19 @@ class FluxModelTests(unittest.TestCase):
         self.assertEqual(result["timesteps"].shape, (1, 4))
         self.assertEqual(result["crepa_self_flow_mask"].shape, (1, 2, 2))
         self.assertEqual(result["crepa_teacher_timesteps"].shape, (1,))
+
+    def test_unfuse_qkv_projections_uses_explicit_unfuse_method(self):
+        attn = Attention(query_dim=8, heads=1, dim_head=8)
+        attn.unfuse_projections = MagicMock()
+        self.model.model = torch.nn.Sequential(attn)
+        self.model.controlnet = None
+        self.model.config.fuse_qkv_projections = True
+        self.model._qkv_projections_fused = True
+
+        self.model.unfuse_qkv_projections()
+
+        attn.unfuse_projections.assert_called_once_with()
+        self.assertFalse(self.model._qkv_projections_fused)
 
 
 if __name__ == "__main__":

--- a/tests/test_packed_attention_processors.py
+++ b/tests/test_packed_attention_processors.py
@@ -1,0 +1,196 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from diffusers.models.attention_processor import Attention
+
+from simpletuner.helpers.models.chroma.transformer import ChromaTransformer2DModel
+from simpletuner.helpers.models.flux.attention import FluxFusedFlashAttnProcessor3
+from simpletuner.helpers.models.ltxvideo2.transformer import LTX2Attention, LTX2VideoTransformer3DModel
+from simpletuner.helpers.models.lumina2.transformer import Lumina2PackedAttnProcessor2_0
+from simpletuner.helpers.training.packed_attention_processors import (
+    PackedAuraFlowAttnProcessor2_0,
+    PackedFusedAttnProcessor2_0,
+    PackedJointAttnProcessor2_0,
+)
+
+
+class _FakePackedBackend:
+    def __init__(self):
+        self.calls = []
+        self.capabilities = SimpleNamespace(fixed_qkvpacked=True, varlen_qkvpacked=True, varlen_unpacked=True)
+
+    def qkvpacked(self, qkv, attention_mask=None, causal=False, softmax_scale=None):
+        self.calls.append(
+            {
+                "shape": tuple(qkv.shape),
+                "mask": attention_mask,
+                "causal": causal,
+                "softmax_scale": softmax_scale,
+            }
+        )
+        return qkv[:, :, 0]
+
+
+class PackedAttentionProcessorTests(unittest.TestCase):
+    def _patch_backend(self, backend):
+        return patch(
+            "simpletuner.helpers.training.packed_attention_processors.get_packed_attention_backend",
+            return_value=backend,
+        )
+
+    def test_packed_fused_self_attention_dispatches_qkvpacked(self):
+        backend = _FakePackedBackend()
+        attn = Attention(query_dim=8, heads=2, dim_head=4, out_dim=8, bias=True, out_bias=True)
+        attn.fuse_projections(fuse=True)
+        processor = PackedFusedAttnProcessor2_0(preferred_backend="flash2-hub")
+        hidden_states = torch.randn(2, 5, 8)
+
+        with self._patch_backend(backend):
+            output = processor(attn, hidden_states)
+
+        self.assertEqual(output.shape, hidden_states.shape)
+        self.assertEqual(backend.calls[0]["shape"], (2, 5, 3, 2, 4))
+        self.assertIsNone(backend.calls[0]["mask"])
+
+    def test_packed_joint_attention_concatenates_context_and_sample(self):
+        backend = _FakePackedBackend()
+        attn = Attention(
+            query_dim=8,
+            added_kv_proj_dim=8,
+            heads=2,
+            dim_head=4,
+            out_dim=8,
+            context_pre_only=False,
+            bias=True,
+            out_bias=True,
+        )
+        attn.fuse_projections(fuse=True)
+        processor = PackedJointAttnProcessor2_0(preferred_backend="flash2-hub")
+        hidden_states = torch.randn(2, 5, 8)
+        encoder_hidden_states = torch.randn(2, 3, 8)
+
+        with self._patch_backend(backend):
+            sample, context = processor(attn, hidden_states, encoder_hidden_states)
+
+        self.assertEqual(sample.shape, hidden_states.shape)
+        self.assertEqual(context.shape, encoder_hidden_states.shape)
+        self.assertEqual(backend.calls[0]["shape"], (2, 8, 3, 2, 4))
+
+    def test_packed_auraflow_attention_preserves_context_first_order(self):
+        backend = _FakePackedBackend()
+        attn = Attention(
+            query_dim=8,
+            added_kv_proj_dim=8,
+            heads=2,
+            dim_head=4,
+            out_dim=8,
+            context_pre_only=False,
+            bias=False,
+            out_bias=False,
+        )
+        attn.fuse_projections(fuse=True)
+        processor = PackedAuraFlowAttnProcessor2_0(preferred_backend="flash2-hub")
+        hidden_states = torch.randn(2, 5, 8)
+        encoder_hidden_states = torch.randn(2, 3, 8)
+
+        with self._patch_backend(backend):
+            sample, context = processor(attn, hidden_states, encoder_hidden_states)
+
+        self.assertEqual(sample.shape, hidden_states.shape)
+        self.assertEqual(context.shape, encoder_hidden_states.shape)
+        self.assertEqual(backend.calls[0]["shape"], (2, 8, 3, 2, 4))
+
+    def test_lumina2_packed_processor_handles_gqa_and_bool_mask(self):
+        backend = _FakePackedBackend()
+        attn = Attention(
+            query_dim=16,
+            cross_attention_dim=None,
+            heads=4,
+            kv_heads=2,
+            dim_head=4,
+            qk_norm="rms_norm",
+            bias=False,
+            out_bias=False,
+            out_dim=16,
+        )
+        attn.fuse_projections(fuse=True)
+        processor = Lumina2PackedAttnProcessor2_0(preferred_backend="flash2-hub")
+        hidden_states = torch.randn(2, 5, 16)
+        attention_mask = torch.tensor([[True, True, True, False, False], [True, True, True, True, True]])
+
+        with self._patch_backend(backend):
+            output = processor(attn, hidden_states, hidden_states, attention_mask=attention_mask)
+
+        self.assertEqual(output.shape, hidden_states.shape)
+        self.assertEqual(backend.calls[0]["shape"], (2, 5, 3, 4, 4))
+        self.assertTrue(torch.equal(backend.calls[0]["mask"], attention_mask))
+
+    def test_ltx2_self_attention_uses_packed_backend_when_enabled(self):
+        backend = _FakePackedBackend()
+        attn = LTX2Attention(query_dim=8, heads=2, kv_heads=2, dim_head=4, bias=True, out_bias=True)
+        attn.fuse_projections()
+        attn.processor._packed_attention_backend = "flash2-hub"
+        hidden_states = torch.randn(2, 5, 8)
+
+        with self._patch_backend(backend):
+            output = attn(hidden_states)
+
+        self.assertEqual(output.shape, hidden_states.shape)
+        self.assertEqual(backend.calls[0]["shape"], (2, 5, 3, 2, 4))
+
+    def test_chroma_transformer_fuse_installs_flux_packed_processor(self):
+        backend = _FakePackedBackend()
+        model = ChromaTransformer2DModel(
+            in_channels=4,
+            out_channels=4,
+            num_layers=1,
+            num_single_layers=1,
+            attention_head_dim=8,
+            num_attention_heads=2,
+            joint_attention_dim=16,
+            axes_dims_rope=(2, 2, 4),
+            approximator_num_channels=16,
+            approximator_hidden_dim=32,
+            approximator_layers=1,
+        )
+
+        with patch("simpletuner.helpers.models.flux.attention.get_packed_attention_backend", return_value=backend):
+            model.fuse_qkv_projections(preferred_backend="flash2-hub")
+
+        self.assertIsInstance(model.transformer_blocks[0].attn.processor, FluxFusedFlashAttnProcessor3)
+        self.assertIsInstance(model.single_transformer_blocks[0].attn.processor, FluxFusedFlashAttnProcessor3)
+        model.unfuse_qkv_projections()
+        self.assertNotIsInstance(model.transformer_blocks[0].attn.processor, FluxFusedFlashAttnProcessor3)
+        self.assertNotIsInstance(model.single_transformer_blocks[0].attn.processor, FluxFusedFlashAttnProcessor3)
+
+    def test_ltx2_transformer_fuse_enables_packed_self_attention_processors(self):
+        model = LTX2VideoTransformer3DModel(
+            in_channels=4,
+            out_channels=4,
+            num_attention_heads=2,
+            attention_head_dim=4,
+            cross_attention_dim=8,
+            audio_in_channels=4,
+            audio_out_channels=4,
+            audio_num_attention_heads=2,
+            audio_attention_head_dim=4,
+            audio_cross_attention_dim=8,
+            caption_channels=8,
+            num_layers=1,
+        )
+
+        model.fuse_qkv_projections(preferred_backend="flash2-hub")
+        block = model.transformer_blocks[0]
+        self.assertEqual(block.attn1.processor._packed_attention_backend, "flash2-hub")
+        self.assertEqual(block.audio_attn1.processor._packed_attention_backend, "flash2-hub")
+        self.assertEqual(block.attn2.processor._packed_attention_backend, "flash2-hub")
+        model.unfuse_qkv_projections()
+        self.assertIsNone(block.attn1.processor._packed_attention_backend)
+        self.assertIsNone(block.audio_attn1.processor._packed_attention_backend)
+        self.assertIsNone(block.attn2.processor._packed_attention_backend)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_packed_attention_processors.py
+++ b/tests/test_packed_attention_processors.py
@@ -78,6 +78,30 @@ class PackedAttentionProcessorTests(unittest.TestCase):
         self.assertEqual(context.shape, encoder_hidden_states.shape)
         self.assertEqual(backend.calls[0]["shape"], (2, 8, 3, 2, 4))
 
+    def test_packed_joint_attention_splits_4d_sample_by_sequence_length(self):
+        backend = _FakePackedBackend()
+        attn = Attention(
+            query_dim=8,
+            added_kv_proj_dim=8,
+            heads=2,
+            dim_head=4,
+            out_dim=8,
+            context_pre_only=False,
+            bias=True,
+            out_bias=True,
+        )
+        attn.fuse_projections(fuse=True)
+        processor = PackedJointAttnProcessor2_0(preferred_backend="flash2-hub")
+        hidden_states = torch.randn(2, 8, 4, 5)
+        encoder_hidden_states = torch.randn(2, 3, 8)
+
+        with self._patch_backend(backend):
+            sample, context = processor(attn, hidden_states, encoder_hidden_states)
+
+        self.assertEqual(sample.shape, hidden_states.shape)
+        self.assertEqual(context.shape, encoder_hidden_states.shape)
+        self.assertEqual(backend.calls[0]["shape"], (2, 23, 3, 2, 4))
+
     def test_packed_auraflow_attention_preserves_context_first_order(self):
         backend = _FakePackedBackend()
         attn = Attention(


### PR DESCRIPTION
This pull request introduces a unified and extensible approach for fusing and unfusing QKV (Query, Key, Value) projections across multiple model architectures, with particular focus on supporting "packed" attention backends (such as FlashAttention 3). The changes standardize the interface for fused QKV projections, allow selection of attention backends via configuration, and add robust backend capability checks. Additionally, the implementation is extended to more models, including Flux2 and LTXVideo2, and improves how attention processors interact with backend selection.

Key changes include:

**Unified QKV Projection Fusing/Unfusing and Backend Selection**
- Standardized the `fuse_qkv_projections` and `unfuse_qkv_projections` methods across model classes to accept an optional `preferred_backend` argument, enabling dynamic selection of the attention backend and ensuring consistent state management for fused projections. [[1]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbL3131-R3139) [[2]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbL3147-R3162) [[3]](diffhunk://#diff-5aa130951df78ab03d60ca20b1126a94d40fb0035ac90907eb33b3de05345489L342-R346) [[4]](diffhunk://#diff-5aa130951df78ab03d60ca20b1126a94d40fb0035ac90907eb33b3de05345489L383-R385) [[5]](diffhunk://#diff-addfb7856391b679fc97201760fbe5fb699fd1f228983020f2182e5dd52d390dL549-R549) [[6]](diffhunk://#diff-12fa44f4ca1a10294383d8e7cd1db43d9b4581d04da0f5a36ed72dd385f23b3aL634-R630) [[7]](diffhunk://#diff-12fa44f4ca1a10294383d8e7cd1db43d9b4581d04da0f5a36ed72dd385f23b3aL647-R650) [[8]](diffhunk://#diff-2390d666883fb499d80e71fbe6b05b21e5141f934149c7fc66937368b6ae0c02R156-R176)
- Extended and refactored the attention processor classes (e.g., `FluxFusedFlashAttnProcessor3`, `Flux2AttnProcessor`, `Flux2ParallelSelfAttnProcessor`, `LTX2AudioVideoAttnProcessor`) to support packed attention backends, including backend capability checks and dynamic backend selection based on the presence of attention masks. [[1]](diffhunk://#diff-0b9511ea0604f4fc9e514122eddf1c4fd4bd8ddcd266865ecd0f9e678a9ad4b3L195-R209) [[2]](diffhunk://#diff-0b9511ea0604f4fc9e514122eddf1c4fd4bd8ddcd266865ecd0f9e678a9ad4b3L299-L305) [[3]](diffhunk://#diff-dc724b7872bbf8da3e20198895e6b013646442113c5cbaaced6028c23aaabc78R182) [[4]](diffhunk://#diff-dc724b7872bbf8da3e20198895e6b013646442113c5cbaaced6028c23aaabc78R232-R234) [[5]](diffhunk://#diff-dc724b7872bbf8da3e20198895e6b013646442113c5cbaaced6028c23aaabc78R338) [[6]](diffhunk://#diff-dc724b7872bbf8da3e20198895e6b013646442113c5cbaaced6028c23aaabc78R380-R382) [[7]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3R336) [[8]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3R398-R406)

**Model-Specific Enhancements**
- Added or updated QKV fusing/unfusing logic in the AuraFlow, Chroma, Flux, Flux2, and LTXVideo2 transformer/model classes to use the new packed attention processors and backend selection logic. This includes new imports and processor assignments. [[1]](diffhunk://#diff-12fa44f4ca1a10294383d8e7cd1db43d9b4581d04da0f5a36ed72dd385f23b3aR27) [[2]](diffhunk://#diff-1e836d669cbd355cab74022e2eec2abb058e907223d6f5249d04739b0fb5a025R31) [[3]](diffhunk://#diff-1e836d669cbd355cab74022e2eec2abb058e907223d6f5249d04739b0fb5a025R692-R704) [[4]](diffhunk://#diff-dc724b7872bbf8da3e20198895e6b013646442113c5cbaaced6028c23aaabc78R42) [[5]](diffhunk://#diff-dc724b7872bbf8da3e20198895e6b013646442113c5cbaaced6028c23aaabc78R948-R963) [[6]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3R50)
- Improved Flux2 and LTXVideo2 attention processors to use a helper function for running packed QKV attention, and to set or unset the backend appropriately when fusing or unfusing projections. [[1]](diffhunk://#diff-dc724b7872bbf8da3e20198895e6b013646442113c5cbaaced6028c23aaabc78R132-R137) [[2]](diffhunk://#diff-dc724b7872bbf8da3e20198895e6b013646442113c5cbaaced6028c23aaabc78R948-R963) [[3]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3R50) [[4]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3R398-R406)

**Robustness and Logging**
- Added capability checks and improved error messages when a backend does not support required packed attention features, preventing silent failures.
- Improved logging and warnings for unsupported configurations, especially in the Flux model, making it clearer when features are enabled/disabled due to backend limitations.

**Dependency and Import Cleanup**
- Cleaned up imports to remove unused attention processor classes and add new packed attention processor imports where needed. [[1]](diffhunk://#diff-12fa44f4ca1a10294383d8e7cd1db43d9b4581d04da0f5a36ed72dd385f23b3aL9-R9) [[2]](diffhunk://#diff-12fa44f4ca1a10294383d8e7cd1db43d9b4581d04da0f5a36ed72dd385f23b3aR27) [[3]](diffhunk://#diff-1e836d669cbd355cab74022e2eec2abb058e907223d6f5249d04739b0fb5a025R31)

These changes pave the way for more flexible and performant attention mechanisms, while making the codebase more maintainable and robust to future backend and processor extensions.