### PR TITLE
docs: update PixArt quickstart validation notes

### DIFF
--- a/documentation/quickstart/SIGMA.es.md
+++ b/documentation/quickstart/SIGMA.es.md
@@ -102,6 +102,8 @@ Ahí, necesitarás modificar las siguientes variables:
 - `VALIDATION_RESOLUTION` - Como PixArt Sigma viene en formato 1024px o 2048xp, deberías configurar esto con cuidado en `1024x1024` para este ejemplo.
   - Además, PixArt fue afinado con buckets multi-aspect, y se pueden especificar otras resoluciones separándolas con comas: `1024x1024,1280x768`
 - `VALIDATION_GUIDANCE` - PixArt se beneficia de un valor muy bajo. Configura esto entre `3.6` y `4.4`.
+- `pixart_validation_pipeline_mode` - Mantén `trained-stage` para la validación normal. Usa `full-pipeline` al validar la pipeline dividida v0.7, incluido el stage split estilo MoE de 900M: stage 1 corre hasta `1 - refiner_training_strength` como latents y stage 2 continúa desde ese límite.
+  - Si entrenas solo un stage, define `pixart_validation_stage1_model` o `pixart_validation_stage2_model` cuando necesites sobrescribir el checkpoint fijo del peer-stage usado para validación.
 
 Hay algunas más si usas una máquina Mac M-series:
 

--- a/documentation/quickstart/SIGMA.hi.md
+++ b/documentation/quickstart/SIGMA.hi.md
@@ -102,6 +102,8 @@ cp config/config.json.example config/config.json
 - `VALIDATION_RESOLUTION` - PixArt Sigma 1024px या 2048px मॉडल फॉर्मैट में आता है, इसलिए इस उदाहरण के लिए इसे सावधानी से `1024x1024` रखें।
   - साथ ही, PixArt को multi‑aspect buckets पर fine‑tune किया गया था, और अन्य resolutions को कॉमा से अलग कर के दिया जा सकता है: `1024x1024,1280x768`
 - `VALIDATION_GUIDANCE` - PixArt को बहुत कम मान लाभ देता है। इसे `3.6` से `4.4` के बीच सेट करें।
+- `pixart_validation_pipeline_mode` - सामान्य validation के लिए `trained-stage` रखें। v0.7 split pipeline, जिसमें 900M MoE-style stage split भी शामिल है, validate करने के लिए `full-pipeline` उपयोग करें: stage 1 `1 - refiner_training_strength` तक latents के रूप में चलता है, फिर stage 2 उसी boundary से resume करता है।
+  - यदि आप केवल एक stage train करते हैं, तो validation में उपयोग होने वाले fixed peer-stage checkpoint को override करने के लिए `pixart_validation_stage1_model` या `pixart_validation_stage2_model` सेट करें।
 
 Mac M‑series मशीन पर कुछ अतिरिक्त सेटिंग्स:
 

--- a/documentation/quickstart/SIGMA.ja.md
+++ b/documentation/quickstart/SIGMA.ja.md
@@ -102,6 +102,8 @@ cp config/config.json.example config/config.json
 - `VALIDATION_RESOLUTION` - PixArt Sigma は 1024px または 2048px のモデル形式なので、この例では `1024x1024` に慎重に設定してください。
   - PixArt はマルチアスペクトバケットでファインチューニングされているため、カンマ区切りで他の解像度を指定できます: `1024x1024,1280x768`
 - `VALIDATION_GUIDANCE` - PixArt は非常に低い値が有効です。`3.6`〜`4.4` の範囲に設定してください。
+- `pixart_validation_pipeline_mode` - 通常の validation では `trained-stage` のままにします。v0.7 split pipeline（900M MoE-style stage split を含む）を検証する場合は `full-pipeline` を使います。stage 1 は `1 - refiner_training_strength` まで latents として実行され、stage 2 が同じ境界から再開します。
+  - 片方の stage だけを学習する場合、validation で使う固定 peer-stage checkpoint を上書きするには `pixart_validation_stage1_model` または `pixart_validation_stage2_model` を設定します。
 
 Mac M-series を使用している場合の追加設定:
 

--- a/documentation/quickstart/SIGMA.md
+++ b/documentation/quickstart/SIGMA.md
@@ -102,6 +102,8 @@ There, you will need to modify the following variables:
 - `VALIDATION_RESOLUTION` - As PixArt Sigma comes in a 1024px or 2048xp model format, you should carefully set this to `1024x1024` for this example.
   - Additionally, PixArt was fine-tuned on multi-aspect buckets, and other resolutions may be specified using commas to separate them: `1024x1024,1280x768`
 - `VALIDATION_GUIDANCE` - PixArt benefits from a very-low value. Set this between `3.6` to `4.4`.
+- `pixart_validation_pipeline_mode` - Keep `trained-stage` for normal validation. Use `full-pipeline` when validating the v0.7 split pipeline, including the 900M MoE-style stage split: stage 1 runs to `1 - refiner_training_strength` as latents, then stage 2 resumes from that boundary.
+  - If you train only one stage, set `pixart_validation_stage1_model` or `pixart_validation_stage2_model` when you need to override the fixed peer-stage checkpoint used for validation.
 
 There are a few more if using a Mac M-series machine:
 

