### PR TITLE
add packed attn processors tests

### DIFF
--- a/tests/test_packed_attention_processors.py
+++ b/tests/test_packed_attention_processors.py
@@ -6,8 +6,13 @@ import torch
 from diffusers.models.attention_processor import Attention
 
 from simpletuner.helpers.models.chroma.transformer import ChromaTransformer2DModel
+from simpletuner.helpers.models.flux2.transformer import Flux2Attention, Flux2ParallelSelfAttention
 from simpletuner.helpers.models.flux.attention import FluxFusedFlashAttnProcessor3
-from simpletuner.helpers.models.ltxvideo2.transformer import LTX2Attention, LTX2VideoTransformer3DModel
+from simpletuner.helpers.models.ltxvideo2.transformer import (
+    LTX2Attention,
+    LTX2VideoTransformer3DModel,
+    _ltx2_prepare_attention_mask,
+)
 from simpletuner.helpers.models.lumina2.transformer import Lumina2PackedAttnProcessor2_0
 from simpletuner.helpers.training.packed_attention_processors import (
     PackedAuraFlowAttnProcessor2_0,
@@ -164,6 +169,54 @@ class PackedAttentionProcessorTests(unittest.TestCase):
         self.assertEqual(output.shape, hidden_states.shape)
         self.assertEqual(backend.calls[0]["shape"], (2, 5, 3, 2, 4))
 
+    def test_ltx2_self_attention_uses_fused_projection_after_split_layers_removed(self):
+        backend = _FakePackedBackend()
+        attn = LTX2Attention(query_dim=8, heads=2, kv_heads=2, dim_head=4, bias=True, out_bias=True)
+        attn.fuse_projections()
+        delattr(attn, "to_q")
+        delattr(attn, "to_k")
+        delattr(attn, "to_v")
+        attn.processor._packed_attention_backend = "flash2-hub"
+        hidden_states = torch.randn(2, 5, 8)
+
+        with self._patch_backend(backend):
+            output = attn(hidden_states)
+
+        self.assertEqual(output.shape, hidden_states.shape)
+        self.assertEqual(backend.calls[0]["shape"], (2, 5, 3, 2, 4))
+
+    def test_ltx2_cross_attention_fuses_kv_for_different_context_dim(self):
+        attn = LTX2Attention(
+            query_dim=8,
+            cross_attention_dim=12,
+            heads=2,
+            kv_heads=2,
+            dim_head=4,
+            bias=True,
+            out_bias=True,
+        )
+        attn.fuse_projections()
+        delattr(attn, "to_k")
+        delattr(attn, "to_v")
+        hidden_states = torch.randn(2, 5, 8)
+        encoder_hidden_states = torch.randn(2, 3, 12)
+
+        output = attn(hidden_states, encoder_hidden_states=encoder_hidden_states)
+
+        self.assertEqual(output.shape, hidden_states.shape)
+        self.assertTrue(hasattr(attn, "to_kv"))
+        self.assertFalse(hasattr(attn, "to_qkv"))
+
+    def test_ltx2_ulysses_attention_mask_uses_post_exchange_key_length(self):
+        attn = LTX2Attention(query_dim=8, heads=4, kv_heads=4, dim_head=2)
+        attention_mask = torch.tensor([[-10000, -10000, 0, 0, 0, 0, 0, 0]], dtype=torch.float32)
+        parallel_config = SimpleNamespace(context_parallel_config=SimpleNamespace(ulysses_anything=True, ulysses_degree=2))
+
+        prepared = _ltx2_prepare_attention_mask(attn, attention_mask, 3, 1, parallel_config)
+
+        self.assertEqual(prepared.shape, (1, 1, 1, 6))
+        self.assertTrue(torch.equal(prepared, torch.zeros_like(prepared)))
+
     def test_chroma_transformer_fuse_installs_flux_packed_processor(self):
         backend = _FakePackedBackend()
         model = ChromaTransformer2DModel(
@@ -189,19 +242,76 @@ class PackedAttentionProcessorTests(unittest.TestCase):
         self.assertNotIsInstance(model.transformer_blocks[0].attn.processor, FluxFusedFlashAttnProcessor3)
         self.assertNotIsInstance(model.single_transformer_blocks[0].attn.processor, FluxFusedFlashAttnProcessor3)
 
+    def test_flux2_double_stream_context_parallel_uses_distributed_dispatch(self):
+        parallel_config = SimpleNamespace(context_parallel_config=SimpleNamespace(ulysses_degree=2))
+        attn = Flux2Attention(
+            query_dim=8,
+            heads=2,
+            dim_head=4,
+            added_kv_proj_dim=8,
+            out_dim=8,
+        )
+        attn.processor._parallel_config = parallel_config
+        attn.processor._packed_attention_backend = "flash2-hub"
+        hidden_states = torch.randn(1, 2, 8)
+        encoder_hidden_states = torch.randn(1, 2, 8)
+        attention_mask = torch.ones(1, 8, dtype=torch.bool)
+
+        with (
+            patch("simpletuner.helpers.models.flux2.transformer._run_packed_qkv_attention") as packed,
+            patch(
+                "simpletuner.helpers.models.flux2.transformer.dispatch_attention_fn",
+                side_effect=lambda query, *_args, **_kwargs: torch.zeros_like(query),
+            ) as dispatch,
+        ):
+            sample, context = attn.processor(
+                attn,
+                hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                attention_mask=attention_mask,
+            )
+
+        packed.assert_not_called()
+        self.assertEqual(sample.shape, hidden_states.shape)
+        self.assertEqual(context.shape, encoder_hidden_states.shape)
+        self.assertIs(dispatch.call_args.kwargs["parallel_config"], parallel_config)
+        self.assertEqual(dispatch.call_args.kwargs["attn_mask"].shape, (1, 1, 1, 8))
+
+    def test_flux2_single_stream_context_parallel_uses_distributed_dispatch(self):
+        parallel_config = SimpleNamespace(context_parallel_config=SimpleNamespace(ulysses_degree=2))
+        attn = Flux2ParallelSelfAttention(query_dim=8, heads=2, dim_head=4, out_dim=8, mlp_ratio=1.0)
+        attn.processor._parallel_config = parallel_config
+        attn.processor._packed_attention_backend = "flash2-hub"
+        hidden_states = torch.randn(1, 3, 8)
+        attention_mask = torch.ones(1, 6, dtype=torch.bool)
+
+        with (
+            patch("simpletuner.helpers.models.flux2.transformer._run_packed_qkv_attention") as packed,
+            patch(
+                "simpletuner.helpers.models.flux2.transformer.dispatch_attention_fn",
+                side_effect=lambda query, *_args, **_kwargs: torch.zeros_like(query),
+            ) as dispatch,
+        ):
+            output = attn.processor(attn, hidden_states, attention_mask=attention_mask)
+
+        packed.assert_not_called()
+        self.assertEqual(output.shape, hidden_states.shape)
+        self.assertIs(dispatch.call_args.kwargs["parallel_config"], parallel_config)
+        self.assertEqual(dispatch.call_args.kwargs["attn_mask"].shape, (1, 1, 1, 6))
+
     def test_ltx2_transformer_fuse_enables_packed_self_attention_processors(self):
         model = LTX2VideoTransformer3DModel(
             in_channels=4,
             out_channels=4,
             num_attention_heads=2,
             attention_head_dim=4,
-            cross_attention_dim=8,
+            cross_attention_dim=12,
             audio_in_channels=4,
             audio_out_channels=4,
-            audio_num_attention_heads=2,
+            audio_num_attention_heads=1,
             audio_attention_head_dim=4,
-            audio_cross_attention_dim=8,
-            caption_channels=8,
+            audio_cross_attention_dim=10,
+            caption_channels=12,
             num_layers=1,
         )
 
@@ -210,6 +320,12 @@ class PackedAttentionProcessorTests(unittest.TestCase):
         self.assertEqual(block.attn1.processor._packed_attention_backend, "flash2-hub")
         self.assertEqual(block.audio_attn1.processor._packed_attention_backend, "flash2-hub")
         self.assertEqual(block.attn2.processor._packed_attention_backend, "flash2-hub")
+        self.assertTrue(hasattr(block.attn1, "to_qkv"))
+        self.assertTrue(hasattr(block.audio_attn1, "to_qkv"))
+        self.assertTrue(hasattr(block.attn2, "to_kv"))
+        self.assertTrue(hasattr(block.audio_attn2, "to_kv"))
+        self.assertTrue(hasattr(block.audio_to_video_attn, "to_kv"))
+        self.assertTrue(hasattr(block.video_to_audio_attn, "to_kv"))
         model.unfuse_qkv_projections()
         self.assertIsNone(block.attn1.processor._packed_attention_backend)
         self.assertIsNone(block.audio_attn1.processor._packed_attention_backend)


### PR DESCRIPTION
This pull request adds comprehensive new tests for packed and parallel attention mechanisms in various transformer models, focusing on validating the correct use of fused projections, distributed dispatch, and attention mask preparation. The changes ensure that attention modules behave correctly when certain layers are fused or removed and that parallel context configurations are properly handled.

**Expanded testing for attention mechanisms:**

* Added tests to verify that `LTX2Attention` uses fused projections correctly after split layers are removed, and that cross-attention fuses key/value projections when the context dimension differs. Also added a test to ensure the attention mask is prepared correctly for Ulysses-style context parallelism.
* Enhanced the `test_ltx2_transformer_fuse_enables_packed_self_attention_processors` to check for the presence of fused projection attributes (`to_qkv`, `to_kv`) on various attention modules after fusion.

**Testing distributed dispatch in Flux2 attention:**

* Added tests to confirm that both double-stream (`Flux2Attention`) and single-stream (`Flux2ParallelSelfAttention`) attention modules use distributed dispatch (not packed QKV attention) when context parallelism is enabled, and that the correct parallel configuration and attention mask shapes are passed to the dispatch function.

**Test setup improvements:**

* Updated import statements to include new attention classes and utility functions required for the new tests, such as `Flux2Attention`, `Flux2ParallelSelfAttention`, and `_ltx2_prepare_attention_mask`.

**Test data adjustments:**

* Modified model instantiations in tests to use new or corrected dimensions for cross-attention and audio-related parameters, aligning with the updated attention module requirements.

These changes significantly improve test coverage and reliability for complex attention mechanisms in the codebase.