### PR TITLE
add custom transformer path to docs

### DIFF
--- a/documentation/OPTIONS.es.md
+++ b/documentation/OPTIONS.es.md
@@ -206,6 +206,13 @@ Donde `foo` es tu entorno de configuración; o simplemente usa `config/config.js
 - **Qué**: Ruta al modelo preentrenado o su identificador en <https://huggingface.co/models>.
 - **Por qué**: Para especificar el modelo base desde el que comenzarás a entrenar. Usa `--revision` y `--variant` para especificar versiones concretas desde un repositorio. También admite rutas de un solo archivo `.safetensors` para SDXL, Flux y SD3.x.
 
+### `--pretrained_transformer_model_name_or_path`
+
+- **Qué**: Ruta opcional a pesos transformer preentrenados o su identificador en <https://huggingface.co/models>.
+- **Predeterminado**: `None` (en los cargadores que admiten esta sobrescritura, el origen del transformer sigue ligado a `--pretrained_model_name_or_path`)
+- **Por qué**: Úsalo cuando el componente transformer vive en un repositorio, carpeta local o checkpoint separado del paquete del modelo base.
+- **Notas**: Combínalo con `--pretrained_transformer_subfolder` cuando los pesos transformer estén dentro de una subcarpeta de esa ruta.
+
 ### `--pretrained_t5_model_name_or_path`
 
 - **Qué**: Ruta al modelo T5 preentrenado o su identificador en <https://huggingface.co/models>.

--- a/documentation/OPTIONS.hi.md
+++ b/documentation/OPTIONS.hi.md
@@ -206,6 +206,13 @@ simpletuner configure config/foo/config.json
 - **What**: pretrained model का path या <https://huggingface.co/models> से उसका identifier.
 - **Why**: उस base model को निर्दिष्ट करने के लिए जिससे training शुरू होगी। Repository से specific versions चुनने के लिए `--revision` और `--variant` उपयोग करें। यह SDXL, Flux, और SD3.x के लिए single‑file `.safetensors` paths भी सपोर्ट करता है।
 
+### `--pretrained_transformer_model_name_or_path`
+
+- **What**: pretrained transformer weights का optional path या <https://huggingface.co/models> से उनका identifier.
+- **Default**: `None` (जो loaders इस override को support करते हैं उनमें transformer source `--pretrained_model_name_or_path` से जुड़ा रहता है)
+- **Why**: जब transformer component base model package से अलग repository, local folder, या checkpoint में हो तब इसका उपयोग करें।
+- **Notes**: अगर transformer weights उस path के subfolder में हैं, तो इसे `--pretrained_transformer_subfolder` के साथ उपयोग करें।
+
 ### `--pretrained_t5_model_name_or_path`
 
 - **What**: pretrained T5 model का path या <https://huggingface.co/models> से उसका identifier.

--- a/documentation/OPTIONS.ja.md
+++ b/documentation/OPTIONS.ja.md
@@ -207,6 +207,13 @@ simpletuner configure config/foo/config.json
 - **内容**: 事前学習済みモデルのパス、または <https://huggingface.co/models> の識別子。
 - **理由**: 学習を開始するベースモデルを指定します。`--revision` と `--variant` でリポジトリ内の特定バージョンを指定できます。SDXL、Flux、SD3.x の単一ファイル `.safetensors` パスにも対応しています。
 
+### `--pretrained_transformer_model_name_or_path`
+
+- **内容**: 事前学習済み transformer 重みの任意パス、または <https://huggingface.co/models> の識別子。
+- **既定**: `None`（この上書きをサポートするローダーでは、transformer の参照元は `--pretrained_model_name_or_path` に従います）
+- **理由**: transformer コンポーネントがベースモデルパッケージとは別のリポジトリ、ローカルフォルダー、またはチェックポイントにある場合に使用します。
+- **注記**: transformer 重みがそのパス内のサブフォルダーにある場合は、`--pretrained_transformer_subfolder` と組み合わせて使用します。
+
 ### `--pretrained_t5_model_name_or_path`
 
 - **内容**: 事前学習済み T5 モデルのパス、または <https://huggingface.co/models> の識別子。

--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -206,6 +206,13 @@ Where `foo` is your config environment - or just use `config/config.json` if you
 - **What**: Path to the pretrained model or its identifier from <https://huggingface.co/models>.
 - **Why**: To specify the base model you'll start training from. Use `--revision` and `--variant` to specify specific versions from a repository. This also supports single-file `.safetensors` paths for SDXL, Flux, and SD3.x.
 
+### `--pretrained_transformer_model_name_or_path`
+
+- **What**: Optional path to pretrained transformer weights or their identifier from <https://huggingface.co/models>.
+- **Default**: `None` (the transformer source stays tied to `--pretrained_model_name_or_path` for loaders that support this override)
+- **Why**: Use this when the transformer component lives in a separate repository, local folder, or checkpoint from the base model package.
+- **Notes**: Pair with `--pretrained_transformer_subfolder` when the transformer weights are inside a subfolder of that path.
+
 ### `--pretrained_t5_model_name_or_path`
 
 - **What**: Path to the pretrained T5 model or its identifier from <https://huggingface.co/models>.

--- a/documentation/OPTIONS.pt-BR.md
+++ b/documentation/OPTIONS.pt-BR.md
@@ -206,6 +206,13 @@ Onde `foo` e seu ambiente de config — ou use `config/config.json` se nao estiv
 - **O que**: Caminho para o modelo pre-treinado ou seu identificador em <https://huggingface.co/models>.
 - **Por que**: Para especificar o modelo base a partir do qual iniciar o treino. Use `--revision` e `--variant` para especificar versoes especificas de um repositorio. Isso tambem suporta caminhos `.safetensors` de arquivo unico para SDXL, Flux e SD3.x.
 
+### `--pretrained_transformer_model_name_or_path`
+
+- **O que**: Caminho opcional para pesos transformer pre-treinados ou seu identificador em <https://huggingface.co/models>.
+- **Padrao**: `None` (para loaders que suportam esta sobrescrita, a origem do transformer continua ligada a `--pretrained_model_name_or_path`)
+- **Por que**: Use quando o componente transformer estiver em um repositorio, pasta local ou checkpoint separado do pacote do modelo base.
+- **Notas**: Combine com `--pretrained_transformer_subfolder` quando os pesos transformer estiverem em uma subpasta desse caminho.
+
 ### `--pretrained_t5_model_name_or_path`
 
 - **O que**: Caminho para o modelo T5 pre-treinado ou seu identificador em <https://huggingface.co/models>.

--- a/documentation/OPTIONS.zh.md
+++ b/documentation/OPTIONS.zh.md
@@ -207,6 +207,13 @@ simpletuner configure config/foo/config.json
 - **内容**：预训练模型路径或 <https://huggingface.co/models> 上的标识符。
 - **原因**：指定训练起点的基础模型。可用 `--revision` 与 `--variant` 选择仓库中的特定版本。也支持 SDXL、Flux、SD3.x 的单文件 `.safetensors` 路径。
 
+### `--pretrained_transformer_model_name_or_path`
+
+- **内容**：可选的预训练 transformer 权重路径，或 <https://huggingface.co/models> 上的标识符。
+- **默认**：`None`（对于支持此覆盖项的加载器，transformer 来源仍跟随 `--pretrained_model_name_or_path`）
+- **原因**：当 transformer 组件位于独立仓库、本地目录或不同于基础模型包的 checkpoint 中时使用。
+- **说明**：如果 transformer 权重位于该路径下的子目录中，请与 `--pretrained_transformer_subfolder` 配合使用。
+
 ### `--pretrained_t5_model_name_or_path`
 
 - **内容**：预训练 T5 模型路径或 <https://huggingface.co/models> 上的标识符。


### PR DESCRIPTION
This pull request updates the documentation for configuration options in multiple languages. The main change is the addition of a new section describing the `--pretrained_transformer_model_name_or_path` option, which allows users to specify a separate path or identifier for pretrained transformer weights, distinct from the base model. This improves clarity for users who need to load transformer components from different locations.

**Documentation updates for new transformer option:**

* Added a section for `--pretrained_transformer_model_name_or_path` to the configuration options documentation in English, Spanish, Hindi, Japanese, Portuguese (Brazil), and Chinese. This section explains the purpose, default behavior, and usage notes for specifying transformer weights separately from the base model. [[1]](diffhunk://#diff-45e063db3ebcffb55dde68f083e92399a74f4cefbb464e8cd36911971c50933fR209-R215) [[2]](diffhunk://#diff-3f0cd39e3a7f176d81408ae40dc4f8c6271347f75b1cee5cf71c4e701d7db561R209-R215) [[3]](diffhunk://#diff-39b5789a705b2e70400106934436b619d10413ca5e37bd7a2b5fa7aa0c0fb8cfR209-R215) [[4]](diffhunk://#diff-fd629904ab3e1ecdd5b568c3ef6ac61e71e3d7741700e360820849938158a1d9R210-R216) [[5]](diffhunk://#diff-2c007ae9176f9f69b3ae16558be55b46d524f460a626f4e5c31e1e9a1d1b14b8R209-R215) [[6]](diffhunk://#diff-cddcc50c252e719be92644d65ea8542cc51d08f15e67d918bfae737904142b1fR210-R216)