### PR TITLE
cosmos3 performance tuning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -312,6 +312,7 @@ base_deps = [
     "py3langid>=0.2.2",
     "pypinyin>=0.50.0",
     "sentencepiece>=0.2.0",
+    "tiktoken>=0.13.0",
     "spacy>=3.7.4",
     "hangul-romanize>=0.1.0",
     "optimum-quanto>=0.2.7",

--- a/simpletuner/helpers/data_backend/factory.py
+++ b/simpletuner/helpers/data_backend/factory.py
@@ -2551,8 +2551,19 @@ class FactoryRegistry:
                 StateTracker.set_default_text_embed_cache(init_backend["text_embed_cache"])
                 logger.debug(f"Set the default text embed cache to {init_backend['id']}.")
 
+                should_precompute_dropout = getattr(self.args, "caption_dropout_probability", 0.1) > 0.0
+                should_precompute_dropout = (
+                    should_precompute_dropout
+                    and getattr(
+                        self.model,
+                        "should_precompute_dropout_caption",
+                        lambda: True,
+                    )()
+                )
                 if text_cache_ondemand:
                     info_log("Skipping null embedding pre-computation for on-demand text cache.")
+                elif not should_precompute_dropout:
+                    info_log("Skipping null embedding pre-computation because caption dropout is disabled.")
                 else:
                     info_log("Pre-computing null embedding")
                 logger.debug(f"rank {get_rank()} may skip computing the embedding..")
@@ -2562,7 +2573,7 @@ class FactoryRegistry:
                     else nullcontext()
                 )
                 with main_process_context:
-                    if not text_cache_ondemand:
+                    if not text_cache_ondemand and should_precompute_dropout:
                         logger.debug(f"rank {get_rank()} is computing the null embed")
                         init_backend["text_embed_cache"].encode_dropout_caption()
                         logger.debug(f"rank {get_rank()} has completed computing the null embed")
@@ -3691,12 +3702,26 @@ class FactoryRegistry:
                     "prompt": caption,
                     "dataset_relative_path": normalized_identifier,
                 }
+                metadata_builder = getattr(self.model, "text_embed_cache_metadata_for_filepath", None)
+                if callable(metadata_builder):
+                    metadata.update(
+                        metadata_builder(
+                            init_backend=init_backend,
+                            image_path=image_path_str,
+                            prompt=caption,
+                            data_backend_id=dataset_id,
+                            dataset_relative_path=normalized_identifier,
+                        )
+                    )
                 if key_type is TextEmbedCacheKey.DATASET_AND_FILENAME:
                     key_value = f"{dataset_id}:{normalized_identifier}"
                 elif key_type is TextEmbedCacheKey.FILENAME:
                     key_value = normalize_data_path(image_path_str, None)
                 else:
                     key_value = caption
+                key_builder = getattr(self.model, "text_embed_cache_key_value", None)
+                if callable(key_builder):
+                    key_value = key_builder(prompt=caption, default_key=key_value, metadata=metadata)
                 prompt_records.append({"prompt": caption, "key": key_value, "metadata": metadata})
 
             # Add entity label records for images with grounding annotations
@@ -4503,7 +4528,12 @@ class FactoryRegistry:
 
         self._create_dataset_and_sampler(backend, init_backend, conditioning_type)
 
-        self._process_text_embeddings(backend, init_backend, conditioning_type)
+        text_precompute_cleanup = getattr(self.model, "after_text_embed_cache_precompute", None)
+        try:
+            self._process_text_embeddings(backend, init_backend, conditioning_type)
+        finally:
+            if callable(text_precompute_cleanup):
+                text_precompute_cleanup()
 
         if backend.get("auto_generated", False):
             self._handle_auto_generated_dataset(backend, init_backend)
@@ -4555,7 +4585,6 @@ class FactoryRegistry:
             logger.debug(f"Encoding images during training: {init_backend['vaecache'].vae_cache_ondemand}")
             if self._is_multi_process():
                 self.accelerator.wait_for_everyone()
