### PR TITLE
Checkpoints tab "Run Inference" button to run inference pipeline from

### DIFF
--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -4206,6 +4206,18 @@ class Trainer:
             )
         )
 
+    def prepare_model_for_inference(self) -> None:
+        """Register the trained component with Accelerator without training state."""
+        primary_model = self.model.get_trained_component(unwrap_model=False)
+        if primary_model is None:
+            raise ValueError("No trained model component is available for inference.")
+        if hasattr(self.model, "before_accelerator_prepare"):
+            self.model.before_accelerator_prepare()
+
+        prepared_model = self.accelerator.prepare_model(primary_model, evaluation_mode=True)
+        self.model.set_prepared_model(prepared_model)
+        prepared_model.eval()
+
     def init_unload_vae(self):
         if self.config.keep_vae_loaded or self.config.vae_cache_ondemand or getattr(self.config, "vae_cache_disable", False):
             return
@@ -4225,7 +4237,7 @@ class Trainer:
 
         delete_all_model_caches(self.accelerator)
 
-    def init_validations(self):
+    def init_validations(self, preserve_text_encoders: bool = False):
         if (
             hasattr(self.accelerator, "state")
             and hasattr(self.accelerator.state, "deepspeed_plugin")
@@ -4281,7 +4293,7 @@ class Trainer:
             is_fsdp=self.config.use_fsdp,
             publishing_manager=self.publishing_manager,
         )
-        if not self.config.train_text_encoder and self.validation is not None:
+        if not preserve_text_encoders and not self.config.train_text_encoder and self.validation is not None:
             self.validation.clear_text_encoders()
         self.init_benchmark_base_model()
         self.accelerator.wait_for_everyone()

--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -764,29 +764,50 @@ def get_validation_resolutions():
      - if it has an x in it, we will split and treat as WIDTHxHEIGHT
      - if it has comma, we will split and treat each value as above
     """
-    validation_resolution_parameter = StateTracker.get_args().validation_resolution
-    if type(validation_resolution_parameter) is str and "," in validation_resolution_parameter:
-        return [parse_validation_resolution(res) for res in validation_resolution_parameter.split(",")]
-    return [parse_validation_resolution(validation_resolution_parameter)]
+    return parse_validation_resolutions(
+        StateTracker.get_args().validation_resolution,
+        model_flavour=StateTracker.get_args().model_flavour,
+    )
 
 
-def parse_validation_resolution(input_str: str) -> tuple:
+_MODEL_FLAVOUR_FROM_STATE = object()
+
+
+def parse_validation_resolutions(
+    input_value, *, model_flavour: str | None | object = _MODEL_FLAVOUR_FROM_STATE
+) -> list[tuple[int, int]]:
+    values = str(input_value).split(",") if isinstance(input_value, str) else [input_value]
+    return [
+        parse_validation_resolution(value.strip() if isinstance(value, str) else value, model_flavour=model_flavour)
+        for value in values
+    ]
+
+
+def parse_validation_resolution(
+    input_str: str, *, model_flavour: str | None | object = _MODEL_FLAVOUR_FROM_STATE
+) -> tuple[int, int]:
     """
     If the args.validation_resolution:
      - is an int, we'll treat it as height and width square aspect
      - if it has an x in it, we will split and treat as WIDTHxHEIGHT
      - if it has comma, we will split and treat each value as above
     """
-    is_df_ii = True if str(StateTracker.get_args().model_flavour).startswith("ii-") else False
-    if isinstance(input_str, int) or input_str.isdigit():
-        if is_df_ii and int(input_str) < 256:
+    if model_flavour is _MODEL_FLAVOUR_FROM_STATE:
+        model_flavour = StateTracker.get_args().model_flavour
+    is_df_ii = str(model_flavour).startswith("ii-")
+    value = str(input_str).strip().lower()
+    if value.isdigit():
+        if is_df_ii and int(value) < 256:
             raise ValueError("Cannot use less than 256 resolution for DeepFloyd stage 2.")
-        return (int(input_str), int(input_str))
-    if "x" in input_str:
-        pieces = input_str.split("x")
+        return (int(value), int(value))
+    if "x" in value:
+        pieces = value.split("x")
+        if len(pieces) != 2 or not all(piece.isdigit() for piece in pieces):
+            raise ValueError(f"Invalid validation resolution '{input_str}'.")
         if is_df_ii and (int(pieces[0]) < 256 or int(pieces[1]) < 256):
             raise ValueError("Cannot use less than 256 resolution for DeepFloyd stage 2.")
         return (int(pieces[0]), int(pieces[1]))
+    raise ValueError(f"Invalid validation resolution '{input_str}'.")
 
 
 def load_video_frames(video_path):
@@ -1363,7 +1384,8 @@ class ValidationPreviewer:
         self._warned_unsupported = False
         self._warned_callback = False
         self._webhook_handler = StateTracker.get_webhook_handler()
-        if self.enabled and not self._webhook_handler:
+        self._preview_callback = getattr(config, "_validation_preview_callback", None)
+        if self.enabled and not self._webhook_handler and not callable(self._preview_callback):
             logger.warning("validation_preview is enabled but no webhook is configured; previews are disabled.")
             self.enabled = False
         if self.enabled and not self.model.supports_validation_preview():
@@ -1488,8 +1510,6 @@ class ValidationPreviewer:
         return [{"src": data_uri, "mime_type": "image/gif"}]
 
     def _emit_event(self, images, videos, metadata: _PreviewMetadata, step: int, timestep):
-        if self._webhook_handler is None:
-            return
         total_steps = metadata.total_steps
         if not total_steps:
             total_steps = getattr(self.config, "validation_num_inference_steps", None)
@@ -1512,13 +1532,16 @@ class ValidationPreviewer:
                 "step_label": step_label,
             },
         }
-        self._webhook_handler.send_raw(
-            structured_data=payload,
-            message_type="validation.image",
-            images=images,
-            videos=videos,
-            job_id=StateTracker.get_job_id(),
-        )
+        if callable(self._preview_callback):
+            self._preview_callback(structured_data=payload, images=images, videos=videos)
+        if self._webhook_handler is not None:
+            self._webhook_handler.send_raw(
+                structured_data=payload,
+                message_type="validation.image",
+                images=images,
+                videos=videos,
+                job_id=StateTracker.get_job_id(),
+            )
 
     def _should_emit_for_step(self, step: int) -> bool:
         """

--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -784,7 +784,7 @@ def parse_validation_resolutions(
 
 
 def parse_validation_resolution(
-    input_str: str, *, model_flavour: str | None | object = _MODEL_FLAVOUR_FROM_STATE
+    input_str: str | int, *, model_flavour: str | None | object = _MODEL_FLAVOUR_FROM_STATE
 ) -> tuple[int, int]:
     """
     If the args.validation_resolution:

--- a/simpletuner/inference.py
+++ b/simpletuner/inference.py
@@ -1,0 +1,521 @@
+"""Checkpoint inference worker used by the WebUI."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from PIL import Image
+
+from simpletuner.helpers.caching.text_embeds import TextEmbeddingCache
+from simpletuner.helpers.data_backend.local import LocalDataBackend
+from simpletuner.helpers.training.attention_backend import AttentionBackendController, AttentionPhase
+from simpletuner.helpers.training.state_tracker import StateTracker
+from simpletuner.helpers.training.trainer import Trainer
+from simpletuner.helpers.training.validation import (
+    ValidationAbortedException,
+    _validation_text_cache_key,
+    parse_validation_resolutions,
+)
+
+logger = logging.getLogger("SimpleTuner-inference")
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(f"{path.suffix}.tmp")
+    with temporary.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+    os.replace(temporary, path)
+
+
+def _prompt_slug(prompt: str, limit: int = 48) -> str:
+    slug = re.sub(r"[^A-Za-z0-9]+", "-", prompt).strip("-").lower()
+    return slug[:limit].rstrip("-") or "prompt"
+
+
+def _timestamp_slug() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+
+
+class CheckpointInferenceRuntime:
+    """Own one loaded checkpoint and its validation pipeline."""
+
+    def __init__(
+        self,
+        *,
+        trainer_config: dict[str, Any],
+        checkpoint_name: str,
+        session_dir: Path,
+        job_id: str,
+        abort_callback,
+        streaming_preview: bool = False,
+    ) -> None:
+        self.checkpoint_name = checkpoint_name
+        self.session_dir = session_dir
+        self.job_id = job_id
+        self.trainer: Trainer | None = None
+        self.embed_cache: TextEmbeddingCache | None = None
+        self._load(trainer_config, abort_callback, streaming_preview)
+
+    def _load(self, trainer_config: dict[str, Any], abort_callback, streaming_preview: bool) -> None:
+        config = dict(trainer_config)
+        config.update(
+            {
+                "--resume_from_checkpoint": self.checkpoint_name,
+                "--validation_disable": False,
+                "--validation_prompt_library": False,
+                "--user_prompt_library": None,
+                "--validation_prompt": None,
+                "--validation_disable_unconditional": True,
+                "--validation_using_datasets": False,
+                "--validation_preview": streaming_preview,
+                "--disable_benchmark": True,
+                "--gradient_checkpointing": False,
+                "--deepspeed_config": None,
+                "--fsdp_enable": False,
+                "--report_to": "none",
+                "--push_to_hub": False,
+                "__skip_config_fallback__": True,
+            }
+        )
+        trainer = Trainer(config=config, job_id=self.job_id, exit_on_error=True)
+        self.trainer = trainer
+        trainer.config.should_abort = abort_callback
+        trainer._external_abort_checker = abort_callback
+        if streaming_preview:
+            trainer.config._validation_preview_callback = self._write_preview
+
+        trainer.init_noise_schedule()
+        trainer.init_seed()
+        trainer.init_preprocessing_models()
+        trainer.init_precision(preprocessing_models_only=True)
+        trainer.init_load_base_model()
+        trainer.init_controlnet_model()
+        trainer.init_tread_model()
+        trainer.init_precision()
+        trainer.init_freeze_models()
+        trainer.init_trainable_peft_adapter()
+        trainer.init_ema_model()
+        trainer.init_precision(ema_only=True)
+        trainer.move_models(destination="accelerator")
+        trainer.init_distillation()
+        trainer.init_hooks()
+        trainer.prepare_model_for_inference()
+
+        checkpoint_path = Path(trainer.config.output_dir) / self.checkpoint_name
+        trainer.accelerator.load_state(str(checkpoint_path))
+        AttentionBackendController.on_load_checkpoint(str(checkpoint_path))
+        if trainer.distiller is not None:
+            trainer.distiller.on_load_checkpoint(str(checkpoint_path))
+
+        cache_id = f"inference-{self.job_id}"
+        cache_dir = self.session_dir / ".prompt_cache" / self.checkpoint_name
+        backend = LocalDataBackend(trainer.accelerator, id=cache_id)
+        self.embed_cache = TextEmbeddingCache(
+            id=cache_id,
+            data_backend=backend,
+            text_encoders=trainer.model.text_encoders,
+            tokenizers=trainer.model.tokenizers,
+            accelerator=trainer.accelerator,
+            cache_dir=str(cache_dir),
+            model_type=trainer.config.model_family,
+            model=trainer.model,
+        )
+        StateTracker.set_default_text_embed_cache(self.embed_cache)
+        self.embed_cache.discover_all_files()
+        if trainer.model.VALIDATION_USES_NEGATIVE_PROMPT:
+            negative_prompt = trainer.config.validation_negative_prompt or ""
+            if trainer.config.model_family == "ideogram":
+                self.embed_cache.encode_validation_negative_prompt(negative_prompt)
+            elif trainer.model.should_precompute_validation_negative_prompt():
+                self.embed_cache.compute_embeddings_for_prompts(
+                    [negative_prompt],
+                    is_validation=True,
+                    load_from_cache=False,
+                )
+            else:
+                self.embed_cache.encode_validation_negative_prompt(negative_prompt)
+            self._flush_embed_cache()
+        trainer.validation_prompt_metadata = {
+            "validation_prompts": [],
+            "validation_shortnames": [],
+            "validation_sample_images": None,
+        }
+        trainer.init_validations(preserve_text_encoders=True)
+        AttentionBackendController.apply(trainer.config, AttentionPhase.EVAL)
+        trainer.validation.setup_pipeline("checkpoint")
+        if trainer.model.pipeline is None:
+            raise RuntimeError(f"Could not create an inference pipeline for {self.checkpoint_name}.")
+        trainer.validation.setup_scheduler()
+
+    def _write_preview(self, *, structured_data: dict[str, Any], images: list[Any], videos: Any) -> None:
+        if not images or not isinstance(images[0], Image.Image):
+            return
+        preview_path = self.session_dir / "preview.png"
+        temporary = preview_path.with_suffix(".png.tmp")
+        try:
+            preview_path.parent.mkdir(parents=True, exist_ok=True)
+            images[0].save(temporary, format="PNG")
+            os.replace(temporary, preview_path)
+            data = structured_data.get("data") or {}
+            _write_json(
+                self.session_dir / "preview.json",
+                {
+                    "checkpoint": self.checkpoint_name,
+                    "prompt": data.get("prompt") or structured_data.get("body") or "",
+                    "step": data.get("step"),
+                    "step_label": data.get("step_label"),
+                    "updated_at": _utc_now(),
+                    "media_type": "image",
+                    "filename": preview_path.name,
+                },
+            )
+        except OSError as exc:
+            logger.warning("Could not write streaming inference preview: %s", exc)
+
+    def _flush_embed_cache(self) -> None:
+        if self.embed_cache is None:
+            raise RuntimeError("Inference prompt cache is not initialized.")
+        self.embed_cache.process_write_batches = False
+        self.embed_cache.batch_write_thread.join()
+
+    def _prepare_prompt(self, entry: dict[str, Any]) -> None:
+        if self.trainer is None or self.embed_cache is None:
+            raise RuntimeError("Inference runtime is not loaded.")
+        prompt = str(entry["prompt"])
+        shortname = str(entry["shortname"])
+        key = _validation_text_cache_key(self.trainer.config, shortname, prompt)
+        prompt_record: dict[str, Any] = {"prompt": prompt, "key": key}
+        metadata = entry.get("metadata")
+        if isinstance(metadata, dict) and metadata:
+            prompt_record["metadata"] = metadata
+        self.embed_cache.compute_embeddings_for_prompts(
+            [prompt_record],
+            is_validation=True,
+            load_from_cache=False,
+        )
+
+        entity_records = []
+        for index, entity in enumerate(entry.get("bbox_entities") or []):
+            entity_records.append(
+                {
+                    "prompt": entity["label"],
+                    "key": f"__grounding_val_{shortname}__bbox_{index}",
+                }
+            )
+        if entity_records:
+            self.embed_cache.compute_embeddings_for_prompts(
+                entity_records,
+                return_concat=False,
+                is_validation=True,
+                load_from_cache=False,
+            )
+        self._flush_embed_cache()
+
+    def _output_stem(self, *, prompt: str, seed: int, style: str) -> str:
+        timestamp = _timestamp_slug()
+        if style == "compact":
+            return f"{timestamp}_seed{seed}"
+        if style == "prompt":
+            return f"{_prompt_slug(prompt)}_{timestamp}"
+        if style == "content-hash":
+            return f"pending_{timestamp}"
+        return f"{timestamp}_{_prompt_slug(prompt)}_seed{seed}"
+
+    def _save_media(
+        self,
+        media: Any,
+        *,
+        prompt: str,
+        shortname: str,
+        seed: int,
+        style: str,
+        index: int,
+        settings: dict[str, Any],
+    ) -> dict[str, Any]:
+        output_dir = self.session_dir / self.checkpoint_name
+        output_dir.mkdir(parents=True, exist_ok=True)
+        stem = f"{self._output_stem(prompt=prompt, seed=seed, style=style)}_{index + 1:02d}"
+
+        if isinstance(media, Image.Image):
+            extension = ".png"
+            output_path = output_dir / f"{stem}{extension}"
+            media.save(output_path, format="PNG")
+            media_type = "image"
+        elif isinstance(media, list) and media and all(isinstance(frame, Image.Image) for frame in media):
+            from diffusers.utils.export_utils import export_to_video
+
+            extension = ".mp4"
+            output_path = output_dir / f"{stem}{extension}"
+            export_to_video(media, str(output_path), fps=int(getattr(self.trainer.config, "framerate", 16)))
+            media_type = "video"
+        else:
+            raise TypeError(f"Unsupported inference output type: {type(media).__name__}")
+
+        digest = hashlib.sha256(output_path.read_bytes()).hexdigest()
+        if style == "content-hash":
+            hashed_path = output_path.with_name(f"{digest}{extension}")
+            os.replace(output_path, hashed_path)
+            output_path = hashed_path
+
+        metadata = {
+            "session_id": self.session_dir.name,
+            "checkpoint": self.checkpoint_name,
+            "prompt": prompt,
+            "shortname": shortname,
+            "seed": seed,
+            "created_at": _utc_now(),
+            "media_type": media_type,
+            "filename": output_path.name,
+            "sha256": digest,
+            "settings": settings,
+        }
+        _write_json(output_path.with_suffix(f"{output_path.suffix}.json"), metadata)
+        return metadata
+
+    def _apply_settings(self, settings: dict[str, Any]) -> int:
+        if self.trainer is None:
+            raise RuntimeError("Inference runtime is not loaded.")
+        seed = int(settings.get("seed", getattr(self.trainer.config, "validation_seed", 42) or 42))
+        self.trainer.config.validation_seed = seed
+        if settings.get("num_inference_steps") is not None:
+            self.trainer.config.validation_num_inference_steps = int(settings["num_inference_steps"])
+        if settings.get("guidance_scale") is not None:
+            self.trainer.config.validation_guidance = float(settings["guidance_scale"])
+        if settings.get("validation_resolution") is not None:
+            resolution_value = str(settings["validation_resolution"])
+            self.trainer.config.validation_resolution = resolution_value
+            self.trainer.validation.validation_resolutions = parse_validation_resolutions(
+                resolution_value,
+                model_flavour=self.trainer.config.model_flavour,
+            )
+        return seed
+
+    def generate(
+        self,
+        entries: list[dict[str, Any]],
+        *,
+        filename_style: str,
+        settings: dict[str, Any],
+        progress_callback,
+        abort_callback,
+    ) -> list[dict[str, Any]]:
+        if self.trainer is None:
+            raise RuntimeError("Inference runtime is not loaded.")
+        validation = self.trainer.validation
+        results: list[dict[str, Any]] = []
+        seed = self._apply_settings(settings)
+
+        for entry_index, entry in enumerate(entries):
+            if abort_callback():
+                raise ValidationAbortedException("Inference was cancelled.")
+            self._prepare_prompt(entry)
+            shortname = str(entry["shortname"])
+            prompt = str(entry["prompt"])
+            _, checkpoint_media, _, _ = validation.validate_prompt(
+                prompt,
+                shortname,
+                validation_type="checkpoint",
+                adapter_strength=entry.get("adapter_strength"),
+                cache_shortname=shortname,
+                bbox_entities=entry.get("bbox_entities"),
+                bbox_keyframes=entry.get("bbox_keyframes"),
+            )
+            prompt_media = checkpoint_media.get(shortname, [])
+            if not prompt_media:
+                raise RuntimeError(f"Inference produced no image or video for prompt '{shortname}'.")
+            effective_settings = {
+                "seed": seed,
+                "num_inference_steps": self.trainer.config.validation_num_inference_steps,
+                "guidance_scale": self.trainer.config.validation_guidance,
+                "validation_resolution": self.trainer.config.validation_resolution,
+            }
+            for media_index, media in enumerate(prompt_media):
+                results.append(
+                    self._save_media(
+                        media,
+                        prompt=prompt,
+                        shortname=shortname,
+                        seed=seed,
+                        style=filename_style,
+                        index=media_index,
+                        settings=effective_settings,
+                    )
+                )
+            progress_callback(entry_index + 1, len(entries), prompt)
+        return results
+
+    def close(self) -> None:
+        if self.trainer is None:
+            return
+        try:
+            if self.trainer.validation is not None:
+                self.trainer.validation.clean_pipeline()
+        finally:
+            if self.embed_cache is not None:
+                self.embed_cache.process_write_batches = False
+                if self.embed_cache.batch_write_thread.is_alive():
+                    self.embed_cache.batch_write_thread.join(timeout=2)
+            self.trainer.cleanup()
+            self.trainer = None
+            self.embed_cache = None
+
+
+def run_checkpoint_inference(config) -> dict[str, Any]:
+    """Process keeper entry point for checkpoint inference sessions."""
+    write_json = _write_json
+    payload = dict(config.__dict__)
+    session_dir = Path(payload["session_dir"])
+    state_path = session_dir / "session.json"
+    checkpoints = list(payload["checkpoint_names"])
+    entries = list(payload["prompt_entries"])
+    filename_style = str(payload.get("filename_style", "descriptive"))
+    settings = dict(payload.get("settings") or {})
+    keep_loaded = bool(payload.get("keep_loaded")) and len(checkpoints) == 1
+    streaming_preview = bool(payload.get("streaming_preview"))
+    idle_timeout = max(60, int(payload.get("idle_timeout_seconds", 900)))
+    completed_outputs: list[dict[str, Any]] = []
+
+    state = {
+        "session_id": session_dir.name,
+        "job_id": payload["job_id"],
+        "environment": payload["environment"],
+        "checkpoint_names": checkpoints,
+        "status": "loading",
+        "created_at": payload.get("created_at") or _utc_now(),
+        "updated_at": _utc_now(),
+        "completed_prompts": 0,
+        "total_prompts": len(entries) * len(checkpoints),
+        "output_count": 0,
+        "keep_loaded": keep_loaded,
+        "streaming_preview": streaming_preview,
+    }
+
+    def update_state(**changes) -> None:
+        state.update(changes)
+        state["updated_at"] = _utc_now()
+        write_json(state_path, state)
+
+    def aborted() -> bool:
+        return bool(config.should_abort())
+
+    runtime: CheckpointInferenceRuntime | None = None
+    try:
+        completed_prompts = 0
+        for checkpoint_name in checkpoints:
+            if aborted():
+                raise ValidationAbortedException("Inference was cancelled.")
+            update_state(status="loading", loaded_checkpoint=checkpoint_name)
+            runtime = CheckpointInferenceRuntime(
+                trainer_config=payload["trainer_config"],
+                checkpoint_name=checkpoint_name,
+                session_dir=session_dir,
+                job_id=payload["job_id"],
+                abort_callback=config.should_abort,
+                streaming_preview=streaming_preview,
+            )
+            update_state(status="running", loaded_checkpoint=checkpoint_name)
+
+            def report(current: int, total: int, prompt: str) -> None:
+                update_state(
+                    status="running",
+                    current_prompt=prompt,
+                    completed_prompts=completed_prompts + current,
+                    output_count=len(completed_outputs),
+                )
+
+            generated = runtime.generate(
+                entries,
+                filename_style=filename_style,
+                settings=settings,
+                progress_callback=report,
+                abort_callback=aborted,
+            )
+            completed_outputs.extend(generated)
+            completed_prompts += len(entries)
+            update_state(completed_prompts=completed_prompts, output_count=len(completed_outputs))
+            if checkpoint_name != checkpoints[-1] or not keep_loaded:
+                runtime.close()
+                runtime = None
+
+        if not keep_loaded:
+            update_state(status="completed", loaded_checkpoint=None, completed_at=_utc_now())
+            return state
+
+        update_state(status="loaded", current_prompt=None)
+        last_activity = time.monotonic()
+        while not aborted():
+            command = config.consume_process_command(timeout=0.5)
+            if command is None:
+                if time.monotonic() - last_activity >= idle_timeout:
+                    update_state(status="unloading", message="Inference session reached its idle timeout.")
+                    break
+                continue
+            command_name = str(command.get("command") or "").lower()
+            if command_name == "inference_unload":
+                update_state(status="unloading")
+                break
+            if command_name != "inference_generate":
+                continue
+            command_data = command.get("data") or {}
+            command_entries = list(command_data.get("prompt_entries") or [])
+            if not command_entries:
+                continue
+            last_activity = time.monotonic()
+            state["total_prompts"] += len(command_entries)
+            update_state(status="running")
+
+            base_completed = int(state["completed_prompts"])
+
+            def report_interactive(current: int, total: int, prompt: str) -> None:
+                update_state(
+                    status="running",
+                    current_prompt=prompt,
+                    completed_prompts=base_completed + current,
+                    output_count=len(completed_outputs),
+                )
+
+            generated = runtime.generate(
+                command_entries,
+                filename_style=str(command_data.get("filename_style") or filename_style),
+                settings=dict(command_data.get("settings") or settings),
+                progress_callback=report_interactive,
+                abort_callback=aborted,
+            )
+            completed_outputs.extend(generated)
+            update_state(
+                status="loaded",
+                current_prompt=None,
+                completed_prompts=base_completed + len(command_entries),
+                output_count=len(completed_outputs),
+            )
+
+        update_state(status="completed", loaded_checkpoint=None, completed_at=_utc_now())
+        return state
+    except ValidationAbortedException as exc:
+        update_state(status="cancelled", message=str(exc), completed_at=_utc_now())
+        return state
+    except Exception as exc:
+        logger.exception("Checkpoint inference failed")
+        update_state(status="failed", message=str(exc), completed_at=_utc_now())
+        raise
+    finally:
+        if runtime is not None:
+            runtime.close()
+
+
+def main() -> int:
+    raise SystemExit("simpletuner-inference is managed by the SimpleTuner WebUI checkpoint inference service.")

--- a/simpletuner/inference.py
+++ b/simpletuner/inference.py
@@ -53,6 +53,8 @@ def _timestamp_slug() -> str:
 class CheckpointInferenceRuntime:
     """Own one loaded checkpoint and its validation pipeline."""
 
+    EMBED_CACHE_FLUSH_TIMEOUT_SECONDS = 10
+
     def __init__(
         self,
         *,
@@ -190,7 +192,13 @@ class CheckpointInferenceRuntime:
         if self.embed_cache is None:
             raise RuntimeError("Inference prompt cache is not initialized.")
         self.embed_cache.process_write_batches = False
-        self.embed_cache.batch_write_thread.join()
+        self.embed_cache.batch_write_thread.join(timeout=self.EMBED_CACHE_FLUSH_TIMEOUT_SECONDS)
+        if self.embed_cache.batch_write_thread.is_alive():
+            logger.warning(
+                "Timed out after %s seconds while flushing the inference prompt cache.",
+                self.EMBED_CACHE_FLUSH_TIMEOUT_SECONDS,
+            )
+            raise RuntimeError("Timed out while flushing the inference prompt cache.")
 
     def _prepare_prompt(self, entry: dict[str, Any]) -> None:
         if self.trainer is None or self.embed_cache is None:

--- a/simpletuner/simpletuner_sdk/process_keeper.py
+++ b/simpletuner/simpletuner_sdk/process_keeper.py
@@ -187,6 +187,7 @@ import marshal
 import signal
 import time
 import threading
+import queue
 import logging
 import types
 import importlib
@@ -293,6 +294,7 @@ should_abort = False
 command_check_thread = None
 manual_validation_event = threading.Event()
 manual_checkpoint_event = threading.Event()
+custom_command_queue = queue.Queue()
 
 
 def consume_manual_validation_request():
@@ -309,6 +311,14 @@ def consume_manual_checkpoint_request():
         manual_checkpoint_event.clear()
         return True
     return False
+
+
+def consume_process_command(timeout=0.1):
+    """Return the next command not handled by the training command bridge."""
+    try:
+        return custom_command_queue.get(timeout=timeout)
+    except queue.Empty:
+        return None
 
 
 def send_event(event_type, data=None):
@@ -423,6 +433,8 @@ def check_commands():
                 elif command_name == "trigger_checkpoint":
                     logger.info("Received manual checkpoint trigger")
                     manual_checkpoint_event.set()
+                else:
+                    custom_command_queue.put(cmd)
 
                 # Write back remaining commands
                 with open(command_file, 'w') as f:
@@ -490,6 +502,7 @@ class ConfigWrapper:
         self.should_abort = lambda: should_abort
         self.consume_manual_validation_request = consume_manual_validation_request
         self.consume_manual_checkpoint_request = consume_manual_checkpoint_request
+        self.consume_process_command = consume_process_command
 
 wrapped_config = ConfigWrapper(config)
 

--- a/simpletuner/simpletuner_sdk/server/routes/checkpoints.py
+++ b/simpletuner/simpletuner_sdk/server/routes/checkpoints.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
+from simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service import (
+    CHECKPOINT_INFERENCE_SERVICE,
+    CheckpointInferenceServiceError,
+)
 from simpletuner.simpletuner_sdk.server.services.checkpoints_service import CHECKPOINTS_SERVICE, CheckpointsServiceError
 from simpletuner.simpletuner_sdk.server.services.cloud.auth.middleware import get_current_user
 from simpletuner.simpletuner_sdk.server.services.cloud.auth.models import User
@@ -55,6 +60,43 @@ class UploadCheckpointsRequest(BaseModel):
     callback_url: Optional[str] = Field(None, description="Webhook URL for progress callbacks")
 
 
+class InferenceSettings(BaseModel):
+    seed: Optional[int] = None
+    num_inference_steps: Optional[int] = Field(None, ge=1, le=1000)
+    guidance_scale: Optional[float] = Field(None, ge=0, le=100)
+    validation_resolution: Optional[str] = Field(None, min_length=1, max_length=256)
+
+
+class StartInferenceRequest(BaseModel):
+    environment: str
+    checkpoint_names: List[str] = Field(..., min_length=1)
+    use_configured_prompt: bool = True
+    use_builtin_library: bool = False
+    user_library_filename: Optional[str] = None
+    custom_prompts: List[str] = Field(default_factory=list)
+    filename_style: str = "descriptive"
+    keep_loaded: bool = False
+    streaming_preview: bool = False
+    idle_timeout_minutes: int = Field(15, ge=1, le=1440)
+    settings: InferenceSettings = Field(default_factory=InferenceSettings)
+
+
+class GenerateInferenceRequest(BaseModel):
+    environment: str
+    custom_prompts: List[str] = Field(..., min_length=1)
+    filename_style: Optional[str] = None
+    settings: InferenceSettings = Field(default_factory=InferenceSettings)
+
+
+class InferenceSessionRequest(BaseModel):
+    environment: str
+
+
+class DeleteInferenceHistoryRequest(BaseModel):
+    environment: str
+    media_paths: List[str] = Field(..., min_length=1, max_length=100)
+
+
 def _call_service(func, *args, **kwargs):
     """Execute a service call and translate domain errors to HTTP errors."""
     try:
@@ -62,6 +104,8 @@ def _call_service(func, *args, **kwargs):
     except CheckpointsServiceError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.message)
     except HuggingfaceServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message)
