### PR TITLE
docs: update DeepFloyd validation notes

### DIFF
--- a/documentation/DEEPFLOYD.es.md
+++ b/documentation/DEEPFLOYD.es.md
@@ -160,6 +160,12 @@ Arriba se proporciona una configuración básica de Dreambooth para DeepFloyd:
 
 Nota: las imágenes se reducen un 25% cada vez para evitar saltos extremos de tamaño que provoquen un promedio incorrecto de los detalles de la escena.
 
+## Modos de pipeline de validación
+
+La validación de DeepFloyd ahora puede encadenar stages directamente en SimpleTuner. `deepfloyd_validation_pipeline_mode=auto` es el valor predeterminado: prompt validation ejecuta stage I -> stage II, mientras que dataset-image validation permanece en el stage entrenado. Usa `trained-stage` para forzar validación single-stage, o `full-pipeline` para cargar siempre el peer stage fijo. Sobrescribe los peer checkpoints con `deepfloyd_validation_stage1_model` y `deepfloyd_validation_stage2_model`.
+
+La validación opcional de stage III puede activarse con `deepfloyd_validation_stage3_mode=sd-x4-upscaler`; esto usa `deepfloyd_validation_stage3_model` como upscaler terminal 4x después de stage II.
+
 ## Ejecutar inferencia
 
 Actualmente, DeepFloyd no tiene scripts de inferencia dedicados en el toolkit de SimpleTuner.

--- a/documentation/DEEPFLOYD.hi.md
+++ b/documentation/DEEPFLOYD.hi.md
@@ -160,6 +160,12 @@ SDXL या Stable Diffusion 1.x/2.x की तुलना में, DeepFloyd
 
 Note: images को 25% के चरणों में downsample किया जाता है ताकि image size में बड़े jump से scene details का गलत averaging न हो।
 
+## Validation pipeline modes
+
+DeepFloyd validation अब SimpleTuner में stages को सीधे chain कर सकता है। `deepfloyd_validation_pipeline_mode=auto` default है: prompt validation stage I -> stage II चलाता है, जबकि dataset-image validation trained stage पर रहता है। single-stage validation force करने के लिए `trained-stage` उपयोग करें, या fixed peer stage हमेशा load करने के लिए `full-pipeline` उपयोग करें। peer checkpoints को `deepfloyd_validation_stage1_model` और `deepfloyd_validation_stage2_model` से override करें।
+
+Optional stage III validation को `deepfloyd_validation_stage3_mode=sd-x4-upscaler` से enable किया जा सकता है; यह stage II के बाद `deepfloyd_validation_stage3_model` को terminal 4x upscaler के रूप में उपयोग करता है।
+
 ## इनफेरेंस चलाना
 
 फिलहाल, SimpleTuner toolkit में DeepFloyd के लिए कोई dedicated inference scripts नहीं हैं।

--- a/documentation/DEEPFLOYD.ja.md
+++ b/documentation/DEEPFLOYD.ja.md
@@ -160,6 +160,12 @@ SDXL または Stable Diffusion 1.x/2.x と比較すると、DeepFloyd の美的
 
 注記: 画像は 25% ずつダウンサンプルされるため、極端なサイズ変化でシーンの詳細が不正に平均化されるのを避けられます。
 
+## 検証パイプラインモード
+
+DeepFloyd validation は SimpleTuner 内で stage を直接つなげられます。`deepfloyd_validation_pipeline_mode=auto` が既定値です。prompt validation では stage I -> stage II を実行し、dataset-image validation では学習中の stage のままにします。単一 stage validation に固定する場合は `trained-stage`、固定 peer stage を常に読み込む場合は `full-pipeline` を使います。peer checkpoint は `deepfloyd_validation_stage1_model` と `deepfloyd_validation_stage2_model` で上書きできます。
+
+任意の stage III validation は `deepfloyd_validation_stage3_mode=sd-x4-upscaler` で有効化できます。stage II の後、`deepfloyd_validation_stage3_model` を terminal 4x upscaler として使います。
+
 ## 推論の実行
 
 現在、DeepFloyd 専用の推論スクリプトは SimpleTuner ツールキットにはありません。

--- a/documentation/DEEPFLOYD.md
+++ b/documentation/DEEPFLOYD.md
@@ -160,6 +160,12 @@ Provided above is a basic Dreambooth configuration for DeepFloyd:
 
 Note: images are downsampled 25% at a time so to avoid extreme leaps in image size causing an incorrect averaging of the scene's details.
 
+## Validation pipeline modes
+
+DeepFloyd validation can chain stages directly in SimpleTuner. `deepfloyd_validation_pipeline_mode=auto` is the default: prompt validation runs stage I -> stage II, while dataset-image validation stays on the trained stage. Use `trained-stage` to force single-stage validation, or `full-pipeline` to always load the fixed peer stage. Override peer checkpoints with `deepfloyd_validation_stage1_model` and `deepfloyd_validation_stage2_model`.
+
+Optional stage III validation can be enabled with `deepfloyd_validation_stage3_mode=sd-x4-upscaler`; this uses `deepfloyd_validation_stage3_model` as the terminal 4x upscaler after stage II.
+
 ## Running inference
 
 Currently, DeepFloyd does not have any dedicated inference scripts in the SimpleTuner toolkit.

