### PR TITLE
cloud: update configuration wizard to show correct hardware type selector

### DIFF
--- a/simpletuner/simpletuner_sdk/server/services/cloud/pricing.py
+++ b/simpletuner/simpletuner_sdk/server/services/cloud/pricing.py
@@ -245,12 +245,12 @@ class ConfigurablePricingProvider(GPUPricingProvider):
 REPLICATE_DEFAULT_HARDWARE = {
     "gpu-l40s": {
         "name": "L40S (48GB)",
-        "cost_per_second": 0.000975,
+        "cost_per_second": 0.000972222,
         "memory_gb": 48,
     },
-    "gpu-a100-large": {
-        "name": "A100 (80GB)",
-        "cost_per_second": 0.001400,
+    "gpu-h100": {
+        "name": "H100 (80GB)",
+        "cost_per_second": 0.001525,
         "memory_gb": 80,
     },
 }

--- a/simpletuner/simpletuner_sdk/server/services/cloud/provider_registry.py
+++ b/simpletuner/simpletuner_sdk/server/services/cloud/provider_registry.py
@@ -143,7 +143,7 @@ async def get_enriched_providers() -> List[Dict[str, Any]]:
                     except (TypeError, ValueError):
                         multiplier = 1
                 option["cost_per_hour"] = round(base_costs[base_profile] * multiplier, 2)
-                option["cost_per_second"] = round((base_costs[base_profile] / 3600) * multiplier, 6)
+                option["cost_per_second"] = (base_costs[base_profile] / 3600) * multiplier
 
             provider_data.update(
                 {

--- a/simpletuner/simpletuner_sdk/server/services/cloud/provider_registry.py
+++ b/simpletuner/simpletuner_sdk/server/services/cloud/provider_registry.py
@@ -93,7 +93,12 @@ async def get_enriched_providers() -> List[Dict[str, Any]]:
     - Hardware info and costs
     """
     from ...routes.cloud._shared import get_job_store
-    from .replicate_client import DEFAULT_MODEL, get_default_hardware_cost_per_hour, get_hardware_info_async
+    from .replicate_client import (
+        DEFAULT_HARDWARE_INFO,
+        DEFAULT_MODEL,
+        get_default_hardware_cost_per_hour,
+        get_hardware_info_async,
+    )
     from .replicate_profiles import (
         DEFAULT_REPLICATE_HARDWARE_PROFILE,
         get_replicate_hardware_profile,
@@ -120,6 +125,25 @@ async def get_enriched_providers() -> List[Dict[str, Any]]:
             hardware_info = await get_hardware_info_async(store)
             l40s_info = hardware_info.get(definition.default_hardware_id, {})
             cost_per_hour = await get_default_hardware_cost_per_hour(store)
+            profile_options = list_replicate_hardware_profiles()
+            base_costs = {
+                "h100": (hardware_info.get("gpu-h100") or DEFAULT_HARDWARE_INFO["gpu-h100"]).get("cost_per_second", 0.001525)
+                * 3600,
+                "l40s": (hardware_info.get("gpu-l40s") or DEFAULT_HARDWARE_INFO["gpu-l40s"]).get(
+                    "cost_per_second", 0.000972222
+                )
+                * 3600,
+            }
+            for option in profile_options:
+                base_profile = "h100" if option["id"].startswith("h100") else "l40s"
+                multiplier = 1
+                if "-x" in option["id"]:
+                    try:
+                        multiplier = int(option["id"].rsplit("-x", 1)[1])
+                    except (TypeError, ValueError):
+                        multiplier = 1
+                option["cost_per_hour"] = round(base_costs[base_profile] * multiplier, 2)
+                option["cost_per_second"] = round((base_costs[base_profile] / 3600) * multiplier, 6)
 
             provider_data.update(
                 {
@@ -129,7 +153,7 @@ async def get_enriched_providers() -> List[Dict[str, Any]]:
                     "cost_per_hour": round(cost_per_hour, 2),
                     "configured": bool(get_secrets_manager().get_replicate_token()),
                     "hardware_profile": default_profile.id,
-                    "hardware_profiles": list_replicate_hardware_profiles(),
+                    "hardware_profiles": profile_options,
                 }
             )
 

--- a/simpletuner/simpletuner_sdk/server/services/cloud/replicate_client.py
+++ b/simpletuner/simpletuner_sdk/server/services/cloud/replicate_client.py
@@ -41,10 +41,10 @@ def _get_credential_resolver():
 DEFAULT_MODEL = get_replicate_hardware_profile(DEFAULT_REPLICATE_HARDWARE_PROFILE).model
 
 # Default hardware info for cost estimation (fallback values if not configured)
-# These are based on Replicate's published pricing as of 2024
+# These are based on Replicate's published pricing.
 DEFAULT_HARDWARE_INFO: Dict[str, Dict[str, Any]] = {
-    "gpu-l40s": {"name": "L40S (48GB)", "cost_per_second": 0.000975},
-    "gpu-a100-large": {"name": "A100 (80GB)", "cost_per_second": 0.001400},
+    "gpu-l40s": {"name": "L40S (48GB)", "cost_per_second": 0.000972222},
+    "gpu-h100": {"name": "H100 (80GB)", "cost_per_second": 0.001525},
 }
 
 # Cached hardware info (loaded from config or defaults)
@@ -112,7 +112,7 @@ async def get_default_hardware_cost_per_hour(store: Optional[Any] = None) -> flo
     """
     hardware = await get_hardware_info_async(store)
     l40s = hardware.get("gpu-l40s", DEFAULT_HARDWARE_INFO["gpu-l40s"])
-    return l40s.get("cost_per_second", 0.000975) * 3600
+    return l40s.get("cost_per_second", 0.000972222) * 3600
 
 
 def update_hardware_info_cache(hardware_info: Dict[str, Dict[str, Any]]) -> None:

--- a/simpletuner/simpletuner_sdk/server/services/cloud/replicate_profiles.py
+++ b/simpletuner/simpletuner_sdk/server/services/cloud/replicate_profiles.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Any, Dict, List
 
 DEFAULT_REPLICATE_HARDWARE_PROFILE = "h100"
 
@@ -70,7 +70,7 @@ REPLICATE_HARDWARE_PROFILES: Dict[str, ReplicateHardwareProfile] = {
 }
 
 
-def list_replicate_hardware_profiles() -> List[Dict[str, str]]:
+def list_replicate_hardware_profiles() -> List[Dict[str, Any]]:
     """Return profile metadata suitable for API/UI responses."""
     return [
         {

--- a/simpletuner/static/js/modules/cloud/job-submission.js
+++ b/simpletuner/static/js/modules/cloud/job-submission.js
@@ -266,17 +266,33 @@ window.cloudSubmissionMethods = {
         return String(selected || '').startsWith('l40s') ? 'l40s' : 'h100';
     },
 
+    getSelectedReplicateHardwareProfile() {
+        const selected = this.preSubmitModal?.hardwareProfile || this.getDefaultReplicateHardwareProfile();
+        const profiles = this.getReplicateHardwareProfiles();
+        return profiles.find((profile) => profile.id === selected) ||
+               profiles.find((profile) => profile.id === this.getSelectedReplicateBaseHardware()) ||
+               null;
+    },
+
     setReplicateBaseHardwareProfile(profileId) {
         if (!profileId) {
             return;
         }
-        this.preSubmitModal.hardwareProfile = profileId;
-        this.saveHardwareProfile(profileId);
+        const currentProfile = this.preSubmitModal?.hardwareProfile || this.getDefaultReplicateHardwareProfile();
+        const multiplier = String(currentProfile || '').match(/-x\d+$/)?.[0] || '';
+        const candidateProfile = `${profileId}${multiplier}`;
+        const profiles = this.getReplicateHardwareProfiles();
+        const nextProfile = profiles.some((profile) => profile.id === candidateProfile)
+            ? candidateProfile
+            : profileId;
+        this.preSubmitModal.hardwareProfile = nextProfile;
+        this.saveHardwareProfile(nextProfile);
     },
 
     getReplicateBaseHardwareCostDisplay() {
         const selected = this.getSelectedReplicateBaseHardware();
-        const profile = this.getReplicateBaseHardwareOptions().find((option) => option.id === selected);
+        const profile = this.getSelectedReplicateHardwareProfile() ||
+                        this.getReplicateBaseHardwareOptions().find((option) => option.id === selected);
         if (typeof profile?.cost_per_hour === 'number') {
             return '$' + profile.cost_per_hour.toFixed(2) + '/hr';
         }
@@ -288,6 +304,11 @@ window.cloudSubmissionMethods = {
 
     getReplicateBaseHardwareCostDetail() {
         const selected = this.getSelectedReplicateBaseHardware();
+        const profile = this.getSelectedReplicateHardwareProfile() ||
+                        this.getReplicateBaseHardwareOptions().find((option) => option.id === selected);
+        if (typeof profile?.cost_per_second === 'number') {
+            return '$' + profile.cost_per_second.toFixed(6) + '/sec';
+        }
         if (selected === 'h100') {
             return '$0.001525/sec';
         }

--- a/simpletuner/static/js/modules/cloud/job-submission.js
+++ b/simpletuner/static/js/modules/cloud/job-submission.js
@@ -255,6 +255,45 @@ window.cloudSubmissionMethods = {
         ];
     },
 
+    getReplicateBaseHardwareOptions() {
+        return this.getReplicateHardwareProfiles()
+            .filter((profile) => profile.id === 'l40s' || profile.id === 'h100')
+            .sort((a, b) => (a.id === 'l40s' ? -1 : 1));
+    },
+
+    getSelectedReplicateBaseHardware() {
+        const selected = this.preSubmitModal?.hardwareProfile || this.getDefaultReplicateHardwareProfile();
+        return String(selected || '').startsWith('l40s') ? 'l40s' : 'h100';
+    },
+
+    setReplicateBaseHardwareProfile(profileId) {
+        if (!profileId) {
+            return;
+        }
+        this.preSubmitModal.hardwareProfile = profileId;
+        this.saveHardwareProfile(profileId);
+    },
+
+    getReplicateBaseHardwareCostDisplay() {
+        const selected = this.getSelectedReplicateBaseHardware();
+        const profile = this.getReplicateBaseHardwareOptions().find((option) => option.id === selected);
+        if (typeof profile?.cost_per_hour === 'number') {
+            return '$' + profile.cost_per_hour.toFixed(2) + '/hr';
+        }
+        if (selected === 'h100') {
+            return '$5.49/hr';
+        }
+        return '$3.50/hr';
+    },
+
+    getReplicateBaseHardwareCostDetail() {
+        const selected = this.getSelectedReplicateBaseHardware();
+        if (selected === 'h100') {
+            return '$0.001525/sec';
+        }
+        return '$0.000972/sec';
+    },
+
     getDefaultReplicateHardwareProfile() {
         const storedProfile = localStorage.getItem('cloud_replicate_hardware_profile');
         if (storedProfile) {

--- a/simpletuner/templates/cloud_tab.html
+++ b/simpletuner/templates/cloud_tab.html
@@ -161,18 +161,46 @@
                     <h6 class="mb-0"><i class="fas fa-server me-2"></i>Hardware</h6>
                 </div>
                 <div class="cloud-card-body py-2">
-                    <template x-for="provider in providers.filter(p => p.id === activeProvider)" :key="provider.id">
+                    <template x-if="activeProvider === 'replicate'">
                         <div class="small">
-                            <div class="d-flex justify-content-between mb-1">
-                                <span class="text-muted">GPU</span>
-                                <span class="text-info" x-text="provider.hardware || 'N/A'"></span>
+                            <div class="mb-2">
+                                <span class="text-muted d-block mb-1">Hardware</span>
+                                <div class="d-flex gap-2">
+                                    <template x-for="profile in getReplicateBaseHardwareOptions()" :key="profile.id">
+                                        <button type="button"
+                                                class="btn btn-sm rounded-pill flex-fill"
+                                                data-testid="cloud-settings-hardware-profile"
+                                                :class="getSelectedReplicateBaseHardware() === profile.id ? 'btn-info text-dark' : 'btn-outline-secondary'"
+                                                @click="setReplicateBaseHardwareProfile(profile.id)">
+                                            <span x-text="profile.label || profile.id.toUpperCase()"></span>
+                                        </button>
+                                    </template>
+                                </div>
                             </div>
-                            <div class="d-flex justify-content-between">
-                                <span class="text-muted">Cost</span>
-                                <span x-text="provider.cost_per_hour ? ('$' + provider.cost_per_hour.toFixed(2) + '/hr') : 'N/A'"></span>
+                            <div class="d-flex justify-content-between align-items-start">
+                                <span class="text-muted">Cost (per hour)</span>
+                                <span class="text-end">
+                                    <span x-text="getReplicateBaseHardwareCostDisplay()"></span>
+                                    <span class="d-block text-muted" style="font-size: 0.7rem;"
+                                          x-text="getReplicateBaseHardwareCostDetail()"></span>
+                                </span>
                             </div>
                         </div>
                     </template>
+                    <div x-show="activeProvider !== 'replicate'">
+                        <template x-for="provider in providers.filter(p => p.id === activeProvider)" :key="provider.id">
+                            <div class="small">
+                                <div class="d-flex justify-content-between mb-1">
+                                    <span class="text-muted">GPU</span>
+                                    <span class="text-info" x-text="provider.hardware || 'N/A'"></span>
+                                </div>
+                                <div class="d-flex justify-content-between">
+                                    <span class="text-muted">Cost</span>
+                                    <span x-text="provider.cost_per_hour ? ('$' + provider.cost_per_hour.toFixed(2) + '/hr') : 'N/A'"></span>
+                                </div>
+                            </div>
+                        </template>
+                    </div>
                 </div>
             </div>
 

--- a/simpletuner/templates/cloud_tab.html
+++ b/simpletuner/templates/cloud_tab.html
@@ -171,6 +171,7 @@
                                                 class="btn btn-sm rounded-pill flex-fill"
                                                 data-testid="cloud-settings-hardware-profile"
                                                 :class="getSelectedReplicateBaseHardware() === profile.id ? 'btn-info text-dark' : 'btn-outline-secondary'"
+                                                :aria-pressed="getSelectedReplicateBaseHardware() === profile.id ? 'true' : 'false'"
                                                 @click="setReplicateBaseHardwareProfile(profile.id)">
                                             <span x-text="profile.label || profile.id.toUpperCase()"></span>
                                         </button>

--- a/simpletuner/templates/partials/cloud_hero_cta.html
+++ b/simpletuner/templates/partials/cloud_hero_cta.html
@@ -21,7 +21,7 @@
                 <div class="hero-features">
                     <div class="hero-feature">
                         <i class="fas fa-bolt text-warning"></i>
-                        <span>L40S & A100 GPUs</span>
+                        <span>L40S & H100 GPUs</span>
                     </div>
                     <div class="hero-feature">
                         <i class="fas fa-dollar-sign text-success"></i>

--- a/simpletuner/templates/partials/cloud_onboarding_flow.html
+++ b/simpletuner/templates/partials/cloud_onboarding_flow.html
@@ -231,6 +231,7 @@
                                                 class="btn btn-sm rounded-pill"
                                                 data-testid="cloud-onboarding-hardware-profile"
                                                 :class="getSelectedReplicateBaseHardware() === profile.id ? 'btn-info text-dark' : 'btn-outline-secondary'"
+                                                :aria-pressed="getSelectedReplicateBaseHardware() === profile.id ? 'true' : 'false'"
                                                 @click="setReplicateBaseHardwareProfile(profile.id)">
                                             <span x-text="profile.label || profile.id.toUpperCase()"></span>
                                         </button>

--- a/simpletuner/templates/partials/cloud_onboarding_flow.html
+++ b/simpletuner/templates/partials/cloud_onboarding_flow.html
@@ -224,11 +224,27 @@
                     <div class="cost-breakdown">
                         <div class="cost-row">
                             <span class="cost-label">Hardware</span>
-                            <span class="cost-value">L40S (48GB VRAM)</span>
+                            <span class="cost-value">
+                                <span class="d-flex gap-2 justify-content-end">
+                                    <template x-for="profile in getReplicateBaseHardwareOptions()" :key="profile.id">
+                                        <button type="button"
+                                                class="btn btn-sm rounded-pill"
+                                                data-testid="cloud-onboarding-hardware-profile"
+                                                :class="getSelectedReplicateBaseHardware() === profile.id ? 'btn-info text-dark' : 'btn-outline-secondary'"
+                                                @click="setReplicateBaseHardwareProfile(profile.id)">
+                                            <span x-text="profile.label || profile.id.toUpperCase()"></span>
+                                        </button>
+                                    </template>
+                                </span>
+                            </span>
                         </div>
                         <div class="cost-row">
-                            <span class="cost-label">Rate</span>
-                            <span class="cost-value">~$3.50/hour</span>
+                            <span class="cost-label">Cost (per hour)</span>
+                            <span class="cost-value">
+                                <span x-text="getReplicateBaseHardwareCostDisplay()"></span>
+                                <span class="d-block text-muted" style="font-size: 0.7rem;"
+                                      x-text="getReplicateBaseHardwareCostDetail()"></span>
+                            </span>
                         </div>
                         <div class="cost-row">
                             <span class="cost-label">Typical LoRA (2000 steps)</span>

--- a/tests/js/job_submission.test.js
+++ b/tests/js/job_submission.test.js
@@ -421,6 +421,49 @@ describe('cloudSubmissionMethods', () => {
                 'l40s-x8',
             ]);
         });
+
+        test('base hardware options expose l40s and h100 buttons', () => {
+            context.providers = [{
+                id: 'replicate',
+                hardware_profiles: [
+                    { id: 'h100', label: 'H100', cost_per_hour: 5.49 },
+                    { id: 'h100-x2', label: '2x H100', cost_per_hour: 10.98 },
+                    { id: 'l40s', label: 'L40S', cost_per_hour: 3.50 },
+                    { id: 'l40s-x2', label: '2x L40S', cost_per_hour: 7.00 },
+                ],
+            }];
+
+            const options = context.getReplicateBaseHardwareOptions();
+
+            expect(options.map((option) => option.id)).toEqual(['l40s', 'h100']);
+        });
+
+        test('settings hardware selector persists selected base profile', () => {
+            context.preSubmitModal.hardwareProfile = 'h100';
+
+            context.setReplicateBaseHardwareProfile('l40s');
+
+            expect(context.preSubmitModal.hardwareProfile).toBe('l40s');
+            expect(localStorage.getItem('cloud_replicate_hardware_profile')).toBe('l40s');
+        });
+
+        test('hardware hourly cost display follows selected base hardware', () => {
+            context.providers = [{
+                id: 'replicate',
+                hardware_profiles: [
+                    { id: 'h100', label: 'H100', cost_per_hour: 5.49 },
+                    { id: 'l40s', label: 'L40S', cost_per_hour: 3.50 },
+                ],
+            }];
+
+            context.preSubmitModal.hardwareProfile = 'h100';
+            expect(context.getReplicateBaseHardwareCostDisplay()).toBe('$5.49/hr');
+            expect(context.getReplicateBaseHardwareCostDetail()).toBe('$0.001525/sec');
+
+            context.preSubmitModal.hardwareProfile = 'l40s';
+            expect(context.getReplicateBaseHardwareCostDisplay()).toBe('$3.50/hr');
+            expect(context.getReplicateBaseHardwareCostDetail()).toBe('$0.000972/sec');
+        });
     });
 
     describe('prepareJobPayload', () => {

--- a/tests/js/job_submission.test.js
+++ b/tests/js/job_submission.test.js
@@ -426,10 +426,10 @@ describe('cloudSubmissionMethods', () => {
             context.providers = [{
                 id: 'replicate',
                 hardware_profiles: [
-                    { id: 'h100', label: 'H100', cost_per_hour: 5.49 },
-                    { id: 'h100-x2', label: '2x H100', cost_per_hour: 10.98 },
-                    { id: 'l40s', label: 'L40S', cost_per_hour: 3.50 },
-                    { id: 'l40s-x2', label: '2x L40S', cost_per_hour: 7.00 },
+                    { id: 'h100', label: 'H100', cost_per_hour: 5.49, cost_per_second: 0.001525 },
+                    { id: 'h100-x2', label: '2x H100', cost_per_hour: 10.98, cost_per_second: 0.00305 },
+                    { id: 'l40s', label: 'L40S', cost_per_hour: 3.50, cost_per_second: 0.000972222 },
+                    { id: 'l40s-x2', label: '2x L40S', cost_per_hour: 7.00, cost_per_second: 0.001944444 },
                 ],
             }];
 
@@ -438,8 +438,34 @@ describe('cloudSubmissionMethods', () => {
             expect(options.map((option) => option.id)).toEqual(['l40s', 'h100']);
         });
 
-        test('settings hardware selector persists selected base profile', () => {
-            context.preSubmitModal.hardwareProfile = 'h100';
+        test('settings hardware selector preserves existing gpu count multiplier', () => {
+            context.providers = [{
+                id: 'replicate',
+                hardware_profiles: [
+                    { id: 'h100', label: 'H100' },
+                    { id: 'h100-x4', label: '4x H100' },
+                    { id: 'l40s', label: 'L40S' },
+                    { id: 'l40s-x4', label: '4x L40S' },
+                ],
+            }];
+            context.preSubmitModal.hardwareProfile = 'h100-x4';
+
+            context.setReplicateBaseHardwareProfile('l40s');
+
+            expect(context.preSubmitModal.hardwareProfile).toBe('l40s-x4');
+            expect(localStorage.getItem('cloud_replicate_hardware_profile')).toBe('l40s-x4');
+        });
+
+        test('settings hardware selector falls back to base profile when matching multiplier is unavailable', () => {
+            context.providers = [{
+                id: 'replicate',
+                hardware_profiles: [
+                    { id: 'h100', label: 'H100' },
+                    { id: 'h100-x4', label: '4x H100' },
+                    { id: 'l40s', label: 'L40S' },
+                ],
+            }];
+            context.preSubmitModal.hardwareProfile = 'h100-x4';
 
             context.setReplicateBaseHardwareProfile('l40s');
 
@@ -447,22 +473,23 @@ describe('cloudSubmissionMethods', () => {
             expect(localStorage.getItem('cloud_replicate_hardware_profile')).toBe('l40s');
         });
 
-        test('hardware hourly cost display follows selected base hardware', () => {
+        test('hardware cost display uses provider supplied pricing', () => {
             context.providers = [{
                 id: 'replicate',
                 hardware_profiles: [
-                    { id: 'h100', label: 'H100', cost_per_hour: 5.49 },
-                    { id: 'l40s', label: 'L40S', cost_per_hour: 3.50 },
+                    { id: 'h100', label: 'H100', cost_per_hour: 6.66, cost_per_second: 0.001851852 },
+                    { id: 'h100-x4', label: '4x H100', cost_per_hour: 26.64, cost_per_second: 0.007407408 },
+                    { id: 'l40s', label: 'L40S', cost_per_hour: 4.44, cost_per_second: 0.001233333 },
                 ],
             }];
 
-            context.preSubmitModal.hardwareProfile = 'h100';
-            expect(context.getReplicateBaseHardwareCostDisplay()).toBe('$5.49/hr');
-            expect(context.getReplicateBaseHardwareCostDetail()).toBe('$0.001525/sec');
+            context.preSubmitModal.hardwareProfile = 'h100-x4';
+            expect(context.getReplicateBaseHardwareCostDisplay()).toBe('$26.64/hr');
+            expect(context.getReplicateBaseHardwareCostDetail()).toBe('$0.007407/sec');
 
             context.preSubmitModal.hardwareProfile = 'l40s';
-            expect(context.getReplicateBaseHardwareCostDisplay()).toBe('$3.50/hr');
-            expect(context.getReplicateBaseHardwareCostDetail()).toBe('$0.000972/sec');
+            expect(context.getReplicateBaseHardwareCostDisplay()).toBe('$4.44/hr');
+            expect(context.getReplicateBaseHardwareCostDetail()).toBe('$0.001233/sec');
         });
     });
 

--- a/tests/test_cloud_services.py
+++ b/tests/test_cloud_services.py
@@ -410,7 +410,7 @@ class TestHardwarePricingConfig(unittest.IsolatedAsyncioTestCase):
         hardware = await get_hardware_info_async(self.store)
         self.assertEqual(hardware, DEFAULT_HARDWARE_INFO)
         self.assertIn("gpu-l40s", hardware)
-        self.assertIn("gpu-a100-large", hardware)
+        self.assertIn("gpu-h100", hardware)
 
     async def test_configured_hardware_info(self) -> None:
         """Test that configured hardware info overrides defaults."""
@@ -421,9 +421,8 @@ class TestHardwarePricingConfig(unittest.IsolatedAsyncioTestCase):
 
         # Configure custom hardware info
         custom_hardware = {
-            "gpu-a100-large": {"cost_per_second": 0.0014, "name": "A100 (80GB)"},
-            "gpu-h100": {"name": "H100 (80GB)", "cost_per_second": 0.0014},
-            "gpu-l40s": {"name": "L40S (48GB)", "cost_per_second": 0.000975},
+            "gpu-h100": {"name": "H100 (80GB)", "cost_per_second": 0.001525},
+            "gpu-l40s": {"name": "L40S (48GB)", "cost_per_second": 0.000972222},
         }
         await self.store.save_provider_config("replicate", {"hardware_info": custom_hardware})
 
@@ -445,8 +444,8 @@ class TestHardwarePricingConfig(unittest.IsolatedAsyncioTestCase):
         clear_hardware_info_cache()
 
         cost = await get_default_hardware_cost_per_hour(self.store)
-        # L40S at $0.000975/sec = $3.51/hr
-        self.assertAlmostEqual(cost, 3.51, places=2)
+        # L40S at $0.000972222/sec = $3.50/hr
+        self.assertAlmostEqual(cost, 3.50, places=2)
 
     async def test_configured_hardware_cost_per_hour(self) -> None:
         """Test that configured hardware cost is used."""

--- a/tests/test_cost_and_pricing.py
+++ b/tests/test_cost_and_pricing.py
@@ -60,7 +60,7 @@ class TestHardwarePricingConfig(unittest.IsolatedAsyncioTestCase):
         hardware = await get_hardware_info_async(self.store)
         self.assertEqual(hardware, DEFAULT_HARDWARE_INFO)
         self.assertIn("gpu-l40s", hardware)
-        self.assertIn("gpu-a100-large", hardware)
+        self.assertIn("gpu-h100", hardware)
 
     async def test_configured_hardware_info(self) -> None:
         """Test that configured hardware info overrides defaults."""
@@ -88,8 +88,8 @@ class TestHardwarePricingConfig(unittest.IsolatedAsyncioTestCase):
         from simpletuner.simpletuner_sdk.server.services.cloud.replicate_client import get_default_hardware_cost_per_hour
 
         cost = await get_default_hardware_cost_per_hour(self.store)
-        # L40S at $0.000975/sec = $3.51/hr
-        self.assertAlmostEqual(cost, 3.51, places=2)
+        # L40S at $0.000972222/sec = $3.50/hr
+        self.assertAlmostEqual(cost, 3.50, places=2)
 
     async def test_configured_hardware_cost_per_hour(self) -> None:
         """Test that configured hardware cost is used."""

--- a/tests/test_cost_estimation.py
+++ b/tests/test_cost_estimation.py
@@ -49,12 +49,12 @@ class TestHardwareOption(unittest.TestCase):
         hw = HardwareOption(
             id="gpu-l40s",
             name="L40S (48GB)",
-            cost_per_second=0.000975,
+            cost_per_second=0.000972222,
             memory_gb=48,
         )
 
-        # ~$3.51/hour
-        self.assertAlmostEqual(hw.cost_per_hour, 3.51, places=2)
+        # ~$3.50/hour
+        self.assertAlmostEqual(hw.cost_per_hour, 3.50, places=2)
 
     def test_to_dict(self):
         """Test to_dict includes all fields."""
@@ -226,7 +226,7 @@ class TestCostCalculation(unittest.TestCase):
             default_hardware={
                 "gpu-l40s": {
                     "name": "L40S",
-                    "cost_per_second": 0.000975,
+                    "cost_per_second": 0.000972222,
                 },
             },
             default_hardware_id="gpu-l40s",
@@ -234,7 +234,7 @@ class TestCostCalculation(unittest.TestCase):
 
         # 1 hour = 3600 seconds
         cost = provider.calculate_cost("gpu-l40s", 3600)
-        self.assertAlmostEqual(cost, 3.51, places=2)
+        self.assertAlmostEqual(cost, 3.50, places=2)
 
     def test_calculate_cost_unknown_hardware(self):
         """Test calculate_cost returns None for unknown hardware."""
@@ -285,7 +285,7 @@ class TestCostCalculation(unittest.TestCase):
             default_hardware={
                 "gpu-l40s": {
                     "name": "L40S",
-                    "cost_per_second": 0.000975,
+                    "cost_per_second": 0.000972222,
                 },
             },
             default_hardware_id="gpu-l40s",
@@ -294,8 +294,8 @@ class TestCostCalculation(unittest.TestCase):
         # Typical training job: 30 minutes
         estimate = provider.estimate_cost("gpu-l40s", 30)
 
-        # Estimated cost: 30 min * $0.000975 * 60 = $1.755
-        self.assertAlmostEqual(estimate["estimated"], 1.755, places=2)
+        # Estimated cost: 30 min * $0.000972222 * 60 = $1.75
+        self.assertAlmostEqual(estimate["estimated"], 1.75, places=2)
 
         # Bounds check
         self.assertLess(estimate["min"], estimate["estimated"])
@@ -331,7 +331,7 @@ class TestCostCalculation(unittest.TestCase):
             default_hardware={
                 "gpu-l40s": {
                     "name": "L40S",
-                    "cost_per_second": 0.000975,
+                    "cost_per_second": 0.000972222,
                 },
             },
             default_hardware_id="gpu-l40s",
@@ -340,8 +340,8 @@ class TestCostCalculation(unittest.TestCase):
         # 24 hours = 1440 minutes
         estimate = provider.estimate_cost("gpu-l40s", 1440)
 
-        # Expected: 1440 * 60 * 0.000975 = $84.24
-        self.assertAlmostEqual(estimate["estimated"], 84.24, places=2)
+        # Expected: 1440 * 60 * 0.000972222 = $84.00
+        self.assertAlmostEqual(estimate["estimated"], 84.00, places=2)
 
 
 class TestReplicatePricing(unittest.TestCase):
@@ -366,20 +366,20 @@ class TestReplicatePricing(unittest.TestCase):
 
         self.assertIsNotNone(hw)
         self.assertEqual(hw.memory_gb, 48)
-        # L40S costs ~$0.000975/s = ~$3.51/hour
-        self.assertAlmostEqual(hw.cost_per_hour, 3.51, places=2)
+        # L40S costs ~$0.000972222/s = ~$3.50/hour
+        self.assertAlmostEqual(hw.cost_per_hour, 3.50, places=2)
 
-    def test_replicate_a100_pricing(self):
-        """Test Replicate A100 pricing."""
+    def test_replicate_h100_pricing(self):
+        """Test Replicate H100 pricing."""
         from simpletuner.simpletuner_sdk.server.services.cloud.pricing import get_pricing_provider
 
         provider = get_pricing_provider("replicate")
-        hw = provider.get_hardware_by_id("gpu-a100-large")
+        hw = provider.get_hardware_by_id("gpu-h100")
 
         self.assertIsNotNone(hw)
         self.assertEqual(hw.memory_gb, 80)
-        # A100 costs ~$0.0014/s = ~$5.04/hour
-        self.assertAlmostEqual(hw.cost_per_hour, 5.04, places=2)
+        # H100 costs ~$0.001525/s = ~$5.49/hour
+        self.assertAlmostEqual(hw.cost_per_hour, 5.49, places=2)
 
     def test_replicate_default_hardware(self):
         """Test Replicate default hardware is L40S."""

--- a/tests/test_replicate_hardware_profiles.py
+++ b/tests/test_replicate_hardware_profiles.py
@@ -25,6 +25,12 @@ class ReplicateHardwareProfileTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(ValueError):
             normalize_replicate_hardware_profile("a10g")
 
+    def test_default_hardware_info_includes_h100_and_l40s_pricing(self):
+        from simpletuner.simpletuner_sdk.server.services.cloud.replicate_client import DEFAULT_HARDWARE_INFO
+
+        self.assertEqual(DEFAULT_HARDWARE_INFO["gpu-l40s"]["cost_per_second"], 0.000972222)
+        self.assertEqual(DEFAULT_HARDWARE_INFO["gpu-h100"]["cost_per_second"], 0.001525)
+
     async def test_replicate_client_uses_profile_model_for_latest_version(self):
         from simpletuner.simpletuner_sdk.server.services.cloud.replicate_client import ReplicateCogClient
 

--- a/tests/test_webui_e2e.py
+++ b/tests/test_webui_e2e.py
@@ -1770,9 +1770,11 @@ class CloudHardwareProfileSubmitTestCase(_TrainerPageMixin, WebUITestCase):
                 name: 'Replicate',
                 hardware_profile: 'l40s-x4',
                 hardware_profiles: [
-                    { id: 'h100', label: 'H100', hardware_type: 'H100' },
-                    { id: 'h100-x8', label: '8x H100', hardware_type: '8x H100' },
-                    { id: 'l40s-x4', label: '4x L40S', hardware_type: '4x L40S' }
+                    { id: 'h100', label: 'H100', hardware_type: 'H100', cost_per_hour: 5.49, cost_per_second: 0.001525 },
+                    { id: 'h100-x8', label: '8x H100', hardware_type: '8x H100', cost_per_hour: 43.92, cost_per_second: 0.0122 },
+                    { id: 'l40s', label: 'L40S', hardware_type: 'L40S', cost_per_hour: 3.50, cost_per_second: 0.000972222 },
+                    { id: 'l40s-x4', label: '4x L40S', hardware_type: '4x L40S', cost_per_hour: 14.00, cost_per_second: 0.003888888 },
+                    { id: 'l40s-x8', label: '8x L40S', hardware_type: '8x L40S', cost_per_hour: 28.00, cost_per_second: 0.007777776 }
                 ]
             }];
             comp.providerConfig = { config: { hardware_profile: 'l40s-x4' }, cost_limit_enabled: false };
@@ -1885,6 +1887,80 @@ class CloudHardwareProfileSubmitTestCase(_TrainerPageMixin, WebUITestCase):
             )
 
         self.for_each_browser("test_replicate_hardware_profile_persists_and_submits", scenario)
+
+    def test_replicate_settings_hardware_buttons_update_cost_and_persist(self) -> None:
+        self.with_sample_environment()
+
+        def scenario(driver, _browser):
+            self._open_cloud_tab(driver)
+            driver.execute_script("localStorage.setItem('cloud_replicate_hardware_profile', 'h100-x8');")
+            self.assertTrue(self._install_cloud_modal_harness(driver))
+
+            driver.execute_script(
+                """
+                const comp = Alpine.$data(document.querySelector('#cloud-tab-content'));
+                comp.preSubmitModal.hardwareProfile = 'h100-x8';
+                comp.showSettingsPanel = true;
+                """
+            )
+
+            WebDriverWait(driver, 5).until(
+                lambda d: d.execute_script(
+                    "return Array.from(document.querySelectorAll('[data-testid=\"cloud-settings-hardware-profile\"]'))"
+                    ".filter((button) => button.offsetParent !== null).length === 2;"
+                )
+            )
+            WebDriverWait(driver, 5).until(
+                lambda d: d.execute_script(
+                    "const panel = document.querySelector('.cloud-settings-panel');"
+                    "return panel && panel.innerText.includes('$43.92/hr') && "
+                    "panel.innerText.includes('$0.012200/sec');"
+                )
+            )
+
+            pressed_before = driver.execute_script(
+                """
+                return Array.from(document.querySelectorAll('[data-testid="cloud-settings-hardware-profile"]'))
+                    .filter((button) => button.offsetParent !== null)
+                    .map((button) => ({ text: button.innerText.trim(), pressed: button.getAttribute('aria-pressed') }));
+                """
+            )
+            self.assertIn({"text": "H100", "pressed": "true"}, pressed_before)
+            self.assertIn({"text": "L40S", "pressed": "false"}, pressed_before)
+
+            clicked = driver.execute_script(
+                """
+                const button = Array.from(document.querySelectorAll('[data-testid="cloud-settings-hardware-profile"]'))
+                    .find((candidate) => candidate.offsetParent !== null && candidate.innerText.trim() === 'L40S');
+                if (!button) { return false; }
+                button.click();
+                return true;
+                """
+            )
+            self.assertTrue(clicked)
+
+            WebDriverWait(driver, 5).until(
+                lambda d: d.execute_script("return localStorage.getItem('cloud_replicate_hardware_profile');") == "l40s-x8"
+            )
+            WebDriverWait(driver, 5).until(
+                lambda d: d.execute_script(
+                    "const panel = document.querySelector('.cloud-settings-panel');"
+                    "return panel && panel.innerText.includes('$28.00/hr') && "
+                    "panel.innerText.includes('$0.007778/sec');"
+                )
+            )
+
+            pressed_after = driver.execute_script(
+                """
+                return Array.from(document.querySelectorAll('[data-testid="cloud-settings-hardware-profile"]'))
+                    .filter((button) => button.offsetParent !== null)
+                    .map((button) => ({ text: button.innerText.trim(), pressed: button.getAttribute('aria-pressed') }));
+                """
+            )
+            self.assertIn({"text": "H100", "pressed": "false"}, pressed_after)
+            self.assertIn({"text": "L40S", "pressed": "true"}, pressed_after)
+
+        self.for_each_browser("test_replicate_settings_hardware_buttons_update_cost_and_persist", scenario)
 
 
 class CloudUploadStatusTestCase(_TrainerPageMixin, WebUITestCase):


### PR DESCRIPTION
This pull request introduces support for the H100 GPU as a hardware option for Replicate cloud jobs, improves the accuracy of hardware cost calculations, and updates the UI to allow users to easily select between L40S and H100 base hardware options. The changes also ensure that hardware pricing is consistent and visible throughout the application, and add corresponding tests to verify these behaviors.

**Backend: Hardware Options and Pricing**
- Added H100 as a supported hardware option, replacing A100, and updated cost values for both L40S and H100 in `DEFAULT_HARDWARE_INFO` and related cost calculations. [[1]](diffhunk://#diff-cc3acb63f439a7d5031728c51f1965ff891297d07afa81db7ad01640c50ebed6L248-R253) [[2]](diffhunk://#diff-f75317808d3b2a92aa32ed126c6b3aeba00a82f6623e93a02c7850a9e4324973L44-R47) [[3]](diffhunk://#diff-f75317808d3b2a92aa32ed126c6b3aeba00a82f6623e93a02c7850a9e4324973L115-R115) [[4]](diffhunk://#diff-bad938181425efd67738da676d4cfdf0f28882d93e6f4ba405607afda308ab69R28-R33)
- Enhanced the provider enrichment logic to calculate and expose per-hour and per-second costs for both L40S and H100 hardware profiles, including support for multi-GPU profiles. [[1]](diffhunk://#diff-ea3b5c76e6e0290294ffdbf366ce08103608a9a13ed061da8b1469f339de33f7R128-R146) [[2]](diffhunk://#diff-ea3b5c76e6e0290294ffdbf366ce08103608a9a13ed061da8b1469f339de33f7L132-R156)
- Updated type hints and profile listing logic to support richer hardware profile metadata. [[1]](diffhunk://#diff-8d4b7abcbcce93a7cf3a44c2469f15b73341590b45497b51fb1e24fae27cb6a3L6-R6) [[2]](diffhunk://#diff-8d4b7abcbcce93a7cf3a44c2469f15b73341590b45497b51fb1e24fae27cb6a3L73-R73)

**Frontend: UI Improvements for Hardware Selection**
- Added UI components to `cloud_tab.html` and onboarding flows to let users select between L40S and H100, displaying accurate cost information for each. [[1]](diffhunk://#diff-572e770cacde5670b626d5ec3ff558d2d332346d01ce283e83df77eac78dd3eeR164-R190) [[2]](diffhunk://#diff-572e770cacde5670b626d5ec3ff558d2d332346d01ce283e83df77eac78dd3eeR205) [[3]](diffhunk://#diff-5794d33e95b8341b6f7ca8686a424d4858fe66211db3885ee873cac652f218ccL227-R247)
- Updated the hero CTA to reference H100 instead of A100.
- Implemented new JavaScript methods for fetching, selecting, and displaying base hardware options and their costs, with persistence of user selection.

**Testing**
- Added and updated tests to verify hardware options and cost calculations, as well as frontend logic for hardware selection and display. [[1]](diffhunk://#diff-39ad30baf61e981373490a53bde407404555b7f1a483d2cf5dd4ab483026b8e2R424-R466) [[2]](diffhunk://#diff-bad938181425efd67738da676d4cfdf0f28882d93e6f4ba405607afda308ab69R28-R33)