### PR TITLE
docs: update SDXL quickstart validation notes

### DIFF
--- a/documentation/quickstart/SDXL.es.md
+++ b/documentation/quickstart/SDXL.es.md
@@ -105,6 +105,8 @@ Ahí, necesitarás modificar las siguientes variables:
 - `validation_resolution` - Configura esto en `1024x1024` para este ejemplo.
   - Además, Stable Diffusion XL fue afinado con buckets multi-aspect, y se pueden especificar otras resoluciones separándolas con comas: `1024x1024,1280x768`
 - `validation_guidance` - Usa el valor con el que estés cómodo para pruebas en inferencia. Configura entre `4.2` y `6.4`.
+- `sdxl_validation_pipeline_mode` - Mantén `trained-stage` para la validación normal. Usa `full-pipeline` para validar con la división SDXL base/refiner: stage 1 corre hasta `1 - refiner_training_strength` con salida latente y stage 2 continúa desde el mismo límite.
+  - Al entrenar solo un stage, `sdxl_validation_stage1_model` y `sdxl_validation_stage2_model` pueden sobrescribir el checkpoint fijo base/refiner usado como peer stage.
 - `use_gradient_checkpointing` - Probablemente esto debería ser `true` a menos que tengas MUCHÍSIMA VRAM y quieras sacrificar algo para hacerlo más rápido.
 - `learning_rate` - `1e-4` es bastante común para redes de bajo rango, aunque `1e-5` puede ser una opción más conservadora si notas "burning" o sobreentrenamiento temprano.
 

--- a/documentation/quickstart/SDXL.hi.md
+++ b/documentation/quickstart/SDXL.hi.md
@@ -105,6 +105,8 @@ popd
 - `validation_resolution` - इस उदाहरण के लिए इसे `1024x1024` पर सेट करें।
   - साथ ही, Stable Diffusion XL को multi‑aspect buckets पर fine‑tune किया गया था, और अन्य resolutions को कॉमा से अलग कर के दिया जा सकता है: `1024x1024,1280x768`
 - `validation_guidance` - inference में परीक्षण के लिए जिस मान के साथ आप सहज हों, वही रखें। इसे `4.2` से `6.4` के बीच सेट करें।
+- `sdxl_validation_pipeline_mode` - सामान्य validation के लिए `trained-stage` रखें। SDXL base/refiner split से validate करने के लिए `full-pipeline` उपयोग करें: stage 1 latent output के साथ `1 - refiner_training_strength` तक चलता है, फिर stage 2 उसी boundary से resume करता है।
+  - केवल एक stage train करते समय, `sdxl_validation_stage1_model` और `sdxl_validation_stage2_model` peer stage के रूप में उपयोग होने वाले fixed base/refiner checkpoint को override कर सकते हैं।
 - `use_gradient_checkpointing` - यदि आपके पास बहुत VRAM नहीं है, तो इसे `true` रखें।
 - `learning_rate` - low‑rank नेटवर्क्स के लिए `1e-4` सामान्य है, लेकिन यदि "burning" या early overtraining दिखे तो `1e-5` अधिक conservative हो सकता है।
 

--- a/documentation/quickstart/SDXL.ja.md
+++ b/documentation/quickstart/SDXL.ja.md
@@ -105,6 +105,8 @@ popd
 - `validation_resolution` - この例では`1024x1024`に設定します。
   - さらに、Stable Diffusion XLはマルチアスペクトバケットでファインチューニングされており、カンマで区切って他の解像度を指定できます: `1024x1024,1280x768`
 - `validation_guidance` - 推論時にテストするための快適な値を使用します。`4.2`から`6.4`の間に設定します。
+- `sdxl_validation_pipeline_mode` - 通常の validation では `trained-stage` のままにします。`full-pipeline` を使うと SDXL base/refiner split で validation します。stage 1 は latent output で `1 - refiner_training_strength` まで実行され、stage 2 が同じ境界から再開します。
+  - 片方の stage だけを学習する場合、`sdxl_validation_stage1_model` と `sdxl_validation_stage2_model` で peer stage として使う固定 base/refiner checkpoint を上書きできます。
 - `use_gradient_checkpointing` - 大量のVRAMがあり、速度を上げるために一部を犠牲にしたい場合を除き、おそらく`true`にする必要があります。
 - `learning_rate` - `1e-4`は低ランクネットワークでかなり一般的ですが、「バーニング」や早期の過学習に気づいた場合は`1e-5`がより保守的な選択かもしれません。
 

--- a/documentation/quickstart/SDXL.md
+++ b/documentation/quickstart/SDXL.md
@@ -105,6 +105,8 @@ There, you will need to modify the following variables:
 - `validation_resolution` - Set this to `1024x1024` for this example.
   - Additionally, Stable Diffusion XL was fine-tuned on multi-aspect buckets, and other resolutions may be specified using commas to separate them: `1024x1024,1280x768`
 - `validation_guidance` - Use whatever value you are comfortable with for testing at inference time. Set this between `4.2` to `6.4`.
+- `sdxl_validation_pipeline_mode` - Keep `trained-stage` for normal validation. Use `full-pipeline` to validate through the SDXL base/refiner split: stage 1 runs to `1 - refiner_training_strength` with latent output, then stage 2 resumes from the same boundary.
+  - When training only one stage, `sdxl_validation_stage1_model` and `sdxl_validation_stage2_model` can override the fixed base/refiner checkpoint used as the peer stage.
 - `use_gradient_checkpointing` - This should probably be `true` unless you have a LOT of VRAM and want to sacrifice some to make it go faster.
 - `learning_rate` - `1e-4` is fairly common for low-rank networks, though `1e-5` might be a more conservative choice if you notice any "burning" or early overtraining.
 

