### PR TITLE
local data backend: thread-parallel read and write

### DIFF
--- a/simpletuner/helpers/data_backend/local.py
+++ b/simpletuner/helpers/data_backend/local.py
@@ -378,4 +378,5 @@ class LocalDataBackend(BaseDataBackend):
 
         max_workers = min(16, max(1, len(filepaths)))
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            list(executor.map(write_one, zip(filepaths, data_list)))
+            for _ in executor.map(write_one, zip(filepaths, data_list)):
+                pass

--- a/simpletuner/helpers/data_backend/local.py
+++ b/simpletuner/helpers/data_backend/local.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 from pathlib import Path
 from typing import Any, List, Tuple, Union
@@ -256,31 +257,43 @@ class LocalDataBackend(BaseDataBackend):
             raise ValueError(f"read_image_batch must be given a list of image filepaths. Received type: {type(filepaths)}")
         output_images = []
         available_keys = []
-        for filepath in filepaths:
+
+        def read_one(filepath: str) -> tuple[str, Any, Exception | None]:
             try:
                 image_data = self.read_image(filepath, delete_problematic_images)
+                return filepath, image_data, None
+            except Exception as e:
+                return filepath, None, e
+
+        max_workers = min(16, max(1, len(filepaths)))
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            results = list(executor.map(read_one, filepaths))
+
+        for filepath, image_data, error in results:
+            if error is None:
                 if image_data is None:
                     log_level = logging.WARNING if should_log() else logging.DEBUG
                     logger.log(log_level, f"Unable to load image '{filepath}', skipping.")
                     continue
                 output_images.append(image_data)
                 available_keys.append(filepath)
-            except Exception as e:
-                if delete_problematic_images:
-                    logger.error(f"Deleting image '{filepath}', because --delete_problematic_images is provided. Error: {e}")
-                    try:
-                        self.delete(filepath)
-                    except Exception as del_e:
-                        logger.error(f"Failed to delete problematic image {filepath}: {del_e}")
-                else:
-                    log_level = logging.WARNING if should_log() else logging.DEBUG
-                    logger.log(
-                        log_level,
-                        (
-                            f"A problematic image {filepath} is detected, but we are not allowed to remove it, because "
-                            f"--delete_problematic_images is not provided. Please correct this manually. Error: {e}"
-                        ),
-                    )
+                continue
+
+            if delete_problematic_images:
+                logger.error(f"Deleting image '{filepath}', because --delete_problematic_images is provided. Error: {error}")
+                try:
+                    self.delete(filepath)
+                except Exception as del_e:
+                    logger.error(f"Failed to delete problematic image {filepath}: {del_e}")
+            else:
+                log_level = logging.WARNING if should_log() else logging.DEBUG
+                logger.log(
+                    log_level,
+                    (
+                        f"A problematic image {filepath} is detected, but we are not allowed to remove it, because "
+                        f"--delete_problematic_images is not provided. Please correct this manually. Error: {error}"
+                    ),
+                )
         return available_keys, output_images
 
     def create_directory(self, directory_path: str) -> None:
@@ -354,10 +367,15 @@ class LocalDataBackend(BaseDataBackend):
             logger.error(error_msg)
             raise ValueError(error_msg)
 
-        for filepath, data in zip(filepaths, data_list):
+        def write_one(item: tuple[str, Any]) -> None:
+            filepath, data = item
             try:
                 self.write(filepath, data)
                 logger.debug(f"Successfully wrote to {filepath}")
             except Exception as e:
                 logger.error(f"Failed to write to {filepath}: {e}")
                 raise
+
+        max_workers = min(16, max(1, len(filepaths)))
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            list(executor.map(write_one, zip(filepaths, data_list)))

--- a/simpletuner/helpers/data_backend/local.py
+++ b/simpletuner/helpers/data_backend/local.py
@@ -267,7 +267,7 @@ class LocalDataBackend(BaseDataBackend):
 
         max_workers = min(16, max(1, len(filepaths)))
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            results = list(executor.map(read_one, filepaths))
+            results = executor.map(read_one, filepaths)
 
         for filepath, image_data, error in results:
             if error is None:

