### PR TITLE
TorchAO pipeline-level quantisation improvements

### DIFF
--- a/simpletuner/helpers/training/quantisation/__init__.py
+++ b/simpletuner/helpers/training/quantisation/__init__.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from functools import partial
+from inspect import Parameter, signature
 from typing import Any, Callable, Mapping, Optional
 
 import torch
@@ -112,6 +113,60 @@ def _get_torchao_config_cls(component_type: str):
     return TorchAoConfig
 
 
+TORCHAO_QUANT_TYPE_CONFIG_MAP = {
+    "float8_dynamic_activation_float8_weight": "Float8DynamicActivationFloat8WeightConfig",
+    "float8_dynamic_activation_int4_weight": "Float8DynamicActivationInt4WeightConfig",
+    "int4_weight_only": "Int4WeightOnlyConfig",
+    "int8_dynamic_activation_int8_weight": "Int8DynamicActivationInt8WeightConfig",
+    "int8_dynamic_activation_intx_weight": "Int8DynamicActivationIntxWeightConfig",
+    "int8_weight_only": "Int8WeightOnlyConfig",
+    "float8_weight_only": "Float8WeightOnlyConfig",
+}
+
+
+def _normalize_torchao_quant_type_kwargs(quant_type_kwargs: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = dict(quant_type_kwargs)
+    for key, value in list(normalized.items()):
+        if key.endswith("_dtype"):
+            normalized[key] = _normalize_dtype(value)
+    return normalized
+
+
+def _build_torchao_quant_type(quant_type: Any, quant_type_kwargs: Mapping[str, Any]):
+    from torchao.quantization import quant_api
+    from torchao.quantization.quant_api import AOBaseConfig
+
+    if isinstance(quant_type, AOBaseConfig):
+        if quant_type_kwargs:
+            raise ValueError("quant_type_kwargs cannot be used when quant_type is already a TorchAO config instance.")
+        return quant_type
+    if not isinstance(quant_type, str):
+        raise TypeError(
+            "quant_type must be a TorchAO quantization name or AOBaseConfig instance, " f"got {type(quant_type).__name__}"
+        )
+
+    config_cls_name = TORCHAO_QUANT_TYPE_CONFIG_MAP.get(quant_type)
+    if config_cls_name is None:
+        raise ValueError(
+            f"Unsupported TorchAO quant_type '{quant_type}'. Supported values: "
+            f"{', '.join(sorted(TORCHAO_QUANT_TYPE_CONFIG_MAP))}."
+        )
+    config_cls = getattr(quant_api, config_cls_name)
+    return config_cls(**_normalize_torchao_quant_type_kwargs(quant_type_kwargs))
+
+
+def _split_torchao_config_kwargs(torchao_cls, override_dict: dict[str, Any], quant_type_kwargs: Mapping[str, Any]):
+    outer_keys = {
+        name
+        for name, parameter in signature(torchao_cls.__init__).parameters.items()
+        if name not in {"self", "quant_type"} and parameter.kind is not Parameter.VAR_KEYWORD
+    }
+    outer_kwargs = {key: override_dict.pop(key) for key in list(override_dict) if key in outer_keys}
+    inner_kwargs = dict(override_dict)
+    inner_kwargs.update(quant_type_kwargs)
+    return outer_kwargs, inner_kwargs
+
+
 def _build_torchao_config(
     weight_dtype=None,
     overrides: Optional[Mapping[str, Any]] = None,
@@ -129,11 +184,26 @@ def _build_torchao_config(
 
     override_dict = dict(overrides) if isinstance(overrides, Mapping) else {}
     quant_type_override = override_dict.pop("quant_type", None)
-    quant_type_kwargs = override_dict.pop("quant_type_kwargs", None)
-    if isinstance(quant_type_kwargs, Mapping):
-        override_dict.update(quant_type_kwargs)
+    quant_type_kwargs = override_dict.pop("quant_type_kwargs", {})
+    if quant_type_kwargs is None:
+        quant_type_kwargs = {}
+    if not isinstance(quant_type_kwargs, Mapping):
+        raise TypeError(f"quant_type_kwargs must be a mapping, got {type(quant_type_kwargs).__name__}")
     quant_type_override = quant_type_override or default_quant_type
-    return torchao_cls(quant_type=quant_type_override, **override_dict)
+    outer_kwargs, inner_kwargs = _split_torchao_config_kwargs(
+        torchao_cls,
+        override_dict,
+        quant_type_kwargs,
+    )
+    quant_type = _build_torchao_quant_type(quant_type_override, inner_kwargs)
+    return torchao_cls(quant_type=quant_type, **outer_kwargs)
+
+
+TORCHAO_PIPELINE_PRESET_MAP = {
+    "int4-torchao": "int4_weight_only",
+    "int8-torchao": "int8_weight_only",
+    "fp8-torchao": "float8_weight_only",
+}
 
 
 def _get_quanto_config_cls(component_type: str):
@@ -197,11 +267,6 @@ def _build_quanto_fp8uz_config(
     )
 
 
-TORCHAO_PIPELINE_PRESET_MAP = {
-    "int4-torchao": "int4_weight_only",
-    "int8-torchao": "int8_weight_only",
-    "fp8-torchao": "float8_weight_only",
-}
 QUANTO_PIPELINE_PRESET_MAP = {
     "int8-quanto": "int8",
     "int4-quanto": "int4",

--- a/tests/test_torchao_pipeline_quantization.py
+++ b/tests/test_torchao_pipeline_quantization.py
@@ -1,0 +1,95 @@
+import unittest
+
+from simpletuner.helpers.training.quantisation import get_pipeline_quantization_builder
+
+
+class TestTorchAoPipelineQuantization(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            from torchao.quantization.quant_api import (
+                AOBaseConfig,
+                Float8DynamicActivationInt4WeightConfig,
+                Float8WeightOnlyConfig,
+                Int4WeightOnlyConfig,
+                Int8DynamicActivationIntxWeightConfig,
+                Int8WeightOnlyConfig,
+            )
+        except ImportError as exc:
+            raise unittest.SkipTest(f"torchao config classes are unavailable: {exc}") from exc
+
+        cls.AOBaseConfig = AOBaseConfig
+        cls.Float8DynamicActivationInt4WeightConfig = Float8DynamicActivationInt4WeightConfig
+        cls.Float8WeightOnlyConfig = Float8WeightOnlyConfig
+        cls.Int4WeightOnlyConfig = Int4WeightOnlyConfig
+        cls.Int8DynamicActivationIntxWeightConfig = Int8DynamicActivationIntxWeightConfig
+        cls.Int8WeightOnlyConfig = Int8WeightOnlyConfig
+
+    def test_torchao_pipeline_presets_build_ao_config_instances(self):
+        expected_quant_types = {
+            "int4-torchao": self.Int4WeightOnlyConfig,
+            "int8-torchao": self.Int8WeightOnlyConfig,
+            "fp8-torchao": self.Float8WeightOnlyConfig,
+        }
+
+        for preset, expected_quant_type in expected_quant_types.items():
+            with self.subTest(preset=preset):
+                builder = get_pipeline_quantization_builder(preset)
+                config = builder(component_type="diffusers")
+
+                self.assertIsInstance(config.quant_type, self.AOBaseConfig)
+                self.assertIsInstance(config.quant_type, expected_quant_type)
+
+    def test_torchao_pipeline_quant_type_kwargs_apply_to_inner_config(self):
+        builder = get_pipeline_quantization_builder("int8-torchao")
+        config = builder(
+            overrides={
+                "quant_type": "int4_weight_only",
+                "quant_type_kwargs": {"group_size": 64},
+                "modules_to_not_convert": ["proj_out"],
+            },
+            component_type="diffusers",
+        )
+
+        self.assertIsInstance(config.quant_type, self.Int4WeightOnlyConfig)
+        self.assertEqual(config.quant_type.group_size, 64)
+        self.assertEqual(config.modules_to_not_convert, ["proj_out"])
+
+    def test_torchao_pipeline_top_level_quant_kwargs_are_preserved(self):
+        builder = get_pipeline_quantization_builder("int8-torchao")
+        config = builder(
+            overrides={
+                "group_size": 64,
+                "include_input_output_embeddings": True,
+            },
+            component_type="transformers",
+        )
+
+        self.assertIsInstance(config.quant_type, self.Int8WeightOnlyConfig)
+        self.assertEqual(config.quant_type.group_size, 64)
+        self.assertTrue(config.include_input_output_embeddings)
+
+    def test_torchao_pipeline_supports_dynamic_activation_int4_weight_configs(self):
+        cases = {
+            "float8_dynamic_activation_int4_weight": self.Float8DynamicActivationInt4WeightConfig,
+            "int8_dynamic_activation_intx_weight": self.Int8DynamicActivationIntxWeightConfig,
+        }
+
+        for quant_type, expected_type in cases.items():
+            with self.subTest(quant_type=quant_type):
+                builder = get_pipeline_quantization_builder("int4-torchao")
+                config = builder(
+                    overrides={
+                        "quant_type": quant_type,
+                        "quant_type_kwargs": {"weight_dtype": "int4"} if quant_type.startswith("int8_") else {},
+                    },
+                    component_type="diffusers",
+                )
+
+                self.assertIsInstance(config.quant_type, expected_type)
+                if quant_type.startswith("int8_"):
+                    self.assertEqual(str(config.quant_type.weight_dtype), "torch.int4")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2778 

This pull request adds support for more flexible and robust TorchAO quantization configuration in the `simpletuner` package. It introduces utility functions to handle quantization type mapping and argument normalization, improves the way quantization configuration objects are built, and adds comprehensive tests for these new behaviors.

**Enhancements to TorchAO quantization configuration:**

* Added a mapping (`TORCHAO_QUANT_TYPE_CONFIG_MAP`) from quantization type names to their corresponding TorchAO config class names, and a `_build_torchao_quant_type` function to instantiate the correct config class based on a string or an existing config instance.
* Introduced `_normalize_torchao_quant_type_kwargs` and `_split_torchao_config_kwargs` to cleanly separate and process arguments for quantization configuration, ensuring correct assignment to outer and inner config objects.
* Updated `_build_torchao_config` to use the new argument splitting and quant type building logic, improving error handling and flexibility for overrides and nested config options.

**Testing improvements:**

* Added a new test suite (`tests/test_torchao_pipeline_quantization.py`) to verify that pipeline quantization builders correctly instantiate TorchAO config objects, handle quant type kwargs, preserve top-level kwargs, and support dynamic activation quantization types.

**Other changes:**

* Moved the `TORCHAO_PIPELINE_PRESET_MAP` definition to group it with related logic, improving code organization. [[1]](diffhunk://#diff-b1e7c0be21b43a43948fe6f04ff01641e8890b137f8cd8c3d2300fe420411198L132-R206) [[2]](diffhunk://#diff-b1e7c0be21b43a43948fe6f04ff01641e8890b137f8cd8c3d2300fe420411198L200-L204)