### PR TITLE
docker: add SIMPLETUNER_WORKSPACE and ensure fallback discovers correct paths

### DIFF
--- a/docker-start.sh
+++ b/docker-start.sh
@@ -4,7 +4,7 @@
 # This file can then later be sourced in a login shell
 echo "Exporting environment variables..."
 printenv |
-	grep -E '^RUNPOD_|^PATH=|^HF_HOME=|^HF_TOKEN=|^HUGGING_FACE_HUB_TOKEN=|^WANDB_API_KEY=|^WANDB_TOKEN=|^_=' |
+	grep -E '^RUNPOD_|^PATH=|^HF_HOME=|^HF_TOKEN=|^HUGGING_FACE_HUB_TOKEN=|^SIMPLETUNER_WORKSPACE=|^WANDB_API_KEY=|^WANDB_TOKEN=|^_=' |
 	sed 's/^\(.*\)=\(.*\)$/export \1="\2"/' >>/etc/rp_environment
 
 # Add it to Bash login script

--- a/simpletuner/cli/common.py
+++ b/simpletuner/cli/common.py
@@ -11,6 +11,8 @@ import subprocess
 from pathlib import Path
 from typing import List, Optional
 
+from simpletuner.simpletuner_sdk.server.utils.paths import get_simpletuner_data_roots
+
 CONFIG_FILENAMES = {
     "json": "config.json",
     "toml": "config.toml",
@@ -61,7 +63,7 @@ def _find_webui_state_file(filename: str) -> Optional[Path]:
     if base_candidate:
         candidates.append(Path(base_candidate).expanduser() / "webui" / filename)
 
-    for root in (Path("/workspace/simpletuner"), Path("/notebooks/simpletuner"), Path.home() / ".simpletuner"):
+    for root in get_simpletuner_data_roots():
         candidates.append(root / "webui" / filename)
 
     seen = set()

--- a/simpletuner/simpletuner_sdk/server/services/webui_state.py
+++ b/simpletuner/simpletuner_sdk/server/services/webui_state.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from simpletuner.simpletuner_sdk.server.utils.assets import get_asset_version
+from simpletuner.simpletuner_sdk.server.utils.paths import get_simpletuner_data_roots
 
 _WEBUI_CONFIG_ENV = "SIMPLETUNER_WEB_UI_CONFIG"
 _XDG_HOME_ENV = "XDG_HOME"
@@ -263,12 +264,7 @@ class WebUIStateStore:
             root.mkdir(parents=True, exist_ok=True)
             return root / "webui"
 
-        candidate_roots = []
-        if Path("/workspace").exists():
-            candidate_roots.append(Path("/workspace/simpletuner"))
-        if Path("/notebooks").exists():
-            candidate_roots.append(Path("/notebooks/simpletuner"))
-        candidate_roots.append(Path.home() / ".simpletuner")
+        candidate_roots = get_simpletuner_data_roots()
 
         for root in candidate_roots:
             webui_dir = root / "webui"

--- a/simpletuner/simpletuner_sdk/server/utils/paths.py
+++ b/simpletuner/simpletuner_sdk/server/utils/paths.py
@@ -6,6 +6,29 @@ import os
 from pathlib import Path
 from typing import Optional, Union
 
+_WORKSPACE_ENV = "SIMPLETUNER_WORKSPACE"
+
+
+def get_simpletuner_data_roots() -> list[Path]:
+    """Return candidate roots for user-managed SimpleTuner data."""
+    candidate_roots: list[Path] = []
+
+    workspace_override = os.environ.get(_WORKSPACE_ENV)
+    if workspace_override:
+        candidate_roots.append(Path(workspace_override).expanduser())
+
+    if Path("/workspace").exists():
+        candidate_roots.append(Path("/workspace/simpletuner"))
+    if Path("/notebooks").exists():
+        candidate_roots.append(Path("/notebooks/simpletuner"))
+    candidate_roots.append(Path.home() / ".simpletuner")
+
+    roots: list[Path] = []
+    for root in candidate_roots:
+        if root not in roots:
+            roots.append(root)
+    return roots
+
 
 def get_simpletuner_root() -> Path:
     """Get the root directory of SimpleTuner installation.
@@ -38,12 +61,7 @@ def get_config_directory() -> Path:
     if env_override:
         return Path(env_override).expanduser()
 
-    candidate_roots = []
-    if Path("/workspace").exists():
-        candidate_roots.append(Path("/workspace/simpletuner"))
-    if Path("/notebooks").exists():
-        candidate_roots.append(Path("/notebooks/simpletuner"))
-    candidate_roots.append(Path.home() / ".simpletuner")
+    candidate_roots = get_simpletuner_data_roots()
 
     for root in candidate_roots:
         candidate = root / "config"
@@ -100,13 +118,7 @@ def get_avatars_directory() -> Path:
         avatars_dir.mkdir(parents=True, exist_ok=True)
         return avatars_dir
 
-    # Check standard SimpleTuner data directories
-    candidate_roots = []
-    if Path("/workspace").exists():
-        candidate_roots.append(Path("/workspace/simpletuner"))
-    if Path("/notebooks").exists():
-        candidate_roots.append(Path("/notebooks/simpletuner"))
-    candidate_roots.append(Path.home() / ".simpletuner")
+    candidate_roots = get_simpletuner_data_roots()
 
     for root in candidate_roots:
         if root.exists():

--- a/tests/test_webui_backend.py
+++ b/tests/test_webui_backend.py
@@ -6,12 +6,14 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from simpletuner.cli.common import _find_webui_state_file
 from simpletuner.simpletuner_sdk.server.services.webui_state import (
     OnboardingStepState,
     WebUIDefaults,
     WebUIOnboardingState,
     WebUIStateStore,
 )
+from simpletuner.simpletuner_sdk.server.utils.paths import get_config_directory
 
 
 class WebUIStateStoreTests(unittest.TestCase):
@@ -185,6 +187,49 @@ class WebUIStateStoreTests(unittest.TestCase):
         self.assertNotIn("--num_processes", loaded.accelerate_overrides)
         # Manual metadata remains so users can switch back without losing previous input
         self.assertEqual(loaded.accelerate_overrides.get("manual_count"), 4)
+
+
+class WebUIWorkspacePathTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.temp_path = Path(self._tmpdir.name)
+        self.workspace = self.temp_path / "workspace"
+        self._env_patches = patch.dict(
+            os.environ,
+            {
+                "HOME": str(self.temp_path / "home"),
+                "SIMPLETUNER_WORKSPACE": str(self.workspace),
+                "SIMPLETUNER_WEB_UI_CONFIG": "",
+                "SIMPLETUNER_CONFIG_DIR": "",
+                "XDG_HOME": "",
+                "XDG_CONFIG_HOME": "",
+            },
+        )
+        self._env_patches.start()
+
+    def tearDown(self) -> None:
+        self._env_patches.stop()
+        self._tmpdir.cleanup()
+
+    def test_workspace_env_controls_webui_fallback_paths(self) -> None:
+        store = WebUIStateStore()
+        bundle = store.get_defaults_bundle()
+
+        self.assertEqual(store.base_dir, self.workspace / "webui")
+        self.assertEqual(bundle["fallbacks"]["configs_dir"], str(self.workspace / "config"))
+        self.assertEqual(bundle["fallbacks"]["output_dir"], str(self.workspace / "output"))
+        self.assertEqual(bundle["fallbacks"]["datasets_dir"], str(self.workspace / "datasets"))
+
+    def test_workspace_env_controls_cli_webui_state_discovery(self) -> None:
+        defaults_path = self.workspace / "webui" / "defaults.json"
+        defaults_path.parent.mkdir(parents=True)
+        defaults_path.write_text("{}", encoding="utf-8")
+
+        self.assertEqual(_find_webui_state_file("defaults.json"), defaults_path)
+
+    def test_workspace_env_controls_default_config_directory(self) -> None:
+        self.assertEqual(get_config_directory(), self.workspace / "config")
+        self.assertTrue((self.workspace / "config").exists())
 
 
 class WebUIDefaultsUpdateTests(WebUIStateStoreTests):


### PR DESCRIPTION
Addresses [comment](https://github.com/bghira/SimpleTuner/issues/2778#issuecomment-4779160129) made in #2778 

This pull request refactors how SimpleTuner determines the root directories for user-managed data, centralizing the logic into a single utility function and adding support for a new `SIMPLETUNER_WORKSPACE` environment variable. This change improves flexibility and maintainability by ensuring all components use consistent logic for locating data directories. It also adds comprehensive tests for the new workspace environment variable behavior.

**Centralized data root resolution:**

* Added `get_simpletuner_data_roots()` in `simpletuner_sdk/server/utils/paths.py` to return candidate data roots, including support for the `SIMPLETUNER_WORKSPACE` environment variable.
* Updated all locations that previously hardcoded data root candidates (like `/workspace/simpletuner`, `/notebooks/simpletuner`, and `~/.simpletuner`) to use this new utility function, including in config, avatars, and web UI state logic. [[1]](diffhunk://#diff-0d0a40cb1ff9b02313ad016c51bf9917e60b2f30808181cbeba593ce01fbac98L41-R64) [[2]](diffhunk://#diff-0d0a40cb1ff9b02313ad016c51bf9917e60b2f30808181cbeba593ce01fbac98L103-R121) [[3]](diffhunk://#diff-0212aa5234fd39c68f2274c7f9107f167807aafb524f77ed06de97cb58bc9913L266-R267) [[4]](diffhunk://#diff-4f14713e1af41143a20c4c51431f8c2bb274e4b697bd2c4781777cc67d867d39L64-R66)

**Environment variable and Docker integration:**

* Modified `docker-start.sh` to export the `SIMPLETUNER_WORKSPACE` environment variable if present, ensuring it is available in containerized environments.

**Testing improvements:**

* Added `WebUIWorkspacePathTests` to verify that the `SIMPLETUNER_WORKSPACE` environment variable correctly controls data directory resolution in both the CLI and web UI backend.

**Codebase maintenance:**

* Updated imports to use the new utility function where appropriate. [[1]](diffhunk://#diff-4f14713e1af41143a20c4c51431f8c2bb274e4b697bd2c4781777cc67d867d39R14-R15) [[2]](diffhunk://#diff-0212aa5234fd39c68f2274c7f9107f167807aafb524f77ed06de97cb58bc9913R13) [[3]](diffhunk://#diff-cc6652424464a659faab4d1a871385c203c4fafe6a802a904481b6dcf26ac7d1R9-R16)