### PR TITLE
SDXL: pooled prompt embeds need batch dim for batched writer

### DIFF
--- a/simpletuner/helpers/caching/text_embeds.py
+++ b/simpletuner/helpers/caching/text_embeds.py
@@ -229,11 +229,15 @@ class TextEmbeddingCache(WebhookMixin):
             if not isinstance(value, torch.Tensor):
                 per_sample_output[key] = value
                 continue
+            if value.ndim > 0 and value.shape[0] != batch_size and batch_size == 1:
+                value = value.unsqueeze(0)
             if value.shape[0] != batch_size:
                 raise ValueError(
                     f"Batched text encoder output '{key}' shape {tuple(value.shape)} does not match batch size {batch_size}."
                 )
             sample_value = value[batch_index : batch_index + 1]
+            if key in {"pooled_prompt_embeds", "negative_pooled_prompt_embeds"} and sample_value.ndim == 2:
+                sample_value = sample_value.squeeze(0)
             if true_length is not None and key in {"prompt_embeds", "attention_mask"} and sample_value.ndim >= 2:
                 sample_value = sample_value[:, :true_length]
             per_sample_output[key] = sample_value.clone().contiguous()

--- a/tests/test_text_embeds.py
+++ b/tests/test_text_embeds.py
@@ -236,6 +236,44 @@ class TextEmbeddingCacheKeyTests(unittest.TestCase):
         self.assertEqual(saved[1][1]["attention_mask"].shape, torch.Size([1, 3]))
         self.assertEqual(saved[0][1]["add_text_embeds"].shape, torch.Size([1, 5]))
 
+    def test_batched_encode_normalizes_single_sample_pooled_outputs(self):
+        for pooled_is_batched in (False, True):
+            with self.subTest(pooled_is_batched=pooled_is_batched):
+                cache = _make_cache(TextEmbedCacheKey.CAPTION)
+                saved = []
+                cache.save_to_cache = lambda filename, embeddings: saved.append((filename, embeddings))
+
+                class BatchModel(_DummyModel):
+                    def __init__(self):
+                        super().__init__(TextEmbedCacheKey.CAPTION)
+
+                    def encode_text_batch(self, prompts, is_negative_prompt=False, prompt_contexts=None):
+                        pooled_prompt_embeds = torch.arange(5, dtype=torch.float32)
+                        negative_pooled_prompt_embeds = torch.arange(5, 10, dtype=torch.float32)
+                        if pooled_is_batched:
+                            pooled_prompt_embeds = pooled_prompt_embeds.unsqueeze(0)
+                            negative_pooled_prompt_embeds = negative_pooled_prompt_embeds.unsqueeze(0)
+                        return {
+                            "prompt_embeds": torch.ones(1, 2, 3),
+                            "attention_mask": torch.ones(1, 2, dtype=torch.bool),
+                            "pooled_prompt_embeds": pooled_prompt_embeds,
+                            "negative_pooled_prompt_embeds": negative_pooled_prompt_embeds,
+                        }
+
+                cache.model = BatchModel()
+                records = [{"prompt": "short", "key": "short", "metadata": {}}]
+
+                cache._encode_and_cache_prompt_batch(records, ["short.pt"])
+
+                self.assertEqual(len(saved), 1)
+                embeddings = saved[0][1]
+                self.assertEqual(embeddings["pooled_prompt_embeds"].shape, torch.Size([5]))
+                self.assertEqual(embeddings["negative_pooled_prompt_embeds"].shape, torch.Size([5]))
+                torch.testing.assert_close(embeddings["pooled_prompt_embeds"], torch.arange(5, dtype=torch.float32))
+                torch.testing.assert_close(
+                    embeddings["negative_pooled_prompt_embeds"], torch.arange(5, 10, dtype=torch.float32)
+                )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request updates the `_slice_batch_output_for_cache` function in `simpletuner/helpers/caching/text_embeds.py` to better handle tensor shapes and ensure compatibility with batch processing. The main changes focus on adjusting tensor dimensions when dealing with single-item batches and specific output keys.

Tensor shape handling improvements:

* Added logic to unsqueeze tensors with mismatched batch dimensions when `batch_size == 1`, ensuring consistent tensor shapes for downstream processing.
* For the keys `pooled_prompt_embeds` and `negative_pooled_prompt_embeds`, added a squeeze operation to remove unnecessary batch dimensions when the tensor is 2D, improving compatibility with expected output formats.