+    except CheckpointInferenceServiceError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.message)
 
 
@@ -89,6 +133,106 @@ async def list_checkpoints(
         )
 
     return _call_service(CHECKPOINTS_SERVICE.list_checkpoints, environment, sort_by)
+
+
+@router.get("/inference/prompt-sources")
+async def inference_prompt_sources(
+    environment: str = Query(...),
+    _user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    return _call_service(CHECKPOINT_INFERENCE_SERVICE.prompt_sources, environment)
+
+
+@router.post("/inference/start")
+async def start_inference(
+    request: StartInferenceRequest,
+    _user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    return _call_service(
+        CHECKPOINT_INFERENCE_SERVICE.start,
+        environment=request.environment,
+        checkpoint_names=request.checkpoint_names,
+        use_configured_prompt=request.use_configured_prompt,
+        use_builtin_library=request.use_builtin_library,
+        user_library_filename=request.user_library_filename,
+        custom_prompts=request.custom_prompts,
+        filename_style=request.filename_style,
+        keep_loaded=request.keep_loaded,
+        streaming_preview=request.streaming_preview,
+        idle_timeout_minutes=request.idle_timeout_minutes,
+        settings=request.settings.model_dump(exclude_none=True),
+    )
+
+
+@router.get("/inference/{session_id}/status")
+async def inference_status(
+    session_id: str,
+    environment: str = Query(...),
+    _user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    return _call_service(CHECKPOINT_INFERENCE_SERVICE.status, environment, session_id)
+
+
+@router.post("/inference/{session_id}/generate")
+async def generate_inference(
+    session_id: str,
+    request: GenerateInferenceRequest,
+    _user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    return _call_service(
+        CHECKPOINT_INFERENCE_SERVICE.generate,
+        environment=request.environment,
+        session_id=session_id,
+        custom_prompts=request.custom_prompts,
+        filename_style=request.filename_style,
+        settings=request.settings.model_dump(exclude_none=True),
+    )
+
+
+@router.post("/inference/{session_id}/unload")
+async def unload_inference(
+    session_id: str,
+    request: InferenceSessionRequest,
+    _user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    return _call_service(CHECKPOINT_INFERENCE_SERVICE.stop, request.environment, session_id, cancel=False)
+
+
+@router.post("/inference/{session_id}/cancel")
+async def cancel_inference(
+    session_id: str,
+    request: InferenceSessionRequest,
+    _user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    return _call_service(CHECKPOINT_INFERENCE_SERVICE.stop, request.environment, session_id, cancel=True)
+
+
+@router.get("/inference/history")
+async def inference_history(
+    environment: str = Query(...),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(24, ge=1, le=100),
+    _user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    return _call_service(CHECKPOINT_INFERENCE_SERVICE.history, environment, page=page, page_size=page_size)
+
+
+@router.delete("/inference/history")
+async def delete_inference_history(
+    request: DeleteInferenceHistoryRequest,
+    _user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    return _call_service(CHECKPOINT_INFERENCE_SERVICE.delete_history, request.environment, request.media_paths)
+
+
+@router.get("/inference/media/{media_path:path}")
+async def inference_media(
+    media_path: str,
+    environment: str = Query(...),
+    _user: User = Depends(get_current_user),
+):
+    path = _call_service(CHECKPOINT_INFERENCE_SERVICE.media_path, environment, media_path)
+    return FileResponse(path)
 
 
 @router.post("/{checkpoint_name}/validate")

--- a/simpletuner/simpletuner_sdk/server/routes/webui_state.py
+++ b/simpletuner/simpletuner_sdk/server/routes/webui_state.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
@@ -564,6 +564,42 @@ class CollapsedSectionsPayload(BaseModel):
     """Payload for updating collapsed sections state."""
 
     sections: Dict[str, bool]
+
+
+class CheckpointInferenceSettingsPayload(BaseModel):
+    """Persisted settings for the checkpoint inference workspace."""
+
+    filename_style: Literal["descriptive", "compact", "prompt", "content-hash"] = "descriptive"
+    keep_loaded: bool = False
+    streaming_preview: bool = False
+
+
+@router.get("/ui-state/checkpoint-inference")
+async def get_checkpoint_inference_settings(
+    _user: User = Depends(get_current_user),
+) -> CheckpointInferenceSettingsPayload:
+    """Get checkpoint inference UI settings."""
+    store = WebUIStateStore()
+    try:
+        settings = store.get_checkpoint_inference_settings()
+        return CheckpointInferenceSettingsPayload.model_validate(settings)
+    except ValueError as error:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error
+
+
+@router.post("/ui-state/checkpoint-inference")
+async def save_checkpoint_inference_settings(
+    payload: CheckpointInferenceSettingsPayload,
+    _user: User = Depends(get_current_user),
+) -> CheckpointInferenceSettingsPayload:
+    """Save checkpoint inference UI settings."""
+    store = WebUIStateStore()
+    try:
+        settings = payload.model_dump()
+        store.save_checkpoint_inference_settings(settings)
+        return payload
+    except ValueError as error:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error
 
 
 @router.get("/ui-state/collapsed-sections/{tab_name}")

--- a/simpletuner/simpletuner_sdk/server/services/checkpoint_inference_service.py
+++ b/simpletuner/simpletuner_sdk/server/services/checkpoint_inference_service.py
@@ -1,0 +1,511 @@
+"""Checkpoint inference orchestration for the WebUI."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import uuid
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+from fastapi import status
+
+from simpletuner.helpers.prompts import prompts as built_in_prompts
+from simpletuner.helpers.training.validation import parse_validation_resolutions
+from simpletuner.helpers.utils.checkpoint_manager import CheckpointManager
+from simpletuner.simpletuner_sdk import process_keeper
+from simpletuner.simpletuner_sdk.api_state import APIState
+from simpletuner.simpletuner_sdk.server.services.config_store import ConfigStore
+from simpletuner.simpletuner_sdk.server.services.field_registry import field_registry
+from simpletuner.simpletuner_sdk.server.services.prompt_library_service import PromptLibraryError, PromptLibraryService
+from simpletuner.simpletuner_sdk.server.services.webui_state import WebUIStateStore
+
+
+class CheckpointInferenceServiceError(Exception):
+    def __init__(self, message: str, status_code: int = status.HTTP_400_BAD_REQUEST) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+class CheckpointInferenceService:
+    FILENAME_STYLES = {"descriptive", "compact", "prompt", "content-hash"}
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._sessions: dict[str, dict[str, str]] = {}
+        self._environment_sessions: dict[str, str] = {}
+
+    def _get_config_store(self) -> ConfigStore:
+        defaults = WebUIStateStore().load_defaults()
+        if defaults.configs_dir:
+            return ConfigStore(config_dir=Path(defaults.configs_dir).expanduser(), config_type="model")
+        return ConfigStore(config_type="model")
+
+    def _load_environment(self, environment: str) -> tuple[dict[str, Any], Path]:
+        try:
+            config, _ = self._get_config_store().load_config(environment)
+        except FileNotFoundError as exc:
+            raise CheckpointInferenceServiceError(
+                f"Environment '{environment}' not found.", status.HTTP_404_NOT_FOUND
+            ) from exc
+        output_dir = config.get("--output_dir") or config.get("output_dir")
+        if not output_dir:
+            raise CheckpointInferenceServiceError(f"Environment '{environment}' has no output directory configured.")
+        return config, Path(os.path.expanduser(str(output_dir))).resolve()
+
+    @staticmethod
+    def _config_value(config: dict[str, Any], name: str, default=None):
+        return config.get(f"--{name}", config.get(name, default))
+
+    @staticmethod
+    def _config_value_with_registry_default(config: dict[str, Any], name: str) -> Any:
+        value = CheckpointInferenceService._config_value(config, name)
+        if value is not None:
+            return value
+        field = field_registry.get_field(name)
+        if field is None:
+            raise RuntimeError(f"Configuration field '{name}' is not registered.")
+        return field.default_value
+
+    @classmethod
+    def _inference_resolutions(cls, config: dict[str, Any], settings: dict[str, Any]) -> list[tuple[int, int]]:
+        value = settings.get("validation_resolution")
+        if value is None:
+            value = cls._config_value_with_registry_default(config, "validation_resolution")
+        try:
+            return parse_validation_resolutions(
+                value,
+                model_flavour=cls._config_value(config, "model_flavour"),
+            )
+        except (TypeError, ValueError) as exc:
+            raise CheckpointInferenceServiceError(str(exc)) from exc
+
+    @staticmethod
+    def _write_session_state(path: Path, state: dict[str, Any]) -> None:
+        temporary = path.with_suffix(f"{path.suffix}.tmp")
+        with temporary.open("w", encoding="utf-8") as handle:
+            json.dump(state, handle, indent=2)
+            handle.write("\n")
+        os.replace(temporary, path)
+
+    def _training_is_active(self) -> bool:
+        job_id = APIState.get_state("current_job_id")
+        if not job_id:
+            return False
+        return process_keeper.get_process_status(job_id) in {"pending", "running", "aborting"}
+
+    def active_session(self) -> dict[str, str] | None:
+        for session_id, record in list(self._sessions.items()):
+            process_status = process_keeper.get_process_status(record["job_id"])
+            if process_status in {"pending", "running", "aborting"}:
+                return record
+            self._environment_sessions.pop(record["environment"], None)
+        return None
+
+    @staticmethod
+    def _normalise_entry(shortname: str, value: Any, source: str) -> dict[str, Any]:
+        if isinstance(value, str):
+            payload: dict[str, Any] = {"prompt": value}
+        elif isinstance(value, dict):
+            payload = dict(value)
+        else:
+            raise CheckpointInferenceServiceError(f"Prompt '{shortname}' has an unsupported value.")
+        prompt = str(payload.get("prompt") or "").strip()
+        if not prompt:
+            raise CheckpointInferenceServiceError(f"Prompt '{shortname}' is empty.")
+        return {
+            "shortname": shortname,
+            "prompt": prompt,
+            "source": source,
+            **{key: payload[key] for key in ("adapter_strength", "bbox_entities", "bbox_keyframes") if key in payload},
+        }
+
+    def resolve_prompts(
+        self,
+        *,
+        config: dict[str, Any],
+        use_configured_prompt: bool,
+        use_builtin_library: bool,
+        user_library_filename: str | None,
+        custom_prompts: list[str],
+    ) -> list[dict[str, Any]]:
+        entries: list[dict[str, Any]] = []
+        seen_shortnames: set[str] = set()
+
+        def append(shortname: str, value: Any, source: str) -> None:
+            candidate = shortname
+            suffix = 2
+            while candidate in seen_shortnames:
+                candidate = f"{shortname}_{suffix}"
+                suffix += 1
+            seen_shortnames.add(candidate)
+            entries.append(self._normalise_entry(candidate, value, source))
+
+        if use_configured_prompt:
+            configured = self._config_value(config, "validation_prompt")
+            if configured not in (None, "", "None"):
+                append("configured", str(configured), "configured")
+
+        if use_builtin_library:
+            for shortname, prompt in built_in_prompts.items():
+                append(f"builtin_{shortname}", prompt, "builtin")
+
+        if user_library_filename:
+            try:
+                configured_library = self._config_value(config, "user_prompt_library")
+                configured_path = Path(str(configured_library)).expanduser() if configured_library else None
+                if (
+                    configured_path is not None
+                    and configured_path.name == Path(user_library_filename).name
+                    and configured_path.is_file()
+                ):
+                    with configured_path.open("r", encoding="utf-8") as handle:
+                        parsed_entries = PromptLibraryService.parse_entries(json.load(handle))
+                    library = {"entries": PromptLibraryService.serialise_entries(parsed_entries)}
+                else:
+                    library = PromptLibraryService().read_library(Path(user_library_filename).name)
+            except (OSError, json.JSONDecodeError, PromptLibraryError) as exc:
+                raise CheckpointInferenceServiceError(str(exc)) from exc
+            for shortname, prompt in library["entries"].items():
+                append(f"library_{shortname}", prompt, "user-library")
+
+        for index, prompt in enumerate(custom_prompts, start=1):
+            prompt = str(prompt).strip()
+            if prompt:
+                append(f"custom_{index:03d}", prompt, "custom")
+        return entries
+
+    def prompt_sources(self, environment: str) -> dict[str, Any]:
+        config, _ = self._load_environment(environment)
+        configured_prompt = self._config_value(config, "validation_prompt")
+        configured_library = self._config_value(config, "user_prompt_library")
+        inference_steps = int(self._config_value_with_registry_default(config, "validation_num_inference_steps"))
+        guidance_scale = float(self._config_value_with_registry_default(config, "validation_guidance"))
+        validation_resolution = str(self._config_value_with_registry_default(config, "validation_resolution"))
+        records = PromptLibraryService().list_libraries()
+        libraries = [asdict(record) for record in records]
+        configured_filename = Path(str(configured_library)).name if configured_library else None
+        if configured_library and configured_filename not in {record["filename"] for record in libraries}:
+            configured_path = Path(str(configured_library)).expanduser()
+            if configured_path.is_file():
+                try:
+                    with configured_path.open("r", encoding="utf-8") as handle:
+                        configured_entries = PromptLibraryService.parse_entries(json.load(handle))
+                except (OSError, json.JSONDecodeError, PromptLibraryError) as exc:
+                    raise CheckpointInferenceServiceError(str(exc)) from exc
+                libraries.append(
+                    {
+                        "filename": configured_filename,
+                        "display_name": configured_path.stem,
+                        "prompt_count": len(configured_entries),
+                    }
+                )
+        return {
+            "configured_prompt": configured_prompt if configured_prompt not in (None, "None") else None,
+            "builtin_count": len(built_in_prompts),
+            "configured_user_library": configured_filename,
+            "user_libraries": libraries,
+            "inference_defaults": {
+                "num_inference_steps": inference_steps,
+                "guidance_scale": guidance_scale,
+                "validation_resolution": validation_resolution,
+            },
+        }
+
+    def start(
+        self,
+        *,
+        environment: str,
+        checkpoint_names: list[str],
+        use_configured_prompt: bool,
+        use_builtin_library: bool,
+        user_library_filename: str | None,
+        custom_prompts: list[str],
+        filename_style: str,
+        keep_loaded: bool,
+        streaming_preview: bool,
+        idle_timeout_minutes: int,
+        settings: dict[str, Any],
+    ) -> dict[str, Any]:
+        if not checkpoint_names:
+            raise CheckpointInferenceServiceError("Select at least one checkpoint.")
+        if keep_loaded and len(checkpoint_names) != 1:
+            raise CheckpointInferenceServiceError("Keep loaded is available only for a single checkpoint.")
+        if filename_style not in self.FILENAME_STYLES:
+            raise CheckpointInferenceServiceError("Unsupported inference filename style.")
+        if self._training_is_active():
+            raise CheckpointInferenceServiceError(
+                "Training currently owns the accelerator. Use Trigger Validation or wait for training to finish.",
+                status.HTTP_409_CONFLICT,
+            )
+
+        config, output_dir = self._load_environment(environment)
+        validation_resolutions = self._inference_resolutions(config, settings)
+        manager = CheckpointManager(str(output_dir))
+        for checkpoint_name in checkpoint_names:
+            if Path(checkpoint_name).name != checkpoint_name:
+                raise CheckpointInferenceServiceError("Checkpoint names may not contain path components.")
+            valid, message = manager.validate_checkpoint(checkpoint_name)
+            if not valid:
+                raise CheckpointInferenceServiceError(f"{checkpoint_name} is not inference-ready: {message}")
+
+        prompt_entries = self.resolve_prompts(
+            config=config,
+            use_configured_prompt=use_configured_prompt,
+            use_builtin_library=use_builtin_library,
+            user_library_filename=user_library_filename,
+            custom_prompts=custom_prompts,
+        )
+        if not prompt_entries:
+            raise CheckpointInferenceServiceError("Select a prompt source or enter a custom prompt.")
+
+        with self._lock:
+            active = self.active_session()
+            if active:
+                raise CheckpointInferenceServiceError(
+                    f"Inference session {active['session_id']} is already using the accelerator.",
+                    status.HTTP_409_CONFLICT,
+                )
+            session_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ") + f"-{uuid.uuid4().hex[:8]}"
+            job_id = f"infer-{uuid.uuid4().hex[:8]}"
+            session_dir = output_dir / "inference" / session_id
+            session_dir.mkdir(parents=True, exist_ok=False)
+            created_at = datetime.now(timezone.utc).isoformat()
+            payload = {
+                "session_id": session_id,
+                "session_dir": str(session_dir),
+                "job_id": job_id,
+                "environment": environment,
+                "checkpoint_names": checkpoint_names,
+                "prompt_entries": prompt_entries,
+                "filename_style": filename_style,
+                "keep_loaded": keep_loaded,
+                "streaming_preview": streaming_preview,
+                "idle_timeout_seconds": idle_timeout_minutes * 60,
+                "settings": settings,
+                "trainer_config": config,
+                "created_at": created_at,
+            }
+            from simpletuner.inference import run_checkpoint_inference
+
+            process_keeper.submit_job(job_id, run_checkpoint_inference, payload)
+            record = {"session_id": session_id, "job_id": job_id, "environment": environment}
+            self._sessions[session_id] = record
+            self._environment_sessions[environment] = session_id
+
+        return {
+            **record,
+            "status": "loading",
+            "prompt_count": len(prompt_entries),
+            "generation_count": len(prompt_entries) * len(checkpoint_names) * len(validation_resolutions),
+            "streaming_preview": streaming_preview,
+        }
+
+    def _session_path(self, environment: str, session_id: str) -> Path:
+        _, output_dir = self._load_environment(environment)
+        candidate = (output_dir / "inference" / session_id).resolve()
+        root = (output_dir / "inference").resolve()
+        if candidate.parent != root:
+            raise CheckpointInferenceServiceError("Invalid inference session ID.")
+        return candidate
+
+    def status(self, environment: str, session_id: str) -> dict[str, Any]:
+        session_path = self._session_path(environment, session_id)
+        state_path = session_path / "session.json"
+        if not state_path.exists():
+            record = self._sessions.get(session_id)
+            if record:
+                return {**record, "status": process_keeper.get_process_status(record["job_id"])}
+            raise CheckpointInferenceServiceError("Inference session not found.", status.HTTP_404_NOT_FOUND)
+        with state_path.open("r", encoding="utf-8") as handle:
+            state = json.load(handle)
+        record = self._sessions.get(session_id)
+        if record and state.get("status") in {
+            "pending",
+            "queued",
+            "loading",
+            "running",
+            "loaded",
+            "unloading",
+            "cancelling",
+        }:
+            process_status = process_keeper.get_process_status(record["job_id"])
+            if process_status in {"terminated", "failed", "crashed"}:
+                state["status"] = "cancelled" if process_status == "terminated" else "failed"
+                state["updated_at"] = datetime.now(timezone.utc).isoformat()
+                self._write_session_state(state_path, state)
+        self._add_session_media(state, environment, session_path)
+        return state
+
+    @staticmethod
+    def _media_url(environment: str, relative_media: str, *, version: int | None = None) -> str:
+        query = f"environment={quote(environment, safe='')}"
+        if version is not None:
+            query += f"&v={version}"
+        return f"/api/checkpoints/inference/media/{quote(relative_media, safe='/')}?{query}"
+
+    def _add_session_media(self, state: dict[str, Any], environment: str, session_path: Path) -> None:
+        inference_root = session_path.parent
+        outputs: list[dict[str, Any]] = []
+        for sidecar in session_path.glob("*/*.*.json"):
+            try:
+                with sidecar.open("r", encoding="utf-8") as handle:
+                    record = json.load(handle)
+            except (OSError, json.JSONDecodeError):
+                continue
+            relative_media = sidecar.relative_to(inference_root).as_posix()[: -len(".json")]
+            if not (inference_root / relative_media).is_file():
+                continue
+            record["media_path"] = relative_media
+            record["media_url"] = self._media_url(environment, relative_media)
+            record["streaming"] = False
+            outputs.append(record)
+        if outputs:
+            state["latest_output"] = max(outputs, key=lambda item: item.get("created_at", ""))
+
+        preview_path = session_path / "preview.png"
+        preview_metadata_path = session_path / "preview.json"
+        if not preview_path.is_file() or not preview_metadata_path.is_file():
+            return
+        try:
+            with preview_metadata_path.open("r", encoding="utf-8") as handle:
+                preview = json.load(handle)
+            relative_preview = preview_path.relative_to(inference_root).as_posix()
+            preview["media_path"] = relative_preview
+            preview["media_url"] = self._media_url(
+                environment,
+                relative_preview,
+                version=preview_path.stat().st_mtime_ns,
+            )
+            preview["streaming"] = True
+            state["preview"] = preview
+        except (OSError, json.JSONDecodeError):
+            return
+
+    def generate(
+        self,
+        *,
+        environment: str,
+        session_id: str,
+        custom_prompts: list[str],
+        filename_style: str | None,
+        settings: dict[str, Any],
+    ) -> dict[str, Any]:
+        state = self.status(environment, session_id)
+        if state.get("status") != "loaded":
+            raise CheckpointInferenceServiceError(
+                "The inference session is not ready for custom prompts.", status.HTTP_409_CONFLICT
+            )
+        record = self._sessions.get(session_id)
+        if not record:
+            raise CheckpointInferenceServiceError(
+                "The loaded inference worker is no longer available.", status.HTTP_409_CONFLICT
+            )
+        entries = self.resolve_prompts(
+            config={},
+            use_configured_prompt=False,
+            use_builtin_library=False,
+            user_library_filename=None,
+            custom_prompts=custom_prompts,
+        )
+        if not entries:
+            raise CheckpointInferenceServiceError("Enter at least one custom prompt.")
+        if filename_style is not None and filename_style not in self.FILENAME_STYLES:
+            raise CheckpointInferenceServiceError("Unsupported inference filename style.")
+        config, _ = self._load_environment(environment)
+        self._inference_resolutions(config, settings)
+        state_path = self._session_path(environment, session_id) / "session.json"
+        state["status"] = "queued"
+        state["updated_at"] = datetime.now(timezone.utc).isoformat()
+        self._write_session_state(state_path, state)
+        process_keeper.send_process_command(
+            record["job_id"],
+            "inference_generate",
+            {"prompt_entries": entries, "filename_style": filename_style, "settings": settings},
+        )
+        return {"session_id": session_id, "status": "queued", "prompt_count": len(entries)}
+
+    def stop(self, environment: str, session_id: str, *, cancel: bool) -> dict[str, Any]:
+        record = self._sessions.get(session_id)
+        if not record or record.get("environment") != environment:
+            state = self.status(environment, session_id)
+            return {"session_id": session_id, "status": state.get("status")}
+        if cancel:
+            process_keeper.terminate_process(record["job_id"])
+        else:
+            process_keeper.send_process_command(record["job_id"], "inference_unload")
+        return {"session_id": session_id, "status": "cancelling" if cancel else "unloading"}
+
+    def history(self, environment: str, *, page: int, page_size: int) -> dict[str, Any]:
+        _, output_dir = self._load_environment(environment)
+        inference_root = output_dir / "inference"
+        records: list[dict[str, Any]] = []
+        if inference_root.exists():
+            for sidecar in inference_root.glob("*/*/*.*.json"):
+                try:
+                    with sidecar.open("r", encoding="utf-8") as handle:
+                        record = json.load(handle)
+                except (OSError, json.JSONDecodeError):
+                    continue
+                relative_media = sidecar.relative_to(inference_root).as_posix()[: -len(".json")]
+                record["media_path"] = relative_media
+                record["media_url"] = self._media_url(environment, relative_media)
+                records.append(record)
+        records.sort(key=lambda item: item.get("created_at", ""), reverse=True)
+        total = len(records)
+        offset = (page - 1) * page_size
+        return {"items": records[offset : offset + page_size], "page": page, "page_size": page_size, "total": total}
+
+    def delete_history(self, environment: str, media_paths: list[str]) -> dict[str, Any]:
+        if not media_paths:
+            raise CheckpointInferenceServiceError("Select at least one inference output.")
+        _, output_dir = self._load_environment(environment)
+        root = (output_dir / "inference").resolve()
+        targets: list[tuple[Path, Path]] = []
+        seen: set[str] = set()
+
+        for media_path in media_paths:
+            if media_path in seen:
+                raise CheckpointInferenceServiceError("Duplicate inference output path.")
+            seen.add(media_path)
+
+            relative = Path(media_path)
+            candidate = (root / relative).resolve()
+            if relative.is_absolute() or not candidate.is_relative_to(root):
+                raise CheckpointInferenceServiceError("Invalid inference output path.")
+            if len(candidate.relative_to(root).parts) != 3:
+                raise CheckpointInferenceServiceError("Invalid inference output path.")
+
+            sidecar = candidate.with_suffix(f"{candidate.suffix}.json")
+            if not candidate.is_file() or not sidecar.is_file():
+                raise CheckpointInferenceServiceError(
+                    f"Inference output '{media_path}' was not found.", status.HTTP_404_NOT_FOUND
+                )
+            targets.append((candidate, sidecar))
+
+        try:
+            for media, sidecar in targets:
+                media.unlink()
+                sidecar.unlink()
+        except OSError as exc:
+            raise CheckpointInferenceServiceError(
+                f"Failed to delete inference output: {exc}", status.HTTP_500_INTERNAL_SERVER_ERROR
+            ) from exc
+
+        return {"deleted_count": len(targets), "media_paths": media_paths}
+
+    def media_path(self, environment: str, media_path: str) -> Path:
+        _, output_dir = self._load_environment(environment)
+        root = (output_dir / "inference").resolve()
+        candidate = (root / media_path).resolve()
+        if not candidate.is_relative_to(root) or not candidate.is_file():
+            raise CheckpointInferenceServiceError("Inference output not found.", status.HTTP_404_NOT_FOUND)
+        return candidate
+
+
+CHECKPOINT_INFERENCE_SERVICE = CheckpointInferenceService()

--- a/simpletuner/simpletuner_sdk/server/services/checkpoint_inference_service.py
+++ b/simpletuner/simpletuner_sdk/server/services/checkpoint_inference_service.py
@@ -34,9 +34,10 @@ class CheckpointInferenceServiceError(Exception):
 
 class CheckpointInferenceService:
     FILENAME_STYLES = {"descriptive", "compact", "prompt", "content-hash"}
+    MEDIA_SUFFIXES = {".png", ".mp4"}
 
     def __init__(self) -> None:
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._sessions: dict[str, dict[str, str]] = {}
         self._environment_sessions: dict[str, str] = {}
 
@@ -73,6 +74,22 @@ class CheckpointInferenceService:
         return field.default_value
 
     @classmethod
+    def _unsupported_multigpu_modes(cls, config: dict[str, Any]) -> list[str]:
+        modes = []
+        if cls._config_value(config, "validation_multigpu") == "batch-parallel":
+            modes.append("batch-parallel")
+
+        context_parallel_size = cls._config_value(config, "context_parallel_size")
+        if context_parallel_size not in (None, ""):
+            try:
+                context_parallel_enabled = int(context_parallel_size) > 1
+            except (TypeError, ValueError) as exc:
+                raise CheckpointInferenceServiceError("context_parallel_size must be an integer.") from exc
+            if context_parallel_enabled:
+                modes.append("context-parallel")
+        return modes
+
+    @classmethod
     def _inference_resolutions(cls, config: dict[str, Any], settings: dict[str, Any]) -> list[tuple[int, int]]:
         value = settings.get("validation_resolution")
         if value is None:
@@ -100,12 +117,40 @@ class CheckpointInferenceService:
         return process_keeper.get_process_status(job_id) in {"pending", "running", "aborting"}
 
     def active_session(self) -> dict[str, str] | None:
-        for session_id, record in list(self._sessions.items()):
-            process_status = process_keeper.get_process_status(record["job_id"])
-            if process_status in {"pending", "running", "aborting"}:
-                return record
-            self._environment_sessions.pop(record["environment"], None)
-        return None
+        active = None
+        with self._lock:
+            for session_id, record in list(self._sessions.items()):
+                process_status = process_keeper.get_process_status(record["job_id"])
+                if process_status in {"pending", "running", "aborting"}:
+                    if active is None:
+                        active = record
+                    continue
+                self._discard_session(session_id)
+        return active
+
+    def _discard_session(self, session_id: str) -> None:
+        with self._lock:
+            record = self._sessions.pop(session_id, None)
+            if record and self._environment_sessions.get(record["environment"]) == session_id:
+                self._environment_sessions.pop(record["environment"], None)
+
+    @classmethod
+    def _is_generated_media_path(cls, relative: Path) -> bool:
+        return (
+            not relative.is_absolute()
+            and len(relative.parts) == 3
+            and not any(part.startswith(".") for part in relative.parts)
+            and relative.suffix.lower() in cls.MEDIA_SUFFIXES
+        )
+
+    @staticmethod
+    def _is_preview_media_path(relative: Path) -> bool:
+        return (
+            not relative.is_absolute()
+            and len(relative.parts) == 2
+            and not relative.parts[0].startswith(".")
+            and relative.parts[1] == "preview.png"
+        )
 
     @staticmethod
     def _normalise_entry(shortname: str, value: Any, source: str) -> dict[str, Any]:
@@ -215,6 +260,7 @@ class CheckpointInferenceService:
                 "guidance_scale": guidance_scale,
                 "validation_resolution": validation_resolution,
             },
+            "unsupported_multigpu_modes": self._unsupported_multigpu_modes(config),
         }
 
     def start(
@@ -318,13 +364,15 @@ class CheckpointInferenceService:
         session_path = self._session_path(environment, session_id)
         state_path = session_path / "session.json"
         if not state_path.exists():
-            record = self._sessions.get(session_id)
+            with self._lock:
+                record = self._sessions.get(session_id)
             if record:
                 return {**record, "status": process_keeper.get_process_status(record["job_id"])}
             raise CheckpointInferenceServiceError("Inference session not found.", status.HTTP_404_NOT_FOUND)
         with state_path.open("r", encoding="utf-8") as handle:
             state = json.load(handle)
-        record = self._sessions.get(session_id)
+        with self._lock:
+            record = self._sessions.get(session_id)
         if record and state.get("status") in {
             "pending",
             "queued",
@@ -339,6 +387,8 @@ class CheckpointInferenceService:
                 state["status"] = "cancelled" if process_status == "terminated" else "failed"
                 state["updated_at"] = datetime.now(timezone.utc).isoformat()
                 self._write_session_state(state_path, state)
+        if state.get("status") in {"completed", "failed", "cancelled"}:
+            self._discard_session(session_id)
         self._add_session_media(state, environment, session_path)
         return state
 
@@ -351,15 +401,20 @@ class CheckpointInferenceService:
 
     def _add_session_media(self, state: dict[str, Any], environment: str, session_path: Path) -> None:
         inference_root = session_path.parent
+        resolved_root = inference_root.resolve()
         outputs: list[dict[str, Any]] = []
         for sidecar in session_path.glob("*/*.*.json"):
+            if not sidecar.resolve().is_relative_to(resolved_root):
+                continue
             try:
                 with sidecar.open("r", encoding="utf-8") as handle:
                     record = json.load(handle)
             except (OSError, json.JSONDecodeError):
                 continue
             relative_media = sidecar.relative_to(inference_root).as_posix()[: -len(".json")]
-            if not (inference_root / relative_media).is_file():
+            relative = Path(relative_media)
+            media = (inference_root / relative).resolve()
+            if not self._is_generated_media_path(relative) or not media.is_relative_to(resolved_root) or not media.is_file():
                 continue
             record["media_path"] = relative_media
             record["media_url"] = self._media_url(environment, relative_media)
@@ -401,7 +456,8 @@ class CheckpointInferenceService:
             raise CheckpointInferenceServiceError(
                 "The inference session is not ready for custom prompts.", status.HTTP_409_CONFLICT
             )
-        record = self._sessions.get(session_id)
+        with self._lock:
+            record = self._sessions.get(session_id)
         if not record:
             raise CheckpointInferenceServiceError(
                 "The loaded inference worker is no longer available.", status.HTTP_409_CONFLICT
@@ -431,7 +487,8 @@ class CheckpointInferenceService:
         return {"session_id": session_id, "status": "queued", "prompt_count": len(entries)}
 
     def stop(self, environment: str, session_id: str, *, cancel: bool) -> dict[str, Any]:
-        record = self._sessions.get(session_id)
+        with self._lock:
+            record = self._sessions.get(session_id)
         if not record or record.get("environment") != environment:
             state = self.status(environment, session_id)
             return {"session_id": session_id, "status": state.get("status")}
@@ -444,15 +501,26 @@ class CheckpointInferenceService:
     def history(self, environment: str, *, page: int, page_size: int) -> dict[str, Any]:
         _, output_dir = self._load_environment(environment)
         inference_root = output_dir / "inference"
+        resolved_root = inference_root.resolve()
         records: list[dict[str, Any]] = []
         if inference_root.exists():
             for sidecar in inference_root.glob("*/*/*.*.json"):
+                if not sidecar.resolve().is_relative_to(resolved_root):
+                    continue
                 try:
                     with sidecar.open("r", encoding="utf-8") as handle:
                         record = json.load(handle)
                 except (OSError, json.JSONDecodeError):
                     continue
                 relative_media = sidecar.relative_to(inference_root).as_posix()[: -len(".json")]
+                relative = Path(relative_media)
+                media = (inference_root / relative).resolve()
+                if (
+                    not self._is_generated_media_path(relative)
+                    or not media.is_relative_to(resolved_root)
+                    or not media.is_file()
+                ):
+                    continue
                 record["media_path"] = relative_media
                 record["media_url"] = self._media_url(environment, relative_media)
                 records.append(record)
@@ -478,7 +546,7 @@ class CheckpointInferenceService:
             candidate = (root / relative).resolve()
             if relative.is_absolute() or not candidate.is_relative_to(root):
                 raise CheckpointInferenceServiceError("Invalid inference output path.")
-            if len(candidate.relative_to(root).parts) != 3:
+            if not self._is_generated_media_path(relative):
                 raise CheckpointInferenceServiceError("Invalid inference output path.")
 
             sidecar = candidate.with_suffix(f"{candidate.suffix}.json")
@@ -502,8 +570,14 @@ class CheckpointInferenceService:
     def media_path(self, environment: str, media_path: str) -> Path:
         _, output_dir = self._load_environment(environment)
         root = (output_dir / "inference").resolve()
-        candidate = (root / media_path).resolve()
-        if not candidate.is_relative_to(root) or not candidate.is_file():
+        relative = Path(media_path)
+        candidate = (root / relative).resolve()
+        is_generated = self._is_generated_media_path(relative)
+        is_preview = self._is_preview_media_path(relative)
+        if relative.is_absolute() or not candidate.is_relative_to(root) or not (is_generated or is_preview):
+            raise CheckpointInferenceServiceError("Inference output not found.", status.HTTP_404_NOT_FOUND)
+        sidecar = candidate.parent / "preview.json" if is_preview else candidate.with_suffix(f"{candidate.suffix}.json")
+        if not candidate.is_file() or not sidecar.is_file():
             raise CheckpointInferenceServiceError("Inference output not found.", status.HTTP_404_NOT_FOUND)
         return candidate
 

--- a/simpletuner/simpletuner_sdk/server/services/training_service.py
+++ b/simpletuner/simpletuner_sdk/server/services/training_service.py
@@ -1112,7 +1112,15 @@ def start_training_job(
     """
     import asyncio
 
+    from .checkpoint_inference_service import CHECKPOINT_INFERENCE_SERVICE
     from .local_gpu_allocator import get_gpu_allocator
+
+    if CHECKPOINT_INFERENCE_SERVICE.active_session():
+        return TrainingJobResult(
+            job_id=None,
+            status="rejected",
+            reason="A checkpoint inference session is using the accelerator. Unload it before starting training.",
+        )
 
     # Check for active cache or scan jobs that hold GPU resources
     try:

--- a/simpletuner/simpletuner_sdk/server/services/webui_state.py
+++ b/simpletuner/simpletuner_sdk/server/services/webui_state.py
@@ -773,6 +773,18 @@ class WebUIStateStore:
         """Save UI element states (collapsed sections, etc.)."""
         self._write_json("ui_state", state)
 
+    def get_checkpoint_inference_settings(self) -> Dict[str, Any]:
+        """Get persisted checkpoint inference UI settings."""
+        ui_state = self.load_ui_state()
+        settings = ui_state.get("checkpoint_inference")
+        return settings if isinstance(settings, dict) else {}
+
+    def save_checkpoint_inference_settings(self, settings: Dict[str, Any]) -> None:
+        """Save checkpoint inference UI settings without replacing unrelated UI state."""
+        ui_state = self.load_ui_state()
+        ui_state["checkpoint_inference"] = settings
+        self.save_ui_state(ui_state)
+
     def get_collapsed_sections(self, tab_name: str) -> Dict[str, bool]:
         """Get collapsed state for sections in a specific tab."""
         ui_state = self.load_ui_state()

--- a/simpletuner/static/css/checkpoints.css
+++ b/simpletuner/static/css/checkpoints.css
@@ -144,6 +144,21 @@ body:has(#checkpointInferenceModal.show) .content-wrapper {
     border-radius: 0 0 16px 16px;
 }
 
+.checkpoint-inference-modal .inference-multigpu-warning {
+    display: flex;
+    flex: 0 0 100%;
+    align-items: flex-start;
+    gap: 0.625rem;
+    width: 100%;
+    margin: 0;
+    padding: 0.75rem 1rem;
+    font-size: 0.875rem;
+}
+
+.checkpoint-inference-modal .inference-multigpu-warning i {
+    margin-top: 0.15rem;
+}
+
 .checkpoint-inference-modal .modal-title,
 .checkpoint-inference-modal h6,
 .checkpoint-inference-modal .form-label,

--- a/simpletuner/static/css/checkpoints.css
+++ b/simpletuner/static/css/checkpoints.css
@@ -50,6 +50,410 @@
     box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.2);
 }
 
+.checkpoint-card.inference-selected {
+    box-shadow: inset 0 0 0 2px var(--bs-primary);
+}
+
+.checkpoint-inference-check {
+    min-height: 0;
+    margin: 0;
+}
+
+.checkpoint-inference-check .form-check-input {
+    margin: 0;
+}
+
+.checkpoint-inference-launch {
+    position: relative;
+}
+
+.checkpoint-inference-launch-count {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.25rem;
+    height: 1.25rem;
+    margin-block: auto;
+    padding: 0.2rem 0.3rem;
+    transform: translateX(45%);
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+    box-shadow: 0 0 0 2px var(--card-bg);
+}
+
+#checkpointInferenceModal {
+    z-index: 1105;
+}
+
+#checkpointInferenceModal.show {
+    background: rgba(0, 0, 0, 0.72);
+    backdrop-filter: blur(2px);
+}
+
+body:has(#checkpointInferenceModal.show) .content-wrapper {
+    z-index: 1100;
+}
+
+#checkpointInferenceModal .modal-dialog {
+    width: calc(100vw - 2rem);
+    max-width: 1120px;
+    max-height: calc(100dvh - 2rem);
+    margin: 1rem auto;
+}
+
+@media (min-width: 1025px) {
+    #checkpointInferenceModal {
+        padding-left: 240px;
+    }
+
+    #checkpointInferenceModal .modal-dialog {
+        width: calc(100vw - 240px - 2rem);
+    }
+}
+
+#checkpointInferenceModal .checkpoint-inference-modal {
+    max-height: calc(100dvh - 2rem);
+    overflow: hidden;
+    background: var(--modal-surface);
+    color: var(--text-primary);
+    border: 1px solid var(--modal-border);
+    border-radius: 16px;
+    box-shadow: 0 25px 50px var(--black-50);
+}
+
+.checkpoint-inference-modal .modal-header,
+.checkpoint-inference-modal .modal-footer {
+    flex-shrink: 0;
+    padding: 1.25rem 1.5rem;
+    background: var(--modal-header-bg);
+    border-color: var(--modal-border);
+}
+
+.checkpoint-inference-modal .modal-header {
+    position: relative;
+    display: block;
+    padding-right: 4.75rem;
+    border-radius: 16px 16px 0 0;
+}
+
+.checkpoint-inference-modal .modal-footer {
+    border-radius: 0 0 16px 16px;
+}
+
+.checkpoint-inference-modal .modal-title,
+.checkpoint-inference-modal h6,
+.checkpoint-inference-modal .form-label,
+.checkpoint-inference-modal .form-check-label {
+    color: var(--text-bright);
+}
+
+.checkpoint-inference-modal .text-muted {
+    color: var(--text-muted) !important;
+}
+
+.checkpoint-inference-modal .inference-modal-close {
+    position: absolute;
+    top: 1.25rem;
+    right: 1.5rem;
+    display: inline-grid;
+    inline-size: 2rem;
+    block-size: 2rem;
+    margin: 0;
+    padding: 0;
+    place-items: center;
+    color: var(--text-muted);
+    border-color: var(--modal-border);
+}
+
+.checkpoint-inference-modal .inference-modal-close:hover {
+    color: var(--text-bright);
+    background: var(--blue-bg-15);
+    border-color: var(--blue-border);
+}
+
+.checkpoint-inference-modal .modal-body {
+    min-height: min(68vh, 720px);
+    padding: 1.5rem;
+    background: var(--modal-surface);
+}
+
+.inference-modal-tabs {
+    flex-shrink: 0;
+    padding: 0.75rem 1.5rem 0;
+    background: var(--modal-surface);
+    border-bottom: 1px solid var(--modal-border);
+}
+
+.checkpoint-inference-modal .nav-tabs .nav-link {
+    padding: 0.625rem 1rem;
+    color: var(--text-muted);
+    border: 1px solid transparent;
+    border-bottom: 0;
+    border-radius: 8px 8px 0 0;
+}
+
+.checkpoint-inference-modal .nav-tabs .nav-link:hover {
+    color: var(--text-bright);
+    background: var(--blue-bg-15);
+    border-color: var(--blue-border);
+}
+
+.checkpoint-inference-modal .nav-tabs .nav-link.active {
+    color: var(--text-bright);
+    background: var(--blue-bg-20);
+    border-color: var(--blue-border);
+    box-shadow: inset 0 2px 0 var(--blue-500);
+}
+
+.checkpoint-inference-modal .form-control,
+.checkpoint-inference-modal .form-select {
+    color: var(--text-primary);
+    background-color: var(--slate-800-50);
+    border-color: var(--modal-border);
+}
+
+.checkpoint-inference-modal .form-control:focus,
+.checkpoint-inference-modal .form-select:focus {
+    border-color: var(--blue-500);
+    box-shadow: 0 0 0 0.2rem var(--blue-bg-20);
+}
+
+.checkpoint-inference-modal .form-check-input:checked {
+    background-color: var(--blue-500);
+    border-color: var(--blue-500);
+}
+
+.checkpoint-inference-modal .btn-primary {
+    color: #fff;
+    background: var(--blue-gradient);
+    border-color: transparent;
+    box-shadow: 0 2px 8px var(--blue-bg-30);
+}
+
+.checkpoint-inference-modal .btn-primary:hover:not(:disabled) {
+    background: var(--blue-gradient-hover);
+    box-shadow: 0 4px 12px var(--blue-bg-30);
+}
+
+.inference-section-divider {
+    border-left: 1px solid var(--modal-border);
+}
+
+.inference-checkpoint-list {
+    max-height: 240px;
+    overflow-y: auto;
+}
+
+.inference-checkpoint-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.625rem 0;
+    border-bottom: 1px solid var(--modal-border);
+}
+
+.inference-icon-button {
+    inline-size: 2rem;
+    block-size: 2rem;
+    padding: 0;
+}
+
+.inference-prompt-textarea {
+    resize: vertical;
+    min-height: 7rem;
+}
+
+.inference-source-preview {
+    margin-top: 0.375rem;
+    margin-left: 1.5rem;
+    padding: 0.5rem 0.625rem;
+    overflow: auto;
+    border-left: 3px solid var(--blue-500);
+    border-radius: var(--radius-sm);
+    background: var(--slate-800-60);
+    color: var(--text-secondary);
+    font-size: 0.8125rem;
+    line-height: 1.45;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
+.inference-source-preview code {
+    color: inherit;
+    font: inherit;
+    white-space: inherit;
+}
+
+.inference-session-panel {
+    padding: 1rem;
+    border: 1px solid var(--modal-border);
+    border-radius: 8px;
+    background: var(--slate-800-60);
+}
+
+.inference-session-panel .progress {
+    background: var(--slate-800-80);
+}
+
+.inference-session-panel .progress-bar {
+    background: var(--blue-gradient);
+}
+
+.inference-current-output {
+    display: grid;
+    grid-template-columns: minmax(240px, 420px) minmax(0, 1fr);
+    gap: 1rem;
+    align-items: start;
+}
+
+.inference-current-output-media {
+    position: relative;
+    overflow: hidden;
+    aspect-ratio: 16 / 10;
+    border: 1px solid var(--modal-border);
+    border-radius: var(--radius-sm);
+    background: #111;
+}
+
+.inference-current-output-media img,
+.inference-current-output-media video {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+.inference-current-output-badge {
+    position: absolute;
+    top: 0.625rem;
+    right: 0.625rem;
+}
+
+.inference-current-output-details {
+    min-width: 0;
+    padding: 0.25rem 0;
+}
+
+.inference-current-output-prompt {
+    overflow-wrap: anywhere;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    white-space: pre-wrap;
+}
+
+.inference-history-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.inference-history-item {
+    position: relative;
+    min-width: 0;
+    overflow: hidden;
+    border: 1px solid var(--modal-border);
+    border-radius: var(--radius-sm);
+    background: var(--slate-800-60);
+}
+
+.inference-history-item.selected {
+    border-color: var(--blue-500);
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
+}
+
+.inference-history-select {
+    position: absolute;
+    z-index: 1;
+    top: 0.625rem;
+    left: 0.625rem;
+    display: grid;
+    width: 1.75rem;
+    height: 1.75rem;
+    place-items: center;
+    border: 1px solid rgba(255, 255, 255, 0.45);
+    border-radius: var(--radius-sm);
+    background: rgba(15, 23, 42, 0.82);
+    cursor: pointer;
+}
+
+.inference-history-select .form-check-input,
+.inference-history-select-page {
+    margin: 0;
+}
+
+.inference-history-item img,
+.inference-history-item video {
+    display: block;
+    width: 100%;
+    aspect-ratio: 1;
+    object-fit: cover;
+    background: #111;
+}
+
+.inference-history-caption {
+    padding: 0.75rem;
+}
+
+.inference-history-prompt {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    min-height: 2.5em;
+}
+
+body[data-theme="light"] .checkpoint-inference-modal .modal-header .modal-title,
+body[data-theme="light"] .checkpoint-inference-modal .modal-header .text-muted {
+    color: #fff !important;
+}
+
+body[data-theme="light"] .checkpoint-inference-modal .modal-footer {
+    background: var(--modal-surface);
+}
+
+@media (max-width: 991.98px) {
+    .inference-section-divider {
+        padding-top: 1rem;
+        border-top: 1px solid var(--bs-border-color);
+        border-left: 0;
+    }
+
+    .inference-current-output {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+@media (max-width: 768px) {
+    body:has(#checkpointInferenceModal.show) .topbar,
+    body:has(#checkpointInferenceModal.show) .event-dock-shell {
+        display: none !important;
+    }
+
+    #checkpointInferenceModal .modal-dialog {
+        width: 100vw;
+        max-width: 100vw;
+        height: 100dvh;
+        max-height: 100dvh;
+        margin: 0;
+    }
+
+    #checkpointInferenceModal .checkpoint-inference-modal {
+        height: 100dvh;
+        max-height: 100dvh;
+        border: 0;
+        border-radius: 0;
+    }
+
+    .checkpoint-inference-modal .modal-body {
+        min-height: 0;
+    }
+}
+
 .checkpoint-card.selected::before {
     background: var(--primary-gradient);
 }

--- a/simpletuner/static/js/modules/checkpoints.js
+++ b/simpletuner/static/js/modules/checkpoints.js
@@ -26,6 +26,43 @@ if (!window.checkpointsManager) {
             retentionDirty: false,
             cleanupPreview: null,
             validationResult: null,
+            inferenceSelection: [],
+            inference: {
+                activeTab: 'setup',
+                promptSources: {
+                    configured_prompt: null,
+                    builtin_count: 0,
+                    configured_user_library: null,
+                    user_libraries: [],
+                    inference_defaults: {
+                        num_inference_steps: null,
+                        guidance_scale: null,
+                        validation_resolution: null
+                    }
+                },
+                promptSourcesLoaded: false,
+                form: {
+                    use_configured_prompt: true,
+                    use_builtin_library: false,
+                    user_library_filename: '',
+                    custom_prompts: '',
+                    filename_style: 'descriptive',
+                    keep_loaded: false,
+                    streaming_preview: false,
+                    idle_timeout_minutes: 15,
+                    seed: '',
+                    num_inference_steps: '',
+                    guidance_scale: '',
+                    validation_resolution: ''
+                },
+                session: null,
+                interactivePrompt: '',
+                history: [],
+                historySelection: [],
+                historyPage: 1,
+                historyTotal: 0,
+                statusTimer: null
+            },
             markdownService: window.markdownService || null,
             loading: {
                 checkpoints: false,
@@ -34,7 +71,12 @@ if (!window.checkpointsManager) {
                 preview: false,
                 cleanup: false,
                 saveRetention: false,
-                cloudOutputs: false
+                cloudOutputs: false,
+                inferenceSources: false,
+                inferenceStart: false,
+                inferenceHistory: false,
+                inferenceDelete: false,
+                inferenceAction: false
             },
             cloudOutputs: [],
             visibilitySettings: {
@@ -94,6 +136,7 @@ if (!window.checkpointsManager) {
                 this.markdownService = window.markdownService || this.markdownService;
 
                 await this.loadVisibilitySettings();
+                await this.loadInferenceSettings();
                 await this.loadCheckpoints();
                 await this.loadRetentionConfig();
                 await this.checkHuggingFaceAuth();
@@ -225,6 +268,8 @@ if (!window.checkpointsManager) {
                     const data = await response.json();
                     const checkpoints = Array.isArray(data.checkpoints) ? data.checkpoints : [];
                     this.checkpoints = checkpoints.map((cp, idx) => this.normalizeCheckpoint(cp, idx));
+                    const availableNames = new Set(this.checkpoints.map(cp => cp.name));
+                    this.inferenceSelection = this.inferenceSelection.filter(name => availableNames.has(name));
                     this.sortCheckpoints();
 
                     // Calculate common aspect ratio from existing validation images
@@ -401,6 +446,7 @@ if (!window.checkpointsManager) {
                     }
 
                     this.checkpoints = this.checkpoints.filter(cp => cp.id !== checkpoint.id);
+                    this.inferenceSelection = this.inferenceSelection.filter(name => name !== checkpoint.name);
 
                     if (this.selectedCheckpoint && (this.selectedCheckpoint.id === checkpoint.id || this.selectedCheckpoint.name === checkpoint.name)) {
                         this.selectedCheckpoint = null;
@@ -442,6 +488,395 @@ if (!window.checkpointsManager) {
                 html = html.replace(/\n/g, '<br />');
 
                 return `<p>${html}</p>`;
+            },
+
+            // Checkpoint Inference
+            async loadInferenceSettings() {
+                try {
+                    const response = await ApiClient.fetch('/api/webui/ui-state/checkpoint-inference');
+                    const data = await response.json();
+                    if (!response.ok) {
+                        throw new Error(data.detail || 'Failed to load checkpoint inference settings');
+                    }
+                    this.inference.form.filename_style = data.filename_style;
+                    this.inference.form.keep_loaded = data.keep_loaded;
+                    this.inference.form.streaming_preview = data.streaming_preview;
+                } catch (error) {
+                    console.error('Failed to load checkpoint inference settings:', error);
+                }
+            },
+
+            async saveInferenceSettings() {
+                try {
+                    const response = await ApiClient.fetch('/api/webui/ui-state/checkpoint-inference', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            filename_style: this.inference.form.filename_style,
+                            keep_loaded: this.inference.form.keep_loaded,
+                            streaming_preview: this.inference.form.streaming_preview
+                        })
+                    });
+                    const data = await response.json();
+                    if (!response.ok) {
+                        throw new Error(data.detail || 'Failed to save checkpoint inference settings');
+                    }
+                } catch (error) {
+                    console.error('Failed to save checkpoint inference settings:', error);
+                    if (window.showToast) window.showToast(error.message, 'error');
+                }
+            },
+
+            isInferenceSelected(checkpointName) {
+                return this.inferenceSelection.includes(checkpointName);
+            },
+
+            toggleInferenceCheckpoint(checkpointName) {
+                if (this.isInferenceSelected(checkpointName)) {
+                    this.inferenceSelection = this.inferenceSelection.filter(name => name !== checkpointName);
+                } else {
+                    this.inferenceSelection = [...this.inferenceSelection, checkpointName];
+                }
+                if (this.inferenceSelection.length !== 1) {
+                    this.inference.form.keep_loaded = false;
+                }
+            },
+
+            selectedInferenceCheckpoints() {
+                return this.inferenceSelection
+                    .map(name => this.checkpoints.find(checkpoint => checkpoint.name === name))
+                    .filter(Boolean);
+            },
+
+            async openInferenceWorkspace(tab = 'setup') {
+                this.inference.activeTab = tab;
+                const modalElement = document.getElementById('checkpointInferenceModal');
+                if (modalElement && window.bootstrap) {
+                    window.bootstrap.Modal.getOrCreateInstance(modalElement).show();
+                }
+                const requests = [this.loadInferenceHistory(1)];
+                if (tab === 'setup') requests.push(this.loadInferencePromptSources());
+                await Promise.all(requests);
+            },
+
+            async loadInferencePromptSources() {
+                this.loading.inferenceSources = true;
+                try {
+                    const environment = await this.ensureEnvironment();
+                    const response = await ApiClient.fetch(
+                        `/api/checkpoints/inference/prompt-sources?environment=${encodeURIComponent(environment)}`
+                    );
+                    if (!response.ok) {
+                        throw new Error('Failed to load inference prompt sources');
+                    }
+                    const promptSources = await response.json();
+                    const previousDefaults = this.inference.promptSources.inference_defaults || {};
+                    const nextDefaults = promptSources.inference_defaults || {};
+                    const stepsMatchPrevious = String(this.inference.form.num_inference_steps) === String(
+                        previousDefaults.num_inference_steps ?? ''
+                    );
+                    const guidanceMatchesPrevious = String(this.inference.form.guidance_scale) === String(
+                        previousDefaults.guidance_scale ?? ''
+                    );
+                    const resolutionMatchesPrevious = String(this.inference.form.validation_resolution) === String(
+                        previousDefaults.validation_resolution ?? ''
+                    );
+                    if (!this.inference.promptSourcesLoaded
+                        || this.inference.form.num_inference_steps === ''
+                        || stepsMatchPrevious) {
+                        this.inference.form.num_inference_steps = nextDefaults.num_inference_steps ?? '';
+                    }
+                    if (!this.inference.promptSourcesLoaded
+                        || this.inference.form.guidance_scale === ''
+                        || guidanceMatchesPrevious) {
+                        this.inference.form.guidance_scale = nextDefaults.guidance_scale ?? '';
+                    }
+                    if (!this.inference.promptSourcesLoaded
+                        || this.inference.form.validation_resolution === ''
+                        || resolutionMatchesPrevious) {
+                        this.inference.form.validation_resolution = nextDefaults.validation_resolution ?? '';
+                    }
+                    this.inference.promptSources = promptSources;
+                    if (!this.inference.promptSourcesLoaded) {
+                        this.inference.form.user_library_filename = this.inference.promptSources.configured_user_library || '';
+                        this.inference.form.use_configured_prompt = Boolean(this.inference.promptSources.configured_prompt);
+                        this.inference.promptSourcesLoaded = true;
+                    }
+                } catch (error) {
+                    console.error('Failed to load inference prompt sources:', error);
+                    if (window.showToast) window.showToast(error.message, 'error');
+                } finally {
+                    this.loading.inferenceSources = false;
+                }
+            },
+
+            inferenceCustomPrompts() {
+                return this.inference.form.custom_prompts
+                    .split(/\r?\n/)
+                    .map(prompt => prompt.trim())
+                    .filter(Boolean);
+            },
+
+            selectedInferenceLibrary() {
+                return this.inference.promptSources.user_libraries.find(
+                    library => library.filename === this.inference.form.user_library_filename
+                ) || null;
+            },
+
+            inferencePromptCount() {
+                let count = this.inferenceCustomPrompts().length;
+                if (this.inference.form.use_configured_prompt && this.inference.promptSources.configured_prompt) count += 1;
+                if (this.inference.form.use_builtin_library) count += this.inference.promptSources.builtin_count || 0;
+                const library = this.selectedInferenceLibrary();
+                if (library) count += library.prompt_count || 0;
+                return count;
+            },
+
+            inferenceRunCount() {
+                return this.inferencePromptCount() * this.inferenceSelection.length * this.inferenceResolutionCount();
+            },
+
+            inferenceResolutionCount() {
+                const resolutions = String(this.inference.form.validation_resolution || '')
+                    .split(',')
+                    .map(resolution => resolution.trim())
+                    .filter(Boolean);
+                return Math.max(1, resolutions.length);
+            },
+
+            inferenceSettings() {
+                const settings = {};
+                if (this.inference.form.seed !== '') settings.seed = Number(this.inference.form.seed);
+                if (this.inference.form.num_inference_steps !== '') {
+                    settings.num_inference_steps = Number(this.inference.form.num_inference_steps);
+                }
+                if (this.inference.form.guidance_scale !== '') {
+                    settings.guidance_scale = Number(this.inference.form.guidance_scale);
+                }
+                if (this.inference.form.validation_resolution.trim() !== '') {
+                    settings.validation_resolution = this.inference.form.validation_resolution.trim();
+                }
+                return settings;
+            },
+
+            async _inferenceJson(response) {
+                const data = await response.json();
+                if (!response.ok) {
+                    throw new Error(data.detail || 'Inference request failed');
+                }
+                return data;
+            },
+
+            async startInference() {
+                if (this.loading.inferenceStart || !this.inferenceSelection.length || !this.inferencePromptCount()) return;
+                this.loading.inferenceStart = true;
+                try {
+                    const environment = await this.ensureEnvironment();
+                    const response = await ApiClient.fetch('/api/checkpoints/inference/start', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            environment,
+                            checkpoint_names: this.inferenceSelection,
+                            use_configured_prompt: this.inference.form.use_configured_prompt,
+                            use_builtin_library: this.inference.form.use_builtin_library,
+                            user_library_filename: this.inference.form.user_library_filename || null,
+                            custom_prompts: this.inferenceCustomPrompts(),
+                            filename_style: this.inference.form.filename_style,
+                            keep_loaded: this.inference.form.keep_loaded,
+                            streaming_preview: this.inference.form.streaming_preview,
+                            idle_timeout_minutes: Number(this.inference.form.idle_timeout_minutes),
+                            settings: this.inferenceSettings()
+                        })
+                    });
+                    this.inference.session = await this._inferenceJson(response);
+                    this.scheduleInferenceStatusPoll();
+                } catch (error) {
+                    console.error('Failed to start checkpoint inference:', error);
+                    if (window.showToast) window.showToast(error.message, 'error');
+                } finally {
+                    this.loading.inferenceStart = false;
+                }
+            },
+
+            scheduleInferenceStatusPoll() {
+                if (this.inference.statusTimer) window.clearTimeout(this.inference.statusTimer);
+                this.inference.statusTimer = window.setTimeout(() => this.pollInferenceStatus(), 1000);
+            },
+
+            async pollInferenceStatus() {
+                if (!this.inference.session?.session_id) return;
+                try {
+                    const environment = await this.ensureEnvironment();
+                    const response = await ApiClient.fetch(
+                        `/api/checkpoints/inference/${encodeURIComponent(this.inference.session.session_id)}/status?environment=${encodeURIComponent(environment)}`
+                    );
+                    this.inference.session = await this._inferenceJson(response);
+                    const active = ['pending', 'loading', 'running', 'unloading'].includes(this.inference.session.status);
+                    if (active) {
+                        this.scheduleInferenceStatusPoll();
+                    } else {
+                        await this.loadInferenceHistory(1);
+                    }
+                } catch (error) {
+                    console.error('Failed to poll inference status:', error);
+                    if (window.showToast) window.showToast(error.message, 'error');
+                }
+            },
+
+            inferenceProgressPercent() {
+                const session = this.inference.session;
+                if (!session?.total_prompts) return 0;
+                return Math.min(100, Math.round((session.completed_prompts || 0) / session.total_prompts * 100));
+            },
+
+            inferenceDisplayOutput() {
+                const session = this.inference.session;
+                if (!session) return null;
+                const latest = session.latest_output || null;
+                const preview = session.preview || null;
+                if (!session.streaming_preview || !preview) return latest;
+                if (!latest) return preview;
+                const previewTime = Date.parse(preview.updated_at || '') || 0;
+                const latestTime = Date.parse(latest.created_at || '') || 0;
+                return previewTime > latestTime ? preview : latest;
+            },
+
+            inferenceIsActive() {
+                return ['pending', 'queued', 'loading', 'running', 'unloading', 'cancelling']
+                    .includes(this.inference.session?.status);
+            },
+
+            inferenceHistoryPageCount() {
+                return Math.max(1, Math.ceil(this.inference.historyTotal / 24));
+            },
+
+            isInferenceHistorySelected(mediaPath) {
+                return this.inference.historySelection.includes(mediaPath);
+            },
+
+            toggleInferenceHistoryItem(mediaPath) {
+                if (this.isInferenceHistorySelected(mediaPath)) {
+                    this.inference.historySelection = this.inference.historySelection.filter(path => path !== mediaPath);
+                } else {
+                    this.inference.historySelection = [...this.inference.historySelection, mediaPath];
+                }
+            },
+
+            inferenceHistoryPageSelected() {
+                return this.inference.history.length > 0
+                    && this.inference.history.every(item => this.isInferenceHistorySelected(item.media_path));
+            },
+
+            toggleInferenceHistoryPage() {
+                if (this.inferenceHistoryPageSelected()) {
+                    this.inference.historySelection = [];
+                    return;
+                }
+                this.inference.historySelection = this.inference.history.map(item => item.media_path);
+            },
+
+            async deleteInferenceHistorySelection() {
+                const mediaPaths = this.inference.historySelection.slice();
+                if (!mediaPaths.length || this.loading.inferenceDelete) return;
+                const label = mediaPaths.length === 1 ? 'generation' : 'generations';
+                if (!confirm(`Delete ${mediaPaths.length} selected ${label}? This cannot be undone.`)) return;
+
+                this.loading.inferenceDelete = true;
+                try {
+                    const environment = await this.ensureEnvironment();
+                    const response = await ApiClient.fetch('/api/checkpoints/inference/history', {
+                        method: 'DELETE',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ environment, media_paths: mediaPaths })
+                    });
+                    const result = await this._inferenceJson(response);
+                    const remaining = Math.max(0, this.inference.historyTotal - result.deleted_count);
+                    const page = Math.min(this.inference.historyPage, Math.max(1, Math.ceil(remaining / 24)));
+                    this.inference.historySelection = [];
+                    await this.loadInferenceHistory(page);
+                    if (window.showToast) {
+                        window.showToast(`Deleted ${result.deleted_count} ${label}.`, 'success');
+                    }
+                } catch (error) {
+                    console.error('Failed to delete inference history:', error);
+                    if (window.showToast) window.showToast(error.message, 'error');
+                } finally {
+                    this.loading.inferenceDelete = false;
+                }
+            },
+
+            async queueInteractivePrompt() {
+                const prompt = this.inference.interactivePrompt.trim();
+                if (!prompt || this.loading.inferenceAction || this.inference.session?.status !== 'loaded') return;
+                this.loading.inferenceAction = true;
+                try {
+                    const environment = await this.ensureEnvironment();
+                    const response = await ApiClient.fetch(
+                        `/api/checkpoints/inference/${encodeURIComponent(this.inference.session.session_id)}/generate`,
+                        {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({
+                                environment,
+                                custom_prompts: [prompt],
+                                filename_style: this.inference.form.filename_style,
+                                settings: this.inferenceSettings()
+                            })
+                        }
+                    );
+                    await this._inferenceJson(response);
+                    this.inference.interactivePrompt = '';
+                    this.inference.session.status = 'running';
+                    this.scheduleInferenceStatusPoll();
+                } catch (error) {
+                    if (window.showToast) window.showToast(error.message, 'error');
+                } finally {
+                    this.loading.inferenceAction = false;
+                }
+            },
+
+            async stopInference(cancel = false) {
+                if (!this.inference.session?.session_id || this.loading.inferenceAction) return;
+                this.loading.inferenceAction = true;
+                try {
+                    const environment = await this.ensureEnvironment();
+                    const action = cancel ? 'cancel' : 'unload';
+                    const response = await ApiClient.fetch(
+                        `/api/checkpoints/inference/${encodeURIComponent(this.inference.session.session_id)}/${action}`,
+                        {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ environment })
+                        }
+                    );
+                    const result = await this._inferenceJson(response);
+                    this.inference.session.status = result.status;
+                    this.scheduleInferenceStatusPoll();
+                } catch (error) {
+                    if (window.showToast) window.showToast(error.message, 'error');
+                } finally {
+                    this.loading.inferenceAction = false;
+                }
+            },
+
+            async loadInferenceHistory(page = 1) {
+                this.loading.inferenceHistory = true;
+                try {
+                    const environment = await this.ensureEnvironment();
+                    const response = await ApiClient.fetch(
+                        `/api/checkpoints/inference/history?environment=${encodeURIComponent(environment)}&page=${page}&page_size=24`
+                    );
+                    const data = await this._inferenceJson(response);
+                    this.inference.history = data.items || [];
+                    this.inference.historySelection = [];
+                    this.inference.historyPage = data.page;
+                    this.inference.historyTotal = data.total;
+                } catch (error) {
+                    console.error('Failed to load inference history:', error);
+                } finally {
+                    this.loading.inferenceHistory = false;
+                }
             },
 
             // Retention Management

