### PR TITLE
tests: add coverage for extraction script

### DIFF
--- a/tests/test_extract_model_metadata.py
+++ b/tests/test_extract_model_metadata.py
@@ -1,0 +1,43 @@
+import types
+import unittest
+
+from scripts.extract_model_metadata import extract_metadata_from_module
+
+
+class ExtractModelMetadataTestCase(unittest.TestCase):
+    def test_ignores_imported_model_classes(self) -> None:
+        module = types.ModuleType("simpletuner.helpers.models.boogu_image.model")
+
+        class ImportedFlux:
+            NAME = "Flux.1"
+
+            @classmethod
+            def get_flavour_choices(cls):
+                return ["dev"]
+
+        class LocalBooguImage:
+            NAME = "Boogu-Image"
+            PREDICTION_TYPE = "flow_matching"
+
+            @classmethod
+            def get_flavour_choices(cls):
+                return ["v0.1-base", "v0.1-turbo"]
+
+        ImportedFlux.__module__ = "simpletuner.helpers.models.flux.model"
+        LocalBooguImage.__module__ = module.__name__
+        module.Flux = ImportedFlux
+        module.BooguImage = LocalBooguImage
+
+        result = extract_metadata_from_module(
+            module,
+            "simpletuner.helpers.models.boogu_image.model",
+            "boogu_image",
+        )
+
+        self.assertEqual(result["class_name"], "BooguImage")
+        self.assertEqual(result["name"], "Boogu-Image")
+        self.assertEqual(result["flavour_choices"], ["v0.1-base", "v0.1-turbo"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request adds a new unit test to verify that the `extract_metadata_from_module` function correctly ignores imported model classes and only extracts metadata from local model classes. The test ensures the function behaves as expected when both local and imported classes are present in a module.

Testing improvements:

* Added `ExtractModelMetadataTestCase` to `tests/test_extract_model_metadata.py` to test that `extract_metadata_from_module` ignores imported model classes and extracts metadata only from local classes.