### PR TITLE
FSDP: disable cpu memory efficiency knob when loading text encoder(s)

### DIFF
--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -2341,7 +2341,7 @@ class Trainer:
             yield
         finally:
             if previous_value is None:
-                os.environ[env_name] = str(bool(getattr(fsdp_plugin, "cpu_ram_efficient_loading", False)))
+                os.environ.pop(env_name, None)
             else:
                 os.environ[env_name] = previous_value
 

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -24,6 +24,7 @@ import threading
 import time
 from collections import deque
 from concurrent.futures import Future, ThreadPoolExecutor
+from contextlib import contextmanager
 from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
@@ -2323,8 +2324,30 @@ class Trainer:
         StateTracker.set_vae_dtype(self.model.vae.dtype)
         StateTracker.set_vae(self.model.vae)
 
+    @contextmanager
+    def _disable_fsdp_cpu_ram_efficient_loading_for_text_encoder(self):
+        accelerator = getattr(self, "accelerator", None)
+        state = getattr(accelerator, "state", None)
+        distributed_type = getattr(state, "distributed_type", getattr(accelerator, "distributed_type", None))
+        fsdp_plugin = getattr(state, "fsdp_plugin", None)
+        if distributed_type != DistributedType.FSDP or not getattr(fsdp_plugin, "cpu_ram_efficient_loading", False):
+            yield
+            return
+
+        env_name = "FSDP_CPU_RAM_EFFICIENT_LOADING"
+        previous_value = os.environ.get(env_name)
+        os.environ[env_name] = "False"
+        try:
+            yield
+        finally:
+            if previous_value is None:
+                os.environ[env_name] = str(bool(getattr(fsdp_plugin, "cpu_ram_efficient_loading", False)))
+            else:
+                os.environ[env_name] = previous_value
+
     def init_text_encoder(self, move_to_accelerator: bool = True):
-        self.model.load_text_encoder(move_to_device=move_to_accelerator)
+        with self._disable_fsdp_cpu_ram_efficient_loading_for_text_encoder():
+            self.model.load_text_encoder(move_to_device=move_to_accelerator)
 
     def init_freeze_models(self):
         self.model.freeze_components()

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -667,7 +667,7 @@ class TestTrainer(unittest.TestCase):
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("FSDP_CPU_RAM_EFFICIENT_LOADING", None)
             trainer.init_text_encoder()
-            self.assertEqual(os.environ["FSDP_CPU_RAM_EFFICIENT_LOADING"], "True")
+            self.assertNotIn("FSDP_CPU_RAM_EFFICIENT_LOADING", os.environ)
 
     def test_init_text_encoder_leaves_env_unchanged_without_fsdp_cpu_ram_efficient_loading(self):
         trainer = object.__new__(Trainer)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -610,6 +610,86 @@ except ImportError:
 
 
 class TestTrainer(unittest.TestCase):
