### PR TITLE
(#2812) fix vllm version for newer torch dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,20 +132,12 @@ def build_triton_wheel_url(version: str, base_url: str) -> str:
     return f"triton @ {base_url}/{filename}"
 
 
-def build_vllm_cuda13_wheel_url() -> str:
-    """Build a direct wheel URL for vLLM's CUDA 13 release wheel."""
-    version = os.environ.get("SIMPLETUNER_VLLM_CUDA13_VERSION", "0.19.1")
-    cpu_arch = os.environ.get("SIMPLETUNER_VLLM_CUDA13_ARCH", platform.machine())
-    if cpu_arch == "AMD64":
-        cpu_arch = "x86_64"
-    platform_tag = os.environ.get("SIMPLETUNER_VLLM_CUDA13_PLATFORM_TAG", f"manylinux_2_35_{cpu_arch}")
-    filename = f"vllm-{version}%2Bcu130-cp38-abi3-{platform_tag}.whl"
-    return f"vllm @ https://github.com/vllm-project/vllm/releases/download/v{version}/{filename}"
+VLLM_TORCH_211_DEPENDENCY = "vllm>=0.20.0,<0.26.0"
 
 
 def get_cuda13_dependencies():
     """Get CUDA 13 specific dependencies (use --extra-index-url https://download.pytorch.org/whl/cu130)."""
-    dependencies = [
+    return [
         *PYTORCH_DEPENDENCIES,
         "triton>=3.3.0",
         "deepspeed>=0.17.2",
@@ -157,10 +149,8 @@ def get_cuda13_dependencies():
         "nvidia-ml-py>=12.555",
         "lm-eval>=0.4.4",
         "ramtorch",
+        VLLM_TORCH_211_DEPENDENCY,
     ]
-    if not _is_building_dist:
-        dependencies.append(build_vllm_cuda13_wheel_url())
-    return dependencies
 
 
 def get_cuda_nightly_dependencies():
@@ -253,17 +243,13 @@ def get_cpu_dependencies():
 
 
 def get_captioning_cuda13_dependencies():
-    """CaptionFlow dependencies with the vLLM CUDA 13 wheel selected explicitly."""
-    dependencies = [
+    """CaptionFlow dependencies with a vLLM release compatible with the PyTorch 2.11 stack."""
+    return [
         "caption-flow>=0.5.2",
         "numpy>=2.2.0,<2.3.0",
         "transformers>=5.5.1,<6.0.0",
+        VLLM_TORCH_211_DEPENDENCY,
     ]
-    if not _is_building_dist:
-        dependencies.append(build_vllm_cuda13_wheel_url())
-    else:
-        dependencies.append("vllm>=0.19.1,<0.20.0")
-    return dependencies
 
 
 PLATFORM_DEPENDENCIES = {
@@ -372,7 +358,7 @@ base_deps = [
     "webshart>=0.4.6",
 ]
 
-# CUDA-specific extras contain direct URLs that PyPI rejects, so only include them
+# Nightly CUDA extras contain direct URLs that PyPI rejects, so only include them
 # for editable / local installs, not when building distributable wheels / sdists.
 _is_building_dist = any(arg in sys.argv for arg in ("bdist_wheel", "sdist", "build"))
 

--- a/tests/test_setup_platform_dependencies.py
+++ b/tests/test_setup_platform_dependencies.py
@@ -61,6 +61,17 @@ class SetupPlatformDependencyTests(unittest.TestCase):
         self.assertIn("transformer_engine[pytorch]>=2.16.0,<2.17.0", extras_require["transformerengine-cuda13"])
         self.assertIn("transformer_engine[pytorch]>=2.16.0,<2.17.0", extras_require["cuda13-transformerengine"])
 
+    def test_cuda13_vllm_uses_torch_211_compatible_release(self):
+        extras_require = load_setup_kwargs()["extras_require"]
+        expected = "vllm>=0.20.0,<0.26.0"
+
+        for extra_name in ("cuda13", "captioning-cuda13", "cuda13-captioning"):
+            with self.subTest(extra=extra_name):
+                dependencies = extras_require[extra_name]
+                self.assertIn(expected, dependencies)
+                self.assertFalse(any(dependency.startswith("vllm @ ") for dependency in dependencies))
+                self.assertNotIn("vllm>=0.19.1,<0.20.0", dependencies)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request updates how the `vllm` dependency is handled for CUDA 13 and captioning extras, ensuring compatibility with PyTorch 2.11 and simplifying dependency management. The main changes include removing the direct wheel URL for `vllm`, standardizing on a version range, and updating tests to reflect this new approach.

**Dependency management improvements:**

* Replaced the custom `build_vllm_cuda13_wheel_url` function with a standard version range for `vllm` (`vllm>=0.20.0,<0.26.0`) for CUDA 13 and captioning dependencies, ensuring compatibility with PyTorch 2.11 and simplifying installation from PyPI. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L135-R140) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R152-L163) [[3]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L256-L266)
* Updated the `get_cuda13_dependencies` and `get_captioning_cuda13_dependencies` functions to use the new `VLLM_TORCH_211_DEPENDENCY` variable instead of direct URLs or older version pins. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R152-L163) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L256-L266)
* Clarified comments to reflect that only nightly CUDA extras may contain direct URLs, not the standard CUDA 13 extras.

**Testing updates:**

* Added tests to verify that the CUDA 13 and captioning extras now use the correct `vllm` version range and do not include direct wheel URLs or outdated version pins.