### PR TITLE
eliminate alpha image double-decode

### DIFF
--- a/simpletuner/helpers/image_manipulation/load.py
+++ b/simpletuner/helpers/image_manipulation/load.py
@@ -33,20 +33,21 @@ LARGE_ENOUGH_NUMBER = 100
 PngImagePlugin.MAX_TEXT_CHUNK = LARGE_ENOUGH_NUMBER * (1024**2)
 
 
+def _trainingsample_array_to_rgb_image(img_tsr: np.ndarray) -> Image.Image:
+    # trainingsample's imdecode already returns RGB tensors, no extra swap needed
+    if len(img_tsr.shape) == 2:
+        img_tsr = tsr.cvt_color_py(img_tsr, 8)  # 8 = COLOR_GRAY2RGB
+    elif img_tsr.shape[2] == 1:
+        img_tsr = tsr.cvt_color_py(img_tsr, 8)  # 8 = COLOR_GRAY2RGB
+    elif img_tsr.shape[2] == 4:
+        img_tsr, _timing = tsr.rgba_to_rgb_optimized(img_tsr)
+    return Image.fromarray(img_tsr)
+
+
 def decode_image_with_trainingsample(img_bytes: bytes) -> Union[Image.Image, None]:
     """Decode image using trainingsample with optimized format conversions."""
     img_tsr = tsr.imdecode_py(img_bytes, 1)  # 1 = IMREAD_COLOR
-    if img_tsr is not None:
-        # trainingsample's imdecode already returns RGB tensors, no extra swap needed
-        # Handle grayscale with ultra-fast conversion if needed
-        if len(img_tsr.shape) == 2:
-            # Convert grayscale to RGB using optimized method
-            img_tsr = tsr.cvt_color_py(img_tsr, 8)  # 8 = COLOR_GRAY2RGB
-        elif img_tsr.shape[2] == 1:
-            # Single channel to RGB
-            img_tsr = tsr.cvt_color_py(img_tsr, 8)  # 8 = COLOR_GRAY2RGB
-
-    return img_tsr if img_tsr is None else Image.fromarray(img_tsr)
+    return img_tsr if img_tsr is None else _trainingsample_array_to_rgb_image(img_tsr)
 
 
 def decode_image_with_pil(img_data: bytes) -> Image.Image:
@@ -127,21 +128,23 @@ def load_image(img_data: Union[bytes, IO[Any], str]) -> Image.Image:
     # remove iCCP chunk if found
     img_data = remove_iccp_chunk(img_data)
 
-    # Try to preload the image bytes with channels unchanged to determine
-    # if the image has an alpha channel. If it does we should add a white
-    # background to it using PIL.
-    has_alpha = False
+    # Decode once with channels unchanged so alpha detection and the common
+    # RGB conversion can share the same array.
+    image_preload = None
     try:
         image_preload = tsr.imdecode_py(img_data, -1)  # -1 = IMREAD_UNCHANGED
-        if image_preload is not None and len(image_preload.shape) >= 3 and image_preload.shape[2] == 4:
-            has_alpha = True
-        del image_preload
     except Exception:
         # If trainingsample fails, we'll use PIL fallback regardless
         pass
 
     img = None
-    if not has_alpha:
+    if image_preload is not None:
+        try:
+            img = _trainingsample_array_to_rgb_image(image_preload)
+        except Exception:
+            # If trainingsample conversion fails, fall back to PIL
+            pass
+    if img is None:
         try:
             img = decode_image_with_trainingsample(img_data)
         except Exception:

--- a/simpletuner/helpers/image_manipulation/training_sample.py
+++ b/simpletuner/helpers/image_manipulation/training_sample.py
@@ -9,6 +9,7 @@ import time
 from math import sqrt
 
 import numpy as np
+import trainingsample as tsr
 from diffusers.utils.export_utils import export_to_gif
 from PIL import Image
 from PIL.ImageOps import exif_transpose
@@ -722,9 +723,7 @@ class TrainingSample:
                         try:
                             img_array = np.array(self.image)
                             if len(img_array.shape) == 3 and img_array.shape[2] == 3:
-                                resized_arrays = self.batch_processor.batch_resize_images(
-                                    [img_array], [self.intermediary_size]
-                                )
+                                resized_arrays = tsr.batch_resize_images([img_array], [self.intermediary_size])
                                 if resized_arrays and len(resized_arrays) > 0:
                                     self.image = Image.fromarray(resized_arrays[0])
                                 else:
@@ -790,8 +789,7 @@ class TrainingSample:
                 try:
                     img_array = np.array(self.image)
                     if len(img_array.shape) == 3 and img_array.shape[2] == 3:
-                        # Use BatchedTrainingSamples for better performance
-                        resized_arrays = self.batch_processor.batch_resize_images([img_array], [size])
+                        resized_arrays = tsr.batch_resize_images([img_array], [size])
                         if resized_arrays and len(resized_arrays) > 0:
                             self.image = Image.fromarray(resized_arrays[0])
                         else:

--- a/tests/test_image_load.py
+++ b/tests/test_image_load.py
@@ -1,0 +1,34 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+from PIL import Image
+
+from simpletuner.helpers.image_manipulation.load import load_image
+
+
+class LoadImageTests(unittest.TestCase):
+    def test_load_image_reuses_unchanged_trainingsample_decode(self):
+        calls = []
+        decoded = np.zeros((3, 4, 3), dtype=np.uint8)
+
+        def imdecode_py(_img_data, flags):
+            calls.append(flags)
+            if flags == -1:
+                return decoded
+            raise AssertionError("load_image should not decode RGB after unchanged decode succeeds")
+
+        fake_tsr = SimpleNamespace(imdecode_py=imdecode_py)
+
+        with patch("simpletuner.helpers.image_manipulation.load.tsr", fake_tsr):
+            image = load_image(b"jpeg bytes")
+
+        self.assertEqual(calls, [-1])
+        self.assertIsInstance(image, Image.Image)
+        self.assertEqual(image.mode, "RGB")
+        self.assertEqual(image.size, (4, 3))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_training_sample.py
+++ b/tests/test_training_sample.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 from PIL import Image
@@ -112,6 +112,33 @@ class TestTrainingSample(unittest.TestCase):
         original_size = sample.image.size
         sample.prepare()
         self.assertNotEqual(sample.image.size, original_size)  # Ensure resizing occurs
+
+    def test_intermediary_image_resize_uses_direct_trainingsample_call(self):
+        sample = TrainingSample(Image.new("RGB", (64, 64), "white"), self.data_backend_id, {"original_size": (64, 64)})
+        sample.valid_metadata = True
+        sample.target_size = (32, 32)
+        sample.intermediary_size = (48, 32)
+        sample.target_aspect_ratio = 1.0
+        sample.batch_processor.batch_resize_images = MagicMock()
+
+        resized_array = np.zeros((32, 48, 3), dtype=np.uint8)
+        cropper = MagicMock()
+        cropper.crop.side_effect = lambda _width, _height: (sample.image, (0, 0))
+        sample.cropper = cropper
+
+        with patch(
+            "simpletuner.helpers.image_manipulation.training_sample.tsr.batch_resize_images",
+            return_value=[resized_array],
+        ) as resize_images:
+            sample.resize()
+
+        resize_images.assert_called_once()
+        image_args, size_args = resize_images.call_args.args
+        self.assertEqual(len(image_args), 1)
+        self.assertEqual(image_args[0].shape, (64, 64, 3))
+        self.assertEqual(size_args, [(48, 32)])
+        sample.batch_processor.batch_resize_images.assert_not_called()
+        self.assertEqual(sample.image.size, (48, 32))
 
     def test_crop_coordinates(self):
         """Test that cropping returns correct coordinates."""


### PR DESCRIPTION
This pull request refactors image loading and resizing logic to improve efficiency and reliability by reusing decoded image arrays and standardizing on direct calls to `trainingsample` utilities. It also updates the test suite to verify these optimizations and ensure correct integration.

**Image loading and decoding improvements:**

* Refactored `load_image` and related helpers in `load.py` to decode image bytes only once (with unchanged channels), then reuse the resulting array for RGB conversion, reducing redundant decoding and improving performance. (`simpletuner/helpers/image_manipulation/load.py`) [[1]](diffhunk://#diff-6f8e0448d8f477fe8d38f495603da6b8a399c53d036a40699c94bba14824775eL36-R50) [[2]](diffhunk://#diff-6f8e0448d8f477fe8d38f495603da6b8a399c53d036a40699c94bba14824775eL130-R147)
* Added a new helper function `_trainingsample_array_to_rgb_image` to encapsulate optimized format conversions from array to RGB image, including handling of grayscale and RGBA inputs. (`simpletuner/helpers/image_manipulation/load.py`)

**Resizing logic standardization:**

* Updated `TrainingSample.resize` to call `tsr.batch_resize_images` directly for resizing, bypassing the `batch_processor` indirection for improved clarity and reliability. (`simpletuner/helpers/image_manipulation/training_sample.py`) [[1]](diffhunk://#diff-aae35e98c2bd6ad7a5de8fde7e0fc1239f1f971328c84e14c434d708484b865cL725-R726) [[2]](diffhunk://#diff-aae35e98c2bd6ad7a5de8fde7e0fc1239f1f971328c84e14c434d708484b865cL793-R792)
* Ensured that `trainingsample` is imported as `tsr` where needed. (`simpletuner/helpers/image_manipulation/training_sample.py`)

**Testing enhancements:**

* Added a new test to verify that `load_image` reuses the unchanged-channel decode and does not redundantly decode RGB, ensuring the optimization is effective. (`tests/test_image_load.py`)
* Added a test to confirm that intermediary resizing in `TrainingSample` uses the direct `trainingsample` call and not the batch processor, verifying correct integration of the new resizing logic. (`tests/test_training_sample.py`)

These changes streamline image handling, reduce unnecessary computation, and add tests to prevent regressions.