### PR TITLE
ramtorch: support int8 from torchao, quanto and sdnq

### DIFF
--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -62,6 +62,7 @@ from simpletuner.helpers.training.lora_format import (
 from simpletuner.helpers.training.min_snr_gamma import compute_snr
 from simpletuner.helpers.training.multi_process import _get_rank
 from simpletuner.helpers.training.quantisation import (
+    MANUAL_QUANTIZATION_PRESETS,
     PIPELINE_ONLY_PRESETS,
     PIPELINE_QUANTIZATION_PRESETS,
     build_gguf_quantization_config,
@@ -3119,7 +3120,11 @@ class ModelFoundation(ABC):
                     f"{self.__class__.__name__} failed to materialize weights for {model_path}. "
                     "All model parameters remain on the meta device after reload."
                 )
-        if self._ramtorch_enabled() and self.model is not None:
+        if (
+            self._ramtorch_enabled()
+            and not self._ramtorch_base_deferred_until_after_quantization()
+            and self.model is not None
+        ):
             self._apply_ramtorch_layers(
                 self.model,
                 self.MODEL_TYPE.value,
@@ -3583,6 +3588,13 @@ class ModelFoundation(ABC):
     def _ramtorch_enabled(self) -> bool:
         return bool(getattr(self.config, "ramtorch", False))
 
+    def _ramtorch_base_deferred_until_after_quantization(self) -> bool:
+        if not self._ramtorch_enabled():
+            return False
+        if getattr(self.config, "quantize_via", None) == "pipeline":
+            return False
+        return getattr(self.config, "base_model_precision", None) in MANUAL_QUANTIZATION_PRESETS
+
     def _ramtorch_targets(self) -> Optional[list[str]]:
         targets = getattr(self.config, "ramtorch_target_modules", None)
         if targets is None:
@@ -3786,6 +3798,19 @@ class ModelFoundation(ABC):
             logger.debug("RamTorch ControlNet requested but no controlnet module is initialised.")
             return 0
         return self._apply_ramtorch_layers(controlnet, "controlnet")
+
+    def apply_ramtorch_to_transformer(self) -> int:
+        if not self._ramtorch_enabled():
+            return 0
+        if self.model is None:
+            logger.debug("RamTorch requested but no base model module is initialised.")
+            return 0
+        return self._apply_ramtorch_layers(
+            self.model,
+            self.MODEL_TYPE.value,
+            percent=self._ramtorch_transformer_percent(),
+            full_ramtorch=True,
+        )
 
     @property
     def group_offload_configured(self) -> bool:

--- a/simpletuner/helpers/models/ltxvideo2/model.py
+++ b/simpletuner/helpers/models/ltxvideo2/model.py
@@ -818,7 +818,11 @@ class LTXVideo2(VideoModelFoundation):
         if self._module_has_meta_tensors(unwrapped):
             raise RuntimeError("LTX-2 transformer parameters remain on the meta device after loading.")
 
-        if self._ramtorch_enabled() and self.model is not None:
+        if (
+            self._ramtorch_enabled()
+            and not self._ramtorch_base_deferred_until_after_quantization()
+            and self.model is not None
+        ):
             self._apply_ramtorch_layers(self.model, self.MODEL_TYPE.value, percent=self._ramtorch_transformer_percent())
         if move_to_device and self.model is not None:
             self.model.to(self.accelerator.device, dtype=self.config.weight_dtype)

--- a/simpletuner/helpers/ramtorch/modules/linear.py
+++ b/simpletuner/helpers/ramtorch/modules/linear.py
@@ -94,6 +94,16 @@ def _resident_bytes(entry):
     return int(entry.get("bytes", 0))
 
 
+def _dense_weight_for_grad(weight, *, device=None, dtype=None):
+    if hasattr(weight, "dequantize"):
+        weight = weight.dequantize()
+    if device is not None and getattr(weight, "device", None) != device:
+        weight = weight.to(device, non_blocking=True)
+    if dtype is not None and getattr(weight, "dtype", None) != dtype:
+        weight = weight.to(dtype)
+    return weight
+
+
 def _evict_backward_resident_entry(state, key, device):
     entry = state["forward_backward_residency"].pop(key, None)
     if entry is None:
@@ -539,11 +549,11 @@ class BouncingLinearFn(torch.autograd.Function):
             if ctx.autocast_enabled and ctx.autocast_dtype is not None:
                 grad_out_compute = grad_out.to(ctx.autocast_dtype)
                 x_compute = x.to(ctx.autocast_dtype)
-                w_compute = w_dev.to(ctx.autocast_dtype)
+                w_compute = _dense_weight_for_grad(w_dev, device=device, dtype=ctx.autocast_dtype)
             else:
                 grad_out_compute = grad_out
                 x_compute = x
-                w_compute = w_dev
+                w_compute = _dense_weight_for_grad(w_dev, device=device, dtype=grad_out.dtype)
 
             grad_input = grad_out_compute @ w_compute
             if compute_weight_grad:
@@ -637,7 +647,7 @@ class BouncingLinearFn(torch.autograd.Function):
                 if ctx.autocast_enabled:
                     grad_out_compute = grad_out.to(ctx.autocast_dtype)
                     x_compute = x.to(ctx.autocast_dtype)
-                    w_compute = weight_for_backward.to(ctx.autocast_dtype)
+                    w_compute = _dense_weight_for_grad(weight_for_backward, device=device, dtype=ctx.autocast_dtype)
 
                     # compute input grad
                     grad_input = grad_out_compute @ w_compute
@@ -649,7 +659,11 @@ class BouncingLinearFn(torch.autograd.Function):
                         )
                 else:
                     # compute input grad
-                    grad_input = grad_out @ weight_for_backward
+                    grad_input = grad_out @ _dense_weight_for_grad(
+                        weight_for_backward,
+                        device=device,
+                        dtype=grad_out.dtype,
+                    )
 
                     if compute_weight_grad:
                         compute_stream.wait_event(transfer_weight_backward_finished_event)

--- a/simpletuner/helpers/training/quantisation/__init__.py
+++ b/simpletuner/helpers/training/quantisation/__init__.py
@@ -1122,31 +1122,50 @@ def _sdnq_model(
             f"Consider uint8, uint16, or fp16 for better training stability."
         )
 
-    try:
-        model = sdnq_training_post_load_quant(
-            model,
-            weights_dtype=weights_dtype,
-            quantized_matmul_dtype=quantized_matmul_dtype,
-            group_size=group_size,
-            hadamard_group_size=hadamard_group_size,
-            svd_rank=svd_rank,
-            svd_steps=svd_steps,
-            use_svd=use_svd,
-            use_hadamard=use_hadamard,
-            use_grad_ckpt=getattr(args, "gradient_checkpointing", True),
-            use_quantized_matmul=use_quantized_matmul,
-            use_static_quantization=use_static_quantization,
-            use_stochastic_rounding=use_stochastic_rounding,
-            dequantize_fp32=dequantize_fp32,
-            non_blocking=False,
-            add_skip_keys=True,  # Let SDNQ handle module exclusions
-            quantization_device=quantization_device,
-            return_device=return_device,
-            modules_to_not_convert=modules_to_not_convert,
-            modules_to_not_use_matmul=getattr(args, "sdnq_modules_to_not_use_matmul", None),
-            modules_dtype_dict=getattr(args, "sdnq_modules_dtype_dict", None),
-            modules_quant_config=getattr(args, "sdnq_modules_quant_config", None),
+    sdnq_kwargs = {
+        "weights_dtype": weights_dtype,
+        "quantized_matmul_dtype": quantized_matmul_dtype,
+        "group_size": group_size,
+        "hadamard_group_size": hadamard_group_size,
+        "svd_rank": svd_rank,
+        "svd_steps": svd_steps,
+        "use_svd": use_svd,
+        "use_hadamard": use_hadamard,
+        "use_grad_ckpt": getattr(args, "gradient_checkpointing", True),
+        "use_quantized_matmul": use_quantized_matmul,
+        "use_static_quantization": use_static_quantization,
+        "use_stochastic_rounding": use_stochastic_rounding,
+        "dequantize_fp32": dequantize_fp32,
+        "non_blocking": False,
+        "add_skip_keys": True,  # Let SDNQ handle module exclusions
+        "quantization_device": quantization_device,
+        "return_device": return_device,
+        "modules_to_not_convert": modules_to_not_convert,
+        "modules_to_not_use_matmul": getattr(args, "sdnq_modules_to_not_use_matmul", None),
+        "modules_dtype_dict": getattr(args, "sdnq_modules_dtype_dict", None),
+        "modules_quant_config": getattr(args, "sdnq_modules_quant_config", None),
+    }
+    sdnq_supported_kwargs = set(signature(sdnq_training_post_load_quant).parameters)
+    unsupported_requested = []
+    if use_hadamard and "use_hadamard" not in sdnq_supported_kwargs:
+        unsupported_requested.append("sdnq_use_hadamard")
+    if getattr(args, "sdnq_hadamard_group_size", None) is not None and "hadamard_group_size" not in sdnq_supported_kwargs:
+        unsupported_requested.append("sdnq_hadamard_group_size")
+    if (
+        getattr(args, "sdnq_modules_to_not_use_matmul", None) is not None
+        and "modules_to_not_use_matmul" not in sdnq_supported_kwargs
+    ):
+        unsupported_requested.append("sdnq_modules_to_not_use_matmul")
+    if getattr(args, "sdnq_modules_quant_config", None) is not None and "modules_quant_config" not in sdnq_supported_kwargs:
+        unsupported_requested.append("sdnq_modules_quant_config")
+    if unsupported_requested:
+        raise ValueError(
+            "The installed SDNQ package does not support these SimpleTuner options: " + ", ".join(unsupported_requested)
         )
+    sdnq_kwargs = {key: value for key, value in sdnq_kwargs.items() if key in sdnq_supported_kwargs}
+
+    try:
+        model = sdnq_training_post_load_quant(model, **sdnq_kwargs)
         logger.info(
             "SDNQ config: weights_dtype=%s, matmul_dtype=%s, group_size=%s, qmm=%s, compile=%s, fp8_mm=%s, tensorwise_fp8=%s, svd=%s, hadamard=%s.",
             weights_dtype,

--- a/simpletuner/helpers/training/quantisation/__init__.py
+++ b/simpletuner/helpers/training/quantisation/__init__.py
@@ -1156,6 +1156,8 @@ def _sdnq_model(
         and "modules_to_not_use_matmul" not in sdnq_supported_kwargs
     ):
         unsupported_requested.append("sdnq_modules_to_not_use_matmul")
+    if getattr(args, "sdnq_modules_dtype_dict", None) is not None and "modules_dtype_dict" not in sdnq_supported_kwargs:
+        unsupported_requested.append("sdnq_modules_dtype_dict")
     if getattr(args, "sdnq_modules_quant_config", None) is not None and "modules_quant_config" not in sdnq_supported_kwargs:
         unsupported_requested.append("sdnq_modules_quant_config")
     if unsupported_requested:

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -2969,6 +2969,17 @@ class Trainer:
                     )
                     self.model.set_prepared_model(q_model, base_model=False)
 
+        if (
+            getattr(self.config, "ramtorch", False)
+            and not preprocessing_models_only
+            and not ema_only
+            and hasattr(self.model, "_ramtorch_base_deferred_until_after_quantization")
+            and self.model._ramtorch_base_deferred_until_after_quantization()
+        ):
+            applied = self.model.apply_ramtorch_to_transformer()
+            if applied:
+                logger.info("Applied deferred RamTorch to %s base model layers after quantization.", applied)
+
         # After quantization, re-move non-ramtorch layers to GPU
         # Quantization may have moved the model to CPU, leaving normalization weights there
         if getattr(self.config, "ramtorch", False) and not preprocessing_models_only:

--- a/simpletuner/helpers/utils/ramtorch.py
+++ b/simpletuner/helpers/utils/ramtorch.py
@@ -2,7 +2,7 @@ import importlib
 import logging
 from fnmatch import fnmatch
 from functools import lru_cache
-from typing import Iterable, Optional, Sequence
+from typing import Any, Iterable, Optional, Sequence
 
 import torch
 import torch.nn as nn
@@ -96,11 +96,55 @@ def _matches_pattern(name: str, module: nn.Module, patterns: Iterable[str]) -> b
     return False
 
 
+def _is_quanto_linear(module: nn.Module) -> bool:
+    return module.__class__.__name__ == "QLinear" and module.__class__.__module__.startswith("optimum.quanto.")
+
+
+def _is_replaceable_linear(module: nn.Module) -> bool:
+    if isinstance(module, nn.Linear):
+        return True
+    return _is_quanto_linear(module) and hasattr(module, "in_features") and hasattr(module, "out_features")
+
+
+def _tensor_uses_subclass_storage(tensor: Any) -> bool:
+    tensor_type = type(tensor)
+    return tensor_type is not torch.Tensor and tensor_type is not nn.Parameter
+
+
+def _cpu_parameter_from_tensor(tensor: torch.Tensor, *, requires_grad: bool) -> nn.Parameter:
+    tensor = tensor.detach().to("cpu")
+    return nn.Parameter(tensor, requires_grad=requires_grad)
+
+
+def _copy_or_assign_parameter(
+    new_layer: nn.Module,
+    attr_name: str,
+    source_tensor: torch.Tensor | None,
+    *,
+    requires_grad: bool,
+) -> None:
+    if source_tensor is None:
+        setattr(new_layer, attr_name, None)
+        return
+
+    target_param = getattr(new_layer, attr_name)
+    if _tensor_uses_subclass_storage(source_tensor):
+        setattr(new_layer, attr_name, _cpu_parameter_from_tensor(source_tensor, requires_grad=requires_grad))
+    else:
+        with torch.no_grad():
+            target_param.copy_(source_tensor.detach().to("cpu"))
+        target_param.requires_grad = requires_grad
+
+    param = getattr(new_layer, attr_name)
+    if param is not None:
+        setattr(param, "is_ramtorch", True)
+
+
 def _count_eligible_linear_layers(
     module: nn.Module,
     patterns: Optional[list[str]],
     name_prefix: str = "",
-) -> list[tuple[nn.Module, str, nn.Linear, str]]:
+) -> list[tuple[nn.Module, str, nn.Module, str]]:
     """
     Count and collect all Linear layers eligible for replacement.
 
@@ -113,7 +157,7 @@ def _count_eligible_linear_layers(
         for child_name, child in current.named_children():
             qualified_name = f"{prefix}.{child_name}" if prefix else child_name
 
-            if isinstance(child, nn.Linear):
+            if _is_replaceable_linear(child):
                 if patterns is None or _matches_pattern(qualified_name, child, patterns):
                     eligible.append((current, child_name, child, qualified_name))
                 continue
@@ -150,22 +194,11 @@ def replace_linear_layers_with_ramtorch(
 
     imports = ensure_available()
     ramtorch_linear = imports["Linear"]
-    replace_all = imports["replace_all"]
     patterns = normalize_patterns(target_patterns)
     resolved_device = _normalize_device(device)
 
     # Handle percentage: if not specified or 100, replace all
     use_percent = percent is not None and percent < 100
-
-    if patterns is None and not use_percent:
-        # Replace every Linear using RamTorch's helper.
-        num_linear = sum(1 for _, child in module.named_modules() if isinstance(child, nn.Linear))
-        replace_all(module, device=resolved_device)
-        for _, child in module.named_modules():
-            if isinstance(child, ramtorch_linear):
-                for param in child.parameters(recurse=False):
-                    setattr(param, "is_ramtorch", True)
-        return num_linear
 
     # Collect all eligible layers first (needed for percentage calculation)
     eligible = _count_eligible_linear_layers(module, patterns, name_prefix)
@@ -192,27 +225,30 @@ def replace_linear_layers_with_ramtorch(
         if isinstance(child, ramtorch_linear):
             continue
 
+        child_bias = getattr(child, "bias", None)
+        child_weight = getattr(child, "weight")
         new_layer = ramtorch_linear(
-            child.in_features,
-            child.out_features,
-            bias=child.bias is not None,
+            int(child.in_features),
+            int(child.out_features),
+            bias=child_bias is not None,
             device=resolved_device,
-            dtype=child.weight.dtype,
+            dtype=child_weight.dtype,
             skip_init=True,
         )
         new_layer.train(child.training)
 
-        with torch.no_grad():
-            new_layer.weight.copy_(child.weight.detach().to("cpu"))
-            if child.bias is not None and new_layer.bias is not None:
-                new_layer.bias.copy_(child.bias.detach().to("cpu"))
-
-        new_layer.weight.requires_grad = child.weight.requires_grad
-        if new_layer.bias is not None and child.bias is not None:
-            new_layer.bias.requires_grad = child.bias.requires_grad
-        setattr(new_layer.weight, "is_ramtorch", True)
-        if new_layer.bias is not None:
-            setattr(new_layer.bias, "is_ramtorch", True)
+        _copy_or_assign_parameter(
+            new_layer,
+            "weight",
+            child_weight,
+            requires_grad=bool(getattr(child_weight, "requires_grad", False)),
+        )
+        _copy_or_assign_parameter(
+            new_layer,
+            "bias",
+            child_bias,
+            requires_grad=bool(getattr(child_bias, "requires_grad", False)),
+        )
 
         setattr(parent, child_name, new_layer)
         replaced += 1

--- a/simpletuner/helpers/utils/ramtorch.py
+++ b/simpletuner/helpers/utils/ramtorch.py
@@ -111,9 +111,16 @@ def _tensor_uses_subclass_storage(tensor: Any) -> bool:
     return tensor_type is not torch.Tensor and tensor_type is not nn.Parameter
 
 
-def _cpu_parameter_from_tensor(tensor: torch.Tensor, *, requires_grad: bool) -> nn.Parameter:
-    tensor = tensor.detach().to("cpu")
-    return nn.Parameter(tensor, requires_grad=requires_grad)
+def _cpu_tensor_from_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor.detach().to("cpu")
+
+
+def _store_tensor_buffer(module: nn.Module, attr_name: str, tensor: torch.Tensor) -> None:
+    if attr_name in module._parameters:
+        del module._parameters[attr_name]
+    if attr_name in module._buffers:
+        del module._buffers[attr_name]
+    module.register_buffer(attr_name, tensor)
 
 
 def _copy_or_assign_parameter(
@@ -129,7 +136,7 @@ def _copy_or_assign_parameter(
 
     target_param = getattr(new_layer, attr_name)
     if _tensor_uses_subclass_storage(source_tensor):
-        setattr(new_layer, attr_name, _cpu_parameter_from_tensor(source_tensor, requires_grad=requires_grad))
+        _store_tensor_buffer(new_layer, attr_name, _cpu_tensor_from_tensor(source_tensor))
     else:
         with torch.no_grad():
             target_param.copy_(source_tensor.detach().to("cpu"))
@@ -725,6 +732,8 @@ def move_embeddings_to_device(module: nn.Module, device: object) -> int:
     for name, child in module.named_modules():
         # Move buffers from all modules (e.g., position_ids in CLIPTextEmbeddings)
         for buf_name, buf in child.named_buffers(recurse=False):
+            if getattr(buf, "is_ramtorch", False):
+                continue
             if buf.device.type == "cpu":
                 child.register_buffer(buf_name, buf.to(device))
 
@@ -758,6 +767,7 @@ def mark_ddp_ignore_params(module: nn.Module) -> int:
         Number of parameters added to the ignore list.
     """
     ramtorch_names = [name for name, param in module.named_parameters() if getattr(param, "is_ramtorch", False)]
+    ramtorch_names.extend(name for name, buffer in module.named_buffers() if getattr(buffer, "is_ramtorch", False))
     if not ramtorch_names:
         device_types = {param.device.type for _, param in module.named_parameters() if param.device is not None}
         if "cuda" in device_types and "cpu" in device_types:

--- a/tests/test_ramtorch.py
+++ b/tests/test_ramtorch.py
@@ -144,6 +144,8 @@ class RamTorchUtilsTests(unittest.TestCase):
         self.assertIsInstance(model[0], _StubLinear)
         self.assertIs(type(model[0].weight), original_weight_type)
         self.assertIsInstance(model[0].weight, Int8QuantizedTrainingLinearWeight)
+        self.assertNotIn("weight", dict(model[0].named_parameters(recurse=False)))
+        self.assertIn("weight", dict(model[0].named_buffers(recurse=False)))
         self.assertTrue(getattr(model[0].weight, "is_ramtorch", False))
 
     def test_replace_quanto_qlinear_preserves_weight_subclass(self):
@@ -169,7 +171,26 @@ class RamTorchUtilsTests(unittest.TestCase):
         self.assertEqual(replaced, 1)
         self.assertIsInstance(model[0], _StubLinear)
         self.assertIsInstance(model[0].weight, WeightQBytesTensor)
+        self.assertNotIn("weight", dict(model[0].named_parameters(recurse=False)))
+        self.assertIn("weight", dict(model[0].named_buffers(recurse=False)))
         self.assertTrue(getattr(model[0].weight, "is_ramtorch", False))
+
+    def test_move_embeddings_to_device_skips_ramtorch_buffers(self):
+        class _BufferModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("regular_buffer", torch.ones(2))
+                weight = torch.ones(2)
+                weight.is_ramtorch = True
+                self.register_buffer("ramtorch_buffer", weight)
+
+        model = _BufferModel()
+        moved = ramtorch_utils.move_embeddings_to_device(model, torch.device("meta"))
+
+        self.assertEqual(moved, 0)
+        self.assertEqual(model.regular_buffer.device.type, "meta")
+        self.assertEqual(model.ramtorch_buffer.device.type, "cpu")
+        self.assertTrue(getattr(model.ramtorch_buffer, "is_ramtorch", False))
 
     def test_torchao_int8_ramtorch_backward_uses_dense_weight_view(self):
         try:
@@ -286,11 +307,15 @@ class RamTorchUtilsTests(unittest.TestCase):
                     setattr(self.linear_b.bias, "is_ramtorch", True)
 
         model = _IgnoreModel()
+        buffer = torch.ones(2)
+        buffer.is_ramtorch = True
+        model.register_buffer("ramtorch_buffer", buffer)
         ignored = ramtorch_utils.mark_ddp_ignore_params(model)
-        self.assertEqual(ignored, 2)
+        self.assertEqual(ignored, 3)
         ignore_set = getattr(model, "_ddp_params_and_buffers_to_ignore", set())
         self.assertIn("linear_b.weight", ignore_set)
         self.assertIn("linear_b.bias", ignore_set)
+        self.assertIn("ramtorch_buffer", ignore_set)
 
     def test_prefetch_hooks_follow_ramtorch_module_order(self):
         from simpletuner.helpers.ramtorch_extensions import add_ramtorch_prefetch_hooks

--- a/tests/test_ramtorch.py
+++ b/tests/test_ramtorch.py
@@ -1,6 +1,7 @@
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import torch
@@ -67,10 +68,9 @@ class RamTorchUtilsTests(unittest.TestCase):
             replaced = ramtorch_utils.replace_linear_layers_with_ramtorch(model, device="cuda", target_patterns=None)
 
         self.assertEqual(replaced, 2)
-        self.assertEqual(replace_all_calls["count"], 1)
-        # No replacements performed because replace_all is stubbed.
-        self.assertIsInstance(model.linear1, nn.Linear)
-        self.assertIsInstance(model.block[0], nn.Linear)
+        self.assertEqual(replace_all_calls["count"], 0)
+        self.assertIsInstance(model.linear1, _StubLinear)
+        self.assertIsInstance(model.block[0], _StubLinear)
 
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA not available")
     def test_replace_linear_with_percent_50(self):
@@ -118,7 +118,104 @@ class RamTorchUtilsTests(unittest.TestCase):
             replaced = ramtorch_utils.replace_linear_layers_with_ramtorch(model, device="cuda", percent=100)
 
         self.assertEqual(replaced, 2)
-        self.assertEqual(replace_all_calls["count"], 1)  # Should use replace_all for efficiency
+        self.assertEqual(replace_all_calls["count"], 0)
+
+    def test_replace_torchao_int8_linear_preserves_weight_subclass(self):
+        try:
+            from torchao.prototype.quantized_training import int8_weight_only_quantized_training
+            from torchao.prototype.quantized_training.int8 import Int8QuantizedTrainingLinearWeight
+            from torchao.quantization import quantize_
+        except ImportError as exc:
+            self.skipTest(f"TorchAO int8 training quantization is unavailable: {exc}")
+
+        model = nn.Sequential(nn.Linear(16, 16))
+        quantize_(model, int8_weight_only_quantized_training())
+        model.requires_grad_(False)
+        original_weight_type = type(model[0].weight)
+
+        with patch.object(
+            ramtorch_utils,
+            "ensure_available",
+            return_value=self._build_stub_imports(lambda mod, device=None: None),
+        ):
+            replaced = ramtorch_utils.replace_linear_layers_with_ramtorch(model, device="cpu")
+
+        self.assertEqual(replaced, 1)
+        self.assertIsInstance(model[0], _StubLinear)
+        self.assertIs(type(model[0].weight), original_weight_type)
+        self.assertIsInstance(model[0].weight, Int8QuantizedTrainingLinearWeight)
+        self.assertTrue(getattr(model[0].weight, "is_ramtorch", False))
+
+    def test_replace_quanto_qlinear_preserves_weight_subclass(self):
+        try:
+            from optimum.quanto import freeze, qint8, quantize
+            from optimum.quanto.nn.qlinear import QLinear
+            from optimum.quanto.tensor.weights.qbytes import WeightQBytesTensor
+        except ImportError as exc:
+            self.skipTest(f"Quanto int8 quantization is unavailable: {exc}")
+
+        model = nn.Sequential(nn.Linear(16, 16))
+        quantize(model, weights=qint8)
+        freeze(model)
+        self.assertIsInstance(model[0], QLinear)
+
+        with patch.object(
+            ramtorch_utils,
+            "ensure_available",
+            return_value=self._build_stub_imports(lambda mod, device=None: None),
+        ):
+            replaced = ramtorch_utils.replace_linear_layers_with_ramtorch(model, device="cpu")
+
+        self.assertEqual(replaced, 1)
+        self.assertIsInstance(model[0], _StubLinear)
+        self.assertIsInstance(model[0].weight, WeightQBytesTensor)
+        self.assertTrue(getattr(model[0].weight, "is_ramtorch", False))
+
+    def test_torchao_int8_ramtorch_backward_uses_dense_weight_view(self):
+        try:
+            from torchao.prototype.quantized_training import int8_weight_only_quantized_training
+            from torchao.quantization import quantize_
+        except ImportError as exc:
+            self.skipTest(f"TorchAO int8 training quantization is unavailable: {exc}")
+
+        from simpletuner.helpers.ramtorch.modules.linear import Linear as RamTorchLinear
+
+        linear = nn.Linear(16, 16)
+        quantize_(linear, int8_weight_only_quantized_training())
+
+        ramtorch_linear = RamTorchLinear(16, 16, bias=True, device="cpu", dtype=linear.weight.dtype, skip_init=True)
+        ramtorch_linear.weight = nn.Parameter(linear.weight.detach(), requires_grad=False)
+        ramtorch_linear.weight.is_ramtorch = True
+        ramtorch_linear.bias = nn.Parameter(linear.bias.detach().clone(), requires_grad=False)
+        ramtorch_linear.bias.is_ramtorch = True
+
+        x = torch.randn(2, 16, requires_grad=True)
+        loss = ramtorch_linear(x).sum()
+        loss.backward()
+
+        self.assertIsNotNone(x.grad)
+        self.assertGreater(float(x.grad.abs().sum()), 0.0)
+
+    def test_manual_quantization_defers_base_ramtorch_until_after_quantization(self):
+        from simpletuner.helpers.models.common import ModelFoundation
+
+        model = SimpleNamespace(
+            config=SimpleNamespace(
+                ramtorch=True,
+                quantize_via="accelerator",
+                base_model_precision="int8-torchao",
+            ),
+            _ramtorch_enabled=lambda: True,
+        )
+
+        self.assertTrue(ModelFoundation._ramtorch_base_deferred_until_after_quantization(model))
+
+        model.config.quantize_via = "pipeline"
+        self.assertFalse(ModelFoundation._ramtorch_base_deferred_until_after_quantization(model))
+
+        model.config.quantize_via = "accelerator"
+        model.config.base_model_precision = "no_change"
+        self.assertFalse(ModelFoundation._ramtorch_base_deferred_until_after_quantization(model))
 
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA not available")
     def test_replace_linear_with_percent_0(self):


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to RamTorch integration, quantization compatibility, and linear layer replacement logic. The main changes include deferring RamTorch application until after quantization when appropriate, improving the replacement of `nn.Linear` layers (including support for custom linear modules), and enhancing quantization argument validation. These updates improve model compatibility, training stability, and code maintainability.

**RamTorch Integration and Deferred Application:**

- Added logic to defer applying RamTorch to base model layers until after quantization, controlled by the new `_ramtorch_base_deferred_until_after_quantization` method and corresponding changes in model loading and training workflows. This ensures correct sequencing for quantized models. [[1]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbL3122-R3127) [[2]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR3591-R3597) [[3]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R2972-R2982) [[4]](diffhunk://#diff-64820a284b076801c442da19649e63dc4a2e00e645d7f92abbc5754b3dbae22fL821-R825) [[5]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR3802-R3814)

**Linear Layer Replacement Enhancements:**

- Refactored `replace_linear_layers_with_ramtorch` to support custom linear modules (like `QLinear` from Optimum Quanto), improved parameter copying (including handling tensor subclasses), and removed the use of the `replace_all` helper for more granular control. [[1]](diffhunk://#diff-35085c1320aeab677e8f229708eb17ff88af3495d0da5f1c1162af961acefd08R99-R147) [[2]](diffhunk://#diff-35085c1320aeab677e8f229708eb17ff88af3495d0da5f1c1162af961acefd08L116-R160) [[3]](diffhunk://#diff-35085c1320aeab677e8f229708eb17ff88af3495d0da5f1c1162af961acefd08L153-L169) [[4]](diffhunk://#diff-35085c1320aeab677e8f229708eb17ff88af3495d0da5f1c1162af961acefd08R228-R251)

**Quantization Argument Validation:**

- Improved SDNQ quantization support by dynamically checking for supported arguments in `sdnq_training_post_load_quant`, raising clear errors if unsupported options are requested. This prevents runtime failures due to mismatched package versions.

**RamTorch Linear Module Backward Pass Fixes:**

- Updated the backward computation in RamTorch linear modules to ensure weights are properly dequantized and moved to the correct device and dtype before gradient computation, improving correctness for quantized and autocast scenarios. [[1]](diffhunk://#diff-441a88da38f1f69f115a1a51d5e1d39eb502f623cb9c022d5b97b4f7a68c0bb6R97-R106) [[2]](diffhunk://#diff-441a88da38f1f69f115a1a51d5e1d39eb502f623cb9c022d5b97b4f7a68c0bb6L542-R556) [[3]](diffhunk://#diff-441a88da38f1f69f115a1a51d5e1d39eb502f623cb9c022d5b97b4f7a68c0bb6L640-R650) [[4]](diffhunk://#diff-441a88da38f1f69f115a1a51d5e1d39eb502f623cb9c022d5b97b4f7a68c0bb6L652-R666)

**Test Suite Updates:**

- Adjusted tests to reflect the new linear replacement logic, especially regarding the removal of the `replace_all` stub, and to check for correct replacement with custom linear modules.

Other minor changes include type annotation updates and utility function additions to support the above improvements.