+    def test_init_text_encoder_disables_fsdp_cpu_ram_efficient_loading_during_load(self):
+        trainer = object.__new__(Trainer)
+        observed_env_values = []
+
+        def load_text_encoder(move_to_device: bool = True):
+            observed_env_values.append((move_to_device, os.environ.get("FSDP_CPU_RAM_EFFICIENT_LOADING")))
+
+        trainer.model = SimpleNamespace(load_text_encoder=load_text_encoder)
+        trainer.accelerator = SimpleNamespace(
+            state=SimpleNamespace(
+                distributed_type=DistributedType.FSDP,
+                fsdp_plugin=SimpleNamespace(cpu_ram_efficient_loading=True),
+            )
+        )
+
+        with patch.dict(os.environ, {"FSDP_CPU_RAM_EFFICIENT_LOADING": "True"}, clear=False):
+            trainer.init_text_encoder(move_to_accelerator=False)
+            self.assertEqual(os.environ["FSDP_CPU_RAM_EFFICIENT_LOADING"], "True")
+
+        self.assertEqual(observed_env_values, [(False, "False")])
+
+    def test_init_text_encoder_restores_fsdp_cpu_ram_efficient_loading_after_error(self):
+        trainer = object.__new__(Trainer)
+
+        def load_text_encoder(move_to_device: bool = True):
+            raise RuntimeError("load failed")
+
+        trainer.model = SimpleNamespace(load_text_encoder=load_text_encoder)
+        trainer.accelerator = SimpleNamespace(
+            state=SimpleNamespace(
+                distributed_type=DistributedType.FSDP,
+                fsdp_plugin=SimpleNamespace(cpu_ram_efficient_loading=True),
+            )
+        )
+
+        with patch.dict(os.environ, {"FSDP_CPU_RAM_EFFICIENT_LOADING": "True"}, clear=False):
+            with self.assertRaisesRegex(RuntimeError, "load failed"):
+                trainer.init_text_encoder()
+            self.assertEqual(os.environ["FSDP_CPU_RAM_EFFICIENT_LOADING"], "True")
+
+    def test_init_text_encoder_restores_missing_env_from_fsdp_plugin_state(self):
+        trainer = object.__new__(Trainer)
+
+        def load_text_encoder(move_to_device: bool = True):
+            self.assertEqual(os.environ.get("FSDP_CPU_RAM_EFFICIENT_LOADING"), "False")
+
+        trainer.model = SimpleNamespace(load_text_encoder=load_text_encoder)
+        trainer.accelerator = SimpleNamespace(
+            state=SimpleNamespace(
+                distributed_type=DistributedType.FSDP,
+                fsdp_plugin=SimpleNamespace(cpu_ram_efficient_loading=True),
+            )
+        )
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("FSDP_CPU_RAM_EFFICIENT_LOADING", None)
+            trainer.init_text_encoder()
+            self.assertEqual(os.environ["FSDP_CPU_RAM_EFFICIENT_LOADING"], "True")
+
+    def test_init_text_encoder_leaves_env_unchanged_without_fsdp_cpu_ram_efficient_loading(self):
+        trainer = object.__new__(Trainer)
+        observed_env_values = []
+
+        def load_text_encoder(move_to_device: bool = True):
+            observed_env_values.append(os.environ.get("FSDP_CPU_RAM_EFFICIENT_LOADING"))
+
+        trainer.model = SimpleNamespace(load_text_encoder=load_text_encoder)
+        trainer.accelerator = SimpleNamespace(
+            state=SimpleNamespace(
+                distributed_type=DistributedType.FSDP,
+                fsdp_plugin=SimpleNamespace(cpu_ram_efficient_loading=False),
+            )
+        )
+
+        with patch.dict(os.environ, {"FSDP_CPU_RAM_EFFICIENT_LOADING": "True"}, clear=False):
+            trainer.init_text_encoder()
+            self.assertEqual(os.environ["FSDP_CPU_RAM_EFFICIENT_LOADING"], "True")
+
+        self.assertEqual(observed_env_values, ["True"])
+
     def test_resolve_ddp_find_unused_parameters_uses_explicit_config(self):
         trainer = object.__new__(Trainer)
         trainer.config = SimpleNamespace(find_unused_parameters=False, model_family="ltxvideo2")


### PR DESCRIPTION
This pull request introduces a new context manager to the `Trainer` class to ensure that the `FSDP_CPU_RAM_EFFICIENT_LOADING` environment variable is temporarily disabled during text encoder initialization, and restores its previous value afterward. It also adds comprehensive unit tests to verify this behavior under various scenarios.

**Enhancements to FSDP environment variable handling:**

* Added a `_disable_fsdp_cpu_ram_efficient_loading_for_text_encoder` context manager to `Trainer` to temporarily set `FSDP_CPU_RAM_EFFICIENT_LOADING` to `"False"` during `init_text_encoder`, ensuring correct loading behavior for FSDP setups and restoring the original value after loading or on error.
* Modified `init_text_encoder` to use this context manager, encapsulating the environment variable logic.

**Testing improvements:**

* Added multiple unit tests in `tests/test_trainer.py` to verify that `init_text_encoder` correctly disables, restores, or leaves unchanged the `FSDP_CPU_RAM_EFFICIENT_LOADING` environment variable as appropriate, including error and edge cases.

**Dependency updates:**

* Imported `contextlib.contextmanager` to support the new context manager implementation.