### PR TITLE
wan 2.2: add AnimeGen T2V model flavour

### DIFF
--- a/simpletuner/helpers/models/model_metadata.json
+++ b/simpletuner/helpers/models/model_metadata.json
@@ -308,6 +308,8 @@
             "i2v-14b-2.1-720p",
             "i2v-14b-2.2-high",
             "i2v-14b-2.2-low",
+            "animegen-t2v-high",
+            "animegen-t2v-low",
             "flf2v-14b-2.1",
             "vace-1.3b-2.1",
             "vace-14b-2.1",

--- a/simpletuner/helpers/models/wan/model.py
+++ b/simpletuner/helpers/models/wan/model.py
@@ -251,6 +251,9 @@ class Wan(VideoModelFoundation):
 
     # The default model flavor to use when none is specified.
     DEFAULT_MODEL_FLAVOUR = "t2v-480p-1.3b-2.1"
+    WAN22_T2V_A14B_PATH = "Wan-AI/Wan2.2-T2V-A14B-Diffusers"
+    ANIMEGEN_T2V_HIGH_PATH = "https://huggingface.co/aidealab/AnimeGen-T2V/resolve/main/high_noise.safetensors"
+    ANIMEGEN_T2V_LOW_PATH = "https://huggingface.co/aidealab/AnimeGen-T2V/resolve/main/low_noise.safetensors"
     HUGGINGFACE_PATHS = {
         "t2v-480p-1.3b-2.1": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
         "t2v-480p-14b-2.1": "Wan-AI/Wan2.1-T2V-14B-Diffusers",
@@ -258,6 +261,8 @@ class Wan(VideoModelFoundation):
         "i2v-14b-2.1-720p": "Wan-AI/Wan2.1-I2V-14B-720P-Diffusers",
         "i2v-14b-2.2-high": "Wan-AI/Wan2.2-I2V-A14B-Diffusers",
         "i2v-14b-2.2-low": "Wan-AI/Wan2.2-I2V-A14B-Diffusers",
+        "animegen-t2v-high": WAN22_T2V_A14B_PATH,
+        "animegen-t2v-low": WAN22_T2V_A14B_PATH,
         "flf2v-14b-2.1": "Wan-AI/Wan2.1-FLF2V-14B-720P-diffusers",
         "vace-1.3b-2.1": "Wan-AI/Wan2.1-VACE-1.3B-diffusers",
         "vace-14b-2.1": "Wan-AI/Wan2.1-VACE-14B-diffusers",
@@ -303,6 +308,28 @@ class Wan(VideoModelFoundation):
             "sample_steps": 40,
             "boundary_ratio": 0.90,
             "guidance": {"high": 3.5, "low": 3.5},
+        },
+        "animegen-t2v-high": {
+            "trained_stage": "high",
+            "stage_subfolder": None,
+            "other_stage_subfolder": None,
+            "stage_model_path": ANIMEGEN_T2V_HIGH_PATH,
+            "other_stage_model_path": ANIMEGEN_T2V_LOW_PATH,
+            "flow_shift": 3.0,
+            "sample_steps": 8,
+            "boundary_ratio": 0.875,
+            "guidance": {"high": 1.0, "low": 1.0},
+        },
+        "animegen-t2v-low": {
+            "trained_stage": "low",
+            "stage_subfolder": None,
+            "other_stage_subfolder": None,
+            "stage_model_path": ANIMEGEN_T2V_LOW_PATH,
+            "other_stage_model_path": ANIMEGEN_T2V_HIGH_PATH,
+            "flow_shift": 3.0,
+            "sample_steps": 8,
+            "boundary_ratio": 0.875,
+            "guidance": {"high": 1.0, "low": 1.0},
         },
     }
 
@@ -826,8 +853,11 @@ class Wan(VideoModelFoundation):
         if stage_info is None:
             return
 
+        stage_model_path = stage_info.get("stage_model_path")
         if getattr(self.config, "pretrained_transformer_model_name_or_path", None) is None:
-            self.config.pretrained_transformer_model_name_or_path = self.config.pretrained_model_name_or_path
+            self.config.pretrained_transformer_model_name_or_path = (
+                stage_model_path if stage_model_path is not None else self.config.pretrained_model_name_or_path
+            )
         self.config.pretrained_transformer_subfolder = stage_info["stage_subfolder"]
 
         self.config.wan_trained_stage = stage_info["trained_stage"]
@@ -877,23 +907,37 @@ class Wan(VideoModelFoundation):
             return False
         return bool(getattr(self.config, "wan_validation_load_other_stage", False))
 