--- a/tests/helpers/data_backend/test_local_files.py
+++ b/tests/helpers/data_backend/test_local_files.py
@@ -1,6 +1,7 @@
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import Mock
 
 from simpletuner.helpers.data_backend.local import LocalDataBackend
 
@@ -60,6 +61,41 @@ class TestLocalDataBackendListFiles(unittest.TestCase):
         listed_files = self._flatten_listing(listing)
 
         self.assertEqual(listed_files, [str((self.root / "visible.jpg").absolute())])
+
+    def test_read_image_batch_preserves_order_and_skips_failures(self):
+        paths = ["first.jpg", "bad.jpg", "second.jpg"]
+
+        def read_image(filepath, delete_problematic_images=False):
+            if filepath == "bad.jpg":
+                raise ValueError("corrupt")
+            return f"image:{filepath}"
+
+        self.backend.read_image = Mock(side_effect=read_image)
+
+        keys, images = self.backend.read_image_batch(paths)
+
+        self.assertEqual(keys, ["first.jpg", "second.jpg"])
+        self.assertEqual(images, ["image:first.jpg", "image:second.jpg"])
+
+    def test_read_image_batch_deletes_problematic_images_when_requested(self):
+        self.backend.read_image = Mock(side_effect=ValueError("corrupt"))
+        self.backend.delete = Mock()
+
+        keys, images = self.backend.read_image_batch(["bad.jpg"], delete_problematic_images=True)
+
+        self.assertEqual(keys, [])
+        self.assertEqual(images, [])
+        self.backend.delete.assert_called_once_with("bad.jpg")
+
+    def test_write_batch_raises_worker_errors(self):
+        def write(filepath, data):
+            if filepath == "bad.pt":
+                raise OSError("disk full")
+
+        self.backend.write = Mock(side_effect=write)
+
+        with self.assertRaises(OSError):
+            self.backend.write_batch(["ok.pt", "bad.pt"], [b"ok", b"bad"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request adds parallel processing to the `LocalDataBackend`'s image reading and writing methods for improved performance, and introduces new tests to ensure correct behavior, especially with error handling and order preservation. The main changes are grouped below:

**Performance improvements:**

* Updated `read_image_batch` and `write_batch` methods in `simpletuner/helpers/data_backend/local.py` to use `ThreadPoolExecutor` for parallel processing, significantly speeding up batch operations. [[1]](diffhunk://#diff-75e53e112ed370aff7f11f9abcdbeccbcb4ecdee2c827bff4efbe9b22e45cc37R3) [[2]](diffhunk://#diff-75e53e112ed370aff7f11f9abcdbeccbcb4ecdee2c827bff4efbe9b22e45cc37L259-R283) [[3]](diffhunk://#diff-75e53e112ed370aff7f11f9abcdbeccbcb4ecdee2c827bff4efbe9b22e45cc37L357-R381)

**Error handling and robustness:**

* Refactored error handling in `read_image_batch` to properly delete problematic images when requested and to log errors with more accurate exception reporting. [[1]](diffhunk://#diff-75e53e112ed370aff7f11f9abcdbeccbcb4ecdee2c827bff4efbe9b22e45cc37L259-R283) [[2]](diffhunk://#diff-75e53e112ed370aff7f11f9abcdbeccbcb4ecdee2c827bff4efbe9b22e45cc37L281-R294)
* Ensured that exceptions raised during parallel write operations in `write_batch` are properly propagated.

**Testing improvements:**

* Added new unit tests in `tests/helpers/data_backend/test_local_files.py` to verify that `read_image_batch` preserves order, skips failures, deletes problematic images when requested, and that `write_batch` correctly raises worker errors.
* Added `unittest.mock` usage to facilitate mocking in tests.