-
         move_text_encoders(self.args, self.text_encoders, self.accelerator.device)
         init_backend_debug_info = {
             k: v for k, v in init_backend.items() if isinstance(v, Union[list, int, float, str, dict, tuple])

--- a/simpletuner/helpers/models/cosmos3/model.py
+++ b/simpletuner/helpers/models/cosmos3/model.py
@@ -8,9 +8,23 @@ import torch.nn.functional as F
 from diffusers import UniPCMultistepScheduler
 from transformers import AutoTokenizer
 
+from simpletuner.helpers.acceleration import (
+    AccelerationBackend,
+    AccelerationPreset,
+    get_bitsandbytes_presets,
+    get_deepspeed_presets,
+    get_quanto_presets,
+    get_sdnq_presets,
+    get_torchao_presets,
+)
 from simpletuner.helpers.models.common import PipelineTypes, PredictionTypes, TextEmbedCacheKey, get_model_config_path
 from simpletuner.helpers.models.cosmos3.audio_tokenizer import Cosmos3AVAEAudioTokenizer
-from simpletuner.helpers.models.cosmos3.pipeline import Cosmos3OmniPipeline
+from simpletuner.helpers.models.cosmos3.pipeline import (
+    _SYSTEM_PROMPT_IMAGE,
+    _SYSTEM_PROMPT_VIDEO,
+    Cosmos3OmniPipeline,
+    get_3d_mrope_ids_text_tokens,
+)
 from simpletuner.helpers.models.cosmos3.reasoner import (
     COSMOS3_GENERATOR_COMPONENTS,
     COSMOS3_REASONER_COMPONENTS,
@@ -50,6 +64,100 @@ class Cosmos3Image(Cosmos2Image):
 
     TEXT_ENCODER_CONFIGURATION = {}
 
+    @classmethod
+    def max_swappable_blocks(cls, config=None) -> Optional[int]:
+        return 35
+
+    @classmethod
+    def get_acceleration_presets(cls) -> list[AccelerationPreset]:
+        base_memory_config = {
+            "base_model_precision": "no_change",
+            "gradient_checkpointing": True,
+        }
+
+        light_layers = ",".join(f"layers.{idx}.*" for idx in range(9))
+        balanced_layers = ",".join(f"layers.{idx}.*" for idx in range(18))
+
+        return [
+            AccelerationPreset(
+                backend=AccelerationBackend.RAMTORCH,
+                level="light",
+                name="RamTorch - Light",
+                description="Streams 9 of 36 transformer layers (~25%).",
+                tab="basic",
+                tradeoff_vram="Reduces transformer VRAM by streaming early layers from CPU.",
+                tradeoff_speed="Adds host-device transfer overhead.",
+                tradeoff_notes="Requires enough system RAM for CPU-resident weights.",
+                requires_min_system_ram_gb=64,
+                config={**base_memory_config, "ramtorch": True, "ramtorch_target_modules": light_layers},
+            ),
+            AccelerationPreset(
+                backend=AccelerationBackend.RAMTORCH,
+                level="balanced",
+                name="RamTorch - Balanced",
+                description="Streams 18 of 36 transformer layers (~50%).",
+                tab="basic",
+                tradeoff_vram="Reduces transformer VRAM by streaming half the layers from CPU.",
+                tradeoff_speed="Adds substantial host-device transfer overhead.",
+                tradeoff_notes="Requires enough system RAM for CPU-resident weights.",
+                requires_min_system_ram_gb=64,
+                config={**base_memory_config, "ramtorch": True, "ramtorch_target_modules": balanced_layers},
+            ),
+            AccelerationPreset(
+                backend=AccelerationBackend.RAMTORCH,
+                level="aggressive",
+                name="RamTorch - Aggressive",
+                description="Streams all transformer layers.",
+                tab="basic",
+                tradeoff_vram="Maximizes transformer weight offload.",
+                tradeoff_speed="Highest host-device transfer overhead.",
+                tradeoff_notes="Requires enough system RAM for CPU-resident weights.",
+                requires_min_system_ram_gb=64,
+                config={**base_memory_config, "ramtorch": True, "ramtorch_target_modules": "layers.*"},
+            ),
+            AccelerationPreset(
+                backend=AccelerationBackend.MUSUBI_BLOCK_SWAP,
+                level="light",
+                name="Block Swap - Light",
+                description="Swaps 9 of 36 transformer layers (~25%).",
+                tab="basic",
+                tradeoff_vram="Keeps most layers GPU-resident.",
+                tradeoff_speed="Adds moderate block transfer overhead.",
+                tradeoff_notes="Requires enough system RAM for CPU-resident blocks.",
+                requires_min_system_ram_gb=64,
+                config={**base_memory_config, "musubi_blocks_to_swap": 9},
+            ),
+            AccelerationPreset(
+                backend=AccelerationBackend.MUSUBI_BLOCK_SWAP,
+                level="balanced",
+                name="Block Swap - Balanced",
+                description="Swaps 18 of 36 transformer layers (~50%).",
+                tab="basic",
+                tradeoff_vram="Keeps half of the layers GPU-resident.",
+                tradeoff_speed="Adds significant block transfer overhead.",
+                tradeoff_notes="Requires enough system RAM for CPU-resident blocks.",
+                requires_min_system_ram_gb=64,
+                config={**base_memory_config, "musubi_blocks_to_swap": 18},
+            ),
+            AccelerationPreset(
+                backend=AccelerationBackend.MUSUBI_BLOCK_SWAP,
+                level="aggressive",
+                name="Block Swap - Aggressive",
+                description="Swaps 30 of 36 transformer layers (~83%).",
+                tab="basic",
+                tradeoff_vram="Keeps only a small layer tail GPU-resident.",
+                tradeoff_speed="Highest block transfer overhead.",
+                tradeoff_notes="Requires enough system RAM for CPU-resident blocks.",
+                requires_min_system_ram_gb=64,
+                config={**base_memory_config, "musubi_blocks_to_swap": 30},
+            ),
+            *get_deepspeed_presets(base_memory_config),
+            *get_sdnq_presets(base_memory_config),
+            *get_torchao_presets(base_memory_config),
+            *get_quanto_presets(base_memory_config),
+            *get_bitsandbytes_presets(base_memory_config),
+        ]
+
     def __init__(self, config, accelerator):
         super().__init__(config, accelerator)
         self.text_tokenizer = None
@@ -65,9 +173,9 @@ class Cosmos3Image(Cosmos2Image):
         if len(contexts) != len(prompts):
             raise ValueError(f"Cosmos3 received {len(prompts)} prompts but {len(contexts)} prompt contexts.")
 
-        adapter = self._get_training_pipeline_adapter()
         reasoner = self._load_reasoner()
         samples = []
+        logger.info("Encoding Cosmos3 reasoner cache for %s prompt(s).", len(prompts))
         for prompt, context in zip(prompts, contexts):
             signature = self._cosmos3_text_cache_signature(prompt=prompt, metadata=context)
             required = ("cosmos3_num_frames", "cosmos3_height", "cosmos3_width", "cosmos3_fps")
@@ -77,15 +185,14 @@ class Cosmos3Image(Cosmos2Image):
                     "Cosmos3 reasoner cache requires geometry metadata for every prompt. "
                     f"Missing {missing}; prompt={prompt!r}."
                 )
-            input_ids, _ = adapter.tokenize_prompt(
+            input_ids = self._tokenize_reasoner_prompt(
                 prompt=prompt,
-                negative_prompt="",
                 num_frames=int(context["cosmos3_num_frames"]),
                 height=int(context["cosmos3_height"]),
                 width=int(context["cosmos3_width"]),
                 fps=float(context["cosmos3_fps"]),
             )
-            text_segment = adapter._prepare_text_segment(input_ids, self.accelerator.device)
+            text_segment = self._prepare_reasoner_text_segment(input_ids, self.accelerator.device)
             memory_state = reasoner(
                 input_ids=text_segment["input_ids"],
                 position_ids=text_segment["text_mrope_ids"],
@@ -104,10 +211,25 @@ class Cosmos3Image(Cosmos2Image):
                     "reasoner_memory_state": {"layer_kv": memory_state.layer_kv},
                 }
             )
+        logger.info("Finished Cosmos3 reasoner cache encoding for %s prompt(s).", len(samples))
         return {"cosmos3_reasoner_cache": samples[0] if len(samples) == 1 else samples}
 
     def uses_text_embeddings_cache(self) -> bool:
         return True
+
+    @torch.no_grad()
+    def encode_text_batch(
+        self,
+        text_batch: list,
+        is_negative_prompt: bool = False,
+        prompt_contexts: Optional[list[dict]] = None,
+    ) -> dict:
+        previous_context = getattr(self, "_current_prompt_contexts", None)
+        self._current_prompt_contexts = prompt_contexts
+        try:
+            return self._encode_prompts(text_batch, is_negative_prompt)
+        finally:
+            self._current_prompt_contexts = previous_context
 
     def use_text_cache_dropout_sentinel(self) -> bool:
         return False
@@ -135,11 +257,42 @@ class Cosmos3Image(Cosmos2Image):
         metadata["cosmos3_cache_signature"] = self._cosmos3_text_cache_signature(prompt=prompt, metadata=metadata)
         return metadata
 
+    def text_embed_cache_metadata_for_filepath(
+        self,
+        *,
+        init_backend: dict,
+        image_path: str,
+        prompt: str,
+        data_backend_id: str | None,
+        dataset_relative_path: str | None,
+    ) -> dict:
+        metadata_backend = init_backend.get("metadata_backend")
+        sample_metadata = {}
+        if metadata_backend is not None:
+            sample_metadata = metadata_backend.get_metadata_by_filepath(image_path) or {}
+        target_size = sample_metadata.get("target_size") or sample_metadata.get("original_size")
+        if not target_size or len(target_size) != 2:
+            raise ValueError(f"Cosmos3 text cache precompute requires target_size metadata for {image_path}.")
+        width, height = int(target_size[0]), int(target_size[1])
+        num_frames = int(sample_metadata.get("bucket_frames") or sample_metadata.get("num_frames") or 1)
+        metadata = {
+            "cosmos3_num_frames": num_frames,
+            "cosmos3_height": height,
+            "cosmos3_width": width,
+            "cosmos3_fps": float(sample_metadata.get("fps") or getattr(self.config, "framerate", 24.0) or 24.0),
+            "cosmos3_reasoner_component": self._reasoner_component_id(),
+        }
+        metadata["cosmos3_cache_signature"] = self._cosmos3_text_cache_signature(prompt=prompt, metadata=metadata)
+        return metadata
+
     def text_embed_cache_key_value(self, *, prompt: str, default_key: str, metadata: dict) -> str:
         signature = metadata.get("cosmos3_cache_signature") or self._cosmos3_text_cache_signature(
             prompt=prompt, metadata=metadata
         )
         return f"{default_key}:cosmos3:{signature}"
+
+    def after_text_embed_cache_precompute(self):
+        self._offload_reasoner_after_text_cache()
 
     def slice_text_embedding_for_cache(self, text_encoder_output: dict, batch_index: int, batch_size: int):
         cache = text_encoder_output.get("cosmos3_reasoner_cache")
@@ -233,22 +386,79 @@ class Cosmos3Image(Cosmos2Image):
 
     def _load_reasoner(self):
         component_id = self._reasoner_component_id()
+        device = torch.device(self.accelerator.device)
         cache_key = (
             component_id,
-            str(self.accelerator.device),
+            str(device),
             self.config.weight_dtype,
             getattr(self.config, "revision", None),
         )
         if self.reasoner is not None and self._reasoner_component_cache_key == cache_key:
+            if self.reasoner.device != device:
+                logger.info("Moving Cosmos3 reasoner to %s for text cache encoding.", device)
+                self.reasoner.to(device=device, dtype=self.config.weight_dtype)
             return self.reasoner
+        logger.info("Loading Cosmos3 reasoner component %s on %s.", component_id, device)
         self.reasoner = Cosmos3Reasoner.from_pretrained(
             component_id,
-            device=self.accelerator.device,
+            device=device,
             dtype=self.config.weight_dtype,
             revision=getattr(self.config, "revision", None),
         )
         self._reasoner_component_cache_key = cache_key
         return self.reasoner
+
+    def _offload_reasoner_after_text_cache(self):
+        if self.reasoner is None:
+            return
+        if self.reasoner.device.type == "cuda":
+            logger.info("Moving Cosmos3 reasoner back to CPU after text cache encoding.")
+            self.reasoner.to(device=torch.device("cpu"))
+            torch.cuda.empty_cache()
+
+    def _tokenize_reasoner_prompt(self, *, prompt: str, num_frames: int, height: int, width: int, fps: float) -> list[int]:
+        self._load_text_tokenizer()
+        is_image = num_frames == 1
+        text = Cosmos3OmniPipeline._build_generation_json_prompt(
+            prompt,
+            num_frames=num_frames,
+            fps=fps,
+            height=height,
+            width=width,
+        )
+        conversations = []
+        if getattr(self.config, "default_use_system_prompt", True):
+            conversations.append({"role": "system", "content": _SYSTEM_PROMPT_IMAGE if is_image else _SYSTEM_PROMPT_VIDEO})
+        conversations.append({"role": "user", "content": text})
+        encodings = self.text_tokenizer.apply_chat_template(
+            conversations,
+            tokenize=True,
+            add_generation_prompt=True,
+            add_vision_id=False,
+            return_dict=True,
+        )
+        return list(encodings.input_ids) + [
+            self.text_tokenizer.eos_token_id,
+            self.text_tokenizer.convert_tokens_to_ids("<|vision_start|>"),
+        ]
+
+    def _prepare_reasoner_text_segment(self, input_ids: list[int], device: torch.device | str) -> dict:
+        transformer = self.unwrap_model(self.model) if self.model is not None else None
+        config = transformer.config if transformer is not None else self._load_reasoner().config
+        und_len = len(input_ids)
+        text_mrope_ids, next_mrope_offset = get_3d_mrope_ids_text_tokens(
+            num_tokens=und_len,
+            temporal_offset=0,
+            use_float_positions=getattr(config, "enable_fps_modulation", True),
+        )
+        return {
+            "input_ids": torch.tensor(input_ids, dtype=torch.long, device=device),
+            "text_indexes": torch.arange(und_len, dtype=torch.long, device=device),
+            "und_len": und_len,
+            "text_mrope_ids": text_mrope_ids.to(device),
+            "vision_start_temporal_offset": next_mrope_offset
+            + getattr(config, "unified_3d_mrope_temporal_modality_margin", 15000),
+        }
 
     def _load_preprocessor(self):
         self._load_text_tokenizer()
@@ -259,7 +469,7 @@ class Cosmos3Image(Cosmos2Image):
 
         self.text_tokenizer = AutoTokenizer.from_pretrained(
             get_model_config_path(self.config.model_family, self.config.pretrained_model_name_or_path),
-            subfolder="tokenizer",
+            subfolder="text_tokenizer",
             revision=self.config.revision,
         )
         self.tokenizers = [self.text_tokenizer]
@@ -710,10 +920,7 @@ class Cosmos3Image(Cosmos2Image):
             self.config.tokenizer_max_length = 4096
             logger.info(f"Setting tokenizer max length to {self.config.tokenizer_max_length}")
         if not getattr(self.config, "text_cache_disable", False) and not getattr(self.config, "text_cache_ondemand", False):
-            logger.warning(
-                "Cosmos3 reasoner K/V caching requires on-demand text cache because keys include latent geometry."
-            )
-            self.config.text_cache_ondemand = True
+            logger.info("Cosmos3 reasoner K/V text cache will be pre-computed from bucket metadata.")
 
         self.config.pretrained_vae_model_name_or_path = None
 

--- a/simpletuner/helpers/models/cosmos3/reasoner.py
+++ b/simpletuner/helpers/models/cosmos3/reasoner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -18,6 +19,8 @@ from simpletuner.helpers.models.cosmos3.transformer import (
     Cosmos3VLTextMLP,
     Cosmos3VLTextRotaryEmbedding,
 )
+
+logger = logging.getLogger(__name__)
 
 COSMOS3_REASONER_COMPONENTS = {
     "edge": "SimpleTuner/cosmos3-component-reasoning-layers-bf16-edge",
@@ -229,7 +232,9 @@ class Cosmos3Reasoner(nn.Module):
         if config.component != "cosmos3_reasoner":
             raise ValueError(f"Expected Cosmos3 reasoner component, got {config.component!r}.")
         reasoner = cls(config)
+        logger.info("Loading Cosmos3 reasoner weights from %s", repo_id)
         state_dict = cls._load_component_state_dict(repo_id, revision=revision)
+        logger.info("Loaded Cosmos3 reasoner state dict with %s tensors from %s", len(state_dict), repo_id)
         reasoner.load_state_dict(state_dict, strict=True)
         reasoner.to(device=device, dtype=dtype)
         reasoner.requires_grad_(False)
@@ -257,7 +262,10 @@ class Cosmos3Reasoner(nn.Module):
             raise ValueError(f"Index file {index_path} does not contain a weight_map object.")
 
         state_dict = {}
-        for shard_name in sorted(set(weight_map.values())):
+        shard_names = sorted(set(weight_map.values()))
+        logger.info("Loading Cosmos3 reasoner state dict from %s shard(s)", len(shard_names))
+        for shard_name in shard_names:
+            logger.info("Loading Cosmos3 reasoner shard %s", shard_name)
             state_dict.update(load_file(cls._resolve_component_file(repo_id, shard_name, revision=revision)))
         return state_dict
 

--- a/simpletuner/helpers/models/cosmos3/transformer.py
+++ b/simpletuner/helpers/models/cosmos3/transformer.py
@@ -24,7 +24,11 @@ from diffusers.models.attention_dispatch import dispatch_attention_fn
 from diffusers.models.embeddings import TimestepEmbedding, Timesteps
 from diffusers.models.modeling_utils import ModelMixin
 from diffusers.models.normalization import RMSNorm
-from diffusers.utils import BaseOutput
+from diffusers.utils import BaseOutput, logging
+
+from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
+
+logger = logging.get_logger(__name__)
 
 
 @dataclass
@@ -60,6 +64,38 @@ class Cosmos3AttnProcessor:
     _attention_backend = None
     _parallel_config = None
 
+    @staticmethod
+    def _project_und_qkv(attn: "Cosmos3PackedMoTAttention", und_seq: torch.Tensor):
+        q_dim = attn.num_attention_heads * attn.head_dim
+        kv_dim = attn.num_key_value_heads * attn.head_dim
+        if getattr(attn, "fused_projections", False) and hasattr(attn, "to_qkv"):
+            q_und, k_und, v_und = attn.to_qkv(und_seq).split((q_dim, kv_dim, kv_dim), dim=-1)
+        else:
+            q_und = attn.to_q(und_seq)
+            k_und = attn.to_k(und_seq)
+            v_und = attn.to_v(und_seq)
+        return (
+            q_und.view(-1, attn.num_attention_heads, attn.head_dim),
+            k_und.view(-1, attn.num_key_value_heads, attn.head_dim),
+            v_und.view(-1, attn.num_key_value_heads, attn.head_dim),
+        )
+
+    @staticmethod
+    def _project_gen_qkv(attn: "Cosmos3PackedMoTAttention", gen_seq: torch.Tensor):
+        q_dim = attn.num_attention_heads * attn.head_dim
+        kv_dim = attn.num_key_value_heads * attn.head_dim
+        if getattr(attn, "fused_projections", False) and hasattr(attn, "add_qkv_proj"):
+            q_gen, k_gen, v_gen = attn.add_qkv_proj(gen_seq).split((q_dim, kv_dim, kv_dim), dim=-1)
+        else:
+            q_gen = attn.add_q_proj(gen_seq)
+            k_gen = attn.add_k_proj(gen_seq)
+            v_gen = attn.add_v_proj(gen_seq)
+        return (
+            q_gen.view(-1, attn.num_attention_heads, attn.head_dim),
+            k_gen.view(-1, attn.num_key_value_heads, attn.head_dim),
+            v_gen.view(-1, attn.num_key_value_heads, attn.head_dim),
+        )
+
     def __call__(
         self,
         attn: "Cosmos3PackedMoTAttention",
@@ -68,12 +104,8 @@ class Cosmos3AttnProcessor:
         rotary_emb: tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # Per-pathway projections
-        q_und = attn.to_q(und_seq).view(-1, attn.num_attention_heads, attn.head_dim)
-        k_und = attn.to_k(und_seq).view(-1, attn.num_key_value_heads, attn.head_dim)
-        v_und = attn.to_v(und_seq).view(-1, attn.num_key_value_heads, attn.head_dim)
-        q_gen = attn.add_q_proj(gen_seq).view(-1, attn.num_attention_heads, attn.head_dim)
-        k_gen = attn.add_k_proj(gen_seq).view(-1, attn.num_key_value_heads, attn.head_dim)
-        v_gen = attn.add_v_proj(gen_seq).view(-1, attn.num_key_value_heads, attn.head_dim)
+        q_und, k_und, v_und = self._project_und_qkv(attn, und_seq)
+        q_gen, k_gen, v_gen = self._project_gen_qkv(attn, gen_seq)
 
         q_und = attn.norm_q(q_und)
         k_und = attn.norm_k(k_und)
@@ -233,7 +265,7 @@ class Cosmos3PackedMoTAttention(nn.Module, AttentionModuleMixin):
 
     _default_processor_cls = Cosmos3AttnProcessor
     _available_processors = [Cosmos3AttnProcessor]
-    _supports_qkv_fusion = False
+    _supports_qkv_fusion = True
 
     def __init__(
         self,
@@ -298,6 +330,45 @@ class Cosmos3PackedMoTAttention(nn.Module, AttentionModuleMixin):
         if processor is None:
             processor = self._default_processor_cls()
         self.set_processor(processor)
+        self.fused_projections = False
+
+    @staticmethod
+    def _new_packed_projection(projections: tuple[nn.Linear, ...]) -> nn.Linear:
+        first = projections[0]
+        return nn.Linear(
+            first.in_features,
+            sum(projection.out_features for projection in projections),
+            bias=first.bias is not None,
+            device=first.weight.device,
+            dtype=first.weight.dtype,
+        )
+
+    @staticmethod
+    def _copy_packed_projection(target: nn.Linear, projections: tuple[nn.Linear, ...]) -> None:
+        target.weight.copy_(torch.cat([projection.weight.data for projection in projections]))
+        if target.bias is not None:
+            target.bias.copy_(torch.cat([projection.bias.data for projection in projections]))
+
+    @torch.no_grad()
+    def fuse_projections(self) -> None:
+        if getattr(self, "fused_projections", False):
+            return
+        if self.load_reasoning_layers:
+            self.to_qkv = self._new_packed_projection((self.to_q, self.to_k, self.to_v))
+            self._copy_packed_projection(self.to_qkv, (self.to_q, self.to_k, self.to_v))
+        self.add_qkv_proj = self._new_packed_projection((self.add_q_proj, self.add_k_proj, self.add_v_proj))
+        self._copy_packed_projection(self.add_qkv_proj, (self.add_q_proj, self.add_k_proj, self.add_v_proj))
+        self.fused_projections = True
+
+    @torch.no_grad()
+    def unfuse_projections(self) -> None:
+        if not getattr(self, "fused_projections", False):
+            return
+        if hasattr(self, "to_qkv"):
+            delattr(self, "to_qkv")
+        if hasattr(self, "add_qkv_proj"):
+            delattr(self, "add_qkv_proj")
+        self.fused_projections = False
 
     def forward(
         self,
@@ -316,9 +387,7 @@ class Cosmos3PackedMoTAttention(nn.Module, AttentionModuleMixin):
     ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         if not self.load_reasoning_layers:
             raise RuntimeError("Cosmos3 generator-only attention cannot produce reasoner K/V tensors.")
-        q_und = self.to_q(und_seq).view(-1, self.num_attention_heads, self.head_dim)
-        k_und = self.to_k(und_seq).view(-1, self.num_key_value_heads, self.head_dim)
-        v_und = self.to_v(und_seq).view(-1, self.num_key_value_heads, self.head_dim)
+        q_und, k_und, v_und = self.processor._project_und_qkv(self, und_seq)
 
         q_und = self.norm_q(q_und)
         k_und = self.norm_k(k_und)
@@ -353,9 +422,7 @@ class Cosmos3PackedMoTAttention(nn.Module, AttentionModuleMixin):
         rotary_emb: tuple[torch.Tensor, torch.Tensor],
         reasoner_kv: dict[str, torch.Tensor],
     ) -> torch.Tensor:
-        q_gen = self.add_q_proj(gen_seq).view(-1, self.num_attention_heads, self.head_dim)
-        k_gen = self.add_k_proj(gen_seq).view(-1, self.num_key_value_heads, self.head_dim)
-        v_gen = self.add_v_proj(gen_seq).view(-1, self.num_key_value_heads, self.head_dim)
+        q_gen, k_gen, v_gen = self.processor._project_gen_qkv(self, gen_seq)
 
         q_gen = self.norm_added_q(q_gen)
         k_gen = self.norm_added_k(k_gen)
@@ -530,6 +597,8 @@ class Cosmos3OmniTransformer(ModelMixin, ConfigMixin, PeftAdapterMixin, Attentio
         use_und_k_norm_for_gen: bool = False,
         rope_axes_dim: tuple[int, int, int] | list[int] | None = None,
         load_reasoning_layers: bool = True,
+        musubi_blocks_to_swap: int = 0,
+        musubi_block_swap_device: str = "cpu",
     ):
         super().__init__()
 
@@ -596,6 +665,34 @@ class Cosmos3OmniTransformer(ModelMixin, ConfigMixin, PeftAdapterMixin, Attentio
             self.audio_modality_embed = nn.Parameter(torch.zeros(hidden_size))
 
         self.gradient_checkpointing = False
+        self.gradient_checkpointing_interval = None
+        self._musubi_block_swap = MusubiBlockSwapManager.build(
+            depth=num_hidden_layers,
+            blocks_to_swap=musubi_blocks_to_swap,
+            swap_device=musubi_block_swap_device,
+            logger=logger,
+        )
+
+    def fuse_qkv_projections(self, preferred_backend: str | None = None) -> None:
+        fused = 0
+        for module in self.modules():
+            if isinstance(module, Cosmos3PackedMoTAttention):
+                module.fuse_projections()
+                fused += 1
+        logger.info("Fused Cosmos3 QKV projections for %d attention module(s).", fused)
+
+    def unfuse_qkv_projections(self) -> None:
+        for module in self.modules():
+            if isinstance(module, Cosmos3PackedMoTAttention):
+                module.unfuse_projections()
+
+    def set_gradient_checkpointing_interval(self, interval: int):
+        self.gradient_checkpointing_interval = interval
+
+    def _should_gradient_checkpoint_layer(self, layer_idx: int) -> bool:
+        if not torch.is_grad_enabled() or not self.gradient_checkpointing:
+            return False
+        return self.gradient_checkpointing_interval is None or layer_idx % self.gradient_checkpointing_interval == 0
 
     # -------------------------------------------------------------------------
     # Pure-tensor packing/unpacking helpers (no layer state).
@@ -922,6 +1019,12 @@ class Cosmos3OmniTransformer(ModelMixin, ConfigMixin, PeftAdapterMixin, Attentio
         cos = cos.squeeze(0)
         sin = sin.squeeze(0)
 
+        grad_enabled = torch.is_grad_enabled()
+        musubi_manager = self._musubi_block_swap
+        musubi_offload_active = False
+        if musubi_manager is not None:
+            musubi_offload_active = musubi_manager.activate(self.layers, hidden_states.device, grad_enabled)
+
         if split_reasoner:
             layer_kv = (
                 reasoner_memory_state.layer_kv
@@ -933,25 +1036,33 @@ class Cosmos3OmniTransformer(ModelMixin, ConfigMixin, PeftAdapterMixin, Attentio
             gen_seq = hidden_states
             rotary_gen = (cos[und_len:], sin[und_len:])
             for layer_idx, decoder_layer in enumerate(self.layers):
-                if torch.is_grad_enabled() and self.gradient_checkpointing:
+                if musubi_offload_active and musubi_manager.is_managed_block(layer_idx):
+                    musubi_manager.stream_in(decoder_layer, gen_seq.device)
+                if self._should_gradient_checkpoint_layer(layer_idx):
                     gen_seq = self._gradient_checkpointing_func(
                         lambda x, layer=decoder_layer, kv=layer_kv[layer_idx]: layer.forward_gen_only(x, rotary_gen, kv),
                         gen_seq,
                     )
                 else:
                     gen_seq = decoder_layer.forward_gen_only(gen_seq, rotary_gen, layer_kv[layer_idx])
+                if musubi_offload_active and musubi_manager.is_managed_block(layer_idx):
+                    musubi_manager.stream_out(decoder_layer)
             last_hidden_state = self.norm_moe_gen(gen_seq)
         else:
             und_seq = hidden_states[:und_len]
             gen_seq = hidden_states[und_len:]
             rotary_emb = (cos[:und_len], sin[:und_len], cos[und_len:], sin[und_len:])
-            for decoder_layer in self.layers:
-                if torch.is_grad_enabled() and self.gradient_checkpointing:
+            for layer_idx, decoder_layer in enumerate(self.layers):
+                if musubi_offload_active and musubi_manager.is_managed_block(layer_idx):
+                    musubi_manager.stream_in(decoder_layer, gen_seq.device)
+                if self._should_gradient_checkpoint_layer(layer_idx):
                     und_seq, gen_seq = self._gradient_checkpointing_func(
                         decoder_layer.__call__, und_seq, gen_seq, rotary_emb
                     )
                 else:
                     und_seq, gen_seq = decoder_layer(und_seq, gen_seq, rotary_emb)
+                if musubi_offload_active and musubi_manager.is_managed_block(layer_idx):
+                    musubi_manager.stream_out(decoder_layer)
             und_out = self.norm(und_seq)
             gen_out = self.norm_moe_gen(gen_seq)
             last_hidden_state = torch.cat([und_out, gen_out], dim=0)

--- a/simpletuner/helpers/training/default_settings/safety_check.py
+++ b/simpletuner/helpers/training/default_settings/safety_check.py
@@ -147,6 +147,7 @@ def safety_check(args, accelerator):
         "auraflow",
         "hunyuanvideo",
         "ernie",
+        "cosmos3",
     ]
     if args.gradient_checkpointing_interval == 1:
         args.gradient_checkpointing_interval = None


### PR DESCRIPTION
This pull request introduces several improvements and feature additions to the Cosmos3 model and the data backend, primarily focused on text embedding cache handling, acceleration presets, and reasoner device management. The most significant changes enhance flexibility and efficiency in text embedding cache precomputation, add advanced acceleration configuration options, and improve device management for the Cosmos3 reasoner component.

**Key changes:**

### Text Embedding Cache & Precomputation

* Added support for model-specific metadata and key generation during text embedding cache precomputation by introducing `text_embed_cache_metadata_for_filepath` and `text_embed_cache_key_value` hooks in the model. This enables more precise and metadata-aware cache keys and metadata for each sample. [[1]](diffhunk://#diff-57615ebb58fa92a702515b29c5d3dcee1e1ac481ee2f71564229f128a28894feR3705-R3724) [[2]](diffhunk://#diff-2538a817e282512f320398fcd869236ba02d174aa5ac011b4e340fb7a5c5d3ceR260-R296)
* Improved logic for when to precompute null embeddings in the backend, now skipping precomputation if caption dropout is disabled or on-demand caching is enabled. [[1]](diffhunk://#diff-57615ebb58fa92a702515b29c5d3dcee1e1ac481ee2f71564229f128a28894feR2554-R2566) [[2]](diffhunk://#diff-57615ebb58fa92a702515b29c5d3dcee1e1ac481ee2f71564229f128a28894feL2565-R2576)
* Added a model hook (`after_text_embed_cache_precompute`) to perform post-processing after text embedding cache precomputation, such as offloading the reasoner from GPU to CPU. [[1]](diffhunk://#diff-2538a817e282512f320398fcd869236ba02d174aa5ac011b4e340fb7a5c5d3ceR260-R296) [[2]](diffhunk://#diff-57615ebb58fa92a702515b29c5d3dcee1e1ac481ee2f71564229f128a28894feR4531-R4536)

### Cosmos3 Reasoner Device Management

* Enhanced device management for the Cosmos3 reasoner: the reasoner is now explicitly moved to the accelerator device before cache encoding and offloaded back to CPU afterward to optimize GPU memory usage and prevent device mismatches.

### Acceleration Presets

* Added detailed RAMTORCH and MUSUBI block swap acceleration presets to `Cosmos3Image`, allowing users to choose between different VRAM/system RAM tradeoffs for transformer layer streaming or swapping. Also integrated existing DeepSpeed, SDNQ, TorchAO, Quanto, and BitsAndBytes presets.

### API and Logging Improvements

* Added a batch text encoding API (`encode_text_batch`) for the Cosmos3 model, improving usability for batch processing.
* Improved logging throughout the Cosmos3 model and data backend for better traceability during text cache encoding and device transitions. [[1]](diffhunk://#diff-2538a817e282512f320398fcd869236ba02d174aa5ac011b4e340fb7a5c5d3ceL68-R178) [[2]](diffhunk://#diff-2538a817e282512f320398fcd869236ba02d174aa5ac011b4e340fb7a5c5d3ceR214-R233) [[3]](diffhunk://#diff-2538a817e282512f320398fcd869236ba02d174aa5ac011b4e340fb7a5c5d3ceR389-R462) [[4]](diffhunk://#diff-2df0b278324c2df7f536e12375d39fe2307af75c2d8ee123dd0ff8448d9a6719R23-R24) [[5]](diffhunk://#diff-2538a817e282512f320398fcd869236ba02d174aa5ac011b4e340fb7a5c5d3ceL713-R923)

### Dependency Update

* Added `tiktoken` as a required dependency in `setup.py`.