--- a/simpletuner/static/js/modules/checkpoints.js
+++ b/simpletuner/static/js/modules/checkpoints.js
@@ -34,6 +34,7 @@ if (!window.checkpointsManager) {
                     builtin_count: 0,
                     configured_user_library: null,
                     user_libraries: [],
+                    unsupported_multigpu_modes: [],
                     inference_defaults: {
                         num_inference_steps: null,
                         guidance_scale: null,
@@ -634,6 +635,16 @@ if (!window.checkpointsManager) {
 
             inferenceRunCount() {
                 return this.inferencePromptCount() * this.inferenceSelection.length * this.inferenceResolutionCount();
+            },
+
+            inferenceMultigpuWarning() {
+                const modes = this.inference.promptSources.unsupported_multigpu_modes || [];
+                if (!modes.length) return '';
+                const labels = modes.map(mode => mode.replaceAll('-', ' '));
+                const configuredModes = labels.length === 1
+                    ? labels[0]
+                    : `${labels.slice(0, -1).join(', ')} and ${labels.at(-1)}`;
+                return `Checkpoint inference currently runs on one process and will not use this environment's configured ${configuredModes} validation ${labels.length === 1 ? 'mode' : 'modes'}.`;
             },
 
             inferenceResolutionCount() {

--- a/simpletuner/templates/checkpoints_tab.html
+++ b/simpletuner/templates/checkpoints_tab.html
@@ -68,12 +68,28 @@
     <!-- Checkpoint List Section -->
     <div class="card mb-4">
         <div class="card-header">
-            <div class="d-flex justify-content-between align-items-center">
+            <div class="d-flex flex-wrap gap-3 justify-content-between align-items-center">
                 <div>
                     <h5 class="mb-1"><i class="fas fa-save me-2"></i>Training Checkpoints</h5>
                     <p class="text-muted mb-0">Browse and manage saved model checkpoints from training runs.</p>
                 </div>
-                <div class="d-flex gap-2 align-items-center">
+                <div class="d-flex flex-wrap gap-2 align-items-center justify-content-end">
+                    <button type="button"
+                            class="btn btn-sm btn-primary checkpoint-inference-launch"
+                            :disabled="inferenceSelection.length === 0"
+                            @click="openInferenceWorkspace('setup')">
+                        <i class="fas fa-wand-magic-sparkles me-1"></i>
+                        Run Inference
+                        <span class="badge text-bg-light checkpoint-inference-launch-count"
+                              x-show="inferenceSelection.length"
+                              x-text="inferenceSelection.length"></span>
+                    </button>
+                    <button type="button"
+                            class="btn btn-sm btn-outline-secondary"
+                            title="Inference history"
+                            @click="openInferenceWorkspace('history')">
+                        <i class="fas fa-images"></i>
+                    </button>
                     <button class="btn btn-sm btn-outline-secondary"
                             @click="restoreHeroCTA()"
                             title="Show introduction">
@@ -164,7 +180,10 @@
             <div x-show="checkpoints.length > 0" x-cloak class="checkpoint-grid">
                 <template x-for="checkpoint in checkpoints" :key="checkpoint.id">
                     <div class="checkpoint-card"
-                         :class="{ 'selected': selectedCheckpoint?.id === checkpoint.id }"
+                         :class="{
+                             'selected': selectedCheckpoint?.id === checkpoint.id,
+                             'inference-selected': isInferenceSelected(checkpoint.name)
+                         }"
                          @click="selectCheckpoint(checkpoint.id)">
                         <div class="checkpoint-card-content">
                             <div class="checkpoint-header">
@@ -173,6 +192,15 @@
                                     <span x-text="`Step ${checkpoint.step}`"></span>
                                 </div>
                                 <div class="d-flex align-items-center gap-2">
+                                    <div class="form-check checkpoint-inference-check">
+                                        <input class="form-check-input"
+                                               type="checkbox"
+                                               :id="`inference-${checkpoint.id}`"
+                                               :checked="isInferenceSelected(checkpoint.name)"
+                                               :aria-label="`Select ${checkpoint.name} for inference`"
+                                               @click.stop
+                                               @change="toggleInferenceCheckpoint(checkpoint.name)">
+                                    </div>
                                     <button type="button"
                                             class="btn btn-sm"
                                             :class="canUpload() ? 'btn-success' : 'btn-secondary'"
@@ -550,6 +578,339 @@
                     </template>
                 </div>
             </template>
+        </div>
+    </div>
+
+    <!-- Checkpoint Inference Workspace -->
+    <div class="modal fade"
+         id="checkpointInferenceModal"
+         tabindex="-1"
+         aria-labelledby="checkpointInferenceModalLabel"
+         aria-hidden="true">
+        <div class="modal-dialog modal-xl modal-dialog-scrollable modal-fullscreen-md-down">
+            <div class="modal-content checkpoint-inference-modal">
+                <div class="modal-header align-items-start">
+                    <div>
+                        <h5 class="modal-title" id="checkpointInferenceModalLabel">
+                            <i class="fas fa-wand-magic-sparkles me-2"></i>Checkpoint Inference
+                        </h5>
+                        <div class="small text-muted mt-1" x-show="inference.session">
+                            <span class="text-capitalize" x-text="inference.session?.status"></span>
+                            <span x-show="inference.session?.loaded_checkpoint"> · <span x-text="inference.session?.loaded_checkpoint"></span></span>
+                        </div>
+                    </div>
+                    <button type="button"
+                            class="btn btn-sm btn-outline-secondary inference-modal-close"
+                            data-bs-dismiss="modal"
+                            title="Close"
+                            aria-label="Close">
+                        <i class="fas fa-times" aria-hidden="true"></i>
+                    </button>
+                </div>
+
+                <div class="inference-modal-tabs">
+                    <ul class="nav nav-tabs border-0">
+                        <li class="nav-item">
+                            <button type="button"
+                                    class="nav-link"
+                                    :class="{ 'active': inference.activeTab === 'setup' }"
+                                    @click="inference.activeTab = 'setup'; loadInferencePromptSources()">
+                                Setup
+                            </button>
+                        </li>
+                        <li class="nav-item">
+                            <button type="button"
+                                    class="nav-link"
+                                    :class="{ 'active': inference.activeTab === 'history' }"
+                                    @click="inference.activeTab = 'history'; loadInferenceHistory(1)">
+                                History
+                                <span class="badge text-bg-secondary ms-1" x-text="inference.historyTotal"></span>
+                            </button>
+                        </li>
+                    </ul>
+                </div>
+
+                <div class="modal-body">
+                    <div x-show="inference.activeTab === 'setup'" x-cloak>
+                        <div class="row g-4">
+                            <section class="col-lg-4 inference-section">
+                                <div class="d-flex justify-content-between align-items-center mb-3">
+                                    <h6 class="mb-0">Checkpoints</h6>
+                                    <span class="badge text-bg-secondary" x-text="inferenceSelection.length"></span>
+                                </div>
+                                <div class="inference-checkpoint-list">
+                                    <template x-for="checkpoint in selectedInferenceCheckpoints()" :key="`selected-inference-${checkpoint.id}`">
+                                        <div class="inference-checkpoint-row">
+                                            <div>
+                                                <div class="fw-semibold" x-text="checkpoint.name"></div>
+                                                <div class="small text-muted" x-text="formatSize(checkpoint.size)"></div>
+                                            </div>
+                                            <button type="button"
+                                                    class="btn btn-sm btn-outline-secondary inference-icon-button"
+                                                    title="Remove checkpoint"
+                                                    @click="toggleInferenceCheckpoint(checkpoint.name)">
+                                                <i class="fas fa-times"></i>
+                                            </button>
+                                        </div>
+                                    </template>
+                                    <div class="text-muted small py-3" x-show="inferenceSelection.length === 0">
+                                        Select checkpoints from the grid.
+                                    </div>
+                                </div>
+
+                                <hr>
+
+                                <h6 class="mb-3">Output</h6>
+                                <label class="form-label small" for="inference-filename-style">Filename format</label>
+                                <select id="inference-filename-style"
+                                        class="form-select form-select-sm mb-3"
+                                        x-model="inference.form.filename_style"
+                                        @change="saveInferenceSettings()">
+                                    <option value="descriptive">Timestamp + prompt + seed</option>
+                                    <option value="compact">Timestamp + seed</option>
+                                    <option value="prompt">Prompt + timestamp</option>
+                                    <option value="content-hash">Content hash</option>
+                                </select>
+
+                                <div class="form-check form-switch mb-2">
+                                    <input class="form-check-input"
+                                           type="checkbox"
+                                           id="inference-keep-loaded"
+                                           x-model="inference.form.keep_loaded"
+                                           @change="saveInferenceSettings()"
+                                           :disabled="inferenceSelection.length !== 1">
+                                    <label class="form-check-label" for="inference-keep-loaded">Keep model loaded</label>
+                                </div>
+                                <div class="form-check form-switch mb-2">
+                                    <input class="form-check-input"
+                                           type="checkbox"
+                                           id="inference-streaming-preview"
+                                           x-model="inference.form.streaming_preview"
+                                           @change="saveInferenceSettings()"
+                                           :disabled="inferenceIsActive() || inference.session?.status === 'loaded'">
+                                    <label class="form-check-label" for="inference-streaming-preview">Streaming preview</label>
+                                </div>
+                                <div x-show="inference.form.keep_loaded" x-cloak>
+                                    <label class="form-label small" for="inference-idle-timeout">Idle timeout (minutes)</label>
+                                    <input id="inference-idle-timeout"
+                                           type="number"
+                                           min="1"
+                                           max="1440"
+                                           class="form-control form-control-sm"
+                                           x-model.number="inference.form.idle_timeout_minutes">
+                                </div>
+                            </section>
+
+                            <section class="col-lg-8 inference-section inference-section-divider">
+                                <div class="d-flex justify-content-between align-items-center mb-3">
+                                    <h6 class="mb-0">Prompts</h6>
+                                    <span class="small text-muted"><span x-text="inferencePromptCount()"></span> prompts · <span x-text="inferenceRunCount()"></span> runs</span>
+                                </div>
+
+                                <div class="form-check mb-1">
+                                    <input class="form-check-input"
+                                           type="checkbox"
+                                           id="inference-configured-prompt"
+                                           x-model="inference.form.use_configured_prompt"
+                                           :disabled="!inference.promptSources.configured_prompt">
+                                    <label class="form-check-label" for="inference-configured-prompt">Configured validation prompt</label>
+                                </div>
+                                <pre class="inference-source-preview mb-3"><code x-text="inference.promptSources.configured_prompt || 'Not configured'"></code></pre>
+
+                                <div class="form-check mb-3">
+                                    <input class="form-check-input"
+                                           type="checkbox"
+                                           id="inference-builtin-library"
+                                           x-model="inference.form.use_builtin_library">
+                                    <label class="form-check-label" for="inference-builtin-library">
+                                        Built-in validation library
+                                        <span class="text-muted" x-text="`(${inference.promptSources.builtin_count})`"></span>
+                                    </label>
+                                </div>
+
+                                <label class="form-label" for="inference-user-library">User prompt library</label>
+                                <select id="inference-user-library" class="form-select form-select-sm mb-3" x-model="inference.form.user_library_filename">
+                                    <option value="">None</option>
+                                    <template x-for="library in inference.promptSources.user_libraries" :key="library.filename">
+                                        <option :value="library.filename" x-text="`${library.display_name} (${library.prompt_count})`"></option>
+                                    </template>
+                                </select>
+
+                                <label class="form-label" for="inference-custom-prompts">Custom prompts</label>
+                                <textarea id="inference-custom-prompts"
+                                          class="form-control inference-prompt-textarea"
+                                          rows="5"
+                                          placeholder="One prompt per line"
+                                          x-model="inference.form.custom_prompts"></textarea>
+
+                                <div class="row g-3 mt-1">
+                                    <div class="col-sm-4">
+                                        <label class="form-label small" for="inference-seed">Seed</label>
+                                        <input id="inference-seed" type="number" class="form-control form-control-sm" placeholder="Config default" x-model="inference.form.seed">
+                                    </div>
+                                    <div class="col-sm-4">
+                                        <label class="form-label small" for="inference-steps">Steps</label>
+                                        <input id="inference-steps" type="number" min="1" max="1000" class="form-control form-control-sm" x-model="inference.form.num_inference_steps">
+                                    </div>
+                                    <div class="col-sm-4">
+                                        <label class="form-label small" for="inference-guidance">CFG</label>
+                                        <input id="inference-guidance" type="number" min="0" max="100" step="0.1" class="form-control form-control-sm" x-model="inference.form.guidance_scale">
+                                    </div>
+                                </div>
+                                <div class="mt-3">
+                                    <label class="form-label small" for="inference-resolution">Resolution</label>
+                                    <input id="inference-resolution"
+                                           type="text"
+                                           class="form-control form-control-sm"
+                                           x-model="inference.form.validation_resolution">
+                                </div>
+                            </section>
+                        </div>
+
+                        <div class="inference-session-panel mt-4" x-show="inference.session" x-cloak>
+                            <div class="d-flex justify-content-between align-items-center gap-3 mb-2">
+                                <div>
+                                    <span class="fw-semibold text-capitalize" x-text="inference.session?.status"></span>
+                                    <span class="small text-muted ms-2" x-text="`${inference.session?.completed_prompts || 0} / ${inference.session?.total_prompts || inference.session?.generation_count || 0}`"></span>
+                                </div>
+                                <span class="small text-danger text-end" x-show="inference.session?.message" x-text="inference.session?.message"></span>
+                            </div>
+                            <div class="progress" role="progressbar" aria-label="Inference progress" :aria-valuenow="inferenceProgressPercent()" aria-valuemin="0" aria-valuemax="100">
+                                <div class="progress-bar progress-bar-striped"
+                                     :class="{ 'progress-bar-animated': inferenceIsActive() }"
+                                     :style="`width: ${inferenceProgressPercent()}%`"></div>
+                            </div>
+
+                            <template x-if="inferenceDisplayOutput()">
+                                <div class="inference-current-output mt-3">
+                                    <div class="inference-current-output-media">
+                                        <template x-if="inferenceDisplayOutput()?.media_type === 'video'">
+                                            <video :src="inferenceDisplayOutput().media_url" controls muted playsinline loop></video>
+                                        </template>
+                                        <template x-if="inferenceDisplayOutput()?.media_type !== 'video'">
+                                            <img :src="inferenceDisplayOutput().media_url"
+                                                 :alt="inferenceDisplayOutput().prompt || 'Inference output'">
+                                        </template>
+                                        <span class="badge inference-current-output-badge"
+                                              :class="inferenceDisplayOutput().streaming ? 'text-bg-primary' : 'text-bg-success'"
+                                              x-text="inferenceDisplayOutput().streaming ? (inferenceDisplayOutput().step_label || 'Streaming') : 'Latest output'"></span>
+                                    </div>
+                                    <div class="inference-current-output-details">
+                                        <h6 class="mb-2">Current output</h6>
+                                        <div class="small text-muted mb-2" x-text="inferenceDisplayOutput().checkpoint || ''"></div>
+                                        <div class="inference-current-output-prompt" x-text="inferenceDisplayOutput().prompt || ''"></div>
+                                    </div>
+                                </div>
+                            </template>
+
+                            <div class="input-group mt-3" x-show="inference.session?.status === 'loaded'" x-cloak>
+                                <textarea class="form-control"
+                                          rows="2"
+                                          placeholder="Enter another prompt"
+                                          x-model="inference.interactivePrompt"
+                                          @keydown.ctrl.enter.prevent="queueInteractivePrompt()"></textarea>
+                                <button class="btn btn-primary"
+                                        type="button"
+                                        title="Generate"
+                                        :disabled="!inference.interactivePrompt.trim() || loading.inferenceAction"
+                                        @click="queueInteractivePrompt()">
+                                    <i class="fas fa-play"></i>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div x-show="inference.activeTab === 'history'" x-cloak>
+                        <div class="d-flex justify-content-between align-items-center mb-3">
+                            <div class="d-flex align-items-center gap-2">
+                                <input class="form-check-input inference-history-select-page"
+                                       type="checkbox"
+                                       title="Select page"
+                                       aria-label="Select all generations on this page"
+                                       :checked="inferenceHistoryPageSelected()"
+                                       :disabled="inference.history.length === 0 || loading.inferenceDelete"
+                                       @change="toggleInferenceHistoryPage()">
+                                <h6 class="mb-0">Generations</h6>
+                            </div>
+                            <div class="d-flex align-items-center gap-2">
+                                <button type="button"
+                                        class="btn btn-sm btn-outline-danger"
+                                        title="Delete selected generations"
+                                        :disabled="inference.historySelection.length === 0 || loading.inferenceDelete"
+                                        @click="deleteInferenceHistorySelection()">
+                                    <i class="fas fa-trash-alt me-1"></i>
+                                    <span x-text="inference.historySelection.length ? `Delete (${inference.historySelection.length})` : 'Delete'"></span>
+                                </button>
+                                <button type="button"
+                                        class="btn btn-sm btn-outline-secondary"
+                                        title="Refresh history"
+                                        :disabled="loading.inferenceHistory || loading.inferenceDelete"
+                                        @click="loadInferenceHistory(inference.historyPage)">
+                                    <i class="fas fa-sync-alt" :class="{ 'fa-spin': loading.inferenceHistory }"></i>
+                                </button>
+                            </div>
+                        </div>
+                        <div class="text-center py-5 text-muted" x-show="loading.inferenceHistory && inference.history.length === 0">
+                            <i class="fas fa-spinner fa-spin"></i>
+                        </div>
+                        <div class="text-center py-5 text-muted" x-show="!loading.inferenceHistory && inference.history.length === 0">
+                            No inference outputs yet.
+                        </div>
+                        <div class="inference-history-grid" x-show="inference.history.length">
+                            <template x-for="item in inference.history" :key="`${item.session_id}-${item.checkpoint}-${item.filename}`">
+                                <article class="inference-history-item"
+                                         :class="{ 'selected': isInferenceHistorySelected(item.media_path) }">
+                                    <label class="inference-history-select" title="Select generation">
+                                        <input class="form-check-input"
+                                               type="checkbox"
+                                               :checked="isInferenceHistorySelected(item.media_path)"
+                                               :disabled="loading.inferenceDelete"
+                                               @change="toggleInferenceHistoryItem(item.media_path)">
+                                        <span class="visually-hidden">Select generation</span>
+                                    </label>
+                                    <template x-if="item.media_type === 'video'">
+                                        <video :src="item.media_url" controls preload="metadata"></video>
+                                    </template>
+                                    <template x-if="item.media_type !== 'video'">
+                                        <img :src="item.media_url" :alt="item.prompt" loading="lazy">
+                                    </template>
+                                    <div class="inference-history-caption">
+                                        <div class="small fw-semibold text-truncate" x-text="item.checkpoint"></div>
+                                        <div class="small text-muted inference-history-prompt" x-text="item.prompt"></div>
+                                        <div class="small text-muted" x-text="`Seed ${item.seed}`"></div>
+                                    </div>
+                                </article>
+                            </template>
+                        </div>
+                        <div class="d-flex justify-content-between align-items-center mt-3" x-show="inference.historyTotal > 24">
+                            <button type="button" class="btn btn-sm btn-outline-secondary" :disabled="inference.historyPage <= 1" @click="loadInferenceHistory(inference.historyPage - 1)">
+                                <i class="fas fa-chevron-left"></i>
+                            </button>
+                            <span class="small text-muted" x-text="`${inference.historyPage} / ${inferenceHistoryPageCount()}`"></span>
+                            <button type="button" class="btn btn-sm btn-outline-secondary" :disabled="inference.historyPage >= inferenceHistoryPageCount()" @click="loadInferenceHistory(inference.historyPage + 1)">
+                                <i class="fas fa-chevron-right"></i>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="modal-footer" x-show="inference.activeTab === 'setup'">
+                    <button type="button" class="btn btn-outline-danger me-auto" x-show="inferenceIsActive()" :disabled="loading.inferenceAction" @click="stopInference(true)">
+                        <i class="fas fa-stop me-1"></i>Cancel
+                    </button>
+                    <button type="button" class="btn btn-outline-secondary" x-show="inference.session?.status === 'loaded'" :disabled="loading.inferenceAction" @click="stopInference(false)">
+                        <i class="fas fa-power-off me-1"></i>Unload
+                    </button>
+                    <button type="button"
+                            class="btn btn-primary"
+                            x-show="!inferenceIsActive() && inference.session?.status !== 'loaded'"
+                            :disabled="loading.inferenceStart || inferenceSelection.length === 0 || inferencePromptCount() === 0"
+                            @click="startInference()">
+                        <i class="fas fa-play me-1"></i>
+                        <span x-text="loading.inferenceStart ? 'Starting...' : `Run ${inferenceRunCount()} generation${inferenceRunCount() === 1 ? '' : 's'}`"></span>
+                    </button>
+                </div>
+            </div>
         </div>
     </div>
 

--- a/simpletuner/templates/checkpoints_tab.html
+++ b/simpletuner/templates/checkpoints_tab.html
@@ -894,7 +894,14 @@
                     </div>
                 </div>
 
-                <div class="modal-footer" x-show="inference.activeTab === 'setup'">
+                <div class="modal-footer inference-modal-footer" x-show="inference.activeTab === 'setup'">
+                    <div class="alert alert-warning inference-multigpu-warning"
+                         x-show="inferenceMultigpuWarning()"
+                         x-cloak
+                         role="alert">
+                        <i class="fas fa-triangle-exclamation" aria-hidden="true"></i>
+                        <span x-text="inferenceMultigpuWarning()"></span>
+                    </div>
                     <button type="button" class="btn btn-outline-danger me-auto" x-show="inferenceIsActive()" :disabled="loading.inferenceAction" @click="stopInference(true)">
                         <i class="fas fa-stop me-1"></i>Cancel
                     </button>

--- a/tests/js/checkpoints_inference.test.js
+++ b/tests/js/checkpoints_inference.test.js
@@ -1,0 +1,240 @@
+window.HintMixin = {
+    createMultiHint: () => ({
+        hints: { hero: false },
+        loadHints: jest.fn(),
+        dismissHint: jest.fn(),
+        showHint: jest.fn(),
+    }),
+};
+window.ApiClient = { fetch: jest.fn() };
+global.ApiClient = window.ApiClient;
+window.checkpointsManager = undefined;
+
+require('../../simpletuner/static/js/modules/checkpoints.js');
+
+describe('checkpoint inference manager', () => {
+    let manager;
+
+    beforeEach(() => {
+        manager = window.checkpointsManager();
+        manager.environment = 'test-environment';
+        manager.checkpoints = [
+            { id: 'checkpoint-100', name: 'checkpoint-100', size: 100 },
+            { id: 'checkpoint-200', name: 'checkpoint-200', size: 200 },
+        ];
+        window.ApiClient.fetch.mockReset();
+    });
+
+    test('tracks inference selection separately and disables persistent mode for batches', () => {
+        manager.selectedCheckpoint = manager.checkpoints[0];
+        manager.toggleInferenceCheckpoint('checkpoint-100');
+        manager.inference.form.keep_loaded = true;
+        manager.toggleInferenceCheckpoint('checkpoint-200');
+
+        expect(manager.inferenceSelection).toEqual(['checkpoint-100', 'checkpoint-200']);
+        expect(manager.selectedCheckpoint.name).toBe('checkpoint-100');
+        expect(manager.inference.form.keep_loaded).toBe(false);
+    });
+
+    test('counts configured, built-in, library, and custom prompts', () => {
+        manager.inferenceSelection = ['checkpoint-100', 'checkpoint-200'];
+        manager.inference.promptSources = {
+            configured_prompt: 'configured',
+            builtin_count: 3,
+            configured_user_library: null,
+            user_libraries: [{ filename: 'user_prompt_library-test.json', prompt_count: 2 }],
+        };
+        Object.assign(manager.inference.form, {
+            use_configured_prompt: true,
+            use_builtin_library: true,
+            user_library_filename: 'user_prompt_library-test.json',
+            custom_prompts: 'first custom\n\nsecond custom',
+            validation_resolution: '512,768x512',
+        });
+
+        expect(manager.inferencePromptCount()).toBe(8);
+        expect(manager.inferenceRunCount()).toBe(32);
+    });
+
+    test('submits the selected checkpoint and prompt settings', async () => {
+        manager.inferenceSelection = ['checkpoint-100'];
+        Object.assign(manager.inference.form, {
+            use_configured_prompt: false,
+            custom_prompts: 'a custom prompt',
+            filename_style: 'content-hash',
+            keep_loaded: true,
+            streaming_preview: true,
+            idle_timeout_minutes: 9,
+            seed: '42',
+            validation_resolution: '512,768x512',
+        });
+        window.ApiClient.fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({ session_id: 'session-one', status: 'loading' }),
+        });
+        jest.spyOn(manager, 'scheduleInferenceStatusPoll').mockImplementation(() => {});
+
+        await manager.startInference();
+
+        const [url, options] = window.ApiClient.fetch.mock.calls[0];
+        expect(url).toBe('/api/checkpoints/inference/start');
+        expect(JSON.parse(options.body)).toEqual(expect.objectContaining({
+            environment: 'test-environment',
+            checkpoint_names: ['checkpoint-100'],
+            custom_prompts: ['a custom prompt'],
+            filename_style: 'content-hash',
+            keep_loaded: true,
+            streaming_preview: true,
+            idle_timeout_minutes: 9,
+            settings: { seed: 42, validation_resolution: '512,768x512' },
+        }));
+        expect(manager.inference.session.session_id).toBe('session-one');
+    });
+
+    test('shows the newest streaming or completed output in setup', () => {
+        manager.inference.session = {
+            streaming_preview: true,
+            preview: {
+                prompt: 'preview',
+                streaming: true,
+                updated_at: '2026-01-01T00:00:02Z',
+            },
+            latest_output: {
+                prompt: 'completed',
+                streaming: false,
+                created_at: '2026-01-01T00:00:01Z',
+            },
+        };
+        expect(manager.inferenceDisplayOutput().prompt).toBe('preview');
+
+        manager.inference.session.latest_output.created_at = '2026-01-01T00:00:03Z';
+        expect(manager.inferenceDisplayOutput().prompt).toBe('completed');
+
+        manager.inference.session.streaming_preview = false;
+        manager.inference.session.latest_output = null;
+        expect(manager.inferenceDisplayOutput()).toBeNull();
+    });
+
+    test('loads active environment inference defaults without replacing user overrides', async () => {
+        window.ApiClient.fetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    configured_prompt: null,
+                    configured_user_library: null,
+                    user_libraries: [],
+                    inference_defaults: {
+                        num_inference_steps: 24,
+                        guidance_scale: 5.5,
+                        validation_resolution: '512,768x512',
+                    },
+                }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    configured_prompt: null,
+                    configured_user_library: null,
+                    user_libraries: [],
+                    inference_defaults: {
+                        num_inference_steps: 30,
+                        guidance_scale: 6.5,
+                        validation_resolution: '1024x1024',
+                    },
+                }),
+            });
+
+        await manager.loadInferencePromptSources();
+        expect(manager.inference.form.num_inference_steps).toBe(24);
+        expect(manager.inference.form.guidance_scale).toBe(5.5);
+        expect(manager.inference.form.validation_resolution).toBe('512,768x512');
+
+        manager.inference.form.num_inference_steps = '12';
+        await manager.loadInferencePromptSources();
+
+        expect(manager.inference.form.num_inference_steps).toBe('12');
+        expect(manager.inference.form.guidance_scale).toBe(6.5);
+        expect(manager.inference.form.validation_resolution).toBe('1024x1024');
+    });
+
+    test('loads and saves persisted inference options', async () => {
+        window.ApiClient.fetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ filename_style: 'prompt', keep_loaded: true, streaming_preview: true }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    filename_style: 'content-hash',
+                    keep_loaded: false,
+                    streaming_preview: true,
+                }),
+            });
+
+        await manager.loadInferenceSettings();
+        expect(manager.inference.form.filename_style).toBe('prompt');
+        expect(manager.inference.form.keep_loaded).toBe(true);
+        expect(manager.inference.form.streaming_preview).toBe(true);
+
+        manager.inference.form.filename_style = 'content-hash';
+        manager.inference.form.keep_loaded = false;
+        await manager.saveInferenceSettings();
+
+        expect(window.ApiClient.fetch).toHaveBeenLastCalledWith(
+            '/api/webui/ui-state/checkpoint-inference',
+            expect.objectContaining({
+                method: 'POST',
+                body: JSON.stringify({
+                    filename_style: 'content-hash',
+                    keep_loaded: false,
+                    streaming_preview: true,
+                }),
+            })
+        );
+    });
+
+    test('selects and deletes inference history samples', async () => {
+        manager.inference.history = [
+            { media_path: 'session-one/checkpoint-100/one.png' },
+            { media_path: 'session-one/checkpoint-100/two.png' },
+        ];
+        manager.inference.historyTotal = 2;
+        global.confirm = jest.fn(() => true);
+        window.ApiClient.fetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ deleted_count: 2 }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ items: [], page: 1, total: 0 }),
+            });
+
+        manager.toggleInferenceHistoryPage();
+        expect(manager.inference.historySelection).toEqual([
+            'session-one/checkpoint-100/one.png',
+            'session-one/checkpoint-100/two.png',
+        ]);
+
+        await manager.deleteInferenceHistorySelection();
+
+        expect(global.confirm).toHaveBeenCalledWith('Delete 2 selected generations? This cannot be undone.');
+        expect(window.ApiClient.fetch).toHaveBeenNthCalledWith(
+            1,
+            '/api/checkpoints/inference/history',
+            expect.objectContaining({
+                method: 'DELETE',
+                body: JSON.stringify({
+                    environment: 'test-environment',
+                    media_paths: [
+                        'session-one/checkpoint-100/one.png',
+                        'session-one/checkpoint-100/two.png',
+                    ],
+                }),
+            })
+        );
+        expect(manager.inference.history).toEqual([]);
+        expect(manager.inference.historySelection).toEqual([]);
+    });
+});

