### PR TITLE
LTX 2.3 context-parallel fixes for uneven sequence lengths

### DIFF
--- a/simpletuner/helpers/models/ltxvideo2/model.py
+++ b/simpletuner/helpers/models/ltxvideo2/model.py
@@ -64,6 +64,39 @@ LTX2_AUDIO_VAE_PREFIX = "audio_vae."
 LTX2_VOCODER_PREFIX = "vocoder."
 
 
+def _align_ltx2_connector_attention_mask(attention_mask: torch.Tensor, sequence_length: int) -> torch.Tensor:
+    mask_length = attention_mask.shape[-1]
+    if mask_length == sequence_length:
+        return attention_mask
+    if mask_length < sequence_length:
+        raise ValueError(
+            f"LTX-2 connector attention mask length {mask_length} is shorter than connector sequence length "
+            f"{sequence_length}."
+        )
+    return attention_mask[..., -sequence_length:]
+
+
+def _pad_ltx2_audio_sequence_for_cp(
+    audio_hidden_states: torch.Tensor,
+    audio_num_frames: int,
+    cp_size: int,
+    strategy: str,
+) -> tuple[torch.Tensor, int]:
+    if cp_size <= 1 or strategy != "alltoall":
+        return audio_hidden_states, audio_num_frames
+    remainder = audio_hidden_states.shape[1] % cp_size
+    if remainder == 0:
+        return audio_hidden_states, audio_num_frames
+
+    pad_tokens = cp_size - remainder
+    padding = audio_hidden_states.new_zeros(
+        audio_hidden_states.shape[0],
+        pad_tokens,
+        audio_hidden_states.shape[2],
+    )
+    return torch.cat([audio_hidden_states, padding], dim=1), audio_num_frames + pad_tokens
+
+
 class LTXVideo2(VideoModelFoundation):
     NAME = "LTXVideo2"
     MODEL_DESCRIPTION = "Audio-video generation model with flow matching"
@@ -1874,6 +1907,15 @@ class LTXVideo2(VideoModelFoundation):
         audio_num_frames = audio_latents.shape[2]
         audio_mel_bins = audio_latents.shape[3]
         packed_audio_noisy = pack_ltx2_audio_latents(audio_noisy).to(self.config.weight_dtype)
+        transformer_audio_num_frames = audio_num_frames
+        cp_size = int(getattr(self.config, "context_parallel_size", 1) or 1)
+        cp_strategy = str(getattr(self.config, "context_parallel_comm_strategy", "allgather") or "allgather").lower()
+        packed_audio_noisy, transformer_audio_num_frames = _pad_ltx2_audio_sequence_for_cp(
+            packed_audio_noisy,
+            transformer_audio_num_frames,
+            cp_size,
+            cp_strategy,
+        )
 
         encoder_hidden_states = prepared_batch["encoder_hidden_states"]
         encoder_attention_mask = prepared_batch.get("encoder_attention_mask")
@@ -1888,6 +1930,12 @@ class LTXVideo2(VideoModelFoundation):
             encoder_hidden_states,
             additive_attention_mask,
             additive_mask=True,
+        )
+        connector_video_attention_mask = _align_ltx2_connector_attention_mask(
+            connector_attention_mask, connector_video_embeds.shape[1]
+        )
+        connector_audio_attention_mask = _align_ltx2_connector_attention_mask(
+            connector_attention_mask, connector_audio_embeds.shape[1]
         )
 
         force_keep_mask = None
@@ -1935,13 +1983,13 @@ class LTXVideo2(VideoModelFoundation):
             "timestep_sign": (
                 prepared_batch.get("twinflow_time_sign") if getattr(self.config, "twinflow_enabled", False) else None
             ),
-            "encoder_attention_mask": connector_attention_mask,
-            "audio_encoder_attention_mask": connector_attention_mask,
+            "encoder_attention_mask": connector_video_attention_mask,
+            "audio_encoder_attention_mask": connector_audio_attention_mask,
             "num_frames": num_frames,
             "height": height,
             "width": width,
             "fps": self.config.framerate or 25,
-            "audio_num_frames": audio_num_frames,
+            "audio_num_frames": transformer_audio_num_frames,
             "return_dict": False,
         }
         if combined_video_coords is not None:
