### PR TITLE
validation: allow a single video to generate across multiple GPUs with context-parallel over replicated weights

### DIFF
--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -55,6 +55,7 @@ from diffusers.utils.torch_utils import is_compiled_module
 from PIL import Image, ImageDraw, ImageFont
 from transformers.utils import ContextManagers
 
+from simpletuner.helpers.data_backend.runtime.context_parallel_sync import get_cp_info, get_model_replica_data_info
 from simpletuner.helpers.image_manipulation.brightness import calculate_luminance
 from simpletuner.helpers.models.common import PipelineTypes, PredictionTypes
 from simpletuner.helpers.models.cosmos.scheduler import RectifiedFlowAB2Scheduler
@@ -1739,7 +1740,38 @@ class Validation:
         return mode
 
     def _use_distributed_validation(self) -> bool:
-        return self._validation_multigpu_mode() == "batch-parallel"
+        return self._validation_multigpu_mode() == "batch-parallel" or self._use_context_parallel_validation()
+
+    def _context_parallel_validation_info(self) -> tuple[bool, int, int, int, int]:
+        cp_info = get_cp_info(self.accelerator)
+        if not cp_info[0]:
+            return False, 0, 0, 1, 1
+        return get_model_replica_data_info(self.accelerator, cp_info)
+
+    def _use_context_parallel_validation(self) -> bool:
+        cp_enabled, *_ = self._context_parallel_validation_info()
+        return cp_enabled
+
+    def _split_validation_work_items(
+        self, work_items: list[_ValidationWorkItem]
+    ) -> tuple[list[_ValidationWorkItem], bool, int]:
+        use_distributed = self._use_distributed_validation()
+        if not use_distributed:
+            return work_items, False, 1
+
+        cp_enabled, data_rank, _data_local_rank, _data_group_size, data_parallel_size = (
+            self._context_parallel_validation_info()
+        )
+        if cp_enabled:
+            return work_items[data_rank::data_parallel_size], True, data_parallel_size
+
+        return split_across_processes(self.accelerator, work_items), True, getattr(self.accelerator, "num_processes", 1)
+
+    def _should_publish_validation_payloads(self) -> bool:
+        cp_enabled, _data_rank, data_local_rank, _data_group_size, _data_parallel_size = (
+            self._context_parallel_validation_info()
+        )
+        return not cp_enabled or data_local_rank == 0
 
     def _validation_seed_source(self):
         if self.config.validation_seed_source == "gpu":
@@ -3281,26 +3313,28 @@ class Validation:
             return
 
         work_items = self._prepare_validation_work_items(_content)
-        use_distributed = self._use_distributed_validation()
-        num_processes = getattr(self.accelerator, "num_processes", 1)
+        local_work_items, use_distributed, validation_worker_count = self._split_validation_work_items(work_items)
+        cp_validation_enabled = self._use_context_parallel_validation()
 
         # Disable batch-parallel if we don't have enough prompts to meaningfully split
-        # This avoids collective communication deadlocks when some processes get empty work
-        if use_distributed and len(work_items) < num_processes:
+        # This avoids collective communication deadlocks when some processes get empty work.
+        # CP validation is model-parallel: one prompt can legitimately occupy a full CP group.
+        if use_distributed and not cp_validation_enabled and len(work_items) < validation_worker_count:
             use_distributed = False
             logger.info(
-                f"Disabling batch-parallel for validation: {len(work_items)} prompt(s) < {num_processes} processes. "
+                f"Disabling batch-parallel for validation: {len(work_items)} prompt(s) < {validation_worker_count} processes. "
                 f"Only main process will execute."
             )
             # When falling back to single-process, only main process should continue
             if not self.accelerator.is_main_process:
                 return
+            local_work_items = work_items
 
-        local_work_items = split_across_processes(self.accelerator, work_items) if use_distributed else work_items
         rank = getattr(self.accelerator, "process_index", 0)
         logger.info(
             f"[Rank {rank}] Processing {len(local_work_items)} local validation work items "
             f"(distributed_mode={use_distributed}, total={len(work_items)}, "
+            f"validation_worker_count={validation_worker_count}, cp_validation={cp_validation_enabled}, "
             f"work_item_prompts={[item.prompt for item in local_work_items]})"
         )
         progress_disable = use_distributed and not self.accelerator.is_main_process
@@ -3323,7 +3357,8 @@ class Validation:
                 decorated_shortname=decorated_shortname,
                 validation_type=validation_type,
             )
-            local_payloads.append(payload)
+            if self._should_publish_validation_payloads():
+                local_payloads.append(payload)
 
             # In non-distributed mode, apply results immediately after each prompt completes
             if not use_distributed:

