### PR TITLE
Fix remote worker config handoff

### DIFF
--- a/simpletuner/worker_agent.py
+++ b/simpletuner/worker_agent.py
@@ -243,7 +243,11 @@ class WorkerAgent:
             pass  # Keepalive, no action needed
 
     async def _start_job(self, event: Dict[str, Any]):
-        """Start a training job"""
+        """Start a training job received from the orchestrator.
+
+        Args:
+            event: Job payload containing the training configuration and job ID.
+        """
         if self.current_job:
             logger.warning("Already running a job, ignoring new job request")
             return
@@ -256,14 +260,14 @@ class WorkerAgent:
         job_dir = Path(f"/tmp/simpletuner_job_{job_id}")
         job_dir.mkdir(exist_ok=True)
 
-        config_path = job_dir / "config.yaml"
+        config_path = job_dir / "config.json"
         dataloader_path = job_dir / "dataloader.yaml"
 
         # Import yaml here to avoid import at module level
         import yaml
 
-        with open(config_path, "w") as f:
-            yaml.dump(event["config"], f)
+        with config_path.open("w", encoding="utf-8") as f:
+            json.dump(event["config"], f)
         with open(dataloader_path, "w") as f:
             yaml.dump(event["dataloader"], f)
 
@@ -273,6 +277,8 @@ class WorkerAgent:
             {
                 "SIMPLETUNER_UPLOAD_ENDPOINT": f"{self.config.orchestrator_url}{event['upload_endpoint']}",
                 "SIMPLETUNER_UPLOAD_TOKEN": event.get("upload_token", ""),
+                "CONFIG_PATH": str(config_path),
+                "SIMPLETUNER_CONFIG_BACKEND": "json",
             }
         )
         if event.get("hf_token"):
@@ -287,10 +293,6 @@ class WorkerAgent:
             sys.executable,
             "-m",
             "simpletuner.train",
-            "--config",
-            str(config_path),
-            "--data_config",
-            str(dataloader_path),
         ]
 
         logger.info(f"Launching training: {' '.join(cmd)}")

--- a/tests/test_worker_agent.py
+++ b/tests/test_worker_agent.py
@@ -1,0 +1,79 @@
+"""Tests for remote worker training job execution."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import unittest
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+from simpletuner.worker_agent import WorkerAgent, WorkerConfig
+
+
+class WorkerAgentJobStartTestCase(unittest.IsolatedAsyncioTestCase):
+    """Test worker job configuration handoff to the training process."""
+
+    async def test_start_job_uses_json_config_path(self) -> None:
+        """Verify the training process receives the dispatched JSON config."""
+        job_id = f"test-{uuid.uuid4().hex}"
+        config = {
+            "model_family": "sdxl",
+            "data_backend_config": "/worker/config/dataloader.json",
+            "output_dir": "/worker/output",
+        }
+        event = {
+            "type": "job_submit",
+            "job_id": job_id,
+            "config": config,
+            "dataloader": None,
+            "upload_endpoint": "/api/cloud/storage",
+        }
+        agent = WorkerAgent(
+            WorkerConfig(
+                orchestrator_url="https://orchestrator.example.com",
+                worker_token="test-token",
+                name="test-worker",
+                persistent=True,
+            )
+        )
+        job_dir = Path(f"/tmp/simpletuner_job_{job_id}")
+        process = Mock()
+
+        def close_background_coroutine(coroutine):
+            """Close the mocked monitor coroutine to avoid leaking it.
+
+            Args:
+                coroutine: Monitor coroutine created by the worker.
+
+            Returns:
+                A mock task placeholder.
+            """
+            coroutine.close()
+            return Mock()
+
+        try:
+            with (
+                patch.object(agent, "_report_job_status", new=AsyncMock()) as report_status,
+                patch("simpletuner.worker_agent.subprocess.Popen", return_value=process) as popen,
+                patch("simpletuner.worker_agent.asyncio.create_task", side_effect=close_background_coroutine),
+            ):
+                await agent._start_job(event)
+
+            config_path = job_dir / "config.json"
+            self.assertEqual(json.loads(config_path.read_text(encoding="utf-8")), config)
+
+            command = popen.call_args.args[0]
+            process_env = popen.call_args.kwargs["env"]
+            self.assertEqual(command, [sys.executable, "-m", "simpletuner.train"])
+            self.assertEqual(process_env["CONFIG_PATH"], str(config_path))
+            self.assertEqual(process_env["SIMPLETUNER_CONFIG_BACKEND"], "json")
+            report_status.assert_awaited_once_with("starting")
+        finally:
+            shutil.rmtree(job_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- serialize the orchestrator-dispatched training config as JSON
- point the trainer at the job-scoped config through `CONFIG_PATH` and the JSON config backend
- remove the unsupported `--config` and `--data_config` arguments from the direct `simpletuner.train` invocation

## Root cause

The remote worker received the complete training config, but wrote it as YAML and passed file arguments that the current training entry point does not consume. The subprocess then fell back to the default `config/config.json` instead of loading the dispatched job config.

This change only fixes the config handoff. Dataset resolution through `data_backend_config` remains unchanged.

## Verification

- regression unit test in the packaged SimpleTuner 4.4.1 environment
- two-node Docker smoke test: the orchestrator dispatched a one-step SDXL LoRA job to a remote worker
- the remote job completed and produced both final LoRA weights and `checkpoint-1`; all 192 saved tensors were finite
- `git diff --check`