-    def _get_or_load_wan_stage_module(self, subfolder: str) -> WanTransformer3DModel:
-        if subfolder in self._wan_cached_stage_modules:
-            return self._wan_cached_stage_modules[subfolder]
+    def _get_or_load_wan_stage_module(
+        self,
+        subfolder: Optional[str],
+        model_path: Optional[str] = None,
+    ) -> WanTransformer3DModel:
+        model_path = model_path or self.config.pretrained_model_name_or_path
+        cache_key = f"{model_path}:{subfolder}"
+        if cache_key in self._wan_cached_stage_modules:
+            return self._wan_cached_stage_modules[cache_key]
 
-        logger.info("Loading Wan stage weights for validation from subfolder '%s'.", subfolder)
-        stage = self.MODEL_CLASS.from_pretrained(
-            self.config.pretrained_model_name_or_path,
-            subfolder=subfolder,
-            torch_dtype=self.config.weight_dtype,
-            use_safetensors=True,
-        )
+        if isinstance(model_path, str) and model_path.lower().endswith(".safetensors"):
+            logger.info("Loading Wan stage weights for validation from single-file checkpoint '%s'.", model_path)
+            stage = self.MODEL_CLASS.from_single_file(
+                model_path,
+                torch_dtype=self.config.weight_dtype,
+                use_safetensors=True,
+            )
+        else:
+            logger.info("Loading Wan stage weights for validation from subfolder '%s'.", subfolder)
+            stage = self.MODEL_CLASS.from_pretrained(
+                model_path,
+                subfolder=subfolder,
+                torch_dtype=self.config.weight_dtype,
+                use_safetensors=True,
+            )
         stage.requires_grad_(False)
         stage.to(self.accelerator.device, dtype=self.config.weight_dtype)
         stage.eval()
         self._apply_time_embedding_override(stage)
         self._patch_condition_embedder(stage)
-        self._wan_cached_stage_modules[subfolder] = stage
+        self._wan_cached_stage_modules[cache_key] = stage
         return stage
 
     def unload_model(self):
@@ -915,16 +959,17 @@ class Wan(VideoModelFoundation):
             load_other = self._should_load_other_stage()
             trained_stage = stage_info["trained_stage"]
             other_subfolder = stage_info["other_stage_subfolder"]
+            other_model_path = stage_info.get("other_stage_model_path")
 
             if trained_stage == "low":
                 if load_other:
                     pipeline.transformer_2 = pipeline.transformer
-                    pipeline.transformer = self._get_or_load_wan_stage_module(other_subfolder)
+                    pipeline.transformer = self._get_or_load_wan_stage_module(other_subfolder, other_model_path)
                 else:
                     pipeline.transformer_2 = None
             else:
                 if load_other:
-                    pipeline.transformer_2 = self._get_or_load_wan_stage_module(other_subfolder)
+                    pipeline.transformer_2 = self._get_or_load_wan_stage_module(other_subfolder, other_model_path)
                 else:
                     pipeline.transformer_2 = None
 
@@ -1331,11 +1376,11 @@ class Wan(VideoModelFoundation):
         if self.config.tokenizer_max_length is not None:
             logger.warning(f"-!- {self.NAME} supports a max length of 512 tokens, --tokenizer_max_length is ignored -!-")
         self.config.tokenizer_max_length = 512
-        if self.config.validation_num_inference_steps > 50:
+        if stage_info is None and self.config.validation_num_inference_steps > 50:
             logger.warning(
                 f"{self.NAME} {self.config.model_flavour} may be wasting compute with more than 50 steps. Consider reducing the value to save time."
             )
-        if self.config.validation_num_inference_steps < 40:
+        if stage_info is None and self.config.validation_num_inference_steps < 40:
             logger.warning(
                 f"{self.NAME} {self.config.model_flavour} expects around 40 or more inference steps. Consider increasing --validation_num_inference_steps to 40."
             )

--- a/tests/test_wan_model.py
+++ b/tests/test_wan_model.py
@@ -6,6 +6,20 @@ from simpletuner.helpers.models.wan.model import Wan
 
 
 class WanModelTests(unittest.TestCase):
+    def _animegen_config(self, flavour: str):
+        return SimpleNamespace(
+            model_family="wan",
+            model_flavour=flavour,
+            pretrained_model_name_or_path=None,
+            pretrained_vae_model_name_or_path=None,
+            pretrained_transformer_model_name_or_path=None,
+            pretrained_transformer_subfolder="transformer",
+            vae_path=None,
+            flow_schedule_shift=5.0,
+            validation_num_inference_steps=40,
+            validation_guidance=3.5,
+        )
+
     def test_special_scheduler_setup_loads_pipeline_scheduler(self):
         model = object.__new__(Wan)
         model.config = SimpleNamespace(flow_schedule_shift=5.0)
@@ -31,6 +45,44 @@ class WanModelTests(unittest.TestCase):
             shift=5.0,
         )
         fix_bounds.assert_called_once_with(scheduler)
