### PR TITLE
remove vLLM from base dependencies; it is captioning only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,6 @@ def get_cuda13_dependencies():
         "nvidia-ml-py>=12.555",
         "lm-eval>=0.4.4",
         "ramtorch",
-        VLLM_TORCH_211_DEPENDENCY,
     ]
 
 

--- a/tests/test_setup_platform_dependencies.py
+++ b/tests/test_setup_platform_dependencies.py
@@ -63,11 +63,17 @@ class SetupPlatformDependencyTests(unittest.TestCase):
                 self.assertTrue(expected.issubset(set(extras_require[extra_name])))
                 self.assertIn("transformer_engine[pytorch]>=2.16.0,<2.17.0", extras_require[extra_name])
 
-    def test_cuda13_vllm_uses_torch_211_compatible_release(self):
+    def test_cuda13_vllm_is_limited_to_captioning_extras(self):
         extras_require = load_setup_kwargs()["extras_require"]
         expected = "vllm>=0.20.0,<0.26.0"
 
-        for extra_name in ("cuda13", "captioning-cuda13", "cuda13-captioning"):
+        for extra_name in ("cuda", "cuda13", "cuda-nightly", "cuda13-nightly", "rocm", "apple", "cpu"):
+            with self.subTest(extra=extra_name):
+                dependencies = extras_require[extra_name]
+                self.assertNotIn(expected, dependencies)
+                self.assertFalse(any(dependency.startswith("vllm") for dependency in dependencies))
+
+        for extra_name in ("captioning-cuda13", "cuda13-captioning"):
             with self.subTest(extra=extra_name):
                 dependencies = extras_require[extra_name]
                 self.assertIn(expected, dependencies)


### PR DESCRIPTION
This pull request updates how the `vllm` dependency is managed for CUDA 13 environments, ensuring that it is only included with captioning-related extras and not with general CUDA dependencies. The main changes are as follows:

Dependency management changes:
* Removed the `VLLM_TORCH_211_DEPENDENCY` from the general CUDA 13 dependencies in `get_cuda13_dependencies`, so `vllm` is no longer installed for all CUDA 13 environments by default.

Test updates:
* Updated the test to ensure that the `vllm` dependency is only present in captioning-related CUDA 13 extras (such as `captioning-cuda13` and `cuda13-captioning`), and explicitly not present in general CUDA or other platform extras. This prevents accidental installation of `vllm` where it is not needed.