### PR TITLE
use a set instead of list for VAECache unprocessed file lookups

### DIFF
--- a/simpletuner/helpers/caching/vae.py
+++ b/simpletuner/helpers/caching/vae.py
@@ -230,6 +230,8 @@ class VAECache(WebhookMixin):
         self.process_queue = Queue()
         self.write_queue = Queue()
         self.vae_input_queue = Queue()
+        self._local_unprocessed_files_set_source = None
+        self._local_unprocessed_files_set = None
 
         # Initialize batch processing helper
         self.batch_processor = BatchedTrainingSamples()
@@ -969,6 +971,8 @@ class VAECache(WebhookMixin):
                 continue
 
         self.local_unprocessed_files = list(set(all_image_files) - set(already_cached_images))
+        self._local_unprocessed_files_set_source = None
+        self._local_unprocessed_files_set = None
         if os.environ.get("SIMPLETUNER_LOG_LEVEL", None) == "DEBUG":
             self.debug_log(f"All ({len(all_image_files)}) image files: (truncated) {list(all_image_files)[:5]}")
             self.debug_log(f"Existing cache files: (truncated) {list(existing_cache_files)[:5]}")
@@ -976,6 +980,13 @@ class VAECache(WebhookMixin):
             self.debug_log(f"VAECache Mapping: (truncated) {list(self.image_path_to_vae_path.items())[:5]}")
 
         return self.local_unprocessed_files
+
+    def _local_unprocessed_file_set(self):
+        source = self.local_unprocessed_files
+        if source is not getattr(self, "_local_unprocessed_files_set_source", None):
+            self._local_unprocessed_files_set_source = source
+            self._local_unprocessed_files_set = set(source)
+        return self._local_unprocessed_files_set
 
     def _reduce_bucket(
         self,
@@ -986,13 +997,14 @@ class VAECache(WebhookMixin):
         relevant_files = []
         total_files = 0
         skipped_files = 0
+        local_unprocessed_files = self._local_unprocessed_file_set()
         for full_image_path in aspect_bucket_cache[bucket]:
             total_files += 1
             comparison_path = self.generate_vae_cache_filename(full_image_path)[0]
             if os.path.splitext(comparison_path)[0] in processed_images:
                 skipped_files += 1
                 continue
-            if full_image_path not in self.local_unprocessed_files:
+            if full_image_path not in local_unprocessed_files:
                 skipped_files += 1
                 continue
             relevant_files.append(full_image_path)
@@ -1986,6 +1998,7 @@ class VAECache(WebhookMixin):
                         "total": 0,
                     }
                     last_reported_index = 0
+                    local_unprocessed_files = self._local_unprocessed_file_set()
 
                     for raw_filepath in tqdm(
                         relevant_files,
@@ -2002,7 +2015,7 @@ class VAECache(WebhookMixin):
                         test_filepath = self._image_filename_from_vaecache_filename(filepath)
                         if test_filepath is None:
                             continue
-                        if test_filepath not in self.local_unprocessed_files:
+                        if test_filepath not in local_unprocessed_files:
                             statistics["not_local"] += 1
                             continue
                         try:

--- a/tests/test_vae.py
+++ b/tests/test_vae.py
@@ -164,6 +164,17 @@ class TestVaeCache(unittest.TestCase):
             file_extensions=video_file_extensions,
         )
 
+    def test_local_unprocessed_file_set_tracks_reassigned_file_list(self):
+        vae_cache = VAECache.__new__(VAECache)
+        vae_cache.local_unprocessed_files = ["/data/first.png"]
+
+        self.assertIn("/data/first.png", vae_cache._local_unprocessed_file_set())
+
+        vae_cache.local_unprocessed_files = ["/data/second.png"]
+
+        self.assertNotIn("/data/first.png", vae_cache._local_unprocessed_file_set())
+        self.assertIn("/data/second.png", vae_cache._local_unprocessed_file_set())
+
 
 class DummyAccelerator:
     def __init__(self):


### PR DESCRIPTION
This pull request optimizes how the `VAECache` class handles and checks membership in the `local_unprocessed_files` list by introducing a cached set representation, which improves performance and ensures correctness when the file list changes. It also adds a unit test to verify this behavior.

**Performance and correctness improvements:**

* Added a cached set (`_local_unprocessed_files_set`) and its source tracker to `VAECache`, with a helper method `_local_unprocessed_file_set()` that keeps the set in sync with `local_unprocessed_files` and is used for faster membership checks. [[1]](diffhunk://#diff-614668871ca0c481a8427daef01930a4dbbf640cd7c1b15e3fba9d8d2cbe4f4eR233-R234) [[2]](diffhunk://#diff-614668871ca0c481a8427daef01930a4dbbf640cd7c1b15e3fba9d8d2cbe4f4eR984-R990)
* Updated methods (`_reduce_bucket` and `process_buckets`) to use the cached set for membership checks instead of the list, improving performance and correctness. [[1]](diffhunk://#diff-614668871ca0c481a8427daef01930a4dbbf640cd7c1b15e3fba9d8d2cbe4f4eR1000-R1007) [[2]](diffhunk://#diff-614668871ca0c481a8427daef01930a4dbbf640cd7c1b15e3fba9d8d2cbe4f4eR2001) [[3]](diffhunk://#diff-614668871ca0c481a8427daef01930a4dbbf640cd7c1b15e3fba9d8d2cbe4f4eL2005-R2018)
* Reset the cached set and its source to `None` whenever `discover_unprocessed_files` updates the file list, ensuring the cache stays accurate.

**Testing:**

* Added a unit test `test_local_unprocessed_file_set_tracks_reassigned_file_list` to verify that the cached set properly tracks changes to `local_unprocessed_files`.