### PR TITLE
add context parallel plans for more model families

### DIFF
--- a/simpletuner/helpers/data_backend/runtime/context_parallel_sync.py
+++ b/simpletuner/helpers/data_backend/runtime/context_parallel_sync.py
@@ -87,18 +87,26 @@ def get_cp_info(accelerator) -> Tuple[bool, Optional[Any], int, int]:
         )
         return False, None, 0, 1
 
-    # Try to find the CP dimension in the mesh
-    # The mesh dimension name should be "cp" when using accelerate's ParallelismConfig
+    # Try to find the CP dimension in the mesh.
+    # Accelerate's ParallelismConfig uses "cp"; SimpleTuner's standalone CP mesh
+    # uses Diffusers' "ring"/"ulysses" dimensions and flattens them as the CP group.
     try:
         cp_group = device_mesh.get_group("cp")
         cp_rank = device_mesh.get_local_rank("cp")
         return True, cp_group, cp_rank, cp_size
     except Exception as e:
-        # Mesh may use different dimension names depending on config
         logger.debug(f"Could not get 'cp' dimension from mesh: {e}")
 
-        # Try alternative mesh dimension names
         mesh_dim_names = getattr(device_mesh, "mesh_dim_names", None)
+        if mesh_dim_names and {"ring", "ulysses"}.issubset(set(mesh_dim_names)):
+            try:
+                cp_mesh = device_mesh["ring", "ulysses"]._flatten("cp")
+                cp_group = cp_mesh.get_group()
+                cp_rank = cp_mesh.get_local_rank()
+                return True, cp_group, cp_rank, cp_size
+            except Exception as flatten_error:
+                logger.debug(f"Could not flatten Diffusers CP mesh dimensions: {flatten_error}")
+
         if mesh_dim_names:
             for dim_name in mesh_dim_names:
                 if "cp" in dim_name.lower() or "context" in dim_name.lower():

--- a/simpletuner/helpers/models/anima/transformer.py
+++ b/simpletuner/helpers/models/anima/transformer.py
@@ -14,6 +14,7 @@ import torch.nn.functional as F
 from diffusers import ModelMixin
 from diffusers.configuration_utils import ConfigMixin, register_to_config
 from diffusers.loaders import PeftAdapterMixin
+from diffusers.models._modeling_parallel import ContextParallelInput, ContextParallelOutput
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 from diffusers.models.normalization import RMSNorm as DiffusersRMSNorm
 from diffusers.utils import USE_PEFT_BACKEND, set_weights_and_activate_adapters
@@ -329,6 +330,13 @@ class _LLMAdapter(nn.Module):
 class AnimaTransformerModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
     _supports_gradient_checkpointing = True
     _no_split_modules = ["CosmosTransformerBlock"]
