### PR TITLE
bugfix: unload model button should remain visible after env switch or reload

### DIFF
--- a/simpletuner/simpletuner_sdk/server/routes/checkpoints.py
+++ b/simpletuner/simpletuner_sdk/server/routes/checkpoints.py
@@ -143,6 +143,14 @@ async def inference_prompt_sources(
     return _call_service(CHECKPOINT_INFERENCE_SERVICE.prompt_sources, environment)
 
 
+@router.get("/inference/active")
+async def active_inference_session(
+    environment: str = Query(...),
+    _user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    return {"session": _call_service(CHECKPOINT_INFERENCE_SERVICE.active_environment_session, environment)}
+
+
 @router.post("/inference/start")
 async def start_inference(
     request: StartInferenceRequest,

--- a/simpletuner/simpletuner_sdk/server/services/checkpoint_inference_service.py
+++ b/simpletuner/simpletuner_sdk/server/services/checkpoint_inference_service.py
@@ -128,6 +128,26 @@ class CheckpointInferenceService:
                 self._discard_session(session_id)
         return active
 
+    def active_environment_session(self, environment: str) -> dict[str, Any] | None:
+        with self._lock:
+            session_id = self._environment_sessions.get(environment)
+            if not session_id:
+                return None
+            record = self._sessions.get(session_id)
+            if not record:
+                self._environment_sessions.pop(environment, None)
+                return None
+
+            process_status = process_keeper.get_process_status(record["job_id"])
+            if process_status not in {"pending", "running", "aborting"}:
+                self._discard_session(session_id)
+                return None
+
+        state = self.status(environment, session_id)
+        if state.get("status") in {"completed", "failed", "cancelled"}:
+            return None
+        return state
+
     def _discard_session(self, session_id: str) -> None:
         with self._lock:
             record = self._sessions.pop(session_id, None)

--- a/simpletuner/static/js/modules/checkpoints.js
+++ b/simpletuner/static/js/modules/checkpoints.js
@@ -555,9 +555,38 @@ if (!window.checkpointsManager) {
                 if (modalElement && window.bootstrap) {
                     window.bootstrap.Modal.getOrCreateInstance(modalElement).show();
                 }
-                const requests = [this.loadInferenceHistory(1)];
+                const requests = [this.loadInferenceHistory(1), this.loadActiveInferenceSession()];
                 if (tab === 'setup') requests.push(this.loadInferencePromptSources());
                 await Promise.all(requests);
+            },
+
+            async loadActiveInferenceSession() {
+                try {
+                    const environment = await this.ensureEnvironment();
+                    const response = await ApiClient.fetch(
+                        `/api/checkpoints/inference/active?environment=${encodeURIComponent(environment)}`
+                    );
+                    const data = await this._inferenceJson(response);
+                    if (data.session) {
+                        this.inference.session = data.session;
+                        if (this.inferenceIsActive()) {
+                            this.scheduleInferenceStatusPoll();
+                        }
+                        return data.session;
+                    }
+
+                    const currentStatus = this.inference.session?.status;
+                    const currentLooksLive = ['pending', 'queued', 'loading', 'running', 'unloading', 'cancelling', 'loaded']
+                        .includes(currentStatus);
+                    const currentEnvironment = this.inference.session?.environment || environment;
+                    if (currentLooksLive && currentEnvironment === environment) {
+                        this.inference.session = null;
+                    }
+                    return null;
+                } catch (error) {
+                    console.error('Failed to load active checkpoint inference session:', error);
+                    return null;
+                }
             },
 
             async loadInferencePromptSources() {

--- a/tests/js/checkpoints_inference.test.js
+++ b/tests/js/checkpoints_inference.test.js
@@ -205,6 +205,46 @@ describe('checkpoint inference manager', () => {
         );
     });
 
+    test('recovers active loaded inference session for current environment', async () => {
+        window.ApiClient.fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                session: {
+                    session_id: 'session-one',
+                    environment: 'test-environment',
+                    status: 'loaded',
+                    loaded_checkpoint: 'checkpoint-100',
+                },
+            }),
+        });
+
+        const result = await manager.loadActiveInferenceSession();
+
+        expect(result.session_id).toBe('session-one');
+        expect(manager.inference.session.status).toBe('loaded');
+        expect(manager.inference.session.loaded_checkpoint).toBe('checkpoint-100');
+        expect(window.ApiClient.fetch).toHaveBeenCalledWith(
+            '/api/checkpoints/inference/active?environment=test-environment'
+        );
+    });
+
+    test('clears stale loaded inference session when no active worker remains', async () => {
+        manager.inference.session = {
+            session_id: 'session-one',
+            environment: 'test-environment',
+            status: 'loaded',
+        };
+        window.ApiClient.fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({ session: null }),
+        });
+
+        const result = await manager.loadActiveInferenceSession();
+
+        expect(result).toBeNull();
+        expect(manager.inference.session).toBeNull();
+    });
+
     test('selects and deletes inference history samples', async () => {
         manager.inference.history = [
             { media_path: 'session-one/checkpoint-100/one.png' },

--- a/tests/test_checkpoint_inference_routes.py
+++ b/tests/test_checkpoint_inference_routes.py
@@ -57,6 +57,19 @@ class CheckpointInferenceRoutesTestCase(_WebUIBaseTestCase, unittest.TestCase):
         self.assertEqual(response.status_code, 409)
         self.assertEqual(response.json()["detail"], "accelerator busy")
 
+    def test_active_inference_session_returns_environment_session(self) -> None:
+        response_payload = {"session_id": "session-one", "status": "loaded"}
+        with patch.object(
+            CHECKPOINT_INFERENCE_SERVICE,
+            "active_environment_session",
+            return_value=response_payload,
+        ) as active_environment_session:
+            response = self.client.get("/api/checkpoints/inference/active?environment=test")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"session": response_payload})
+        active_environment_session.assert_called_once_with("test")
+
     def test_delete_history_forwards_selected_media_paths(self) -> None:
         response_payload = {"deleted_count": 2, "media_paths": ["one.png", "two.png"]}
         with patch.object(CHECKPOINT_INFERENCE_SERVICE, "delete_history", return_value=response_payload) as delete_history:

--- a/tests/test_checkpoint_inference_service.py
+++ b/tests/test_checkpoint_inference_service.py
@@ -374,6 +374,53 @@ class TestCheckpointInferenceService(unittest.TestCase):
         self.assertNotIn("test", self.service._environment_sessions)
 
     @patch("simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service.process_keeper")
+    def test_active_environment_session_returns_loaded_worker_state(self, process_keeper: MagicMock) -> None:
+        session_id = "session-one"
+        session_dir = self.output_dir / "inference" / session_id
+        session_dir.mkdir(parents=True)
+        (session_dir / "session.json").write_text(
+            json.dumps(
+                {
+                    "session_id": session_id,
+                    "environment": "test",
+                    "status": "loaded",
+                    "loaded_checkpoint": "checkpoint-100",
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.service._sessions[session_id] = {
+            "session_id": session_id,
+            "job_id": "infer-one",
+            "environment": "test",
+        }
+        self.service._environment_sessions["test"] = session_id
+        process_keeper.get_process_status.return_value = "running"
+
+        result = self.service.active_environment_session("test")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["status"], "loaded")
+        self.assertEqual(result["loaded_checkpoint"], "checkpoint-100")
+
+    @patch("simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service.process_keeper")
+    def test_active_environment_session_discards_stale_worker_record(self, process_keeper: MagicMock) -> None:
+        session_id = "session-one"
+        self.service._sessions[session_id] = {
+            "session_id": session_id,
+            "job_id": "infer-one",
+            "environment": "test",
+        }
+        self.service._environment_sessions["test"] = session_id
+        process_keeper.get_process_status.return_value = "completed"
+
+        result = self.service.active_environment_session("test")
+
+        self.assertIsNone(result)
+        self.assertNotIn(session_id, self.service._sessions)
+        self.assertNotIn("test", self.service._environment_sessions)
+
+    @patch("simpletuner.simpletuner_sdk.server.services.checkpoint_inference_service.process_keeper")
     def test_generate_queues_prompt_for_loaded_worker(self, process_keeper: MagicMock) -> None:
         session_id = "session-one"
         session_dir = self.output_dir / "inference" / session_id


### PR DESCRIPTION
This pull request adds support for querying the currently active inference session for a given environment, improves the frontend logic to recover or clear session state accordingly, and introduces comprehensive tests for these new behaviors. The main changes span backend API additions, service logic, frontend integration, and tests.

**API and Service Enhancements:**
- Added a new GET endpoint `/api/checkpoints/inference/active` that returns the active inference session for a specified environment (`checkpoints.py`).
- Implemented `active_environment_session` in `CheckpointInferenceService` to safely retrieve the session state for an environment, discarding it if the worker is no longer active (`checkpoint_inference_service.py`).

**Frontend Integration:**
- Updated the checkpoints manager to load the active inference session when opening the inference modal, updating or clearing the session state as appropriate (`checkpoints.js`).

**Testing:**
- Added frontend tests to ensure the active session is correctly recovered or cleared depending on backend response (`checkpoints_inference.test.js`).
- Added backend tests for the new endpoint and service logic, covering both session recovery and stale session discarding (`test_checkpoint_inference_routes.py`, `test_checkpoint_inference_service.py`). [[1]](diffhunk://#diff-b05d788972adb803dc16f8e184bb560453a9f2ad407fb3f9d125a3118a5206efR60-R72) [[2]](diffhunk://#diff-1682107619a3b74054223227530b35321197145d8ea228e5b8dd86847a32229bR376-R422)