--- a/documentation/quickstart/SDXL.pt-BR.md
+++ b/documentation/quickstart/SDXL.pt-BR.md
@@ -105,6 +105,8 @@ Lá, você precisará modificar as seguintes variáveis:
 - `validation_resolution` - Defina como `1024x1024` para este exemplo.
   - Além disso, o Stable Diffusion XL foi fine-tuned em buckets multi-aspect e outras resoluções podem ser especificadas separando por vírgulas: `1024x1024,1280x768`
 - `validation_guidance` - Use qualquer valor com o qual você se sinta confortável para testes em inferência. Defina entre `4.2` e `6.4`.
+- `sdxl_validation_pipeline_mode` - Mantenha `trained-stage` para validação normal. Use `full-pipeline` para validar pela divisão SDXL base/refiner: o stage 1 roda até `1 - refiner_training_strength` com saída latente, e o stage 2 continua a partir do mesmo limite.
+  - Ao treinar apenas um stage, `sdxl_validation_stage1_model` e `sdxl_validation_stage2_model` podem sobrescrever o checkpoint fixo base/refiner usado como peer stage.
 - `use_gradient_checkpointing` - Provavelmente deve ser `true`, a menos que você tenha MUITA VRAM e queira sacrificar um pouco para ficar mais rápido.
 - `learning_rate` - `1e-4` é bastante comum para redes de baixo rank, embora `1e-5` possa ser uma escolha mais conservadora se você notar algum "burning" ou overtraining precoce.
 

--- a/documentation/quickstart/SDXL.zh.md
+++ b/documentation/quickstart/SDXL.zh.md
@@ -105,6 +105,8 @@ popd
 - `validation_resolution` - 本示例设置为 `1024x1024`。
   - 此外，Stable Diffusion XL 在多宽高比桶上进行了微调，可以使用逗号分隔指定其他分辨率：`1024x1024,1280x768`
 - `validation_guidance` - 使用您在推理时习惯使用的值。设置在 `4.2` 到 `6.4` 之间。
+- `sdxl_validation_pipeline_mode` - 常规验证保持 `trained-stage`。使用 `full-pipeline` 可通过 SDXL base/refiner split 进行验证：stage 1 以 latent 输出运行到 `1 - refiner_training_strength`，然后 stage 2 从同一边界继续。
+  - 只训练一个 stage 时，`sdxl_validation_stage1_model` 和 `sdxl_validation_stage2_model` 可覆盖验证中作为 peer stage 使用的固定 base/refiner checkpoint。
 - `use_gradient_checkpointing` - 除非您有大量 VRAM 并想牺牲一些来加快速度，否则这应该是 `true`。
 - `learning_rate` - `1e-4` 对于低秩网络来说相当常见，但如果您注意到任何"烧焦"或早期过度训练，`1e-5` 可能是更保守的选择。
 


### PR DESCRIPTION
This pull request updates the SDXL quickstart documentation in multiple languages to add explanations for new validation pipeline options. The main addition is documentation for the `sdxl_validation_pipeline_mode` variable, describing how to use different validation modes and how to override the peer stage checkpoint when training only one stage.

**Documentation updates for SDXL validation:**

* Added explanation for the `sdxl_validation_pipeline_mode` variable, including usage of `trained-stage` and `full-pipeline` modes, and details on how stage 1 and stage 2 interact during validation. [[1]](diffhunk://#diff-7109a336a555b28d1f73ebb72fea494588ac09227a41fdf0321b2bb6d9eca83bR108-R109) [[2]](diffhunk://#diff-ae3425b709607cd1f09d6018290170cad243ee2ecb59b0551fd150405014b1fcR108-R109) [[3]](diffhunk://#diff-75fc3ebc00448a3d1a0f80e804f5493e7109bdaa78ca888b545863892c7b0d69R108-R109) [[4]](diffhunk://#diff-a4d8885c5a8c1596c659338ffe2902c4ac61f3c4b471e9ad705440a8050d6846R108-R109) [[5]](diffhunk://#diff-e866fc7431bc4f9104086b889e20f7cf5402399b03490649b5e57acf440db9efR108-R109) [[6]](diffhunk://#diff-a5b4060ff2e29f965a2a53cd2136285f14d78d2e3d49b022936fbd905a243021R108-R109)
* Documented the ability to override the default base/refiner checkpoint for the peer stage using `sdxl_validation_stage1_model` and `sdxl_validation_stage2_model` when training only one stage. [[1]](diffhunk://#diff-7109a336a555b28d1f73ebb72fea494588ac09227a41fdf0321b2bb6d9eca83bR108-R109) [[2]](diffhunk://#diff-ae3425b709607cd1f09d6018290170cad243ee2ecb59b0551fd150405014b1fcR108-R109) [[3]](diffhunk://#diff-75fc3ebc00448a3d1a0f80e804f5493e7109bdaa78ca888b545863892c7b0d69R108-R109) [[4]](diffhunk://#diff-a4d8885c5a8c1596c659338ffe2902c4ac61f3c4b471e9ad705440a8050d6846R108-R109) [[5]](diffhunk://#diff-e866fc7431bc4f9104086b889e20f7cf5402399b03490649b5e57acf440db9efR108-R109) [[6]](diffhunk://#diff-a5b4060ff2e29f965a2a53cd2136285f14d78d2e3d49b022936fbd905a243021R108-R109)