--- a/documentation/quickstart/SIGMA.pt-BR.md
+++ b/documentation/quickstart/SIGMA.pt-BR.md
@@ -102,6 +102,8 @@ Lá, você precisará modificar as seguintes variáveis:
 - `VALIDATION_RESOLUTION` - Como PixArt Sigma vem em formato 1024px ou 2048px, você deve definir com cuidado para `1024x1024` neste exemplo.
   - Além disso, o PixArt foi fine-tuned em buckets multi-aspect, e outras resoluções podem ser especificadas usando vírgulas: `1024x1024,1280x768`
 - `VALIDATION_GUIDANCE` - PixArt se beneficia de um valor bem baixo. Defina entre `3.6` e `4.4`.
+- `pixart_validation_pipeline_mode` - Mantenha `trained-stage` para validação normal. Use `full-pipeline` ao validar a pipeline dividida v0.7, incluindo o stage split estilo MoE de 900M: o stage 1 roda até `1 - refiner_training_strength` como latents, e o stage 2 continua a partir desse limite.
+  - Se você treinar apenas um stage, defina `pixart_validation_stage1_model` ou `pixart_validation_stage2_model` quando precisar sobrescrever o checkpoint fixo do peer-stage usado na validação.
 
 Há mais alguns ajustes se estiver usando um Mac M-series:
 

--- a/documentation/quickstart/SIGMA.zh.md
+++ b/documentation/quickstart/SIGMA.zh.md
@@ -102,6 +102,8 @@ cp config/config.json.example config/config.json
 - `VALIDATION_RESOLUTION` - PixArt Sigma 有 1024px 或 2048px 模型，应在此示例中设置为 `1024x1024`。
   - PixArt 也在多宽高比桶上微调，可用逗号分隔指定其他分辨率：`1024x1024,1280x768`
 - `VALIDATION_GUIDANCE` - PixArt 适合较低值。设置为 `3.6` 到 `4.4` 之间。
+- `pixart_validation_pipeline_mode` - 常规验证保持 `trained-stage`。验证 v0.7 split pipeline（包括 900M MoE-style stage split）时使用 `full-pipeline`：stage 1 以 latents 运行到 `1 - refiner_training_strength`，然后 stage 2 从同一边界继续。
+  - 如果只训练一个 stage，需要覆盖验证时使用的固定 peer-stage checkpoint，可设置 `pixart_validation_stage1_model` 或 `pixart_validation_stage2_model`。
 
 如果使用 Mac M 系列机器，还有一些额外设置：
 


### PR DESCRIPTION
This pull request updates the PixArt Sigma quickstart documentation in all supported languages to clarify validation pipeline options and how to override peer-stage checkpoints when training only one stage. These additions help users correctly configure validation for both the standard and split pipeline setups.

**Documentation improvements for validation pipeline:**

* Added explanations for the `pixart_validation_pipeline_mode` variable, describing when to use `trained-stage` versus `full-pipeline` for validation, especially for the v0.7 split pipeline and 900M MoE-style stage split. [[1]](diffhunk://#diff-60d9b7ebd163d65660f8e07b4f68908ec2ac3c81b247be91950293ac9aa1baefR105-R106) [[2]](diffhunk://#diff-562bfcdf5714bc346e89247b47ee18def6a4a926d1e80b1e7b8785e73c75c616R105-R106) [[3]](diffhunk://#diff-31e14a947994e18ba8b2dd583db1fbd7ac2145296b290e83d10b2966d8b23083R105-R106) [[4]](diffhunk://#diff-cd94fc8a1ae89eda691590c6a4b8038afbf6c20788c7da8dc461060ef7b127faR105-R106) [[5]](diffhunk://#diff-41e8924ab6bbc1147487c38e4b2c1b9a62447bb52c05339102e122f1cdd92ff6R105-R106) [[6]](diffhunk://#diff-cd79ee1eaaf9054e62502406769fd089c578c88da651bd4a573810d9d496f2e6R105-R106)
* Documented how to override the fixed peer-stage checkpoint used for validation by setting `pixart_validation_stage1_model` or `pixart_validation_stage2_model` when training only one stage. [[1]](diffhunk://#diff-60d9b7ebd163d65660f8e07b4f68908ec2ac3c81b247be91950293ac9aa1baefR105-R106) [[2]](diffhunk://#diff-562bfcdf5714bc346e89247b47ee18def6a4a926d1e80b1e7b8785e73c75c616R105-R106) [[3]](diffhunk://#diff-31e14a947994e18ba8b2dd583db1fbd7ac2145296b290e83d10b2966d8b23083R105-R106) [[4]](diffhunk://#diff-cd94fc8a1ae89eda691590c6a4b8038afbf6c20788c7da8dc461060ef7b127faR105-R106) [[5]](diffhunk://#diff-41e8924ab6bbc1147487c38e4b2c1b9a62447bb52c05339102e122f1cdd92ff6R105-R106) [[6]](diffhunk://#diff-cd79ee1eaaf9054e62502406769fd089c578c88da651bd4a573810d9d496f2e6R105-R106)