--- a/tests/js/checkpoints_inference.test.js
+++ b/tests/js/checkpoints_inference.test.js
@@ -56,6 +56,17 @@ describe('checkpoint inference manager', () => {
         expect(manager.inferenceRunCount()).toBe(32);
     });
 
+    test('warns when configured validation multigpu modes are unsupported', () => {
+        manager.inference.promptSources.unsupported_multigpu_modes = ['batch-parallel', 'context-parallel'];
+
+        expect(manager.inferenceMultigpuWarning()).toBe(
+            "Checkpoint inference currently runs on one process and will not use this environment's configured batch parallel and context parallel validation modes."
+        );
+
+        manager.inference.promptSources.unsupported_multigpu_modes = [];
+        expect(manager.inferenceMultigpuWarning()).toBe('');
+    });
+
     test('submits the selected checkpoint and prompt settings', async () => {
         manager.inferenceSelection = ['checkpoint-100'];
         Object.assign(manager.inference.form, {

--- a/tests/test_checkpoint_inference_routes.py
+++ b/tests/test_checkpoint_inference_routes.py
@@ -1,0 +1,87 @@
+import unittest
+from unittest.mock import patch
+
+from fastapi import status
+
+from simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service import (
+    CHECKPOINT_INFERENCE_SERVICE,
+    CheckpointInferenceServiceError,
+)
+from tests.test_webui_api import _WebUIBaseTestCase
+
+
+class CheckpointInferenceRoutesTestCase(_WebUIBaseTestCase, unittest.TestCase):
+    def test_start_inference_forwards_validated_request(self) -> None:
+        response_payload = {"session_id": "session-one", "status": "loading"}
+        with patch.object(CHECKPOINT_INFERENCE_SERVICE, "start", return_value=response_payload) as start:
+            response = self.client.post(
+                "/api/checkpoints/inference/start",
+                json={
+                    "environment": "test",
+                    "checkpoint_names": ["checkpoint-100"],
+                    "use_configured_prompt": False,
+                    "custom_prompts": ["a prompt"],
+                    "filename_style": "prompt",
+                    "keep_loaded": True,
+                    "streaming_preview": True,
+                    "settings": {
+                        "seed": 12,
+                        "num_inference_steps": 20,
+                        "validation_resolution": "512,768x512",
+                    },
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), response_payload)
+        self.assertEqual(start.call_args.kwargs["checkpoint_names"], ["checkpoint-100"])
+        self.assertTrue(start.call_args.kwargs["streaming_preview"])
+        self.assertEqual(
+            start.call_args.kwargs["settings"],
+            {"seed": 12, "num_inference_steps": 20, "validation_resolution": "512,768x512"},
+        )
+
+    def test_empty_checkpoint_selection_is_rejected(self) -> None:
+        response = self.client.post(
+            "/api/checkpoints/inference/start",
+            json={"environment": "test", "checkpoint_names": [], "custom_prompts": ["a prompt"]},
+        )
+
+        self.assertEqual(response.status_code, 422)
+
+    def test_service_conflict_maps_to_http_conflict(self) -> None:
+        error = CheckpointInferenceServiceError("accelerator busy", status.HTTP_409_CONFLICT)
+        with patch.object(CHECKPOINT_INFERENCE_SERVICE, "prompt_sources", side_effect=error):
+            response = self.client.get("/api/checkpoints/inference/prompt-sources?environment=test")
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.json()["detail"], "accelerator busy")
+
+    def test_delete_history_forwards_selected_media_paths(self) -> None:
+        response_payload = {"deleted_count": 2, "media_paths": ["one.png", "two.png"]}
+        with patch.object(CHECKPOINT_INFERENCE_SERVICE, "delete_history", return_value=response_payload) as delete_history:
+            response = self.client.request(
+                "DELETE",
+                "/api/checkpoints/inference/history",
+                json={
+                    "environment": "test",
+                    "media_paths": [
+                        "session-one/checkpoint-100/one.png",
+                        "session-one/checkpoint-100/two.png",
+                    ],
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), response_payload)
+        delete_history.assert_called_once_with(
+            "test",
+            [
+                "session-one/checkpoint-100/one.png",
+                "session-one/checkpoint-100/two.png",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_checkpoint_inference_service.py
+++ b/tests/test_checkpoint_inference_service.py
@@ -23,6 +23,20 @@ class TestCheckpointInferenceService(unittest.TestCase):
         self.service = CheckpointInferenceService()
         self.service._load_environment = Mock(return_value=(self.config, self.output_dir))
 
+    @patch("simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service.process_keeper")
+    def test_active_session_prunes_stale_records(self, process_keeper: MagicMock) -> None:
+        active = {"session_id": "active", "job_id": "active-job", "environment": "active-env"}
+        stale = {"session_id": "stale", "job_id": "stale-job", "environment": "stale-env"}
+        self.service._sessions = {"active": active, "stale": stale}
+        self.service._environment_sessions = {"active-env": "active", "stale-env": "stale"}
+        process_keeper.get_process_status.side_effect = lambda job_id: "running" if job_id == "active-job" else "completed"
+
+        result = self.service.active_session()
+
+        self.assertEqual(result, active)
+        self.assertEqual(self.service._sessions, {"active": active})
+        self.assertEqual(self.service._environment_sessions, {"active-env": "active"})
+
     @patch("simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service.PromptLibraryService")
     @patch(
         "simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service.built_in_prompts",
@@ -92,6 +106,8 @@ class TestCheckpointInferenceService(unittest.TestCase):
                 "validation_num_inference_steps": 24,
                 "--validation_guidance": 5.5,
                 "--validation_resolution": "512,768x512",
+                "--validation_multigpu": "batch-parallel",
+                "context_parallel_size": "2",
                 "--user_prompt_library": None,
             }
         )
@@ -106,6 +122,7 @@ class TestCheckpointInferenceService(unittest.TestCase):
                 "validation_resolution": "512,768x512",
             },
         )
+        self.assertEqual(result["unsupported_multigpu_modes"], ["batch-parallel", "context-parallel"])
 
     @patch("simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service.PromptLibraryService")
     def test_prompt_sources_use_registered_defaults_when_environment_omits_values(
@@ -120,6 +137,7 @@ class TestCheckpointInferenceService(unittest.TestCase):
             result["inference_defaults"],
             {"num_inference_steps": 30, "guidance_scale": 7.5, "validation_resolution": "256"},
         )
+        self.assertEqual(result["unsupported_multigpu_modes"], [])
 
     @patch("simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service.process_keeper")
     @patch("simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service.CheckpointManager")
@@ -175,6 +193,7 @@ class TestCheckpointInferenceService(unittest.TestCase):
     def test_history_builds_environment_scoped_media_urls(self) -> None:
         sidecar = self.output_dir / "inference" / "session-one" / "checkpoint-100" / "output.png.json"
         sidecar.parent.mkdir(parents=True)
+        sidecar.with_suffix("").write_bytes(b"generated output")
         sidecar.write_text(
             json.dumps(
                 {
@@ -196,6 +215,16 @@ class TestCheckpointInferenceService(unittest.TestCase):
             "/api/checkpoints/inference/media/session-one/checkpoint-100/output.png?environment=environment%20with%20spaces",
         )
         self.assertEqual(result["items"][0]["media_path"], "session-one/checkpoint-100/output.png")
+
+    def test_history_ignores_orphaned_sidecars(self) -> None:
+        sidecar = self.output_dir / "inference" / "session-one" / "checkpoint-100" / "missing.png.json"
+        sidecar.parent.mkdir(parents=True)
+        sidecar.write_text(json.dumps({"created_at": "2026-01-01T00:00:00+00:00"}), encoding="utf-8")
+
+        result = self.service.history("test", page=1, page_size=24)
+
+        self.assertEqual(result["items"], [])
+        self.assertEqual(result["total"], 0)
 
     def test_delete_history_removes_selected_media_and_sidecars(self) -> None:
         session_dir = self.output_dir / "inference" / "session-one"
@@ -244,6 +273,42 @@ class TestCheckpointInferenceService(unittest.TestCase):
 
         self.assertEqual(context.exception.status_code, 404)
 
+    def test_media_path_allows_generated_outputs_and_streaming_preview(self) -> None:
+        generated = self.output_dir / "inference" / "session-one" / "checkpoint-100" / "output.png"
+        generated.parent.mkdir(parents=True)
+        generated.write_bytes(b"png")
+        generated.with_suffix(".png.json").write_text("{}", encoding="utf-8")
+        preview = generated.parents[1] / "preview.png"
+        preview.write_bytes(b"png")
+        preview.with_suffix(".json").write_text("{}", encoding="utf-8")
+
+        self.assertEqual(
+            self.service.media_path("test", "session-one/checkpoint-100/output.png"),
+            generated.resolve(),
+        )
+        self.assertEqual(self.service.media_path("test", "session-one/preview.png"), preview.resolve())
+
+    def test_media_path_rejects_internal_and_untracked_files(self) -> None:
+        session_dir = self.output_dir / "inference" / "session-one"
+        cache_file = session_dir / ".prompt_cache" / "embedding.png"
+        cache_file.parent.mkdir(parents=True)
+        cache_file.write_bytes(b"internal")
+        cache_file.with_suffix(".png.json").write_text("{}", encoding="utf-8")
+        (session_dir / "session.json").write_text("{}", encoding="utf-8")
+        untracked = session_dir / "checkpoint-100" / "untracked.png"
+        untracked.parent.mkdir()
+        untracked.write_bytes(b"png")
+
+        for media_path in (
+            "session-one/session.json",
+            "session-one/.prompt_cache/embedding.png",
+            "session-one/checkpoint-100/untracked.png",
+        ):
+            with self.subTest(media_path=media_path):
+                with self.assertRaises(CheckpointInferenceServiceError) as context:
+                    self.service.media_path("test", media_path)
+                self.assertEqual(context.exception.status_code, 404)
+
     def test_status_includes_streaming_preview_and_latest_completed_output(self) -> None:
         session_dir = self.output_dir / "inference" / "session-one"
         output = session_dir / "checkpoint-100" / "output.png"
@@ -287,6 +352,26 @@ class TestCheckpointInferenceService(unittest.TestCase):
         self.assertTrue(result["preview"]["streaming"])
         self.assertIn("environment=test%20environment", result["preview"]["media_url"])
         self.assertIn("&v=", result["preview"]["media_url"])
+
+    def test_status_discards_completed_session_record(self) -> None:
+        session_id = "session-one"
+        session_dir = self.output_dir / "inference" / session_id
+        session_dir.mkdir(parents=True)
+        (session_dir / "session.json").write_text(
+            json.dumps({"session_id": session_id, "status": "completed"}),
+            encoding="utf-8",
+        )
+        self.service._sessions[session_id] = {
+            "session_id": session_id,
+            "job_id": "infer-one",
+            "environment": "test",
+        }
+        self.service._environment_sessions["test"] = session_id
+
+        self.service.status("test", session_id)
+
+        self.assertNotIn(session_id, self.service._sessions)
+        self.assertNotIn("test", self.service._environment_sessions)
 
     @patch("simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service.process_keeper")
     def test_generate_queues_prompt_for_loaded_worker(self, process_keeper: MagicMock) -> None:

--- a/tests/test_checkpoint_inference_service.py
+++ b/tests/test_checkpoint_inference_service.py
@@ -1,0 +1,322 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+from simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service import (
+    CheckpointInferenceService,
+    CheckpointInferenceServiceError,
+)
+
+
+class TestCheckpointInferenceService(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.output_dir = Path(self.temporary_directory.name)
+        self.config = {
+            "--output_dir": str(self.output_dir),
+            "--validation_prompt": "configured prompt",
+            "--user_prompt_library": "user_prompt_library-portraits.json",
+        }
+        self.service = CheckpointInferenceService()
+        self.service._load_environment = Mock(return_value=(self.config, self.output_dir))
+
+    @patch("simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service.PromptLibraryService")
+    @patch(
+        "simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service.built_in_prompts",
+        {"landscape": "built-in prompt"},
+    )
+    def test_resolve_prompts_combines_selected_sources(self, prompt_library_service: MagicMock) -> None:
+        prompt_library_service.return_value.read_library.return_value = {
+            "entries": {
+                "portrait": {
+                    "prompt": "library prompt",
+                    "adapter_strength": 0.7,
+                }
+            }
+        }
+
+        result = self.service.resolve_prompts(
+            config=self.config,
+            use_configured_prompt=True,
+            use_builtin_library=True,
+            user_library_filename="user_prompt_library-portraits.json",
+            custom_prompts=["custom prompt", "  "],
+        )
+
+        self.assertEqual([entry["source"] for entry in result], ["configured", "builtin", "user-library", "custom"])
+        self.assertEqual(result[2]["adapter_strength"], 0.7)
+        prompt_library_service.return_value.read_library.assert_called_once_with("user_prompt_library-portraits.json")
+
+    def test_start_rejects_keep_loaded_for_multiple_checkpoints(self) -> None:
+        with self.assertRaises(CheckpointInferenceServiceError) as context:
+            self.service.start(
+                environment="test",
+                checkpoint_names=["checkpoint-100", "checkpoint-200"],
+                use_configured_prompt=True,
+                use_builtin_library=False,
+                user_library_filename=None,
+                custom_prompts=[],
+                filename_style="descriptive",
+                keep_loaded=True,
+                streaming_preview=False,
+                idle_timeout_minutes=15,
+                settings={},
+            )
+
+        self.assertIn("single checkpoint", context.exception.message)
+
+    def test_resolve_prompts_reads_configured_absolute_library(self) -> None:
+        library_path = self.output_dir / "legacy_prompt_library.json"
+        library_path.write_text(json.dumps({"legacy": "legacy prompt"}), encoding="utf-8")
+        config = {**self.config, "--user_prompt_library": str(library_path)}
+
+        result = self.service.resolve_prompts(
+            config=config,
+            use_configured_prompt=False,
+            use_builtin_library=False,
+            user_library_filename=library_path.name,
+            custom_prompts=[],
+        )
+
+        self.assertEqual(result[0]["prompt"], "legacy prompt")
+        self.assertEqual(result[0]["source"], "user-library")
+
+    @patch("simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service.PromptLibraryService")
+    def test_prompt_sources_include_active_environment_inference_defaults(self, prompt_library_service: MagicMock) -> None:
+        prompt_library_service.return_value.list_libraries.return_value = []
+        self.config.update(
+            {
+                "validation_num_inference_steps": 24,
+                "--validation_guidance": 5.5,
+                "--validation_resolution": "512,768x512",
+                "--user_prompt_library": None,
+            }
+        )
+
+        result = self.service.prompt_sources("test")
+
+        self.assertEqual(
+            result["inference_defaults"],
+            {
+                "num_inference_steps": 24,
+                "guidance_scale": 5.5,
+                "validation_resolution": "512,768x512",
+            },
+        )
+
+    @patch("simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service.PromptLibraryService")
+    def test_prompt_sources_use_registered_defaults_when_environment_omits_values(
+        self, prompt_library_service: MagicMock
+    ) -> None:
+        prompt_library_service.return_value.list_libraries.return_value = []
+        self.config["--user_prompt_library"] = None
+
+        result = self.service.prompt_sources("test")
+
+        self.assertEqual(
+            result["inference_defaults"],
+            {"num_inference_steps": 30, "guidance_scale": 7.5, "validation_resolution": "256"},
+        )
+
+    @patch("simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service.process_keeper")
+    @patch("simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service.CheckpointManager")
+    def test_start_submits_valid_checkpoint_session(
+        self,
+        checkpoint_manager: MagicMock,
+        process_keeper: MagicMock,
+    ) -> None:
+        checkpoint_manager.return_value.validate_checkpoint.return_value = (True, "valid")
+        process_keeper.get_process_status.return_value = "not_found"
+
+        result = self.service.start(
+            environment="test",
+            checkpoint_names=["checkpoint-100"],
+            use_configured_prompt=True,
+            use_builtin_library=False,
+            user_library_filename=None,
+            custom_prompts=["custom prompt"],
+            filename_style="content-hash",
+            keep_loaded=True,
+            streaming_preview=True,
+            idle_timeout_minutes=7,
+            settings={"seed": 123, "validation_resolution": "512,768x512"},
+        )
+
+        self.assertEqual(result["status"], "loading")
+        self.assertEqual(result["prompt_count"], 2)
+        self.assertEqual(result["generation_count"], 4)
+        payload = process_keeper.submit_job.call_args.args[2]
+        self.assertEqual(payload["checkpoint_names"], ["checkpoint-100"])
+        self.assertEqual(payload["filename_style"], "content-hash")
+        self.assertTrue(payload["streaming_preview"])
+        self.assertEqual(payload["settings"]["validation_resolution"], "512,768x512")
+        self.assertEqual(payload["idle_timeout_seconds"], 420)
+        self.assertTrue((self.output_dir / "inference" / result["session_id"]).is_dir())
+
+    def test_start_rejects_invalid_validation_resolution(self) -> None:
+        with self.assertRaisesRegex(CheckpointInferenceServiceError, "Invalid validation resolution"):
+            self.service.start(
+                environment="test",
+                checkpoint_names=["checkpoint-100"],
+                use_configured_prompt=True,
+                use_builtin_library=False,
+                user_library_filename=None,
+                custom_prompts=[],
+                filename_style="descriptive",
+                keep_loaded=False,
+                streaming_preview=False,
+                idle_timeout_minutes=15,
+                settings={"validation_resolution": "512,wide"},
+            )
+
+    def test_history_builds_environment_scoped_media_urls(self) -> None:
+        sidecar = self.output_dir / "inference" / "session-one" / "checkpoint-100" / "output.png.json"
+        sidecar.parent.mkdir(parents=True)
+        sidecar.write_text(
+            json.dumps(
+                {
+                    "session_id": "session-one",
+                    "checkpoint": "checkpoint-100",
+                    "filename": "output.png",
+                    "prompt": "a prompt",
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.service.history("environment with spaces", page=1, page_size=24)
+
+        self.assertEqual(result["total"], 1)
+        self.assertEqual(
+            result["items"][0]["media_url"],
+            "/api/checkpoints/inference/media/session-one/checkpoint-100/output.png?environment=environment%20with%20spaces",
+        )
+        self.assertEqual(result["items"][0]["media_path"], "session-one/checkpoint-100/output.png")
+
+    def test_delete_history_removes_selected_media_and_sidecars(self) -> None:
+        session_dir = self.output_dir / "inference" / "session-one"
+        (session_dir / "session.json").parent.mkdir(parents=True)
+        (session_dir / "session.json").write_text('{"status": "completed"}', encoding="utf-8")
+        media_paths = []
+        for filename in ("first.png", "second.mp4"):
+            media = session_dir / "checkpoint-100" / filename
+            media.parent.mkdir(parents=True, exist_ok=True)
+            media.write_bytes(b"generated output")
+            media.with_suffix(f"{media.suffix}.json").write_text(json.dumps({"filename": filename}), encoding="utf-8")
+            media_paths.append(media.relative_to(self.output_dir / "inference").as_posix())
+
+        result = self.service.delete_history("test", media_paths)
+
+        self.assertEqual(result["deleted_count"], 2)
+        for media_path in media_paths:
+            media = self.output_dir / "inference" / media_path
+            self.assertFalse(media.exists())
+            self.assertFalse(media.with_suffix(f"{media.suffix}.json").exists())
+        self.assertTrue((session_dir / "session.json").is_file())
+
+    def test_delete_history_validates_entire_batch_before_deleting(self) -> None:
+        media = self.output_dir / "inference" / "session-one" / "checkpoint-100" / "first.png"
+        media.parent.mkdir(parents=True)
+        media.write_bytes(b"generated output")
+        sidecar = media.with_suffix(".png.json")
+        sidecar.write_text('{"filename": "first.png"}', encoding="utf-8")
+
+        with self.assertRaises(CheckpointInferenceServiceError) as context:
+            self.service.delete_history(
+                "test",
+                ["session-one/checkpoint-100/first.png", "../outside.png"],
+            )
+
+        self.assertEqual(context.exception.status_code, 400)
+        self.assertTrue(media.is_file())
+        self.assertTrue(sidecar.is_file())
+
+    def test_media_path_rejects_traversal(self) -> None:
+        outside_file = self.output_dir / "outside.png"
+        outside_file.write_bytes(b"png")
+
+        with self.assertRaises(CheckpointInferenceServiceError) as context:
+            self.service.media_path("test", "../outside.png")
+
+        self.assertEqual(context.exception.status_code, 404)
+
+    def test_status_includes_streaming_preview_and_latest_completed_output(self) -> None:
+        session_dir = self.output_dir / "inference" / "session-one"
+        output = session_dir / "checkpoint-100" / "output.png"
+        output.parent.mkdir(parents=True)
+        output.write_bytes(b"completed output")
+        output.with_suffix(".png.json").write_text(
+            json.dumps(
+                {
+                    "checkpoint": "checkpoint-100",
+                    "filename": "output.png",
+                    "prompt": "completed prompt",
+                    "media_type": "image",
+                    "created_at": "2026-01-01T00:00:02+00:00",
+                }
+            ),
+            encoding="utf-8",
+        )
+        (session_dir / "preview.png").write_bytes(b"preview")
+        (session_dir / "preview.json").write_text(
+            json.dumps(
+                {
+                    "checkpoint": "checkpoint-100",
+                    "prompt": "preview prompt",
+                    "step_label": "2/20",
+                    "media_type": "image",
+                    "updated_at": "2026-01-01T00:00:01+00:00",
+                }
+            ),
+            encoding="utf-8",
+        )
+        (session_dir / "session.json").write_text(
+            json.dumps({"session_id": "session-one", "status": "completed", "streaming_preview": True}),
+            encoding="utf-8",
+        )
+
+        result = self.service.status("test environment", "session-one")
+
+        self.assertEqual(result["latest_output"]["prompt"], "completed prompt")
+        self.assertFalse(result["latest_output"]["streaming"])
+        self.assertEqual(result["preview"]["step_label"], "2/20")
+        self.assertTrue(result["preview"]["streaming"])
+        self.assertIn("environment=test%20environment", result["preview"]["media_url"])
+        self.assertIn("&v=", result["preview"]["media_url"])
+
+    @patch("simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service.process_keeper")
+    def test_generate_queues_prompt_for_loaded_worker(self, process_keeper: MagicMock) -> None:
+        session_id = "session-one"
+        session_dir = self.output_dir / "inference" / session_id
+        session_dir.mkdir(parents=True)
+        (session_dir / "session.json").write_text(
+            json.dumps({"session_id": session_id, "status": "loaded", "updated_at": "old"}),
+            encoding="utf-8",
+        )
+        self.service._sessions[session_id] = {
+            "session_id": session_id,
+            "job_id": "infer-one",
+            "environment": "test",
+        }
+        process_keeper.get_process_status.return_value = "running"
+
+        result = self.service.generate(
+            environment="test",
+            session_id=session_id,
+            custom_prompts=["another prompt"],
+            filename_style="prompt",
+            settings={"seed": 3},
+        )
+
+        self.assertEqual(result["status"], "queued")
+        process_keeper.send_process_command.assert_called_once()
+        state = json.loads((session_dir / "session.json").read_text(encoding="utf-8"))
+        self.assertEqual(state["status"], "queued")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_checkpoint_inference_worker.py
+++ b/tests/test_checkpoint_inference_worker.py
@@ -30,12 +30,15 @@ class TestCheckpointInferenceWorker(unittest.TestCase):
         thread.is_alive.return_value = True
         runtime.embed_cache = SimpleNamespace(process_write_batches=True, batch_write_thread=thread)
 
-        with self.assertLogs("SimpleTuner-inference", level="WARNING") as logs:
+        with patch("simpletuner.inference.logger.warning") as warning:
             with self.assertRaisesRegex(RuntimeError, "Timed out while flushing"):
                 runtime._flush_embed_cache()
 
         thread.join.assert_called_once_with(timeout=CheckpointInferenceRuntime.EMBED_CACHE_FLUSH_TIMEOUT_SECONDS)
-        self.assertIn("Timed out after 10 seconds", logs.output[0])
+        warning.assert_called_once_with(
+            "Timed out after %s seconds while flushing the inference prompt cache.",
+            CheckpointInferenceRuntime.EMBED_CACHE_FLUSH_TIMEOUT_SECONDS,
+        )
 
     def test_apply_settings_updates_validation_resolutions(self) -> None:
         runtime = object.__new__(CheckpointInferenceRuntime)

--- a/tests/test_checkpoint_inference_worker.py
+++ b/tests/test_checkpoint_inference_worker.py
@@ -1,0 +1,177 @@
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from PIL import Image
+
+from simpletuner.inference import CheckpointInferenceRuntime, run_checkpoint_inference
+
+
+class _WorkerConfig:
+    def __init__(self, payload, commands=None):
+        self.__dict__.update(payload)
+        self._commands = list(commands or [])
+
+    def should_abort(self):
+        return False
+
+    def consume_process_command(self, timeout=0.1):
+        return self._commands.pop(0) if self._commands else {"command": "inference_unload"}
+
+
+class TestCheckpointInferenceWorker(unittest.TestCase):
+    def test_apply_settings_updates_validation_resolutions(self) -> None:
+        runtime = object.__new__(CheckpointInferenceRuntime)
+        runtime.trainer = SimpleNamespace(
+            config=SimpleNamespace(
+                validation_seed=42,
+                validation_num_inference_steps=30,
+                validation_guidance=7.5,
+                validation_resolution="256",
+                model_flavour="",
+            ),
+            validation=SimpleNamespace(validation_resolutions=[(256, 256)]),
+        )
+
+        seed = runtime._apply_settings(
+            {
+                "seed": 7,
+                "num_inference_steps": 20,
+                "guidance_scale": 4.5,
+                "validation_resolution": "512,768x512",
+            }
+        )
+
+        self.assertEqual(seed, 7)
+        self.assertEqual(runtime.trainer.config.validation_resolution, "512,768x512")
+        self.assertEqual(runtime.trainer.validation.validation_resolutions, [(512, 512), (768, 512)])
+
+    def test_streaming_preview_writes_current_frame_and_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            runtime = object.__new__(CheckpointInferenceRuntime)
+            runtime.checkpoint_name = "checkpoint-100"
+            runtime.session_dir = Path(temporary_directory) / "session-one"
+            image = Image.new("RGB", (8, 8), color=(10, 20, 30))
+
+            runtime._write_preview(
+                structured_data={
+                    "body": "preview prompt",
+                    "data": {"prompt": "preview prompt", "step": 2, "step_label": "2/20"},
+                },
+                images=[image],
+                videos=None,
+            )
+
+            self.assertTrue((runtime.session_dir / "preview.png").is_file())
+            metadata = json.loads((runtime.session_dir / "preview.json").read_text(encoding="utf-8"))
+            self.assertEqual(metadata["checkpoint"], "checkpoint-100")
+            self.assertEqual(metadata["step_label"], "2/20")
+
+    def test_content_hash_filename_and_sidecar(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            runtime = object.__new__(CheckpointInferenceRuntime)
+            runtime.checkpoint_name = "checkpoint-100"
+            runtime.session_dir = Path(temporary_directory) / "session-one"
+            runtime.trainer = SimpleNamespace(config=SimpleNamespace(framerate=16))
+            image = Image.new("RGB", (8, 8), color=(10, 20, 30))
+
+            metadata = runtime._save_media(
+                image,
+                prompt="a test prompt",
+                shortname="custom_001",
+                seed=42,
+                style="content-hash",
+                index=0,
+                settings={"seed": 42},
+            )
+
+            output_path = runtime.session_dir / "checkpoint-100" / metadata["filename"]
+            self.assertTrue(output_path.is_file())
+            self.assertEqual(output_path.stem, hashlib.sha256(output_path.read_bytes()).hexdigest())
+            sidecar = output_path.with_suffix(".png.json")
+            self.assertEqual(json.loads(sidecar.read_text(encoding="utf-8"))["prompt"], "a test prompt")
+
+    @patch("simpletuner.inference.CheckpointInferenceRuntime")
+    def test_batch_worker_unloads_between_checkpoints(self, runtime_class: MagicMock) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            session_dir = Path(temporary_directory) / "session-one"
+            session_dir.mkdir()
+            runtimes = [MagicMock(), MagicMock()]
+            runtime_class.side_effect = runtimes
+            for runtime in runtimes:
+                runtime.generate.side_effect = lambda entries, progress_callback, **kwargs: [
+                    progress_callback(len(entries), len(entries), entries[-1]["prompt"])
+                ]
+            config = _WorkerConfig(
+                {
+                    "session_dir": str(session_dir),
+                    "job_id": "infer-one",
+                    "environment": "test",
+                    "checkpoint_names": ["checkpoint-100", "checkpoint-200"],
+                    "prompt_entries": [{"shortname": "one", "prompt": "prompt one"}],
+                    "filename_style": "descriptive",
+                    "settings": {},
+                    "keep_loaded": False,
+                    "trainer_config": {},
+                }
+            )
+
+            result = run_checkpoint_inference(config)
+
+            self.assertEqual(result["status"], "completed")
+            self.assertEqual(result["completed_prompts"], 2)
+            self.assertEqual(runtime_class.call_count, 2)
+            runtimes[0].close.assert_called_once()
+            runtimes[1].close.assert_called_once()
+
+    @patch("simpletuner.inference.CheckpointInferenceRuntime")
+    def test_persistent_worker_processes_custom_prompt_before_unload(self, runtime_class: MagicMock) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            session_dir = Path(temporary_directory) / "session-one"
+            session_dir.mkdir()
+            runtime = runtime_class.return_value
+            runtime.generate.side_effect = lambda entries, progress_callback, **kwargs: [
+                progress_callback(len(entries), len(entries), entries[-1]["prompt"])
+            ]
+            config = _WorkerConfig(
+                {
+                    "session_dir": str(session_dir),
+                    "job_id": "infer-one",
+                    "environment": "test",
+                    "checkpoint_names": ["checkpoint-100"],
+                    "prompt_entries": [{"shortname": "initial", "prompt": "initial prompt"}],
+                    "filename_style": "descriptive",
+                    "settings": {},
+                    "keep_loaded": True,
+                    "streaming_preview": True,
+                    "trainer_config": {},
+                },
+                commands=[
+                    {
+                        "command": "inference_generate",
+                        "data": {
+                            "prompt_entries": [{"shortname": "custom", "prompt": "custom prompt"}],
+                            "filename_style": "prompt",
+                            "settings": {"seed": 7},
+                        },
+                    },
+                    {"command": "inference_unload"},
+                ],
+            )
+
+            result = run_checkpoint_inference(config)
+
+            self.assertEqual(result["status"], "completed")
+            self.assertEqual(result["completed_prompts"], 2)
+            self.assertEqual(runtime.generate.call_count, 2)
+            self.assertEqual(runtime.generate.call_args_list[1].kwargs["filename_style"], "prompt")
+            self.assertTrue(runtime_class.call_args.kwargs["streaming_preview"])
+            runtime.close.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_checkpoint_inference_worker.py
+++ b/tests/test_checkpoint_inference_worker.py
@@ -24,6 +24,19 @@ class _WorkerConfig:
 
 
 class TestCheckpointInferenceWorker(unittest.TestCase):
+    def test_flush_embed_cache_times_out_instead_of_blocking(self) -> None:
+        runtime = object.__new__(CheckpointInferenceRuntime)
+        thread = MagicMock()
+        thread.is_alive.return_value = True
+        runtime.embed_cache = SimpleNamespace(process_write_batches=True, batch_write_thread=thread)
+
+        with self.assertLogs("SimpleTuner-inference", level="WARNING") as logs:
+            with self.assertRaisesRegex(RuntimeError, "Timed out while flushing"):
+                runtime._flush_embed_cache()
+
+        thread.join.assert_called_once_with(timeout=CheckpointInferenceRuntime.EMBED_CACHE_FLUSH_TIMEOUT_SECONDS)
+        self.assertIn("Timed out after 10 seconds", logs.output[0])
+
     def test_apply_settings_updates_validation_resolutions(self) -> None:
         runtime = object.__new__(CheckpointInferenceRuntime)
         runtime.trainer = SimpleNamespace(

--- a/tests/test_process_keeper.py
+++ b/tests/test_process_keeper.py
@@ -2,6 +2,7 @@
 process_keeper tests - subprocess lifecycle and termination guarantees.
 """
 
+import json
 import os
 import queue
 import signal
@@ -122,6 +123,21 @@ def simple_task(config):
     return "completed"
 
 
+def custom_command_task(config):
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        command = config.consume_process_command(timeout=0.1)
+        if command is not None:
+            return command
+    raise TimeoutError("custom command was not received")
+
+
+def empty_checkpoint_inference_task(config):
+    from simpletuner.inference import run_checkpoint_inference
+
+    return run_checkpoint_inference(config)
+
+
 def hanging_task(config):
     # ignores SIGTERM
     signal.signal(signal.SIGTERM, signal.SIG_IGN)
@@ -214,6 +230,48 @@ class TestProcessLifecycle(ProcessKeeperTestCase):
         status = get_process_status(job_id)
         self.assertNotEqual(status, "running")
         self.assertIn(status, ["completed", "failed"])
+
+    def test_custom_command_reaches_worker(self):
+        job_id = "test_custom_command"
+        self.test_jobs.append(job_id)
+        submit_job(job_id, custom_command_task, {})
+
+        deadline = time.time() + 5
+        while time.time() < deadline and get_process_status(job_id) == "pending":
+            time.sleep(0.05)
+        send_process_command(job_id, "inference_generate", {"prompt": "test"})
+
+        while time.time() < deadline and get_process_status(job_id) in {"pending", "running"}:
+            time.sleep(0.05)
+
+        self.assertEqual(get_process_status(job_id), "completed")
+
+    def test_checkpoint_inference_worker_serializes_nested_state_writer(self):
+        job_id = "test_inference_state_writer"
+        self.test_jobs.append(job_id)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            session_dir = os.path.join(temporary_directory, "session-one")
+            os.mkdir(session_dir)
+            submit_job(
+                job_id,
+                empty_checkpoint_inference_task,
+                {
+                    "session_dir": session_dir,
+                    "job_id": job_id,
+                    "environment": "test",
+                    "checkpoint_names": [],
+                    "prompt_entries": [],
+                    "trainer_config": {},
+                },
+            )
+
+            deadline = time.time() + 10
+            while time.time() < deadline and get_process_status(job_id) in {"pending", "running"}:
+                time.sleep(0.05)
+
+            self.assertEqual(get_process_status(job_id), "completed")
+            with open(os.path.join(session_dir, "session.json"), encoding="utf-8") as handle:
+                self.assertEqual(json.load(handle)["status"], "completed")
 
     def test_failure_event_updates_status_and_events(self):
         """A raised exception should surface as a failed status with error event."""

--- a/tests/test_process_keeper.py
+++ b/tests/test_process_keeper.py
@@ -265,7 +265,7 @@ class TestProcessLifecycle(ProcessKeeperTestCase):
                 },
             )
 
-            deadline = time.time() + 10
+            deadline = time.time() + 30
             while time.time() < deadline and get_process_status(job_id) in {"pending", "running"}:
                 time.sleep(0.05)
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1308,6 +1308,11 @@ class TestTrainer(unittest.TestCase):
         # FSDP validation is now supported - validation_disable should remain False
         self.assertFalse(trainer.config.validation_disable)
         mock_validation.assert_called_once()
+        validation_instance.clear_text_encoders.assert_called_once()
+
+        validation_instance.clear_text_encoders.reset_mock()
+        trainer.init_validations(preserve_text_encoders=True)
+        validation_instance.clear_text_encoders.assert_not_called()
 
     @patch("simpletuner.helpers.training.trainer.Validation")
     def test_init_validations_creates_eval_for_epoch_interval(self, mock_validation):

--- a/tests/test_training_service.py
+++ b/tests/test_training_service.py
@@ -362,6 +362,17 @@ class TrainingServiceTests(unittest.TestCase):
         self.assertEqual(captured["config"].get("accelerate_visible_devices"), [1])
         self.assertEqual(captured["config"].get("--num_processes"), 1)
 
+    def test_start_training_job_rejects_active_checkpoint_inference(self) -> None:
+        with patch(
+            "simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service."
+            "CHECKPOINT_INFERENCE_SERVICE.active_session",
+            return_value={"session_id": "session-one"},
+        ):
+            result = training_service.start_training_job({})
+
+        self.assertEqual(result.status, "rejected")
+        self.assertIn("checkpoint inference session", result.reason)
+
     def test_start_training_job_copies_prompt_library(self) -> None:
         captured = {}
 

--- a/tests/test_validation_abort.py
+++ b/tests/test_validation_abort.py
@@ -147,6 +147,9 @@ class TestValidationAbort(unittest.TestCase):
         mock_config.control = False
         mock_config.output_dir = "/tmp/test_validation"
         mock_config.validation_preview = False
+        mock_config.validation_resolution = 256
+        mock_config.model_flavour = None
+        mock_state_tracker.get_args.return_value = mock_config
 
         # Abort on second callback invocation
         def should_abort_check():

--- a/tests/test_validation_audio_mock.py
+++ b/tests/test_validation_audio_mock.py
@@ -133,6 +133,9 @@ class TestAudioValidation(unittest.TestCase):
         mock_config.controlnet = False
         mock_config.control = False
         mock_config.should_abort.return_value = False
+        mock_config.validation_resolution = 256
+        mock_config.model_flavour = None
+        mock_state_tracker.get_args.return_value = mock_config
 
         mock_embed_cache = MagicMock()
         mock_embed_cache.compute_embeddings_for_prompts.return_value = None

--- a/tests/test_validation_preview.py
+++ b/tests/test_validation_preview.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import torch
 
-from simpletuner.helpers.training.validation import ValidationPreviewer, _PreviewMetadata
+from simpletuner.helpers.training.validation import ValidationPreviewer, _PreviewMetadata, parse_validation_resolutions
 
 
 class _DummyModel:
@@ -34,6 +34,39 @@ class _DummyModel:
 
 
 class ValidationPreviewerTests(unittest.TestCase):
+    def test_parse_validation_resolutions_supports_comma_separated_formats(self):
+        self.assertEqual(
+            parse_validation_resolutions("512, 768x512", model_flavour=""),
+            [(512, 512), (768, 512)],
+        )
+
+    def test_parse_validation_resolutions_rejects_invalid_items(self):
+        with self.assertRaisesRegex(ValueError, "Invalid validation resolution"):
+            parse_validation_resolutions("512,wide", model_flavour="")
+
+    @patch("simpletuner.helpers.training.validation.StateTracker")
+    def test_internal_callback_enables_preview_without_webhook(self, mock_state_tracker):
+        mock_state_tracker.get_webhook_handler.return_value = None
+        callback = MagicMock()
+        config = types.SimpleNamespace(
+            validation_preview=True,
+            validation_preview_steps=1,
+            _validation_preview_callback=callback,
+        )
+        previewer = ValidationPreviewer(_DummyModel(), types.SimpleNamespace(is_main_process=True), config)
+        metadata = _PreviewMetadata(
+            shortname="inference",
+            prompt="preview prompt",
+            resolution=(512, 512),
+            validation_type="checkpoint",
+        )
+
+        previewer._emit_event([object()], None, metadata, step=0, timestep=1.0)
+
+        self.assertTrue(previewer.enabled)
+        callback.assert_called_once()
+        self.assertEqual(callback.call_args.kwargs["structured_data"]["data"]["step_label"], "1")
+
     @patch("simpletuner.helpers.training.validation.StateTracker")
     def test_should_emit_interval(self, mock_state_tracker):
         handler = MagicMock()

--- a/tests/test_validation_preview.py
+++ b/tests/test_validation_preview.py
@@ -39,6 +39,7 @@ class ValidationPreviewerTests(unittest.TestCase):
             parse_validation_resolutions("512, 768x512", model_flavour=""),
             [(512, 512), (768, 512)],
         )
+        self.assertEqual(parse_validation_resolutions(512, model_flavour=""), [(512, 512)])
 
     def test_parse_validation_resolutions_rejects_invalid_items(self):
         with self.assertRaisesRegex(ValueError, "Invalid validation resolution"):

--- a/tests/test_webui_api.py
+++ b/tests/test_webui_api.py
@@ -402,6 +402,39 @@ class WebUICollapsedSectionsAPITestCase(_WebUIBaseTestCase):
         data = response.json()
         self.assertEqual(data, {})
 
+    def test_checkpoint_inference_settings_persist(self) -> None:
+        response = self.client.get("/api/webui/ui-state/checkpoint-inference")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"filename_style": "descriptive", "keep_loaded": False, "streaming_preview": False},
+        )
+
+        response = self.client.post(
+            "/api/webui/ui-state/checkpoint-inference",
+            json={"filename_style": "prompt", "keep_loaded": True, "streaming_preview": True},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"filename_style": "prompt", "keep_loaded": True, "streaming_preview": True},
+        )
+
+        response = self.client.get("/api/webui/ui-state/checkpoint-inference")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"filename_style": "prompt", "keep_loaded": True, "streaming_preview": True},
+        )
+
+    def test_checkpoint_inference_settings_reject_unknown_filename_style(self) -> None:
+        response = self.client.post(
+            "/api/webui/ui-state/checkpoint-inference",
+            json={"filename_style": "unknown"},
+        )
+
+        self.assertEqual(response.status_code, 422)
+
     def test_save_and_get_collapsed_sections(self) -> None:
         """Test POST saves sections and GET retrieves them."""
         sections = {"section1": True, "section2": False, "section3": True}

--- a/tests/test_webui_backend.py
+++ b/tests/test_webui_backend.py
@@ -444,6 +444,32 @@ class WebUICollapsedSectionsTests(WebUIStateStoreTests):
 
         self.assertEqual(loaded, custom_state)
 
+    def test_checkpoint_inference_settings_persist_with_other_ui_state(self) -> None:
+        self.store.save_collapsed_sections("basic", {"section1": True})
+        self.store.save_checkpoint_inference_settings(
+            {
+                "filename_style": "content-hash",
+                "keep_loaded": True,
+                "streaming_preview": True,
+            }
+        )
+
+        reloaded_store = WebUIStateStore(base_dir=self.store.base_dir)
+        self.assertEqual(
+            reloaded_store.get_checkpoint_inference_settings(),
+            {
+                "filename_style": "content-hash",
+                "keep_loaded": True,
+                "streaming_preview": True,
+            },
+        )
+        self.assertEqual(reloaded_store.get_collapsed_sections("basic"), {"section1": True})
+
+        persisted = json.loads((self.store.base_dir / "ui_state.json").read_text(encoding="utf-8"))
+        self.assertEqual(persisted["checkpoint_inference"]["filename_style"], "content-hash")
+        self.assertTrue(persisted["checkpoint_inference"]["keep_loaded"])
+        self.assertTrue(persisted["checkpoint_inference"]["streaming_preview"])
+
     def test_concurrent_collapsed_section_saves(self) -> None:
         """Test that concurrent saves to different tabs don't corrupt state.
 

--- a/tests/test_webui_e2e.py
+++ b/tests/test_webui_e2e.py
@@ -456,6 +456,8 @@ class CheckpointInferenceFlowTestCase(_TrainerPageMixin, WebUITestCase):
                     "--validation_num_inference_steps": 18,
                     "--validation_guidance": 3.5,
                     "--validation_resolution": "512,768x512",
+                    "--validation_multigpu": "batch-parallel",
+                    "--context_parallel_size": 2,
                     "--report_to": "none",
                 }
             ),
@@ -556,6 +558,12 @@ class CheckpointInferenceFlowTestCase(_TrainerPageMixin, WebUITestCase):
                 modal.find_element(By.ID, "inference-resolution").get_attribute("value"),
                 "512,768x512",
             )
+            multigpu_warning = WebDriverWait(driver, 5).until(
+                EC.visibility_of_element_located((By.CSS_SELECTOR, ".inference-multigpu-warning"))
+            )
+            self.assertIn("batch parallel and context parallel validation modes", multigpu_warning.text)
+            modal_body = modal.find_element(By.CSS_SELECTOR, ".modal-body")
+            self.assertGreaterEqual(multigpu_warning.rect["y"], modal_body.rect["y"] + modal_body.rect["height"] - 1)
             filename_format = Select(modal.find_element(By.ID, "inference-filename-style"))
             self.assertEqual(filename_format.first_selected_option.get_attribute("value"), "descriptive")
             filename_format.select_by_value("prompt")

--- a/tests/test_webui_e2e.py
+++ b/tests/test_webui_e2e.py
@@ -417,6 +417,265 @@ class BasicConfigurationFlowTestCase(_TrainerPageMixin, WebUITestCase):
         self.for_each_browser("test_config_json_modal_reflects_blank_fields", scenario)
 
 
+class CheckpointInferenceFlowTestCase(_TrainerPageMixin, WebUITestCase):
+    MAX_BROWSERS = 1
+
+    def test_checkpoint_selection_opens_inference_workspace(self) -> None:
+        output_dir = self.home_path / "inference-output"
+        (output_dir / "checkpoint-100").mkdir(parents=True)
+        history_media = output_dir / "inference" / "session-one" / "checkpoint-100" / "sample.png"
+        history_media.parent.mkdir(parents=True)
+        history_media.write_bytes(b"generated image")
+        history_sidecar = history_media.with_suffix(".png.json")
+        history_sidecar.write_text(
+            json.dumps(
+                {
+                    "session_id": "session-one",
+                    "checkpoint": "checkpoint-100",
+                    "filename": "sample.png",
+                    "prompt": "history prompt",
+                    "seed": 42,
+                    "media_type": "image",
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                }
+            ),
+            encoding="utf-8",
+        )
+        env_dir = self.config_dir / "inference-env"
+        env_dir.mkdir(parents=True, exist_ok=True)
+        (env_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "--model_family": "flux",
+                    "--model_type": "lora",
+                    "--model_flavour": "libreflux",
+                    "--pretrained_model_name_or_path": "jimmycarter/LibreFlux-SimpleTuner",
+                    "--output_dir": str(output_dir),
+                    "--data_backend_config": str(env_dir / "multidatabackend.json"),
+                    "--validation_prompt": "a configured validation prompt",
+                    "--validation_num_inference_steps": 18,
+                    "--validation_guidance": 3.5,
+                    "--validation_resolution": "512,768x512",
+                    "--report_to": "none",
+                }
+            ),
+            encoding="utf-8",
+        )
+        (env_dir / "multidatabackend.json").write_text("[]", encoding="utf-8")
+        self.seed_defaults(active_config="inference-env", output_dir=str(output_dir))
+
+        def scenario(driver, _browser):
+            trainer_page = self._trainer_page(driver)
+            trainer_page.navigate_to_trainer()
+            self.dismiss_onboarding(driver)
+            driver.find_element(By.CSS_SELECTOR, ".tab-btn[data-tab='checkpoints']").click()
+
+            WebDriverWait(driver, 15).until(EC.presence_of_element_located((By.ID, "checkpoints-tab-content")))
+            driver.execute_script(
+                "const comp = Alpine.$data(document.getElementById('checkpoints-tab-content'));" "comp.hints.hero = false;"
+            )
+            checkbox = WebDriverWait(driver, 15).until(
+                EC.element_to_be_clickable((By.CSS_SELECTOR, ".checkpoint-inference-check input"))
+            )
+            history_button = driver.find_element(By.CSS_SELECTOR, "button[title='Inference history']")
+            driver.execute_script("arguments[0].scrollIntoView({ block: 'center' });", checkbox)
+            checkbox.click()
+
+            WebDriverWait(driver, 5).until(
+                lambda _driver: driver.find_element(By.CSS_SELECTOR, ".checkpoint-inference-launch-count").is_displayed()
+            )
+            launch_button = driver.find_element(By.CSS_SELECTOR, ".checkpoint-inference-launch")
+            launch_count = launch_button.find_element(By.CSS_SELECTOR, ".checkpoint-inference-launch-count")
+            button_center = launch_button.rect["y"] + launch_button.rect["height"] / 2
+            count_center = launch_count.rect["y"] + launch_count.rect["height"] / 2
+            history_center = history_button.rect["y"] + history_button.rect["height"] / 2
+            self.assertAlmostEqual(count_center, button_center, delta=2)
+            self.assertAlmostEqual(history_center, button_center, delta=2)
+
+            state = driver.execute_script(
+                "const comp = Alpine.$data(document.getElementById('checkpoints-tab-content'));"
+                "return { selection: comp.inferenceSelection.slice(), selected: comp.selectedCheckpoint };"
+            )
+            self.assertEqual(state["selection"], ["checkpoint-100"])
+            self.assertIsNone(state["selected"])
+
+            driver.execute_script("arguments[0].scrollIntoView({ block: 'center' });", launch_button)
+            launch_button.click()
+            modal = WebDriverWait(driver, 15).until(EC.visibility_of_element_located((By.ID, "checkpointInferenceModal")))
+            self.assertIn("checkpoint-100", modal.text)
+            keep_loaded = modal.find_element(By.ID, "inference-keep-loaded")
+            self.assertTrue(keep_loaded.is_enabled())
+            streaming_preview = modal.find_element(By.ID, "inference-streaming-preview")
+            self.assertGreater(streaming_preview.rect["y"], keep_loaded.rect["y"])
+            streaming_preview.click()
+            self.assertTrue(streaming_preview.is_selected())
+            WebDriverWait(driver, 5).until(
+                lambda _driver: requests.get(
+                    f"{self.base_url}/api/webui/ui-state/checkpoint-inference",
+                    timeout=5,
+                ).json()["streaming_preview"]
+            )
+            streaming_preview.click()
+            self.assertFalse(streaming_preview.is_selected())
+            WebDriverWait(driver, 5).until(
+                lambda _driver: not requests.get(
+                    f"{self.base_url}/api/webui/ui-state/checkpoint-inference",
+                    timeout=5,
+                ).json()["streaming_preview"]
+            )
+            keep_loaded.click()
+            self.assertTrue(keep_loaded.is_selected())
+            WebDriverWait(driver, 5).until(
+                lambda _driver: requests.get(
+                    f"{self.base_url}/api/webui/ui-state/checkpoint-inference",
+                    timeout=5,
+                ).json()["keep_loaded"]
+            )
+            streaming_preview.click()
+            WebDriverWait(driver, 5).until(
+                lambda _driver: all(
+                    requests.get(
+                        f"{self.base_url}/api/webui/ui-state/checkpoint-inference",
+                        timeout=5,
+                    ).json()[setting]
+                    for setting in ("keep_loaded", "streaming_preview")
+                )
+            )
+            configured_prompt = modal.find_element(By.ID, "inference-configured-prompt")
+            WebDriverWait(driver, 10).until(lambda _driver: configured_prompt.is_selected())
+            configured_label = modal.find_element(By.CSS_SELECTOR, "label[for='inference-configured-prompt']")
+            configured_preview = modal.find_element(By.CSS_SELECTOR, ".inference-source-preview")
+            self.assertEqual(configured_preview.tag_name, "pre")
+            self.assertEqual(configured_preview.text, "a configured validation prompt")
+            self.assertGreater(configured_preview.rect["y"], configured_label.rect["y"])
+            WebDriverWait(driver, 5).until(
+                lambda _driver: modal.find_element(By.ID, "inference-steps").get_attribute("value") == "18"
+            )
+            self.assertEqual(modal.find_element(By.ID, "inference-guidance").get_attribute("value"), "3.5")
+            self.assertEqual(
+                modal.find_element(By.ID, "inference-resolution").get_attribute("value"),
+                "512,768x512",
+            )
+            filename_format = Select(modal.find_element(By.ID, "inference-filename-style"))
+            self.assertEqual(filename_format.first_selected_option.get_attribute("value"), "descriptive")
+            filename_format.select_by_value("prompt")
+            WebDriverWait(driver, 5).until(
+                lambda _driver: requests.get(
+                    f"{self.base_url}/api/webui/ui-state/checkpoint-inference",
+                    timeout=5,
+                ).json()["filename_style"]
+                == "prompt"
+            )
+            driver.execute_script(
+                "const comp = Alpine.$data(document.getElementById('checkpoints-tab-content'));"
+                "comp.inference.session = {"
+                "  session_id: 'session-one', status: 'running', streaming_preview: false,"
+                "  completed_prompts: 1, total_prompts: 2,"
+                "  latest_output: {"
+                "    media_type: 'image', streaming: false, checkpoint: 'checkpoint-100',"
+                "    prompt: 'latest completed prompt', created_at: '2026-01-01T00:00:00Z',"
+                "    media_url: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=='"
+                "  }"
+                "};"
+            )
+            current_output = WebDriverWait(driver, 5).until(
+                EC.visibility_of_element_located((By.CSS_SELECTOR, ".inference-current-output"))
+            )
+            self.assertIn("latest completed prompt", current_output.text)
+
+            close_geometry = driver.execute_script(
+                "const content = document.querySelector('#checkpointInferenceModal .modal-content').getBoundingClientRect();"
+                "const close = document.querySelector('#checkpointInferenceModal .inference-modal-close').getBoundingClientRect();"
+                "return { right: content.right - close.right, top: close.top - content.top };"
+            )
+            self.assertAlmostEqual(close_geometry["right"], 24, delta=3)
+            self.assertAlmostEqual(close_geometry["top"], 20, delta=3)
+
+            for width, height in (
+                (1440, 1000),
+                (390, 844),
+            ):
+                driver.set_window_size(width, height)
+                WebDriverWait(driver, 5).until(lambda _driver: modal.is_displayed())
+                bounds = driver.execute_script(
+                    "const content = document.querySelector('#checkpointInferenceModal .modal-content');"
+                    "const rect = content.getBoundingClientRect();"
+                    "const main = document.querySelector('.main-content').getBoundingClientRect();"
+                    "return {"
+                    "  left: rect.left, right: rect.right, viewport: window.innerWidth,"
+                    "  modalCenter: rect.left + rect.width / 2, mainCenter: main.left + main.width / 2"
+                    "};"
+                )
+                self.assertGreaterEqual(bounds["left"], -1)
+                self.assertLessEqual(bounds["right"], bounds["viewport"] + 1)
+                if width > 1024:
+                    self.assertAlmostEqual(bounds["modalCenter"], bounds["mainCenter"], delta=2)
+                output_bounds = driver.execute_script(
+                    "const root = document.querySelector('.inference-current-output').getBoundingClientRect();"
+                    "const media = document.querySelector('.inference-current-output-media').getBoundingClientRect();"
+                    "const details = document.querySelector('.inference-current-output-details').getBoundingClientRect();"
+                    "return {"
+                    "  rootLeft: root.left, rootRight: root.right, mediaLeft: media.left, mediaRight: media.right,"
+                    "  mediaBottom: media.bottom, detailsLeft: details.left, detailsRight: details.right,"
+                    "  detailsTop: details.top, width: window.innerWidth"
+                    "};"
+                )
+                self.assertGreaterEqual(output_bounds["mediaLeft"], output_bounds["rootLeft"] - 1)
+                self.assertLessEqual(output_bounds["detailsRight"], output_bounds["rootRight"] + 1)
+                if width <= 991:
+                    self.assertGreaterEqual(output_bounds["detailsTop"], output_bounds["mediaBottom"] - 1)
+                else:
+                    self.assertGreaterEqual(output_bounds["detailsLeft"], output_bounds["mediaRight"] - 1)
+
+            driver.set_window_size(1440, 1000)
+            trainer_page.navigate_to_trainer()
+            WebDriverWait(driver, 15).until(
+                lambda _driver: driver.execute_script(
+                    "const store = window.Alpine?.store?.('trainer');"
+                    "return Array.isArray(store?.onboardingSteps) && store.onboardingSteps.length > 0;"
+                )
+            )
+            self.dismiss_onboarding(driver)
+            trainer_page.switch_to_basic_tab()
+            driver.find_element(By.CSS_SELECTOR, ".tab-btn[data-tab='checkpoints']").click()
+            trainer_page.wait_for_tab("checkpoints")
+            driver.execute_script(
+                "const comp = Alpine.$data(document.getElementById('checkpoints-tab-content'));" "comp.hints.hero = false;"
+            )
+            restored_format = WebDriverWait(driver, 15).until(
+                EC.presence_of_element_located((By.ID, "inference-filename-style"))
+            )
+            WebDriverWait(driver, 5).until(
+                lambda _driver: Select(restored_format).first_selected_option.get_attribute("value") == "prompt"
+                and driver.find_element(By.ID, "inference-keep-loaded").is_selected()
+                and driver.find_element(By.ID, "inference-streaming-preview").is_selected()
+            )
+
+            history_button = driver.find_element(By.CSS_SELECTOR, "button[title='Inference history']")
+            driver.execute_script("arguments[0].scrollIntoView({ block: 'center' });", history_button)
+            history_button.click()
+            history_checkbox = WebDriverWait(driver, 10).until(
+                EC.element_to_be_clickable((By.CSS_SELECTOR, ".inference-history-select input"))
+            )
+            history_checkbox.click()
+            delete_button = WebDriverWait(driver, 5).until(
+                EC.element_to_be_clickable((By.CSS_SELECTOR, "button[title='Delete selected generations']"))
+            )
+            self.assertIn("Delete (1)", delete_button.text)
+            driver.execute_script("window.confirm = () => true;")
+            delete_button.click()
+            WebDriverWait(driver, 10).until(lambda _driver: not history_media.exists())
+            self.assertFalse(history_sidecar.exists())
+            WebDriverWait(driver, 5).until(
+                lambda _driver: driver.execute_script(
+                    "const comp = Alpine.$data(document.getElementById('checkpoints-tab-content'));"
+                    "return comp.inference.historyTotal === 0 && comp.inference.historySelection.length === 0;"
+                )
+            )
+
+        self.for_each_browser("test_checkpoint_selection_opens_inference_workspace", scenario)
+
+
 class MetricsGpuHealthDashboardTestCase(_TrainerPageMixin, WebUITestCase):
     """Test GPU health dashboard toggles."""
 


### PR DESCRIPTION
This pull request introduces a comprehensive set of enhancements focused on expanding checkpoint inference capabilities, improving validation and inference settings handling, and increasing extensibility for both backend and UI state management. The main themes are: adding a robust checkpoint inference API, improving validation logic and flexibility, and introducing mechanisms for handling custom process commands and UI state persistence.

**Checkpoint Inference API and UI Enhancements:**

* Adds new REST API endpoints for checkpoint inference, including session management, prompt sources, media retrieval, and history operations in `checkpoints.py`. New request/response models and error handling for inference are introduced. [[1]](diffhunk://#diff-979a3781c27eab349314f8b9afc15fa9d42a9a5e891cb59743cc4adb2320d273R8-R14) [[2]](diffhunk://#diff-979a3781c27eab349314f8b9afc15fa9d42a9a5e891cb59743cc4adb2320d273R63-R99) [[3]](diffhunk://#diff-979a3781c27eab349314f8b9afc15fa9d42a9a5e891cb59743cc4adb2320d273R108-R109) [[4]](diffhunk://#diff-979a3781c27eab349314f8b9afc15fa9d42a9a5e891cb59743cc4adb2320d273R138-R237)
* Introduces UI state endpoints and persistence for checkpoint inference settings, allowing users to save and retrieve their preferred inference configuration in `webui_state.py` and `webui_state.py` service. [[1]](diffhunk://#diff-9ea725273f59ac1894f1b99e143b91a66135b20f9918ef21c6c784bfc44b95ceR569-R604) [[2]](diffhunk://#diff-0212aa5234fd39c68f2274c7f9107f167807aafb524f77ed06de97cb58bc9913R776-R787)

**Validation and Inference Logic Improvements:**

* Refactors validation resolution parsing to support multiple resolutions and model flavors, improving error handling and flexibility in `validation.py`.
* Updates the validation preview callback logic to support both webhook and direct callback invocation, and ensures proper disabling if neither is configured. [[1]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09L1366-R1388) [[2]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09L1491-L1492) [[3]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09R1535-R1537)
* Adds a method to prepare models for inference mode, ensuring proper registration and evaluation state in `trainer.py`.
* Allows preservation of text encoders during validation initialization, providing finer control over validation state in `trainer.py`. [[1]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27L4228-R4240) [[2]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27L4284-R4296)

**Process Command Extensibility:**

* Introduces a custom command queue and handler to allow the process keeper to receive and expose commands not handled by the default training bridge, enhancing extensibility for future features in `process_keeper.py`. [[1]](diffhunk://#diff-9189b7669099b8835588eb18e71254fe6877e815a04b148799bbe7edebea0ee7R190) [[2]](diffhunk://#diff-9189b7669099b8835588eb18e71254fe6877e815a04b148799bbe7edebea0ee7R297) [[3]](diffhunk://#diff-9189b7669099b8835588eb18e71254fe6877e815a04b148799bbe7edebea0ee7R316-R323) [[4]](diffhunk://#diff-9189b7669099b8835588eb18e71254fe6877e815a04b148799bbe7edebea0ee7R436-R437) [[5]](diffhunk://#diff-9189b7669099b8835588eb18e71254fe6877e815a04b148799bbe7edebea0ee7R505)

**Resource Management and Safety:**

* Prevents starting a new training job if a checkpoint inference session is active, ensuring exclusive access to accelerator resources in `training_service.py`.

These changes collectively provide a more robust, flexible, and user-friendly experience for checkpoint inference, validation, and UI state management, while laying the groundwork for future extensibility and operational safety.

---

**References:**
- [[1]](diffhunk://#diff-979a3781c27eab349314f8b9afc15fa9d42a9a5e891cb59743cc4adb2320d273R8-R14) [[2]](diffhunk://#diff-979a3781c27eab349314f8b9afc15fa9d42a9a5e891cb59743cc4adb2320d273R63-R99) [[3]](diffhunk://#diff-979a3781c27eab349314f8b9afc15fa9d42a9a5e891cb59743cc4adb2320d273R108-R109) [[4]](diffhunk://#diff-979a3781c27eab349314f8b9afc15fa9d42a9a5e891cb59743cc4adb2320d273R138-R237) [[5]](diffhunk://#diff-9ea725273f59ac1894f1b99e143b91a66135b20f9918ef21c6c784bfc44b95ceR569-R604) [[6]](diffhunk://#diff-0212aa5234fd39c68f2274c7f9107f167807aafb524f77ed06de97cb58bc9913R776-R787) [[7]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09L767-R810) [[8]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09L1366-R1388) [[9]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09L1491-L1492) [[10]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09R1535-R1537) [[11]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R4209-R4220) [[12]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27L4228-R4240) [[13]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27L4284-R4296) [[14]](diffhunk://#diff-9189b7669099b8835588eb18e71254fe6877e815a04b148799bbe7edebea0ee7R190) [[15]](diffhunk://#diff-9189b7669099b8835588eb18e71254fe6877e815a04b148799bbe7edebea0ee7R297) [[16]](diffhunk://#diff-9189b7669099b8835588eb18e71254fe6877e815a04b148799bbe7edebea0ee7R316-R323) [[17]](diffhunk://#diff-9189b7669099b8835588eb18e71254fe6877e815a04b148799bbe7edebea0ee7R436-R437) [[18]](diffhunk://#diff-9189b7669099b8835588eb18e71254fe6877e815a04b148799bbe7edebea0ee7R505) [[19]](diffhunk://#diff-9fd1c40702569a890a889ae607e7e9d7000868c8d9364f57eb6e4e394e15c4c4R1115-R1124)