--- a/documentation/DEEPFLOYD.pt-BR.md
+++ b/documentation/DEEPFLOYD.pt-BR.md
@@ -160,6 +160,12 @@ Acima esta uma configuracao basica de Dreambooth para DeepFloyd:
 
 Nota: as imagens sao reduzidas em 25% por vez para evitar saltos extremos no tamanho da imagem que causem uma media incorreta dos detalhes da cena.
 
+## Modos de pipeline de validacao
+
+A validacao do DeepFloyd agora pode encadear stages diretamente no SimpleTuner. `deepfloyd_validation_pipeline_mode=auto` e o padrao: prompt validation roda stage I -> stage II, enquanto dataset-image validation permanece no stage treinado. Use `trained-stage` para forcar validacao single-stage, ou `full-pipeline` para sempre carregar o peer stage fixo. Sobrescreva peer checkpoints com `deepfloyd_validation_stage1_model` e `deepfloyd_validation_stage2_model`.
+
+A validacao opcional de stage III pode ser ativada com `deepfloyd_validation_stage3_mode=sd-x4-upscaler`; isso usa `deepfloyd_validation_stage3_model` como upscaler terminal 4x depois do stage II.
+
 ## Rodando inferencia
 
 Atualmente, o DeepFloyd nao tem scripts de inferencia dedicados no toolkit do SimpleTuner.

--- a/documentation/DEEPFLOYD.zh.md
+++ b/documentation/DEEPFLOYD.zh.md
@@ -160,6 +160,12 @@
 
 注记：图像每次会按 25% 逐步下采样，避免尺寸变化过大导致细节被不正确地平均。
 
+## 验证管线模式
+
+DeepFloyd validation 现在可以在 SimpleTuner 内直接串联阶段。`deepfloyd_validation_pipeline_mode=auto` 是默认值：prompt validation 会运行 stage I -> stage II，而 dataset-image validation 保持在训练中的 stage。使用 `trained-stage` 可强制单阶段验证，或使用 `full-pipeline` 始终加载固定 peer stage。可用 `deepfloyd_validation_stage1_model` 与 `deepfloyd_validation_stage2_model` 覆盖 peer checkpoint。
+
+可选 stage III validation 可通过 `deepfloyd_validation_stage3_mode=sd-x4-upscaler` 启用；它会在 stage II 之后使用 `deepfloyd_validation_stage3_model` 作为最终 4x upscaler。
+
 ## 运行推理
 
 目前 SimpleTuner 工具包中没有 DeepFloyd 专用的推理脚本。


### PR DESCRIPTION
This pull request updates the DeepFloyd documentation in multiple languages to add details about the new validation pipeline modes. The new section explains how validation can chain multiple stages in SimpleTuner, describes the default and optional modes, and documents relevant configuration parameters.

**Documentation updates for validation pipeline modes:**

* Added a new section describing validation pipeline modes, including default behavior (`auto`), options for single-stage and full-pipeline validation, and how to override peer checkpoints with `deepfloyd_validation_stage1_model` and `deepfloyd_validation_stage2_model`. [[1]](diffhunk://#diff-48d0d55b375868cd2a0c44c20b89ed4564439031ea3d22907318c4ffc0096c3dR163-R168) [[2]](diffhunk://#diff-1d29f30b42186c92335d2025d088aa046715b37aa83ecccf41a978ae414f3bc1R163-R168) [[3]](diffhunk://#diff-0e3bde29d6bf85e4e52af8f82fd8f736c65db3644a19805f6f39bafa6362c95eR163-R168) [[4]](diffhunk://#diff-6c58805d70005b730242077ffc5c4b412ce00cfcc5e65045e3ff6613e48d2458R163-R168) [[5]](diffhunk://#diff-8ed6429586fdcfbf5d81f64ff73669a68a577c197e899d6f3f6ae54f605bb750R163-R168) [[6]](diffhunk://#diff-4c1666ddbf79f12aced01731d84f42c1d44bd8b5a290754b22583290d8298ff4R163-R168)
* Documented the optional stage III validation, which can be enabled with `deepfloyd_validation_stage3_mode=sd-x4-upscaler` and uses `deepfloyd_validation_stage3_model` as a terminal 4x upscaler after stage II. [[1]](diffhunk://#diff-48d0d55b375868cd2a0c44c20b89ed4564439031ea3d22907318c4ffc0096c3dR163-R168) [[2]](diffhunk://#diff-1d29f30b42186c92335d2025d088aa046715b37aa83ecccf41a978ae414f3bc1R163-R168) [[3]](diffhunk://#diff-0e3bde29d6bf85e4e52af8f82fd8f736c65db3644a19805f6f39bafa6362c95eR163-R168) [[4]](diffhunk://#diff-6c58805d70005b730242077ffc5c4b412ce00cfcc5e65045e3ff6613e48d2458R163-R168) [[5]](diffhunk://#diff-8ed6429586fdcfbf5d81f64ff73669a68a577c197e899d6f3f6ae54f605bb750R163-R168) [[6]](diffhunk://#diff-4c1666ddbf79f12aced01731d84f42c1d44bd8b5a290754b22583290d8298ff4R163-R168)