+    _cp_plan = {
+        "core": {
+            "hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
+            "encoder_hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
+        },
+        "core.proj_out": ContextParallelOutput(gather_dim=1, expected_dims=3),
+    }
 
     @register_to_config
     def __init__(

--- a/simpletuner/helpers/models/ernie/transformer.py
+++ b/simpletuner/helpers/models/ernie/transformer.py
@@ -9,6 +9,12 @@ from simpletuner.helpers.models.ernie.transformer_diffusers import (
     ErnieImageTransformer2DModel as DiffusersErnieImageTransformer2DModel,
 )
 from simpletuner.helpers.models.ernie.transformer_diffusers import ErnieImageTransformer2DModelOutput
+from simpletuner.helpers.training.context_parallel_tensors import (
+    context_parallel_config,
+    prepare_cp_attention_mask,
+    shard_cp_tensor,
+    unshard_cp_tensor,
+)
 from simpletuner.helpers.training.tread import TREADRouter
 
 logger = logging.getLogger(__name__)
@@ -49,6 +55,7 @@ class ErnieImageTransformer2DModel(
     PeftAdapterMixin,
     FromOriginalModelMixin,
 ):
+    _cp_plan = {}
     _tread_router: Optional[TREADRouter] = None
     _tread_routes: Optional[List[Dict[str, Any]]] = None
 
@@ -152,10 +159,25 @@ class ErnieImageTransformer2DModel(
         current_rotary = rotary_pos_emb
         current_attention_mask = attention_mask
         current_temb = temb
-
+        parallel_config = getattr(self, "_parallel_config", None)
+        cp_active = context_parallel_config(parallel_config) is not None
         routes = self._tread_routes or []
         router = self._tread_router
         use_routing = self.training and len(routes) > 0 and torch.is_grad_enabled()
+        if cp_active and use_routing:
+            raise ValueError("ERNIE TREAD routing is not supported together with context_parallel_size.")
+        if cp_active:
+            hidden_states = shard_cp_tensor(hidden_states, parallel_config, split_dim=1)
+            current_rotary = shard_cp_tensor(current_rotary, parallel_config, split_dim=1)
+            current_temb = [shard_cp_tensor(value, parallel_config, split_dim=0) for value in current_temb]
+            current_attention_mask = prepare_cp_attention_mask(
+                current_attention_mask,
+                hidden_states.shape[1],
+                parallel_config,
+                model_name="ERNIE",
+                crop="left",
+            )
+
         if use_routing and router is None:
             raise ValueError("TREAD routing requested but no router has been configured. Call set_router before training.")
 
@@ -276,6 +298,8 @@ class ErnieImageTransformer2DModel(
                     tread_mask_info,
                     original_x=saved_hidden_states,
                 )
+            if cp_active:
+                capture_hidden_states = unshard_cp_tensor(capture_hidden_states, parallel_config, split_dim=1)
             _store_hidden_state(
                 hidden_states_buffer,
                 f"layer_{capture_idx}",
@@ -294,6 +318,8 @@ class ErnieImageTransformer2DModel(
                 musubi_manager.stream_out(layer)
 
         hidden_states = hidden_states.permute(1, 0, 2).contiguous()
+        if cp_active:
+            hidden_states = unshard_cp_tensor(hidden_states, parallel_config, split_dim=0)
         hidden_states = self.final_norm(hidden_states, conditioning).type_as(hidden_states)
         patches = self.final_linear(hidden_states)[:image_token_count].transpose(0, 1).contiguous()
         output = (

--- a/simpletuner/helpers/models/flux2/transformer.py
+++ b/simpletuner/helpers/models/flux2/transformer.py
@@ -40,6 +40,7 @@ from simpletuner.helpers.models.flowmap import (
 )
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
 from simpletuner.helpers.training.attention_backend import get_packed_attention_backend
+from simpletuner.helpers.training.context_parallel_tensors import context_parallel_config, prepare_cp_attention_mask
 from simpletuner.helpers.training.qk_clip_logging import publish_attention_max_logits
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -229,7 +230,18 @@ class Flux2AttnProcessor:
             getattr(attn, "to_k", None) and getattr(attn, "to_k", None).weight,
         )
 
-        if self._packed_attention_backend is not None:
+        parallel_config = self._parallel_config
+        cp_active = context_parallel_config(parallel_config) is not None
+        if cp_active:
+            attention_mask = prepare_cp_attention_mask(
+                attention_mask,
+                query.shape[1],
+                parallel_config,
+                model_name="Flux2",
+                crop="right",
+            )
+
+        if self._packed_attention_backend is not None and not cp_active:
             hidden_states = _run_packed_qkv_attention(query, key, value, attention_mask, self._packed_attention_backend)
         else:
             hidden_states = dispatch_attention_fn(
@@ -238,7 +250,7 @@ class Flux2AttnProcessor:
                 value,
                 attn_mask=attention_mask,
                 backend=self._attention_backend,
-                # parallel_config=self._parallel_config,
+                parallel_config=parallel_config,
             )
         hidden_states = hidden_states.flatten(2, 3)
         hidden_states = hidden_states.to(query.dtype)
@@ -377,7 +389,18 @@ class Flux2ParallelSelfAttnProcessor:
             getattr(attn, "to_qkv_mlp_proj", None) and attn.to_qkv_mlp_proj.weight,
         )
 
-        if self._packed_attention_backend is not None:
+        parallel_config = self._parallel_config
+        cp_active = context_parallel_config(parallel_config) is not None
+        if cp_active:
+            attention_mask = prepare_cp_attention_mask(
+                attention_mask,
+                query.shape[1],
+                parallel_config,
+                model_name="Flux2",
+                crop="right",
+            )
+
+        if self._packed_attention_backend is not None and not cp_active:
             hidden_states = _run_packed_qkv_attention(query, key, value, attention_mask, self._packed_attention_backend)
         else:
             hidden_states = dispatch_attention_fn(
@@ -386,7 +409,7 @@ class Flux2ParallelSelfAttnProcessor:
                 value,
                 attn_mask=attention_mask,
                 backend=self._attention_backend,
-                # parallel_config=self._parallel_config,
+                parallel_config=parallel_config,
             )
         hidden_states = hidden_states.flatten(2, 3)
         hidden_states = hidden_states.to(query.dtype)

--- a/simpletuner/helpers/models/heartmula/codec/transformer.py
+++ b/simpletuner/helpers/models/heartmula/codec/transformer.py
@@ -9,6 +9,7 @@ from typing import Optional, Tuple
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from diffusers.models._modeling_parallel import ContextParallelInput, ContextParallelOutput
 
 
 class RMSNorm(nn.Module):
@@ -260,6 +261,13 @@ class ProjectLayer(nn.Module):
 
 
 class LlamaTransformer(nn.Module):
+    _cp_plan = {
+        "": {
+            "hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
+        },
+        "proj_out": ContextParallelOutput(gather_dim=1, expected_dims=3),
+    }
+
     def __init__(
         self,
         num_attention_heads: int,

--- a/simpletuner/helpers/models/ideogram/transformer.py
+++ b/simpletuner/helpers/models/ideogram/transformer.py
@@ -13,6 +13,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from diffusers.loaders import PeftAdapterMixin
+from diffusers.models._modeling_parallel import ContextParallelInput, ContextParallelOutput
 
 from simpletuner.helpers.models.flowmap import (
     blend_flowmap_embeddings,
@@ -281,6 +282,16 @@ class Ideogram4Transformer(nn.Module, PeftAdapterMixin):
     """Ideogram 4 flow-matching transformer."""
 
     _supports_gradient_checkpointing = True
+    _cp_plan = {
+        "": {
+            "llm_features": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
+            "x": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
+            "position_ids": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
+            "segment_ids": ContextParallelInput(split_dim=1, expected_dims=2, split_output=False),
+            "indicator": ContextParallelInput(split_dim=1, expected_dims=2, split_output=False),
+        },
+        "final_layer": ContextParallelOutput(gather_dim=1, expected_dims=3),
+    }
 
     def __init__(self, config: Ideogram4Config) -> None:
         super().__init__()

--- a/simpletuner/helpers/models/wan/model.py
+++ b/simpletuner/helpers/models/wan/model.py
@@ -6,7 +6,7 @@ from functools import partial
 from typing import Dict, Optional
 
 import torch
-from diffusers import AutoencoderKLWan, WanImageToVideoPipeline
+from diffusers import AutoencoderKLWan, FlowMatchEulerDiscreteScheduler, WanImageToVideoPipeline
 from torchvision import transforms
 from transformers import CLIPImageProcessor, CLIPVisionModel, T5TokenizerFast, UMT5EncoderModel
 
@@ -31,6 +31,7 @@ from simpletuner.helpers.models.tae.types import VideoTAESpec
 from simpletuner.helpers.models.wan.pipeline import WanPipeline
 from simpletuner.helpers.models.wan.transformer import WanTransformer3DModel
 from simpletuner.helpers.musubi_block_swap import apply_musubi_pretrained_defaults
+from simpletuner.helpers.training.flow_match import fix_flow_match_euler_schedule_bounds
 
 logger = logging.getLogger(__name__)
 from torch.nn import functional as F
@@ -51,20 +52,15 @@ def time_text_monkeypatch(
     encoder_hidden_states,
     encoder_hidden_states_image=None,
     timestep_sign=None,
+    r_timestep=None,
 ):
-    timestep_seq_len: Optional[int] = None
-    if timestep.ndim > 1:
-        timestep_seq_len = timestep.shape[1]
-        timestep = timestep.reshape(-1)
+    temb, timestep_seq_len = self._embed_timestep(timestep, encoder_hidden_states, self.time_embedder)
 
-    timestep = self.timesteps_proj(timestep)
-    if timestep_seq_len is not None:
-        timestep = timestep.unflatten(0, (-1, timestep_seq_len))
-
-    time_embedder_dtype = next(iter(self.time_embedder.parameters())).dtype
-    if timestep.dtype != time_embedder_dtype and time_embedder_dtype != torch.int8:
-        timestep = timestep.to(time_embedder_dtype)
-    temb = self.time_embedder(timestep).type_as(encoder_hidden_states)
+    if r_timestep is not None:
+        delta_timestep = self._prepare_flowmap_delta_timestep(timestep, r_timestep)
+        delta_emb, _ = self._embed_timestep(delta_timestep, encoder_hidden_states, self.delta_embedder)
+        gate = self.flowmap_delta_emb_gate.to(device=temb.device, dtype=temb.dtype)
+        temb = (1.0 - gate) * temb + gate * delta_emb
 
     if timestep_sign is not None:
         time_sign_embed = getattr(self, "time_sign_embed", None)
@@ -322,6 +318,15 @@ class Wan(VideoModelFoundation):
 
     def requires_special_scheduler_setup(self) -> bool:
         return True
+
+    def _load_scheduler_for_pipeline(self, pipeline_type: str):
+        return fix_flow_match_euler_schedule_bounds(
+            FlowMatchEulerDiscreteScheduler.from_pretrained(
+                self._model_config_path(),
+                subfolder="scheduler",
+                shift=self.config.flow_schedule_shift,
+            )
+        )
 
     def supports_crepa_self_flow(self) -> bool:
         return bool(getattr(self, "_wan_expand_timesteps", False))

--- a/simpletuner/helpers/models/wan/transformer.py
+++ b/simpletuner/helpers/models/wan/transformer.py
@@ -688,8 +688,7 @@ class WanTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrigi
     _repeated_blocks = ["WanTransformerBlock"]
     _cp_plan = {
         "rope": {
-            0: ContextParallelInput(split_dim=1, expected_dims=4, split_output=True),
-            1: ContextParallelInput(split_dim=1, expected_dims=4, split_output=True),
+            0: ContextParallelInput(split_dim=2, expected_dims=4, split_output=True),
         },
         "blocks.0": {
             "hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),

--- a/simpletuner/helpers/models/wan_s2v/transformer.py
+++ b/simpletuner/helpers/models/wan_s2v/transformer.py
@@ -22,6 +22,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from diffusers.configuration_utils import ConfigMixin, register_to_config
 from diffusers.loaders import FromOriginalModelMixin, PeftAdapterMixin
+from diffusers.models._modeling_parallel import ContextParallelInput, ContextParallelOutput
 from diffusers.models.attention import FeedForward
 from diffusers.models.attention_processor import Attention
 from diffusers.models.embeddings import PixArtAlphaTextProjection, TimestepEmbedding, Timesteps, get_1d_rotary_pos_embed
@@ -929,6 +930,15 @@ class WanS2VTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
     _keep_in_fp32_modules = ["time_embedder", "scale_shift_table", "norm1", "norm2", "norm3", "causal_audio_encoder"]
     _tread_router: Optional[TREADRouter] = None
     _tread_routes: Optional[List[Dict[str, Any]]] = None
+    _cp_plan = {
+        "rope": {
+            0: ContextParallelInput(split_dim=1, expected_dims=4, split_output=True),
+        },
+        "blocks.0": {
+            "hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
+        },
+        "proj_out": ContextParallelOutput(gather_dim=1, expected_dims=3),
+    }
 
     @register_to_config
     def __init__(

--- a/simpletuner/helpers/models/z_image/transformer.py
+++ b/simpletuner/helpers/models/z_image/transformer.py
@@ -22,7 +22,6 @@ import torch.nn.functional as F
 from diffusers.configuration_utils import ConfigMixin, register_to_config
 from diffusers.loaders import FromOriginalModelMixin, PeftAdapterMixin
 from diffusers.loaders import peft as diffusers_peft
-from diffusers.models._modeling_parallel import ContextParallelInput, ContextParallelOutput
 from diffusers.models.attention_dispatch import dispatch_attention_fn
 from diffusers.models.attention_processor import Attention
 from diffusers.models.modeling_utils import ModelMixin
@@ -39,6 +38,12 @@ from simpletuner.helpers.models.flowmap import (
     validate_flowmap_deltatime_type,
 )
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
+from simpletuner.helpers.training.context_parallel_tensors import (
+    context_parallel_config,
+    prepare_cp_attention_mask,
+    shard_cp_tensor,
+    unshard_cp_tensor,
+)
 from simpletuner.helpers.training.qk_clip_logging import publish_attention_max_logits
 from simpletuner.helpers.training.tread import TREADRouter
 
@@ -55,6 +60,20 @@ def _store_hidden_state(buffer, key: str, hidden_states: torch.Tensor, image_tok
         buffer[key] = hidden_states[:, image_tokens_start:, ...]
     else:
         buffer[key] = hidden_states
+
+
+def _zimage_prepare_attention_mask(
+    attention_mask: torch.Tensor | None,
+    sequence_length: int,
+    parallel_config,
+) -> torch.Tensor | None:
+    return prepare_cp_attention_mask(
+        attention_mask,
+        sequence_length,
+        parallel_config,
+        model_name="Z-Image",
+        crop="right",
+    )
 
 
 # Clamp NaN/Inf that can appear when running in float16. Ported from ComfyUI commit daaceac769a1355ab975758ede064317ea7514b4.
@@ -242,9 +261,8 @@ class ZSingleStreamAttnProcessor:
         dtype = query.dtype
         query, key = query.to(dtype), key.to(dtype)
 
-        # From [batch, seq_len] to [batch, 1, 1, seq_len] -> broadcast to [batch, heads, seq_len, seq_len]
-        if attention_mask is not None and attention_mask.ndim == 2:
-            attention_mask = attention_mask[:, None, None, :]
+        parallel_config = self._parallel_config if getattr(attn, "_zimage_allow_context_parallel", False) else None
+        attention_mask = _zimage_prepare_attention_mask(attention_mask, hidden_states.shape[1], parallel_config)
 
         # Compute joint attention
         publish_attention_max_logits(
@@ -262,7 +280,7 @@ class ZSingleStreamAttnProcessor:
             dropout_p=0.0,
             is_causal=False,
             backend=self._attention_backend,
-            # parallel_config=self._parallel_config,
+            parallel_config=parallel_config,
         )
 
         # Reshape back
@@ -467,13 +485,7 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
     _no_split_modules = ["ZImageTransformerBlock"]
     _repeated_blocks = ["ZImageTransformerBlock"]
     _skip_layerwise_casting_patterns = ["t_embedder", "cap_embedder"]  # precision sensitive layers
-    _cp_plan = {
-        "": {
-            "hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
-            "encoder_hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
-        },
-        "final_layer": ContextParallelOutput(gather_dim=1, expected_dims=3),
-    }
+    _cp_plan = {}
     _tread_router: Optional[TREADRouter] = None
     _tread_routes: Optional[List[Dict[str, Any]]] = None
 
@@ -576,6 +588,8 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
         self.layers = nn.ModuleList(
             [ZImageTransformerBlock(layer_id, dim, n_heads, n_kv_heads, norm_eps, qk_norm) for layer_id in range(n_layers)]
         )
+        for block in self.layers:
+            block.attention._zimage_allow_context_parallel = True
         head_dim = dim // n_heads
         assert head_dim == sum(axes_dims)
         self.axes_dims = axes_dims
@@ -871,6 +885,13 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
         for i, seq_len in enumerate(unified_item_seqlens):
             unified_attn_mask[i, :seq_len] = 1
 
+        parallel_config = getattr(self, "_parallel_config", None)
+        if context_parallel_config(parallel_config) is not None:
+            unified = shard_cp_tensor(unified, parallel_config)
+            unified_freqs_cis = shard_cp_tensor(unified_freqs_cis, parallel_config)
+            if unified_adaln_input is not None:
+                unified_adaln_input = shard_cp_tensor(unified_adaln_input, parallel_config)
+
         # TREAD routing (padded, similar to Flux)
         routes = self._tread_routes or []
         router = self._tread_router
@@ -969,6 +990,7 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
 
         final_adaln = unified_adaln_input if unified_adaln_input is not None else adaln_input
         unified = self.all_final_layer[f"{patch_size}-{f_patch_size}"](unified, final_adaln)
+        unified = unshard_cp_tensor(unified, getattr(self, "_parallel_config", None))
         unified = list(unified.unbind(dim=0))
         x = self.unpatchify(unified, x_size, patch_size, f_patch_size)
 

--- a/simpletuner/helpers/models/z_image_omni/transformer.py
+++ b/simpletuner/helpers/models/z_image_omni/transformer.py
@@ -23,7 +23,6 @@ import torch.nn.functional as F
 from diffusers.configuration_utils import ConfigMixin, register_to_config
 from diffusers.loaders import FromOriginalModelMixin, PeftAdapterMixin
 from diffusers.loaders import peft as diffusers_peft
-from diffusers.models._modeling_parallel import ContextParallelInput, ContextParallelOutput
 from diffusers.models.attention_dispatch import dispatch_attention_fn
 from diffusers.models.attention_processor import Attention
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
@@ -41,6 +40,12 @@ from simpletuner.helpers.models.flowmap import (
     validate_flowmap_deltatime_type,
 )
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
+from simpletuner.helpers.training.context_parallel_tensors import (
+    context_parallel_config,
+    prepare_cp_attention_mask,
+    shard_cp_tensor,
+    unshard_cp_tensor,
+)
 from simpletuner.helpers.training.qk_clip_logging import publish_attention_max_logits
 from simpletuner.helpers.training.tread import TREADRouter
 
@@ -260,9 +265,14 @@ class ZSingleStreamAttnProcessor:
         dtype = query.dtype
         query, key = query.to(dtype), key.to(dtype)
 
-        # From [batch, seq_len] to [batch, 1, 1, seq_len] -> broadcast to [batch, heads, seq_len, seq_len]
-        if attention_mask is not None and attention_mask.ndim == 2:
-            attention_mask = attention_mask[:, None, None, :]
+        parallel_config = self._parallel_config if getattr(attn, "_zimage_omni_allow_context_parallel", False) else None
+        attention_mask = prepare_cp_attention_mask(
+            attention_mask,
+            hidden_states.shape[1],
+            parallel_config,
+            model_name="Z-Image Omni",
+            crop="right",
+        )
 
         # Compute joint attention
         publish_attention_max_logits(
@@ -280,7 +290,7 @@ class ZSingleStreamAttnProcessor:
             dropout_p=0.0,
             is_causal=False,
             backend=self._attention_backend,
-            parallel_config=self._parallel_config,
+            parallel_config=parallel_config,
         )
 
         # Reshape back
@@ -553,13 +563,7 @@ class ZImageOmniTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fr
     _no_split_modules = ["ZImageTransformerBlock"]
     _repeated_blocks = ["ZImageTransformerBlock"]
     _skip_layerwise_casting_patterns = ["t_embedder", "cap_embedder"]
-    _cp_plan = {
-        "": {
-            "hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
-            "encoder_hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
-        },
-        "final_layer": ContextParallelOutput(gather_dim=1, expected_dims=3),
-    }
+    _cp_plan = {}
     _tread_router: Optional[TREADRouter] = None
     _tread_routes: Optional[List[Dict[str, Any]]] = None
 
@@ -678,6 +682,8 @@ class ZImageOmniTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fr
         self.layers = nn.ModuleList(
             [ZImageTransformerBlock(layer_id, dim, n_heads, n_kv_heads, norm_eps, qk_norm) for layer_id in range(n_layers)]
         )
+        for block in self.layers:
+            block.attention._zimage_omni_allow_context_parallel = True
         head_dim = dim // n_heads
         assert head_dim == sum(axes_dims)
         self.axes_dims = axes_dims
@@ -1269,9 +1275,21 @@ class ZImageOmniTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fr
             t_noisy_x = unified_noisy
             t_clean_x = unified_clean
 
+        parallel_config = getattr(self, "_parallel_config", None)
+        cp_active = context_parallel_config(parallel_config) is not None
         routes = self._tread_routes or []
         router = self._tread_router
         use_routing = self.training and len(routes) > 0 and torch.is_grad_enabled()
+        if cp_active and use_routing:
+            raise ValueError("Z-Image Omni TREAD routing is not supported together with context_parallel_size.")
+        if cp_active:
+            unified = shard_cp_tensor(unified, parallel_config)
+            unified_freqs_cis = shard_cp_tensor(unified_freqs_cis, parallel_config)
+            unified_noise_mask_tensor = shard_cp_tensor(unified_noise_mask_tensor, parallel_config)
+            if t_noisy_x.ndim == 3:
+                t_noisy_x = shard_cp_tensor(t_noisy_x, parallel_config)
+                t_clean_x = shard_cp_tensor(t_clean_x, parallel_config)
+
         if use_routing and router is None:
             raise ValueError("TREAD routing requested but no router has been configured. Call set_router before training.")
 
@@ -1359,6 +1377,9 @@ class ZImageOmniTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fr
             unified = layer_out
 
             if hidden_states_buffer is not None:
+                capture_tokens = unified
+                if cp_active:
+                    capture_tokens = unshard_cp_tensor(capture_tokens, parallel_config)
                 max_target_tokens = 1
                 target_positions_per_batch = []
                 for b in range(bsz):
@@ -1378,7 +1399,7 @@ class ZImageOmniTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fr
                     target_positions = target_positions_per_batch[b]
                     target_count = int(target_positions.numel())
                     if target_count > 0:
-                        img_tokens[b, :target_count] = unified[b, cap_len + target_positions]
+                        img_tokens[b, :target_count] = capture_tokens[b, cap_len + target_positions]
                 _store_hidden_state(hidden_states_buffer, f"layer_{capture_idx}", img_tokens, image_tokens_start=0)
                 capture_idx += 1
 
@@ -1403,6 +1424,7 @@ class ZImageOmniTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fr
             c_noisy=t_noisy_x,
             c_clean=t_clean_x,
         )
+        unified = unshard_cp_tensor(unified, getattr(self, "_parallel_config", None))
 
         x = self.unpatchify(unified, x_size, patch_size, f_patch_size, x_pos_offsets)
 

--- a/simpletuner/helpers/models/zlab_i1/transformer.py
+++ b/simpletuner/helpers/models/zlab_i1/transformer.py
@@ -12,6 +12,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from diffusers.configuration_utils import ConfigMixin, register_to_config
 from diffusers.loaders import PeftAdapterMixin
+from diffusers.models._modeling_parallel import ContextParallelInput, ContextParallelOutput
 from diffusers.models.modeling_utils import ModelMixin
 from huggingface_hub import hf_hub_download
 
@@ -452,6 +453,16 @@ class ZlabI1Transformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
     _supports_gradient_checkpointing = True
     _tread_router: Optional[TREADRouter] = None
     _tread_routes: Optional[list[dict[str, Any]]] = None
+    _cp_plan = {
+        "x_embedder": {
+            0: ContextParallelInput(split_dim=1, expected_dims=3, split_output=True),
+        },
+        "rope_embedder": {
+            0: ContextParallelInput(split_dim=1, expected_dims=4, split_output=True),
+            1: ContextParallelInput(split_dim=1, expected_dims=4, split_output=True),
+        },
+        "final_layer": ContextParallelOutput(gather_dim=1, expected_dims=3),
+    }
 
     @register_to_config
     def __init__(

--- a/simpletuner/helpers/training/context_parallel.py
+++ b/simpletuner/helpers/training/context_parallel.py
@@ -1,0 +1,193 @@
+"""SimpleTuner-owned context parallel topology helpers."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+
+logger = logging.getLogger("SimpleTuner")
+
+
+@dataclass(frozen=True)
+class ContextParallelTopology:
+    cp_size: int
+    dp_replicate_size: int
+    dp_shard_size: int
+    strategy: str
+
+
+def normalize_context_parallel_size(value: Any) -> int | None:
+    if value in (None, "", "None"):
+        return None
+    try:
+        cp_size = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Context parallel size must be an integer, got {value!r}.") from exc
+    if cp_size <= 0:
+        raise ValueError("Context parallel size must be greater than 0 when specified.")
+    return cp_size
+
+
+def normalize_context_parallel_strategy(value: Any) -> str:
+    strategy = value or "allgather"
+    strategy = strategy.strip().lower() if isinstance(strategy, str) else "allgather"
+    if strategy not in {"allgather", "alltoall"}:
+        raise ValueError(f"Unsupported context parallel rotation '{value}'. Valid options are 'allgather' and 'alltoall'.")
+    return strategy
+
+
+def resolve_context_parallel_world_size(config: Any) -> int:
+    for world_size_candidate in (
+        os.environ.get("WORLD_SIZE"),
+        os.environ.get("TRAINING_NUM_PROCESSES"),
+        getattr(config, "num_processes", None),
+    ):
+        if world_size_candidate in (None, "", "None"):
+            continue
+        try:
+            return int(world_size_candidate)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Context parallelism requires an integer process count, got {world_size_candidate!r}."
+            ) from exc
+    raise ValueError("Context parallelism requires a known process count before Accelerator setup.")
+
+
+def build_context_parallel_topology(config: Any, world_size: int, cp_size: int, strategy: str) -> ContextParallelTopology:
+    if world_size < cp_size:
+        raise ValueError(f"Context parallel size ({cp_size}) cannot exceed process count ({world_size}).")
+    if world_size % cp_size != 0:
+        raise ValueError(f"Context parallel size ({cp_size}) must evenly divide process count ({world_size}).")
+
+    fsdp_enabled = bool(getattr(config, "fsdp_enable", False))
+    if fsdp_enabled:
+        fsdp_version_value = getattr(config, "fsdp_version", 2)
+        try:
+            fsdp_version = int(fsdp_version_value)
+        except (TypeError, ValueError):
+            fsdp_version = 2
+        if fsdp_version != 2:
+            raise ValueError("Context parallelism currently only supports FSDP version 2 when FSDP is enabled.")
+        return ContextParallelTopology(
+            cp_size=cp_size,
+            dp_replicate_size=1,
+            dp_shard_size=world_size // cp_size,
+            strategy=strategy,
+        )
+
+    return ContextParallelTopology(
+        cp_size=cp_size,
+        dp_replicate_size=world_size // cp_size,
+        dp_shard_size=1,
+        strategy=strategy,
+    )
+
+
+def _accelerator_state(accelerator: Any) -> Any:
+    state = getattr(accelerator, "state", None)
+    if state is None:
+        state = SimpleNamespace()
+        setattr(accelerator, "state", state)
+    return state
+
+
+def _attach_accelerator_cp_state(accelerator: Any, parallelism_config: Any, device_mesh: Any) -> None:
+    state = _accelerator_state(accelerator)
+    state.parallelism_config = parallelism_config
+    state.device_mesh = device_mesh
+    try:
+        setattr(accelerator, "parallelism_config", parallelism_config)
+    except Exception:
+        pass
+    try:
+        setattr(accelerator, "torch_device_mesh", device_mesh)
+    except Exception:
+        pass
+
+
+def configure_cp_only_accelerator(accelerator: Any, topology: ContextParallelTopology) -> None:
+    if topology.cp_size <= 1 or topology.dp_shard_size != 1:
+        return
+    use_ulysses = topology.strategy == "alltoall"
+    if not (torch.distributed.is_available() and torch.distributed.is_initialized()):
+        raise RuntimeError("Standalone context parallelism requires torch.distributed to be initialized.")
+
+    from torch.distributed.device_mesh import init_device_mesh
+
+    device = getattr(accelerator, "device", None)
+    device_type = device.type if isinstance(device, torch.device) else torch._C._get_accelerator().type
+    mesh = init_device_mesh(
+        device_type=device_type,
+        mesh_shape=(
+            topology.dp_replicate_size,
+            1 if use_ulysses else topology.cp_size,
+            topology.cp_size if use_ulysses else 1,
+        ),
+        mesh_dim_names=("dp_replicate", "ring", "ulysses"),
+    )
+    cp_handler = SimpleNamespace(cp_comm_strategy=topology.strategy)
+    parallelism_config = SimpleNamespace(
+        dp_replicate_size=topology.dp_replicate_size,
+        dp_shard_size=topology.dp_shard_size,
+        tp_size=1,
+        sp_size=1,
+        cp_size=topology.cp_size,
+        cp_backend="simpletuner",
+        cp_handler=cp_handler,
+        cp_enabled=topology.cp_size > 1,
+        dp_replicate_enabled=topology.dp_replicate_size > 1,
+        dp_shard_enabled=False,
+        tp_enabled=False,
+        sp_enabled=False,
+    )
+    _attach_accelerator_cp_state(accelerator, parallelism_config, mesh)
+    logger.info(
+        "Standalone context parallelism enabled (size=%s, rotation=%s, dp_replicate_size=%s).",
+        topology.cp_size,
+        topology.strategy,
+        topology.dp_replicate_size,
+    )
+
+
+def apply_standalone_context_parallel(
+    accelerator: Any, module: torch.nn.Module | None, topology: ContextParallelTopology | None
+) -> bool:
+    if module is None or topology is None or topology.cp_size <= 1 or topology.dp_shard_size != 1:
+        return False
+    if not hasattr(module, "enable_parallelism"):
+        raise ValueError(
+            f"{module.__class__.__name__} does not expose enable_parallelism(), so standalone context parallelism "
+            "cannot apply its _cp_plan hooks."
+        )
+    if getattr(module, "_simpletuner_context_parallel_enabled", False):
+        return False
+    if getattr(module, "_cp_plan", None) is None:
+        raise ValueError(
+            f"{module.__class__.__name__} does not define _cp_plan, so it cannot be used with context_parallel_size."
+        )
+
+    from diffusers.models._modeling_parallel import ContextParallelConfig
+
+    mesh = getattr(accelerator, "torch_device_mesh", None)
+    if mesh is None:
+        mesh = getattr(getattr(accelerator, "state", None), "device_mesh", None)
+    if mesh is None:
+        raise RuntimeError("Standalone context parallelism has no device mesh attached to the accelerator.")
+
+    cp_config = ContextParallelConfig(
+        ring_degree=1 if topology.strategy == "alltoall" else topology.cp_size,
+        ulysses_degree=topology.cp_size if topology.strategy == "alltoall" else 1,
+        rotate_method="allgather",
+        mesh=mesh,
+        ring_anything=topology.strategy == "allgather",
+        ulysses_anything=False,
+    )
+    module.enable_parallelism(config=cp_config)
+    setattr(module, "_simpletuner_context_parallel_enabled", True)
+    logger.info("Applied standalone context parallel hooks to %s.", module.__class__.__name__)
+    return True

--- a/simpletuner/helpers/training/context_parallel_tensors.py
+++ b/simpletuner/helpers/training/context_parallel_tensors.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import torch
+
+
+def context_parallel_config(parallel_config):
+    return getattr(parallel_config, "context_parallel_config", None)
+
+
+def context_parallel_enabled(parallel_config) -> bool:
+    return context_parallel_config(parallel_config) is not None
+
+
+def shard_cp_tensor(tensor: torch.Tensor, parallel_config, split_dim: int = 1) -> torch.Tensor:
+    context_config = context_parallel_config(parallel_config)
+    if context_config is None:
+        return tensor
+
+    from diffusers.hooks.context_parallel import PartitionAnythingSharder
+
+    return PartitionAnythingSharder.shard_anything(tensor, split_dim, context_config._flattened_mesh)
+
+
+def unshard_cp_tensor(tensor: torch.Tensor, parallel_config, split_dim: int = 1) -> torch.Tensor:
+    context_config = context_parallel_config(parallel_config)
+    if context_config is None:
+        return tensor
+
+    from diffusers.hooks.context_parallel import PartitionAnythingSharder
+
+    return PartitionAnythingSharder.unshard_anything(tensor, split_dim, context_config._flattened_mesh)
+
+
+def prepare_cp_attention_mask(
+    attention_mask: torch.Tensor | None,
+    sequence_length: int,
+    parallel_config,
+    *,
+    model_name: str,
+    crop: Literal["left", "right"] = "right",
+) -> torch.Tensor | None:
+    if attention_mask is None:
+        return None
+    if attention_mask.ndim == 2:
+        attention_mask = attention_mask[:, None, None, :]
+
+    context_config = context_parallel_config(parallel_config)
+    if context_config is None or getattr(context_config, "ulysses_degree", 1) <= 1:
+        return attention_mask
+
+    key_length = sequence_length * context_config.ulysses_degree
+    mask_length = attention_mask.shape[-1]
+    if mask_length < key_length:
+        raise ValueError(
+            f"{model_name} Ulysses attention mask length {mask_length} is shorter than attention key length {key_length}."
+        )
+    if mask_length > key_length:
+        if crop == "left":
+            attention_mask = attention_mask[..., :key_length]
+        else:
+            attention_mask = attention_mask[..., -key_length:]
+    return attention_mask

--- a/tests/test_context_parallel_plans.py
+++ b/tests/test_context_parallel_plans.py
@@ -1,0 +1,160 @@
+import unittest
+
+from diffusers.models._modeling_parallel import ContextParallelInput, ContextParallelOutput
+
+
+def _get_submodule(module, path: str):
+    if path == "":
+        return module
+    current = module
+    for atom in path.split("."):
+        if atom.isdigit():
+            current = current[int(atom)]
+        else:
+            current = getattr(current, atom)
+    return current
+
+
+def _assert_valid_cp_plan(testcase: unittest.TestCase, module):
+    plan = getattr(module, "_cp_plan", None)
+    testcase.assertIsInstance(plan, dict)
+    testcase.assertTrue(plan)
+    for module_id, entry in plan.items():
+        _get_submodule(module, module_id)
+        if isinstance(entry, dict):
+            testcase.assertTrue(entry)
+            for value in entry.values():
+                if isinstance(value, (list, tuple)):
+                    testcase.assertTrue(value)
+                    for item in value:
+                        testcase.assertIsInstance(item, ContextParallelInput)
+                else:
+                    testcase.assertIsInstance(value, ContextParallelInput)
+        elif isinstance(entry, (list, tuple)):
+            testcase.assertTrue(entry)
+            for item in entry:
+                testcase.assertIsInstance(item, ContextParallelOutput)
+        else:
+            testcase.assertIsInstance(entry, ContextParallelOutput)
+
+
+class ContextParallelPlanTests(unittest.TestCase):
+    def test_anima_cp_plan_targets_exist(self):
+        from simpletuner.helpers.models.anima.transformer import AnimaTransformerModel
+
+        model = AnimaTransformerModel(
+            in_channels=4,
+            out_channels=4,
+            num_attention_heads=2,
+            attention_head_dim=4,
+            num_layers=1,
+            text_embed_dim=8,
+            adaln_lora_dim=4,
+            max_size=(2, 4, 4),
+            patch_size=(1, 2, 2),
+            adapter_dim=8,
+            adapter_layers=1,
+            adapter_heads=2,
+        )
+
+        _assert_valid_cp_plan(self, model)
+
+    def test_heartmula_codec_cp_plan_targets_exist(self):
+        from simpletuner.helpers.models.heartmula.codec.transformer import LlamaTransformer
+
+        model = LlamaTransformer(
+            num_attention_heads=2,
+            attention_head_dim=4,
+            in_channels=4,
+            out_channels=4,
+            num_layers=1,
+            num_layers_2=1,
+        )
+
+        _assert_valid_cp_plan(self, model)
+
+    def test_ideogram_cp_plan_targets_exist(self):
+        from simpletuner.helpers.models.ideogram.transformer import Ideogram4Config, Ideogram4Transformer
+
+        model = Ideogram4Transformer(
+            Ideogram4Config(
+                emb_dim=12,
+                num_layers=1,
+                num_heads=3,
+                intermediate_size=16,
+                adanln_dim=8,
+                in_channels=4,
+                llm_features_dim=12,
+                mrope_section=(1, 1, 1),
+            )
+        )
+
+        _assert_valid_cp_plan(self, model)
+
+    def test_wan_s2v_cp_plan_targets_exist(self):
+        from simpletuner.helpers.models.wan_s2v.transformer import WanS2VTransformer3DModel
+
+        model = WanS2VTransformer3DModel(
+            patch_size=(1, 2, 2),
+            num_attention_heads=2,
+            attention_head_dim=12,
+            in_channels=4,
+            out_channels=4,
+            text_dim=8,
+            freq_dim=8,
+            audio_dim=8,
+            audio_inject_layers=(0,),
+            pose_dim=4,
+            ffn_dim=32,
+            num_layers=1,
+            num_weighted_avg_layers=1,
+            rope_max_seq_len=8,
+            enable_framepack=False,
+            add_last_motion=False,
+        )
+
+        _assert_valid_cp_plan(self, model)
+
+    def test_wan_cp_plan_targets_exist(self):
+        from simpletuner.helpers.models.wan.transformer import WanTransformer3DModel
+
+        model = WanTransformer3DModel(
+            patch_size=(1, 2, 2),
+            num_attention_heads=2,
+            attention_head_dim=12,
+            in_channels=4,
+            out_channels=4,
+            text_dim=8,
+            freq_dim=8,
+            ffn_dim=32,
+            num_layers=1,
+            rope_max_seq_len=8,
+        )
+
+        _assert_valid_cp_plan(self, model)
+        rope_plan = model._cp_plan["rope"]
+        self.assertEqual(tuple(rope_plan.keys()), (0,))
+        self.assertEqual(rope_plan[0].split_dim, 2)
+        self.assertEqual(rope_plan[0].expected_dims, 4)
+        self.assertTrue(rope_plan[0].split_output)
+
+    def test_zlab_i1_cp_plan_targets_exist(self):
+        from simpletuner.helpers.models.zlab_i1.transformer import ZlabI1Transformer2DModel
+
+        model = ZlabI1Transformer2DModel(
+            input_size=4,
+            image_resolution=32,
+            patch_size=2,
+            in_channels=4,
+            hidden_size=24,
+            depth=3,
+            num_heads=3,
+            text_embed_dim=24,
+            text_num_tokens=4,
+        )
+
+        _assert_valid_cp_plan(self, model)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_context_parallel_runtime.py
+++ b/tests/test_context_parallel_runtime.py
@@ -1,0 +1,158 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from simpletuner.helpers.training.context_parallel import (
+    ContextParallelTopology,
+    build_context_parallel_topology,
+    configure_cp_only_accelerator,
+    normalize_context_parallel_size,
+    normalize_context_parallel_strategy,
+)
+
+
+class ContextParallelTopologyTests(unittest.TestCase):
+    def test_cp_only_topology_uses_replicated_data_parallel_axis(self):
+        topology = build_context_parallel_topology(
+            SimpleNamespace(fsdp_enable=False),
+            world_size=8,
+            cp_size=2,
+            strategy="allgather",
+        )
+
+        self.assertEqual(topology.cp_size, 2)
+        self.assertEqual(topology.dp_replicate_size, 4)
+        self.assertEqual(topology.dp_shard_size, 1)
+
+    def test_cp_only_two_gpus_has_one_data_parallel_batch(self):
+        topology = build_context_parallel_topology(
+            SimpleNamespace(fsdp_enable=False),
+            world_size=2,
+            cp_size=2,
+            strategy="allgather",
+        )
+
+        self.assertEqual(topology.dp_replicate_size, 1)
+        self.assertEqual(topology.dp_shard_size, 1)
+
+    def test_fsdp2_topology_keeps_existing_shard_axis(self):
+        topology = build_context_parallel_topology(
+            SimpleNamespace(fsdp_enable=True, fsdp_version=2),
+            world_size=8,
+            cp_size=2,
+            strategy="allgather",
+        )
+
+        self.assertEqual(topology.dp_replicate_size, 1)
+        self.assertEqual(topology.dp_shard_size, 4)
+
+    def test_rejects_non_divisible_world_size(self):
+        with self.assertRaisesRegex(ValueError, "evenly divide"):
+            build_context_parallel_topology(
+                SimpleNamespace(fsdp_enable=False),
+                world_size=7,
+                cp_size=2,
+                strategy="allgather",
+            )
+
+    def test_normalizes_context_parallel_options(self):
+        self.assertIsNone(normalize_context_parallel_size(None))
+        self.assertEqual(normalize_context_parallel_size("2"), 2)
+        self.assertEqual(normalize_context_parallel_strategy("ALLGATHER"), "allgather")
+        self.assertEqual(normalize_context_parallel_strategy(None), "allgather")
+        with self.assertRaises(ValueError):
+            normalize_context_parallel_size("nope")
+        with self.assertRaises(ValueError):
+            normalize_context_parallel_strategy("ring")
+
+
+class ContextParallelAcceleratorAttachTests(unittest.TestCase):
+    @patch("simpletuner.helpers.training.context_parallel.torch.distributed.is_initialized", return_value=True)
+    @patch("simpletuner.helpers.training.context_parallel.torch.distributed.is_available", return_value=True)
+    @patch("torch.distributed.device_mesh.init_device_mesh")
+    def test_configure_cp_only_attaches_parallelism_config_and_mesh(
+        self,
+        mock_init_device_mesh,
+        _mock_dist_available,
+        _mock_dist_initialized,
+    ):
+        mesh = MagicMock()
+        mock_init_device_mesh.return_value = mesh
+        accelerator = SimpleNamespace(device=torch.device("cpu"), state=SimpleNamespace())
+
+        configure_cp_only_accelerator(
+            accelerator,
+            ContextParallelTopology(cp_size=2, dp_replicate_size=4, dp_shard_size=1, strategy="allgather"),
+        )
+
+        mock_init_device_mesh.assert_called_once_with(
+            device_type="cpu",
+            mesh_shape=(4, 2, 1),
+            mesh_dim_names=("dp_replicate", "ring", "ulysses"),
+        )
+        self.assertIs(accelerator.state.device_mesh, mesh)
+        self.assertEqual(accelerator.state.parallelism_config.cp_size, 2)
+        self.assertEqual(accelerator.state.parallelism_config.dp_replicate_size, 4)
+        self.assertEqual(accelerator.state.parallelism_config.dp_shard_size, 1)
+        self.assertTrue(accelerator.state.parallelism_config.cp_enabled)
+        self.assertFalse(accelerator.state.parallelism_config.tp_enabled)
+        self.assertFalse(accelerator.state.parallelism_config.dp_shard_enabled)
+
+    @patch("simpletuner.helpers.training.context_parallel.torch.distributed.is_initialized", return_value=True)
+    @patch("simpletuner.helpers.training.context_parallel.torch.distributed.is_available", return_value=True)
+    @patch("torch.distributed.device_mesh.init_device_mesh")
+    def test_configure_cp_only_attaches_ulysses_mesh_for_alltoall(
+        self,
+        mock_init_device_mesh,
+        _mock_dist_available,
+        _mock_dist_initialized,
+    ):
+        mesh = MagicMock()
+        mock_init_device_mesh.return_value = mesh
+        accelerator = SimpleNamespace(device=torch.device("cpu"), state=SimpleNamespace())
+
+        configure_cp_only_accelerator(
+            accelerator,
+            ContextParallelTopology(cp_size=2, dp_replicate_size=4, dp_shard_size=1, strategy="alltoall"),
+        )
+
+        mock_init_device_mesh.assert_called_once_with(
+            device_type="cpu",
+            mesh_shape=(4, 1, 2),
+            mesh_dim_names=("dp_replicate", "ring", "ulysses"),
+        )
+        self.assertIs(accelerator.state.device_mesh, mesh)
+
+
+class ContextParallelSyncMeshTests(unittest.TestCase):
+    def test_get_cp_info_flattens_diffusers_ring_ulysses_mesh(self):
+        from simpletuner.helpers.data_backend.runtime.context_parallel_sync import get_cp_info
+
+        parallelism_config = SimpleNamespace(cp_size=2, cp_enabled=True)
+        cp_mesh = MagicMock()
+        cp_group = MagicMock()
+        cp_mesh.get_group.return_value = cp_group
+        cp_mesh.get_local_rank.return_value = 1
+        ring_ulysses_mesh = MagicMock()
+        ring_ulysses_mesh._flatten.return_value = cp_mesh
+
+        device_mesh = MagicMock()
+        device_mesh.mesh_dim_names = ("dp_replicate", "ring", "ulysses")
+        device_mesh.get_group.side_effect = KeyError("cp")
+        device_mesh.__getitem__.return_value = ring_ulysses_mesh
+
+        accelerator = SimpleNamespace(parallelism_config=parallelism_config, torch_device_mesh=device_mesh)
+
+        cp_enabled, group, rank, size = get_cp_info(accelerator)
+
+        self.assertTrue(cp_enabled)
+        self.assertIs(group, cp_group)
+        self.assertEqual(rank, 1)
+        self.assertEqual(size, 2)
+        device_mesh.__getitem__.assert_called_once_with(("ring", "ulysses"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_context_parallel_tensors.py
+++ b/tests/test_context_parallel_tensors.py
@@ -1,0 +1,48 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from simpletuner.helpers.training.context_parallel_tensors import (
+    prepare_cp_attention_mask,
+    shard_cp_tensor,
+    unshard_cp_tensor,
+)
+
+
+class ContextParallelTensorHelpersTests(unittest.TestCase):
+    def test_shard_helpers_are_noops_without_context_parallel(self):
+        tensor = torch.randn(2, 4, 3)
+        parallel_config = SimpleNamespace(context_parallel_config=None)
+
+        self.assertIs(shard_cp_tensor(tensor, parallel_config), tensor)
+        self.assertIs(unshard_cp_tensor(tensor, parallel_config), tensor)
+
+    def test_attention_mask_expands_without_context_parallel(self):
+        mask = torch.tensor([[True, False, True]])
+
+        prepared = prepare_cp_attention_mask(mask, 3, None, model_name="Test")
+
+        self.assertEqual(prepared.shape, (1, 1, 1, 3))
+        self.assertTrue(torch.equal(prepared[:, 0, 0], mask))
+
+    def test_attention_mask_crops_to_full_ulysses_key_length(self):
+        mask = torch.arange(10).view(1, 10)
+        parallel_config = SimpleNamespace(context_parallel_config=SimpleNamespace(ulysses_degree=2))
+
+        right = prepare_cp_attention_mask(mask, 3, parallel_config, model_name="Test", crop="right")
+        left = prepare_cp_attention_mask(mask, 3, parallel_config, model_name="Test", crop="left")
+
+        self.assertTrue(torch.equal(right.flatten(), torch.tensor([4, 5, 6, 7, 8, 9])))
+        self.assertTrue(torch.equal(left.flatten(), torch.tensor([0, 1, 2, 3, 4, 5])))
+
+    def test_attention_mask_rejects_short_ulysses_mask(self):
+        mask = torch.ones(1, 5, dtype=torch.bool)
+        parallel_config = SimpleNamespace(context_parallel_config=SimpleNamespace(ulysses_degree=2))
+
+        with self.assertRaisesRegex(ValueError, "shorter than attention key length"):
+            prepare_cp_attention_mask(mask, 3, parallel_config, model_name="Test")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ernie_model.py
+++ b/tests/test_ernie_model.py
@@ -456,6 +456,81 @@ class ErnieModelTests(unittest.TestCase):
         kwargs = model.model.received[-1]
         self.assertIs(kwargs["timestep_sign"], time_sign)
 
+    def test_transformer_declares_manual_context_parallel_plan(self):
+        self.assertEqual(ErnieImageTransformer2DModel._cp_plan, {})
+
+    def test_transformer_context_parallel_path_shards_internal_tensors(self):
+        transformer = ErnieImageTransformer2DModel(
+            hidden_size=12,
+            num_attention_heads=2,
+            num_layers=1,
+            ffn_hidden_size=24,
+            in_channels=4,
+            out_channels=4,
+            text_in_dim=12,
+            rope_axes_dim=(2, 2, 2),
+        )
+        transformer._parallel_config = types.SimpleNamespace(context_parallel_config=types.SimpleNamespace(ulysses_degree=1))
+
+        with (
+            patch(
+                "simpletuner.helpers.models.ernie.transformer.shard_cp_tensor",
+                side_effect=lambda tensor, *_args, **_kwargs: tensor,
+            ) as shard,
+            patch(
+                "simpletuner.helpers.models.ernie.transformer.unshard_cp_tensor",
+                side_effect=lambda tensor, *_args, **_kwargs: tensor,
+            ) as unshard,
+            patch(
+                "simpletuner.helpers.models.ernie.transformer.prepare_cp_attention_mask",
+                side_effect=lambda mask, *_args, **_kwargs: mask,
+            ) as prepare_mask,
+        ):
+            output = transformer(
+                hidden_states=torch.randn(1, 4, 2, 2),
+                timestep=torch.tensor([0.5]),
+                text_bth=torch.randn(1, 1, 12),
+                text_lens=torch.tensor([1]),
+                return_dict=False,
+            )[0]
+
+        self.assertEqual(tuple(output.shape), (1, 4, 2, 2))
+        self.assertGreaterEqual(shard.call_count, 4)
+        unshard.assert_called()
+        prepare_mask.assert_called_once()
+
+    def test_transformer_context_parallel_rejects_tread_before_sharding(self):
+        transformer = ErnieImageTransformer2DModel(
+            hidden_size=12,
+            num_attention_heads=2,
+            num_layers=1,
+            ffn_hidden_size=24,
+            in_channels=4,
+            out_channels=4,
+            text_in_dim=12,
+            rope_axes_dim=(2, 2, 2),
+        )
+        transformer._parallel_config = types.SimpleNamespace(context_parallel_config=types.SimpleNamespace(ulysses_degree=2))
+        transformer.set_router(
+            TREADRouter(seed=1, device=torch.device("cpu")),
+            [{"start_layer_idx": 0, "end_layer_idx": 0, "selection_ratio": 0.5}],
+        )
+
+        with (
+            torch.enable_grad(),
+            patch("simpletuner.helpers.models.ernie.transformer.shard_cp_tensor") as shard,
+            self.assertRaisesRegex(ValueError, "TREAD routing is not supported"),
+        ):
+            transformer(
+                hidden_states=torch.randn(1, 4, 2, 2),
+                timestep=torch.tensor([0.5]),
+                text_bth=torch.randn(1, 1, 12),
+                text_lens=torch.tensor([1]),
+                return_dict=False,
+            )
+
+        shard.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_transformers/test_wan_transformer.py
+++ b/tests/test_transformers/test_wan_transformer.py
@@ -1629,23 +1629,53 @@ class TestWanTransformer3DModel(TransformerBaseTest):
         # Test should complete within reasonable time for small model
         self.run_performance_benchmark(model, inputs, max_time_ms=3000.0)
 
-    def test_time_text_monkeypatch_accepts_timestep_sign(self):
-        """Regression test: time_text_monkeypatch must accept timestep_sign kwarg.
+    def test_time_text_monkeypatch_accepts_forward_kwargs(self):
+        """Regression test: time_text_monkeypatch must accept Wan forward kwargs.
 
         WanTransformer3DModel.forward (wan/transformer.py) unconditionally
-        passes timestep_sign= to condition_embedder for every forward pass,
-        even on non-TwinFlow runs (where the value is None). The monkeypatch
-        signature in wan/model.py must therefore accept this kwarg or every
-        Wan training/validation forward will raise TypeError.
+        passes timestep_sign= and r_timestep= to condition_embedder for every
+        forward pass, even when either value is None. The monkeypatch signature
+        in wan/model.py must therefore accept these kwargs or Wan
+        training/validation forward will raise TypeError.
 
         Originally broken by commit 07e670c4 ("TwinFlow: Wan").
         """
         import inspect
+        from functools import partial
 
         from simpletuner.helpers.models.wan.model import time_text_monkeypatch
 
         params = inspect.signature(time_text_monkeypatch).parameters
         self.assertIn("timestep_sign", params)
+        self.assertIn("r_timestep", params)
+
+        embedding_config = {
+            "dim": self.hidden_dim,
+            "time_freq_dim": 256,
+            "time_proj_dim": self.hidden_dim * 6,
+            "text_embed_dim": self.model_config["text_dim"],
+            "image_embed_dim": self.model_config["image_dim"],
+        }
+        embedding = WanTimeTextImageEmbedding(**embedding_config)
+        embedding.enable_flowmap_time_conditioning(gate_value=0.25, deltatime_type="r")
+        embedding.forward = partial(time_text_monkeypatch, embedding)
+
+        timestep = torch.full((self.batch_size,), 900)
+        r_timestep = torch.zeros_like(timestep)
+        encoder_hidden_states = torch.randn(self.batch_size, 77, embedding_config["text_embed_dim"])
+
+        temb, timestep_proj, text_emb, image_emb = embedding.forward(
+            timestep=timestep,
+            r_timestep=r_timestep,
+            timestep_sign=None,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_hidden_states_image=None,
+        )
+
+        self.assertEqual(temb.shape[0], self.batch_size)
+        self.assertEqual(timestep_proj.shape[0], self.batch_size)
+        self.assertEqual(text_emb.shape[:2], encoder_hidden_states.shape[:2])
+        self.assertIsNone(image_emb)
 
 
 if __name__ == "__main__":

--- a/tests/test_wan_model.py
+++ b/tests/test_wan_model.py
@@ -1,0 +1,37 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from simpletuner.helpers.models.wan.model import Wan
+
+
+class WanModelTests(unittest.TestCase):
+    def test_special_scheduler_setup_loads_pipeline_scheduler(self):
+        model = object.__new__(Wan)
+        model.config = SimpleNamespace(flow_schedule_shift=5.0)
+        model._model_config_path = lambda: "Wan-AI/Wan2.1-T2V-14B-Diffusers"
+        scheduler = object()
+
+        with (
+            patch(
+                "simpletuner.helpers.models.wan.model.FlowMatchEulerDiscreteScheduler.from_pretrained",
+                return_value=scheduler,
+            ) as from_pretrained,
+            patch(
+                "simpletuner.helpers.models.wan.model.fix_flow_match_euler_schedule_bounds",
+                side_effect=lambda value: value,
+            ) as fix_bounds,
+        ):
+            result = model._load_scheduler_for_pipeline("text2img")
+
+        self.assertIs(result, scheduler)
+        from_pretrained.assert_called_once_with(
+            "Wan-AI/Wan2.1-T2V-14B-Diffusers",
+            subfolder="scheduler",
+            shift=5.0,
+        )
+        fix_bounds.assert_called_once_with(scheduler)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_z_image_omni.py
+++ b/tests/test_z_image_omni.py
@@ -1,5 +1,6 @@
 import types
 import unittest
+from unittest.mock import patch
 
 import torch
 
@@ -126,6 +127,48 @@ class TestZImageOmniTransformer(unittest.TestCase):
             axes_dims=[1, 1, 2],
             axes_lens=[4, 4, 4],
         )
+
+    def test_context_parallel_only_marks_unified_transformer_blocks(self):
+        transformer = self._build_small_transformer()
+
+        self.assertEqual(transformer._cp_plan, {})
+        for block in transformer.noise_refiner:
+            self.assertFalse(getattr(block.attention, "_zimage_omni_allow_context_parallel", False))
+        for block in transformer.context_refiner:
+            self.assertFalse(getattr(block.attention, "_zimage_omni_allow_context_parallel", False))
+        for block in transformer.siglip_refiner:
+            self.assertFalse(getattr(block.attention, "_zimage_omni_allow_context_parallel", False))
+        for block in transformer.layers:
+            self.assertTrue(block.attention._zimage_omni_allow_context_parallel)
+
+    def test_context_parallel_rejects_tread_before_sharding(self):
+        transformer = self._build_small_transformer()
+        transformer._parallel_config = types.SimpleNamespace(context_parallel_config=types.SimpleNamespace(ulysses_degree=2))
+        transformer.set_router(
+            types.SimpleNamespace(),
+            [{"start_layer_idx": 0, "end_layer_idx": 0, "selection_ratio": 0.5}],
+        )
+
+        x = [torch.zeros(2, 1, 4, 4)]
+        cap_feats = [[torch.zeros(2, 4)]]
+        cond_latents = [[]]
+        siglip_feats = [None]
+        timesteps = torch.tensor([[0.5, 0.25, 0.75, 0.1]])
+
+        with (
+            torch.enable_grad(),
+            patch("simpletuner.helpers.models.z_image_omni.transformer.shard_cp_tensor") as shard,
+            self.assertRaisesRegex(ValueError, "TREAD routing is not supported"),
+        ):
+            transformer.forward(
+                x=x,
+                t=timesteps,
+                cap_feats=cap_feats,
+                cond_latents=cond_latents,
+                siglip_feats=siglip_feats,
+            )
+
+        shard.assert_not_called()
 
     def test_forward_handles_mixed_siglip_presence(self):
         transformer = self._build_small_transformer().eval()

--- a/tests/test_zimage.py
+++ b/tests/test_zimage.py
@@ -72,6 +72,33 @@ class ZImageTransformerPaddingTests(unittest.TestCase):
         model._set_gradient_checkpointing(enable=True)
         self.assertTrue(model.gradient_checkpointing)
 
+    def test_context_parallel_only_marks_unified_transformer_blocks(self):
+        model = ZImageTransformer2DModel(
+            all_patch_size=(2,),
+            all_f_patch_size=(1,),
+            in_channels=1,
+            dim=4,
+            n_layers=2,
+            n_refiner_layers=1,
+            n_heads=1,
+            n_kv_heads=1,
+            norm_eps=1e-5,
+            qk_norm=False,
+            cap_feat_dim=4,
+            rope_theta=1.0,
+            t_scale=1.0,
+            axes_dims=[4],
+            axes_lens=[1],
+        )
+
+        self.assertEqual(model._cp_plan, {})
+        for block in model.noise_refiner:
+            self.assertFalse(getattr(block.attention, "_zimage_allow_context_parallel", False))
+        for block in model.context_refiner:
+            self.assertFalse(getattr(block.attention, "_zimage_allow_context_parallel", False))
+        for block in model.layers:
+            self.assertTrue(block.attention._zimage_allow_context_parallel)
+
     def test_mask_flattening_for_prompt_embeds(self):
         # Ensure 2D attention masks are flattened when selecting prompt embeddings
         zimage = ZImage.__new__(ZImage)


### PR DESCRIPTION
This pull request introduces and standardizes support for context parallelism (CP) across several model architectures in the codebase. It adds or updates CP plans, integrates tensor sharding/unsharding and attention mask preparation for CP, and improves compatibility with different mesh dimension conventions. Additionally, it includes a few unrelated minor improvements and fixes.

**Context Parallelism Support and Integration:**

* Added or updated `_cp_plan` attributes in multiple model classes to define how inputs and outputs are split/gathered for context parallel execution, including `AnimaTransformerModel`, `LlamaTransformer`, `Ideogram4Transformer`, `WanTransformer3DModel`, and `WanS2VTransformer3DModel`. [[1]](diffhunk://#diff-7c1dc40272484f25b0e4b71131aed062fb49f5dad62b1e62bca93763591d8dfaR333-R339) [[2]](diffhunk://#diff-80ed206dc4adfc279d9af37c06b2f551469700515ab65f151299648be9319e3aR264-R270) [[3]](diffhunk://#diff-80f00dd3a8b1f152434306c6e5e49e225bc515aa077f9a12a409d1973f1b9952R285-R294) [[4]](diffhunk://#diff-41de8cc2788649a626338119dfe8ed7c7a9ebaeee88132abc387bf645115921eL691-R691) [[5]](diffhunk://#diff-1d4dfc9f08081bc14a2ea2ebaf4b84364615fe882ce9afef187776bf85c47fb0R933-R941)
* Integrated context parallel tensor utilities (`shard_cp_tensor`, `unshard_cp_tensor`, `prepare_cp_attention_mask`, etc.) into the forward passes of models such as ERNIE, Flux2, and Z-Image to enable correct sharding, unsharding, and mask preparation during context parallel execution. [[1]](diffhunk://#diff-979feb5b66ed7c5e5eb8f67f9422a9d8134b1d39ee990e1c317a18875071ac9aR12-R17) [[2]](diffhunk://#diff-979feb5b66ed7c5e5eb8f67f9422a9d8134b1d39ee990e1c317a18875071ac9aL155-R180) [[3]](diffhunk://#diff-979feb5b66ed7c5e5eb8f67f9422a9d8134b1d39ee990e1c317a18875071ac9aR301-R302) [[4]](diffhunk://#diff-979feb5b66ed7c5e5eb8f67f9422a9d8134b1d39ee990e1c317a18875071ac9aR321-R322) [[5]](diffhunk://#diff-dc724b7872bbf8da3e20198895e6b013646442113c5cbaaced6028c23aaabc78R43) [[6]](diffhunk://#diff-dc724b7872bbf8da3e20198895e6b013646442113c5cbaaced6028c23aaabc78L232-R244) [[7]](diffhunk://#diff-dc724b7872bbf8da3e20198895e6b013646442113c5cbaaced6028c23aaabc78L241-R253) [[8]](diffhunk://#diff-dc724b7872bbf8da3e20198895e6b013646442113c5cbaaced6028c23aaabc78L380-R403) [[9]](diffhunk://#diff-dc724b7872bbf8da3e20198895e6b013646442113c5cbaaced6028c23aaabc78L389-R412) [[10]](diffhunk://#diff-8a4adb9e6956a827ded3b9935466f2f2d4459ac3be5c6e7c5db05fc21644d0bdR41-R46)

**Device Mesh and Mesh Dimension Handling:**

* Improved `get_cp_info` to support both Accelerate and Diffusers/standalone mesh conventions, attempting to flatten "ring"/"ulysses" mesh dimensions if "cp" is not present.

**Scheduler and Pipeline Enhancements:**

* Added a method to `Wan` to load and fix scheduler bounds for the FlowMatch Euler scheduler, improving pipeline setup. [[1]](diffhunk://#diff-a9a0a770364f81d1b9e431dc59648729cf12b65fac361b9e3b864ff2801f1448L9-R9) [[2]](diffhunk://#diff-a9a0a770364f81d1b9e431dc59648729cf12b65fac361b9e3b864ff2801f1448R34) [[3]](diffhunk://#diff-a9a0a770364f81d1b9e431dc59648729cf12b65fac361b9e3b864ff2801f1448R322-R330)
* Updated the time embedding logic in the `time_text_monkeypatch` function to support delta timestep embeddings for flowmap models.

**Dependency and Import Cleanups:**

* Added or adjusted imports for new CP utilities and scheduler classes in relevant files. [[1]](diffhunk://#diff-7c1dc40272484f25b0e4b71131aed062fb49f5dad62b1e62bca93763591d8dfaR17) [[2]](diffhunk://#diff-80ed206dc4adfc279d9af37c06b2f551469700515ab65f151299648be9319e3aR12) [[3]](diffhunk://#diff-80f00dd3a8b1f152434306c6e5e49e225bc515aa077f9a12a409d1973f1b9952R16) [[4]](diffhunk://#diff-1d4dfc9f08081bc14a2ea2ebaf4b84364615fe882ce9afef187776bf85c47fb0R25) [[5]](diffhunk://#diff-a9a0a770364f81d1b9e431dc59648729cf12b65fac361b9e3b864ff2801f1448L9-R9)

**Miscellaneous:**

* Removed unnecessary imports in Z-Image transformer.