@@ -1958,6 +2006,10 @@ class LTXVideo2(VideoModelFoundation):
             transformer_kwargs["hidden_states_buffer"] = hidden_states_buffer
         if is_audio_only:
             transformer_kwargs["audio_only"] = True
+
+        if os.environ.get("SIMPLETUNER_CP_DEBUG_SHAPES") == "1" and should_log():
+            debug_shapes = {key: tuple(value.shape) for key, value in transformer_kwargs.items() if torch.is_tensor(value)}
+            logger.info("LTX-2 transformer kwargs tensor shapes: %s", debug_shapes)
 
         grounding_kwargs = self._build_grounding_position_net_kwargs(prepared_batch.get("grounding_batch"))
         if grounding_kwargs is not None:
@@ -1987,6 +2039,8 @@ class LTXVideo2(VideoModelFoundation):
 
         if ref_seq_len:
             video_pred = video_pred[:, ref_seq_len:, :]
+        if transformer_audio_num_frames != audio_num_frames:
+            audio_pred = audio_pred[:, :audio_num_frames, :]
 
         video_pred = unpack_ltx2_latents(
             video_pred,

--- a/simpletuner/helpers/models/ltxvideo2/transformer.py
+++ b/simpletuner/helpers/models/ltxvideo2/transformer.py
@@ -89,6 +89,20 @@ def _ltx2_cast_attention_inputs(
     return query.to(dispatch_dtype), key.to(dispatch_dtype), value.to(dispatch_dtype)
 
 
+def _ltx2_project_qkv(
+    attn: "LTX2Attention",
+    hidden_states: torch.Tensor,
+    encoder_hidden_states: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if getattr(attn, "fused_projections", False):
+        if encoder_hidden_states is hidden_states:
+            return attn.to_qkv(hidden_states).chunk(3, dim=-1)
+        key, value = attn.to_kv(encoder_hidden_states).chunk(2, dim=-1)
+        return attn.to_q(hidden_states), key, value
+
+    return attn.to_q(hidden_states), attn.to_k(encoder_hidden_states), attn.to_v(encoder_hidden_states)
+
+
 def _ltx2_active_attention_backend(backend: Optional[AttentionBackendName]) -> AttentionBackendName:
     if backend is not None:
         return AttentionBackendName(backend)
@@ -125,6 +139,24 @@ def _ltx2_normalize_varlen_mask(
             f"expected ({batch_size}, {seq_len_kv})"
         )
     return keep_mask
+
+
+def _ltx2_prompt_timesteps(timestep: torch.Tensor, batch_size: int, name: str) -> torch.Tensor:
+    if timestep.ndim == 0:
+        return timestep.expand(batch_size)
+    if timestep.ndim == 1:
+        if timestep.shape[0] == 1:
+            return timestep.expand(batch_size)
+        if timestep.shape[0] == batch_size:
+            return timestep
+        raise ValueError(f"LTX-2 expected 1 or {batch_size} {name} timesteps, got {timestep.shape[0]}.")
+    if timestep.ndim == 2:
+        if timestep.shape[0] == 1:
+            return timestep[:, 0].expand(batch_size)
+        if timestep.shape[0] == batch_size:
+            return timestep[:, 0]
+        raise ValueError(f"LTX-2 expected tokenwise {name} timesteps for batch size {batch_size}, got {timestep.shape[0]}.")
+    raise ValueError(f"LTX-2 expected scalar, batch, or tokenwise {name} timesteps, got shape {tuple(timestep.shape)}.")
 
 
 def _ltx2_flash3_varlen_hub_attention(
@@ -198,6 +230,8 @@ def _ltx2_dispatch_attention(
             scale=None,
             is_causal=False,
         )
+    if backend_name == AttentionBackendName.FLASH_VARLEN_HUB:
+        attention_mask = _ltx2_normalize_varlen_mask(attention_mask, key.shape[0], key.shape[1])
     return dispatch_attention_fn(
         query,
         key,
@@ -214,6 +248,59 @@ def _store_hidden_state(buffer, key: str, hidden_states: torch.Tensor):
     if buffer is None:
         return
     buffer[key] = hidden_states
+
+
+def _ltx2_shard_cp_tensor(tensor: Optional[torch.Tensor], target_length: int, parallel_config, split_dim: int = 1):
+    if tensor is None:
+        return None
+    context_config = getattr(parallel_config, "context_parallel_config", None)
+    if context_config is None or tensor.dim() <= split_dim or tensor.shape[split_dim] == target_length:
+        return tensor
+    if tensor.shape[split_dim] < target_length:
+        return tensor
+
+    from diffusers.hooks.context_parallel import PartitionAnythingSharder
+
+    sharded = PartitionAnythingSharder.shard_anything(tensor, split_dim, context_config._flattened_mesh)
+    if sharded.shape[split_dim] != target_length:
+        raise ValueError(
+            f"LTX-2 context parallel shard length mismatch: got {sharded.shape[split_dim]}, expected {target_length}."
+        )
+    return sharded
+
+
+def _ltx2_shard_cp_rope(rope, target_length: int, parallel_config):
+    if rope is None:
+        return None
+    if isinstance(rope, tuple):
+        return tuple(_ltx2_shard_cp_rope(item, target_length, parallel_config) for item in rope)
+    split_dim = 2 if rope.dim() == 4 else 1
+    return _ltx2_shard_cp_tensor(rope, target_length, parallel_config, split_dim=split_dim)
+
+
+def _ltx2_prepare_attention_mask(
+    attn: "LTX2Attention",
+    attention_mask: torch.Tensor,
+    sequence_length: int,
+    batch_size: int,
+    parallel_config,
+) -> torch.Tensor:
+    attention_mask = attn.prepare_attention_mask(attention_mask, sequence_length, batch_size)
+    attention_mask = attention_mask.view(batch_size, attn.heads, -1, attention_mask.shape[-1])
+
+    context_config = getattr(parallel_config, "context_parallel_config", None)
+    if context_config is None or getattr(context_config, "ulysses_degree", 1) <= 1:
+        return attention_mask
+
+    key_length = sequence_length * context_config.ulysses_degree
+    mask_length = attention_mask.shape[-1]
+    if mask_length < key_length:
+        raise ValueError(
+            f"LTX-2 Ulysses attention mask length {mask_length} is shorter than attention key length {key_length}."
+        )
+    if mask_length > key_length:
+        attention_mask = attention_mask[..., -key_length:]
+    return attention_mask[:, :1]
 
 
 def apply_interleaved_rotary_emb(x: torch.Tensor, freqs: Tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
@@ -364,10 +451,13 @@ class LTX2AudioVideoAttnProcessor:
         batch_size, sequence_length, _ = (
             hidden_states.shape if encoder_hidden_states is None else encoder_hidden_states.shape
         )
+        is_self_attention = encoder_hidden_states is None
 
         if attention_mask is not None:
-            attention_mask = attn.prepare_attention_mask(attention_mask, sequence_length, batch_size)
-            attention_mask = attention_mask.view(batch_size, attn.heads, -1, attention_mask.shape[-1])
+            mask_parallel_config = self._parallel_config if is_self_attention else None
+            attention_mask = _ltx2_prepare_attention_mask(
+                attn, attention_mask, sequence_length, batch_size, mask_parallel_config
+            )
 
         if encoder_hidden_states is None:
             encoder_hidden_states = hidden_states
@@ -375,9 +465,7 @@ class LTX2AudioVideoAttnProcessor:
         if attn.to_gate_logits is not None:
             gate_logits = attn.to_gate_logits(hidden_states)
 
-        query = attn.to_q(hidden_states)
-        key = attn.to_k(encoder_hidden_states)
-        value = attn.to_v(encoder_hidden_states)
+        query, key, value = _ltx2_project_qkv(attn, hidden_states, encoder_hidden_states)
 
         query = attn.norm_q(query)
         key = attn.norm_k(key)
@@ -410,7 +498,7 @@ class LTX2AudioVideoAttnProcessor:
                 value,
                 attention_mask=attention_mask,
                 backend=self._attention_backend,
-                parallel_config=self._parallel_config,
+                parallel_config=self._parallel_config if is_self_attention else None,
             )
         hidden_states = self._flatten_attention_output(hidden_states, batch_size, attn)
         hidden_states = hidden_states.to(query.dtype)
@@ -426,7 +514,7 @@ class LTX2AudioVideoAttnProcessor:
         return hidden_states
 
 
-class LTX2PerturbedAttnProcessor:
+class LTX2PerturbedAttnProcessor(LTX2AudioVideoAttnProcessor):
     _attention_backend = None
     _packed_attention_backend = None
     _parallel_config = None
@@ -451,10 +539,13 @@ class LTX2PerturbedAttnProcessor:
         batch_size, sequence_length, _ = (
             hidden_states.shape if encoder_hidden_states is None else encoder_hidden_states.shape
         )
+        is_self_attention = encoder_hidden_states is None
 
         if attention_mask is not None:
-            attention_mask = attn.prepare_attention_mask(attention_mask, sequence_length, batch_size)
-            attention_mask = attention_mask.view(batch_size, attn.heads, -1, attention_mask.shape[-1])
+            mask_parallel_config = self._parallel_config if is_self_attention else None
+            attention_mask = _ltx2_prepare_attention_mask(
+                attn, attention_mask, sequence_length, batch_size, mask_parallel_config
+            )
 
         if encoder_hidden_states is None:
             encoder_hidden_states = hidden_states
@@ -462,16 +553,13 @@ class LTX2PerturbedAttnProcessor:
         if attn.to_gate_logits is not None:
             gate_logits = attn.to_gate_logits(hidden_states)
 
-        value = attn.to_v(encoder_hidden_states)
+        query, key, value = _ltx2_project_qkv(attn, hidden_states, encoder_hidden_states)
         if all_perturbed is None:
             all_perturbed = torch.all(perturbation_mask == 0) if perturbation_mask is not None else False
 
         if all_perturbed:
             hidden_states = value
         else:
-            query = attn.to_q(hidden_states)
-            key = attn.to_k(encoder_hidden_states)
-
             query = attn.norm_q(query)
             key = attn.norm_k(key)
 
@@ -505,7 +593,7 @@ class LTX2PerturbedAttnProcessor:
                     value,
                     attention_mask=attention_mask,
                     backend=self._attention_backend,
-                    parallel_config=self._parallel_config,
+                    parallel_config=self._parallel_config if is_self_attention else None,
                 )
             hidden_states = self._flatten_attention_output(hidden_states, batch_size, attn)
             hidden_states = hidden_states.to(query.dtype)
@@ -583,6 +671,51 @@ class LTX2Attention(torch.nn.Module, AttentionModuleMixin):
         if processor is None:
             processor = self._default_processor_cls()
         self.set_processor(processor)
+        self.fused_projections = False
+
+    @torch.no_grad()
+    def fuse_projections(self):
+        if getattr(self, "fused_projections", False):
+            return
+
+        device = self.to_q.weight.device
+        dtype = self.to_q.weight.dtype
+        if self.cross_attention_dim == self.query_dim:
+            concatenated_weights = torch.cat([self.to_q.weight.data, self.to_k.weight.data, self.to_v.weight.data])
+            self.to_qkv = nn.Linear(
+                concatenated_weights.shape[1],
+                concatenated_weights.shape[0],
+                bias=self.use_bias,
+                device=device,
+                dtype=dtype,
+            )
+            self.to_qkv.weight.copy_(concatenated_weights)
+            if self.use_bias:
+                self.to_qkv.bias.copy_(torch.cat([self.to_q.bias.data, self.to_k.bias.data, self.to_v.bias.data]))
+        else:
+            concatenated_weights = torch.cat([self.to_k.weight.data, self.to_v.weight.data])
+            self.to_kv = nn.Linear(
+                concatenated_weights.shape[1],
+                concatenated_weights.shape[0],
+                bias=self.use_bias,
+                device=device,
+                dtype=dtype,
+            )
+            self.to_kv.weight.copy_(concatenated_weights)
+            if self.use_bias:
+                self.to_kv.bias.copy_(torch.cat([self.to_k.bias.data, self.to_v.bias.data]))
+
+        self.fused_projections = True
+
+    @torch.no_grad()
+    def unfuse_projections(self):
+        if not getattr(self, "fused_projections", False):
+            return
+        if hasattr(self, "to_qkv"):
+            delattr(self, "to_qkv")
+        if hasattr(self, "to_kv"):
+            delattr(self, "to_kv")
+        self.fused_projections = False
 
     def forward(
         self,
@@ -1351,14 +1484,18 @@ class LTX2VideoTransformer3DModel(
     _cp_plan = {
         "": {
             "hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
-            "encoder_hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
-            "encoder_attention_mask": ContextParallelInput(split_dim=1, expected_dims=2, split_output=False),
+            "audio_hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
         },
         "rope": {
-            0: ContextParallelInput(split_dim=1, expected_dims=3, split_output=True),
-            1: ContextParallelInput(split_dim=1, expected_dims=3, split_output=True),
+            0: ContextParallelInput(split_dim=2, expected_dims=4, split_output=True),
+            1: ContextParallelInput(split_dim=2, expected_dims=4, split_output=True),
+        },
+        "audio_rope": {
+            0: ContextParallelInput(split_dim=2, expected_dims=4, split_output=True),
+            1: ContextParallelInput(split_dim=2, expected_dims=4, split_output=True),
         },
         "proj_out": ContextParallelOutput(gather_dim=1, expected_dims=3),
+        "audio_proj_out": ContextParallelOutput(gather_dim=1, expected_dims=3),
     }
 
     @register_to_config
@@ -1822,7 +1959,7 @@ class LTX2VideoTransformer3DModel(
                 if audio_sigma is None:
                     audio_sigma = audio_timestep if audio_timestep is not None else timestep
                 temb_prompt_audio, _ = self.audio_prompt_adaln(
-                    audio_sigma.flatten(),
+                    _ltx2_prompt_timesteps(audio_sigma, batch_size, "audio prompt"),
                     batch_size=batch_size,
                     hidden_dtype=audio_hidden_states.dtype,
                 )
@@ -2011,12 +2148,12 @@ class LTX2VideoTransformer3DModel(
             if audio_sigma is None:
                 audio_sigma = sigma
             temb_prompt, _ = self.prompt_adaln(
-                sigma.flatten(),
+                _ltx2_prompt_timesteps(sigma, batch_size, "video prompt"),
                 batch_size=batch_size,
                 hidden_dtype=hidden_states.dtype,
             )
             temb_prompt_audio, _ = self.audio_prompt_adaln(
-                audio_sigma.flatten(),
+                _ltx2_prompt_timesteps(audio_sigma, batch_size, "audio prompt"),
                 batch_size=batch_size,
                 hidden_dtype=audio_hidden_states.dtype,
             )
@@ -2091,6 +2228,37 @@ class LTX2VideoTransformer3DModel(
         saved_tokens = None
         current_video_rotary_emb = video_rotary_emb
         current_ca_video_rotary_emb = video_cross_attn_rotary_emb
+
+        parallel_config = getattr(self, "_parallel_config", None)
+        if getattr(parallel_config, "context_parallel_config", None) is not None:
+            video_sequence_length = hidden_states.shape[1]
+            audio_sequence_length = audio_hidden_states.shape[1]
+            temb = _ltx2_shard_cp_tensor(temb, video_sequence_length, parallel_config)
+            embedded_timestep = _ltx2_shard_cp_tensor(embedded_timestep, video_sequence_length, parallel_config)
+            temb_prompt = _ltx2_shard_cp_tensor(temb_prompt, video_sequence_length, parallel_config)
+            video_cross_attn_scale_shift = _ltx2_shard_cp_tensor(
+                video_cross_attn_scale_shift, video_sequence_length, parallel_config
+            )
+            video_cross_attn_a2v_gate = _ltx2_shard_cp_tensor(
+                video_cross_attn_a2v_gate, video_sequence_length, parallel_config
+            )
+            current_video_rotary_emb = _ltx2_shard_cp_rope(current_video_rotary_emb, video_sequence_length, parallel_config)
+            current_ca_video_rotary_emb = _ltx2_shard_cp_rope(
+                current_ca_video_rotary_emb, video_sequence_length, parallel_config
+            )
+
+            temb_audio = _ltx2_shard_cp_tensor(temb_audio, audio_sequence_length, parallel_config)
+            audio_embedded_timestep = _ltx2_shard_cp_tensor(audio_embedded_timestep, audio_sequence_length, parallel_config)
+            audio_cross_attn_scale_shift = _ltx2_shard_cp_tensor(
+                audio_cross_attn_scale_shift, audio_sequence_length, parallel_config
+            )
+            audio_cross_attn_v2a_gate = _ltx2_shard_cp_tensor(
+                audio_cross_attn_v2a_gate, audio_sequence_length, parallel_config
+            )
+            audio_rotary_emb = _ltx2_shard_cp_rope(audio_rotary_emb, audio_sequence_length, parallel_config)
+            audio_cross_attn_rotary_emb = _ltx2_shard_cp_rope(
+                audio_cross_attn_rotary_emb, audio_sequence_length, parallel_config
+            )
 
         if routes:
             total_layers = len(self.transformer_blocks)

--- a/tests/test_ltxvideo2_attention.py
+++ b/tests/test_ltxvideo2_attention.py
@@ -39,6 +39,35 @@ class TestLTX2AttentionDispatch(unittest.TestCase):
         eager_attention.assert_called_once()
         compiled_attention.assert_not_called()
 
+    def test_flash_varlen_hub_receives_bool_mask(self):
+        query = torch.randn(1, 2, 1, 4)
+        key = torch.randn(1, 3, 1, 4)
+        value = torch.randn(1, 3, 1, 4)
+        additive_mask = torch.tensor([[[[0.0, -10000.0, 0.0]]]], dtype=torch.bfloat16)
+        expected = torch.randn(1, 2, 1, 4)
+
+        with patch.object(ltx2_transformer, "dispatch_attention_fn", return_value=expected) as dispatch_attention:
+            result = ltx2_transformer._ltx2_dispatch_attention(
+                query=query,
+                key=key,
+                value=value,
+                attention_mask=additive_mask,
+                backend=AttentionBackendName.FLASH_VARLEN_HUB,
+                parallel_config=None,
+            )
+
+        self.assertIs(result, expected)
+        forwarded_mask = dispatch_attention.call_args.kwargs["attn_mask"]
+        self.assertEqual(forwarded_mask.dtype, torch.bool)
+        self.assertTrue(torch.equal(forwarded_mask, torch.tensor([[True, False, True]])))
+
+    def test_prompt_timesteps_use_batch_axis_from_tokenwise_timesteps(self):
+        timesteps = torch.tensor([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+
+        prompt_timesteps = ltx2_transformer._ltx2_prompt_timesteps(timesteps, batch_size=2, name="video prompt")
+
+        self.assertTrue(torch.equal(prompt_timesteps, torch.tensor([0.1, 0.4])))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ltxvideo2_model.py
+++ b/tests/test_ltxvideo2_model.py
@@ -1,0 +1,56 @@
+import unittest
+
+import torch
+
+from simpletuner.helpers.models.ltxvideo2.model import _align_ltx2_connector_attention_mask, _pad_ltx2_audio_sequence_for_cp
+from simpletuner.helpers.models.ltxvideo2.transformer import LTX2AudioVideoAttnProcessor, LTX2PerturbedAttnProcessor
+
+
+class TestLTXVideo2ModelHelpers(unittest.TestCase):
+    def test_align_connector_attention_mask_keeps_matching_length(self):
+        attention_mask = torch.tensor([[1, 0, 1]])
+
+        aligned = _align_ltx2_connector_attention_mask(attention_mask, 3)
+
+        self.assertIs(aligned, attention_mask)
+
+    def test_align_connector_attention_mask_crops_left_padding(self):
+        attention_mask = torch.tensor([[0, 0, 1, 1, 1]])
+
+        aligned = _align_ltx2_connector_attention_mask(attention_mask, 3)
+
+        self.assertTrue(torch.equal(aligned, torch.tensor([[1, 1, 1]])))
+
+    def test_align_connector_attention_mask_rejects_short_mask(self):
+        attention_mask = torch.tensor([[1, 1]])
+
+        with self.assertRaisesRegex(ValueError, "shorter than connector sequence length"):
+            _align_ltx2_connector_attention_mask(attention_mask, 3)
+
+    def test_pad_audio_sequence_for_alltoall_cp(self):
+        audio = torch.ones(2, 17, 4)
+
+        padded, audio_num_frames = _pad_ltx2_audio_sequence_for_cp(audio, 17, 2, "alltoall")
+
+        self.assertEqual(padded.shape, (2, 18, 4))
+        self.assertEqual(audio_num_frames, 18)
+        self.assertTrue(torch.equal(padded[:, :17], audio))
+        self.assertTrue(torch.equal(padded[:, 17:], torch.zeros_like(padded[:, 17:])))
+
+    def test_pad_audio_sequence_for_cp_ignores_allgather(self):
+        audio = torch.ones(2, 17, 4)
+
+        padded, audio_num_frames = _pad_ltx2_audio_sequence_for_cp(audio, 17, 2, "allgather")
+
+        self.assertIs(padded, audio)
+        self.assertEqual(audio_num_frames, 17)
+
+    def test_perturbed_processor_reuses_attention_output_flattening(self):
+        self.assertIs(
+            LTX2PerturbedAttnProcessor._flatten_attention_output,
+            LTX2AudioVideoAttnProcessor._flatten_attention_output,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the LTXVideo2 model and its transformer, primarily to enhance support for context parallelism, improve attention mask handling, and optimize projection operations. The changes are grouped below by theme for clarity.

**Context Parallelism and Attention Mask Handling:**

* Added `_pad_ltx2_audio_sequence_for_cp` and `_align_ltx2_connector_attention_mask` helper functions in `model.py` to ensure audio sequences and attention masks are properly aligned and padded for context parallelism, preventing shape mismatches and related errors. [[1]](diffhunk://#diff-64820a284b076801c442da19649e63dc4a2e00e645d7f92abbc5754b3dbae22fR67-R99) [[2]](diffhunk://#diff-64820a284b076801c442da19649e63dc4a2e00e645d7f92abbc5754b3dbae22fR1910-R1918) [[3]](diffhunk://#diff-64820a284b076801c442da19649e63dc4a2e00e645d7f92abbc5754b3dbae22fR1934-R1939) [[4]](diffhunk://#diff-64820a284b076801c442da19649e63dc4a2e00e645d7f92abbc5754b3dbae22fL1938-R1992) [[5]](diffhunk://#diff-64820a284b076801c442da19649e63dc4a2e00e645d7f92abbc5754b3dbae22fR2042-R2043)
* Improved attention mask preparation with the new `_ltx2_prepare_attention_mask` function, which adapts masks for context parallelism and Ulysses attention, and integrated this into the attention processor call paths. [[1]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3R253-R305) [[2]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3R454-R468) [[3]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3L413-R501) [[4]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3R542-L474) [[5]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3L508-R596)
* Updated the context parallel plan (`_cp_plan`) in `LTX2VideoTransformer3DModel` to better handle sharding for audio and video rope and projection outputs, including new entries for audio-specific tensors.

**Attention and Projection Optimizations:**

* Added fused QKV projection support to the attention module, including methods to fuse and unfuse projections, and logic to use fused projections when available for efficiency. [[1]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3R92-R105) [[2]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3R674-R718)
* Refactored QKV projection logic into a dedicated `_ltx2_project_qkv` helper, simplifying the main attention processor logic and supporting fused projections. [[1]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3R92-R105) [[2]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3R454-R468) [[3]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3R542-L474)

**Prompt and Timestep Handling:**

* Added `_ltx2_prompt_timesteps` utility to robustly expand or validate prompt timesteps for batch or tokenwise usage, and updated all prompt/adaptive layer normalization calls to use it. [[1]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3R144-R161) [[2]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3L1825-R1962) [[3]](diffhunk://#diff-a06422ed17c169eaed415c8df7bcf9ea880bd5d3d626b362c5f0ccd3f30fa5f3L2014-R2156)

**Debugging and Miscellaneous Improvements:**

* Added debug logging for tensor shapes in context parallel mode to aid in diagnosing shape mismatches.
* Ensured correct slicing of `audio_pred` when padding is added for context parallelism, preventing output shape errors.
* Made `LTX2PerturbedAttnProcessor` inherit from `LTX2AudioVideoAttnProcessor` for consistency and code reuse.

These changes collectively improve the model's robustness, maintainability, and performance when running in context-parallel and distributed environments.