+
+    def test_animegen_high_flavour_uses_high_noise_single_file_stage(self):
+        model = object.__new__(Wan)
+        model.config = self._animegen_config("animegen-t2v-high")
+
+        Wan.setup_model_flavour(model)
+
+        self.assertEqual(model.config.pretrained_model_name_or_path, Wan.WAN22_T2V_A14B_PATH)
+        self.assertEqual(model.config.pretrained_transformer_model_name_or_path, Wan.ANIMEGEN_T2V_HIGH_PATH)
+        self.assertIsNone(model.config.pretrained_transformer_subfolder)
+        self.assertEqual(model.config.wan_trained_stage, "high")
+        self.assertIsNone(model.config.wan_stage_other_subfolder)
+        self.assertEqual(model.config.flow_schedule_shift, 3.0)
+        self.assertEqual(model.config.validation_num_inference_steps, 8)
+        self.assertEqual(model.config.validation_guidance, 1.0)
+        self.assertEqual(model.config.wan_boundary_ratio, 0.875)
+
+    def test_animegen_low_flavour_uses_low_noise_single_file_stage(self):
+        model = object.__new__(Wan)
+        model.config = self._animegen_config("animegen-t2v-low")
+
+        Wan.setup_model_flavour(model)
+
+        self.assertEqual(model.config.pretrained_model_name_or_path, Wan.WAN22_T2V_A14B_PATH)
+        self.assertEqual(model.config.pretrained_transformer_model_name_or_path, Wan.ANIMEGEN_T2V_LOW_PATH)
+        self.assertIsNone(model.config.pretrained_transformer_subfolder)
+        self.assertEqual(model.config.wan_trained_stage, "low")
+        self.assertIsNone(model.config.wan_stage_other_subfolder)
+        self.assertEqual(model.config.flow_schedule_shift, 3.0)
+        self.assertEqual(model.config.validation_num_inference_steps, 8)
+        self.assertEqual(model.config.validation_guidance, 1.0)
+        self.assertEqual(model.config.wan_boundary_ratio, 0.875)
+
+    def test_animegen_flavours_are_model_flavour_choices(self):
+        choices = Wan.get_flavour_choices()
+
+        self.assertIn("animegen-t2v-high", choices)
+        self.assertIn("animegen-t2v-low", choices)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request adds support for two new AnimeGen T2V model flavors ("animegen-t2v-high" and "animegen-t2v-low") to the `Wan` model, enabling single-file checkpoint loading for these variants. It also updates the configuration and pipeline logic to handle these new flavors and provides corresponding tests to ensure correct integration.

**AnimeGen T2V Model Integration:**

- Added `"animegen-t2v-high"` and `"animegen-t2v-low"` as available model flavors in `model_metadata.json` and in the `HUGGINGFACE_PATHS` mapping in `wan/model.py`. [[1]](diffhunk://#diff-3a800b3ac808a1df9880abef91615c94fc82de37f7c15b33ed2245e7d2de7668R311-R312) [[2]](diffhunk://#diff-a9a0a770364f81d1b9e431dc59648729cf12b65fac361b9e3b864ff2801f1448R254-R265)
- Defined new configuration entries for the AnimeGen flavors, including URLs to their single-file `.safetensors` checkpoints and associated parameters (e.g., flow shift, sample steps, guidance, etc.). [[1]](diffhunk://#diff-a9a0a770364f81d1b9e431dc59648729cf12b65fac361b9e3b864ff2801f1448R254-R265) [[2]](diffhunk://#diff-a9a0a770364f81d1b9e431dc59648729cf12b65fac361b9e3b864ff2801f1448R312-R333)

**Model Loading and Pipeline Logic:**

- Updated the model setup and pipeline loading logic to handle single-file checkpoints for the AnimeGen flavors, including changes to `_get_or_load_wan_stage_module` to support both subfolder and single-file loading and to use a more robust cache key. [[1]](diffhunk://#diff-a9a0a770364f81d1b9e431dc59648729cf12b65fac361b9e3b864ff2801f1448L880-R930) [[2]](diffhunk://#diff-a9a0a770364f81d1b9e431dc59648729cf12b65fac361b9e3b864ff2801f1448L896-R940) [[3]](diffhunk://#diff-a9a0a770364f81d1b9e431dc59648729cf12b65fac361b9e3b864ff2801f1448R962-R972)
- Ensured that the correct transformer model path is set during model flavor setup for these new variants.

**Testing:**

- Added new unit tests to verify that the AnimeGen T2V flavors are correctly recognized, configured, and loaded, and that their parameters are set as expected. [[1]](diffhunk://#diff-fa692cdb9be09a6b1284e14720ae4897ade4a45e3812e8e55d78cc27c58fcf20R9-R22) [[2]](diffhunk://#diff-fa692cdb9be09a6b1284e14720ae4897ade4a45e3812e8e55d78cc27c58fcf20R49-R86)

**Other:**

- Minor adjustment to the validation inference steps warning logic to avoid unnecessary warnings when stage info is present.