--- a/tests/test_validation_context_parallel.py
+++ b/tests/test_validation_context_parallel.py
@@ -1,0 +1,90 @@
+import unittest
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from simpletuner.helpers.training.validation import Validation, _ValidationWorkItem
+
+
+def _validation_for_rank(rank: int, *, world_size: int = 8):
+    validation = Validation.__new__(Validation)
+    validation.accelerator = SimpleNamespace(
+        num_processes=world_size,
+        process_index=rank,
+        is_main_process=rank == 0,
+    )
+    validation.config = SimpleNamespace(validation_multigpu="batch-parallel")
+    return validation
+
+
+def _work_items(count: int):
+    return [
+        _ValidationWorkItem(
+            index=idx,
+            shortname=f"item_{idx}",
+            prompt=f"prompt {idx}",
+            conditioning=None,
+            adapter_strength=None,
+        )
+        for idx in range(count)
+    ]
+
+
+class ValidationContextParallelTests(unittest.TestCase):
+    @contextmanager
+    def _patch_cp(self, *, data_rank: int, data_local_rank: int, data_parallel_size: int = 4):
+        with (
+            patch("simpletuner.helpers.training.validation.get_cp_info", return_value=(True, object(), 0, 2)),
+            patch(
+                "simpletuner.helpers.training.validation.get_model_replica_data_info",
+                return_value=(True, data_rank, data_local_rank, 2, data_parallel_size),
+            ),
+        ):
+            yield
+
+    def test_context_parallel_splits_prompts_by_model_replica(self):
+        items = _work_items(5)
+        validation = _validation_for_rank(2)
+        with self._patch_cp(data_rank=1, data_local_rank=0):
+            local_items, use_distributed, worker_count = validation._split_validation_work_items(items)
+
+        self.assertTrue(use_distributed)
+        self.assertEqual(worker_count, 4)
+        self.assertEqual([item.index for item in local_items], [1])
+
+    def test_context_parallel_replicates_prompt_within_cp_group(self):
+        items = _work_items(3)
+        leader = _validation_for_rank(0)
+        peer = _validation_for_rank(1)
+
+        with self._patch_cp(data_rank=0, data_local_rank=0):
+            leader_items, _, _ = leader._split_validation_work_items(items)
+        with self._patch_cp(data_rank=0, data_local_rank=1):
+            peer_items, _, _ = peer._split_validation_work_items(items)
+
+        self.assertEqual([item.index for item in leader_items], [0])
+        self.assertEqual([item.index for item in peer_items], [0])
+
+    def test_context_parallel_only_leader_publishes_payloads(self):
+        leader = _validation_for_rank(0)
+        peer = _validation_for_rank(1)
+
+        with self._patch_cp(data_rank=0, data_local_rank=0):
+            self.assertTrue(leader._should_publish_validation_payloads())
+        with self._patch_cp(data_rank=0, data_local_rank=1):
+            self.assertFalse(peer._should_publish_validation_payloads())
+
+    def test_context_parallel_keeps_single_prompt_distributed(self):
+        validation = _validation_for_rank(0)
+        items = _work_items(1)
+
+        with self._patch_cp(data_rank=0, data_local_rank=0):
+            local_items, use_distributed, worker_count = validation._split_validation_work_items(items)
+
+        self.assertTrue(use_distributed)
+        self.assertEqual(worker_count, 4)
+        self.assertEqual([item.index for item in local_items], [0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request adds support for context-parallel (CP) distributed validation in the `Validation` workflow, allowing validation work to be split and coordinated across model replicas in addition to the existing batch-parallel mode. It introduces new logic to determine when CP validation should be used, how prompts are distributed among replicas, and ensures only the appropriate process publishes validation results. Comprehensive unit tests are included to verify the new behavior.

**Context-parallel validation support:**

* Added imports and logic to integrate context-parallel information using `get_cp_info` and `get_model_replica_data_info` in `validation.py`.
* Implemented `_context_parallel_validation_info`, `_use_context_parallel_validation`, `_split_validation_work_items`, and `_should_publish_validation_payloads` methods to support CP validation, prompt distribution, and leader-only publishing.

**Validation work distribution improvements:**

* Updated `process_prompts` to use the new `_split_validation_work_items` logic, handle CP-specific distributed conditions, and avoid deadlocks by falling back to single-process mode when needed.
* Ensured only the leader in each CP group publishes validation payloads by checking `_should_publish_validation_payloads` before appending to `local_payloads`.

**Testing:**

* Added a new test suite `test_validation_context_parallel.py` with tests for CP prompt splitting, prompt replication within groups, leader-only publishing, and behavior with a single prompt.