### PR TITLE
local data backend double-traversal fix

### DIFF
--- a/simpletuner/helpers/data_backend/local.py
+++ b/simpletuner/helpers/data_backend/local.py
@@ -138,51 +138,34 @@ class LocalDataBackend(BaseDataBackend):
         if not file_extensions:
             file_extensions = self._default_file_extensions()
 
-        def _rglob_follow_symlinks(path: Path, extensions: List[str]):
-            # Skip Spotlight and Jupyter directories
-            forbidden_directories = {
-                ".Spotlight-V100",
-                ".Trashes",
-                ".fseventsd",
-                ".TemporaryItems",
-                ".zfs",
-                ".ipynb_checkpoints",
-            }
-            if path.name in forbidden_directories:
-                return
+        forbidden_directories = {
+            ".Spotlight-V100",
+            ".Trashes",
+            ".fseventsd",
+            ".TemporaryItems",
+            ".zfs",
+            ".ipynb_checkpoints",
+        }
+        extensions = {ext.lower().lstrip(".") for ext in file_extensions} if file_extensions else None
 
-            # If no extensions are provided, list all files
-            if not extensions:
-                for p in path.rglob("*"):
-                    if p.is_file():
-                        yield p
-            else:
-                for ext in extensions:
-                    for p in path.rglob(ext):
-                        if p.is_file():
-                            yield p
-
-            for p in path.iterdir():
-                if p.is_dir() and not p.is_symlink():
-                    yield from _rglob_follow_symlinks(p, extensions)
-                elif p.is_symlink():
-                    try:
-                        real_path = p.resolve()
-                        if real_path.is_dir():
-                            yield from _rglob_follow_symlinks(real_path, extensions)
-                    except Exception as e:
-                        logger.warning(f"Broken symlink encountered: {p} - {e}")
-
-        # Prepare the extensions for globbing
-        extensions = [f"*.{ext.lower()}" for ext in file_extensions] if file_extensions else None
-
-        paths = list(_rglob_follow_symlinks(Path(instance_data_dir), extensions))
-
-        # Group files by their parent directory
         path_dict = {}
-        for path in paths:
-            parent = str(path.parent)
-            path_dict.setdefault(parent, []).append(str(path.absolute()))
+        seen_directories = set()
+        for root, dirs, files in os.walk(instance_data_dir, followlinks=True):
+            real_root = os.path.realpath(root)
+            if real_root in seen_directories:
+                dirs.clear()
+                continue
+            seen_directories.add(real_root)
+            dirs[:] = [directory for directory in dirs if directory not in forbidden_directories]
+
+            for filename in files:
+                if extensions:
+                    ext = os.path.splitext(filename)[1].lower().lstrip(".")
+                    if ext not in extensions:
+                        continue
+                path = Path(root) / filename
+                parent = str(path.parent)
+                path_dict.setdefault(parent, []).append(str(path.absolute()))
 
         results = [(subdir, [], files) for subdir, files in path_dict.items()]
         return results

--- a/tests/helpers/data_backend/test_local_files.py
+++ b/tests/helpers/data_backend/test_local_files.py
@@ -1,0 +1,66 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from simpletuner.helpers.data_backend.local import LocalDataBackend
+
+
+class TestLocalDataBackendListFiles(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.backend = LocalDataBackend(accelerator=None, id="test_local")
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _write_file(self, relative_path: str):
+        path = self.root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"test")
+        return path
+
+    def _flatten_listing(self, listing):
+        return [file for _subdir, _dirs, files in listing for file in files]
+
+    def test_list_files_does_not_duplicate_nested_files(self):
+        files = [
+            self._write_file("root.jpg"),
+            self._write_file("a/one.JPG"),
+            self._write_file("a/b/two.jpg"),
+        ]
+        self._write_file("a/b/ignored.txt")
+
+        listing = self.backend.list_files(file_extensions=["jpg"], instance_data_dir=str(self.root))
+        listed_files = self._flatten_listing(listing)
+
+        self.assertCountEqual(listed_files, [str(path.absolute()) for path in files])
+        self.assertEqual(len(listed_files), len(set(listed_files)))
+
+    def test_list_files_follows_symlink_directories_without_cycles(self):
+        target = self.root / "target"
+        target.mkdir()
+        file_path = self._write_file("target/image.jpg")
+        symlink_path = self.root / "target" / "loop"
+        try:
+            symlink_path.symlink_to(self.root, target_is_directory=True)
+        except OSError as exc:
+            self.skipTest(f"Symlinks are not available: {exc}")
+
+        listing = self.backend.list_files(file_extensions=["jpg"], instance_data_dir=str(self.root))
+        listed_files = self._flatten_listing(listing)
+
+        self.assertEqual(listed_files, [str(file_path.absolute())])
+
+    def test_list_files_prunes_forbidden_directories(self):
+        self._write_file("visible.jpg")
+        self._write_file(".ipynb_checkpoints/hidden.jpg")
+
+        listing = self.backend.list_files(file_extensions=["jpg"], instance_data_dir=str(self.root))
+        listed_files = self._flatten_listing(listing)
+
+        self.assertEqual(listed_files, [str((self.root / "visible.jpg").absolute())])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request refactors the `list_files` method in `LocalDataBackend` to improve file discovery, especially with symlinks and forbidden directories, and adds comprehensive unit tests to ensure correct behavior. The new implementation uses `os.walk` to traverse directories, prevents duplicate file listings due to symlink cycles, and excludes files in forbidden directories.

**Refactor and bug fixes in file listing:**

* Rewrote the file discovery logic in `list_files` to use `os.walk` with symlink support, preventing duplicate files from symlink cycles and ensuring forbidden directories are pruned from traversal. [[1]](diffhunk://#diff-75e53e112ed370aff7f11f9abcdbeccbcb4ecdee2c827bff4efbe9b22e45cc37L141-L142) [[2]](diffhunk://#diff-75e53e112ed370aff7f11f9abcdbeccbcb4ecdee2c827bff4efbe9b22e45cc37L151-R166)

**Testing improvements:**

* Added a new test suite `TestLocalDataBackendListFiles` in `test_local_files.py` to verify that:
  - Nested files are not duplicated.
  - Symlinked directories are followed without causing cycles.
  - Forbidden directories (like `.ipynb_checkpoints`) are properly excluded from results.