### PR TITLE
quanto + musubi block swap compatibility

### DIFF
--- a/simpletuner/helpers/musubi_block_swap.py
+++ b/simpletuner/helpers/musubi_block_swap.py
@@ -10,12 +10,86 @@ __all__ = ["MusubiBlockSwapManager", "apply_musubi_pretrained_defaults"]
 def _module_on_device(module: nn.Module, device: torch.device) -> bool:
     target = torch.device(device)
     for tensor in module.parameters():
-        if tensor.device != target:
+        if not _tensor_on_device(tensor, target):
             return False
     for tensor in module.buffers():
-        if tensor.device != target:
+        if not _tensor_on_device(tensor, target):
             return False
     return True
+
+
+def _same_device(actual: torch.device, expected: torch.device) -> bool:
+    if actual == expected:
+        return True
+    if actual.type != expected.type:
+        return False
+    return expected.index is None and actual.index in (None, 0)
+
+
+def _is_quanto_tensor(tensor) -> bool:
+    module_name = type(tensor).__module__
+    return module_name.startswith("optimum.quanto.") and hasattr(tensor, "_data")
+
+
+def _tensor_on_device(tensor, device: torch.device) -> bool:
+    if not _same_device(tensor.device, device):
+        return False
+    if not _is_quanto_tensor(tensor):
+        return True
+    for attr in ("_data", "_scale", "_shift", "_scale_shift"):
+        value = getattr(tensor, attr, None)
+        if value is None:
+            continue
+        if _is_quanto_tensor(value):
+            if not _tensor_on_device(value, device):
+                return False
+            continue
+        if hasattr(value, "device") and not _same_device(value.device, device):
+            return False
+    return True
+
+
+def _module_has_quanto_tensor(module: nn.Module) -> bool:
+    return any(_is_quanto_tensor(tensor) for tensor in module.parameters()) or any(
+        _is_quanto_tensor(tensor) for tensor in module.buffers()
+    )
+
+
+def _move_quanto_tensor_to_device(tensor, device: torch.device):
+    if not _same_device(tensor.device, device):
+        tensor.data = tensor.data.to(device, non_blocking=True)
+    for attr in ("_data", "_scale", "_shift", "_scale_shift"):
+        value = getattr(tensor, attr, None)
+        if value is None:
+            continue
+        if _is_quanto_tensor(value):
+            _move_quanto_tensor_to_device(value, device)
+            continue
+        if hasattr(value, "device") and not _same_device(value.device, device):
+            setattr(tensor, attr, value.to(device, non_blocking=True))
+
+
+def _move_module_without_swapping_quanto_params(module: nn.Module, device: torch.device):
+    for child in module.children():
+        _move_module_without_swapping_quanto_params(child, device)
+
+    for key, param in module._parameters.items():
+        if param is None:
+            continue
+        if _is_quanto_tensor(param):
+            _move_quanto_tensor_to_device(param, device)
+        elif not _same_device(param.device, device):
+            param.data = param.data.to(device, non_blocking=True)
+        if param.grad is not None and not _same_device(param.grad.device, device):
+            param.grad = param.grad.to(device, non_blocking=True)
+
+    for key, buffer in module._buffers.items():
+        if buffer is None:
+            continue
+        if _is_quanto_tensor(buffer):
+            _move_quanto_tensor_to_device(buffer, device)
+        elif not _same_device(buffer.device, device):
+            module._buffers[key] = buffer.to(device, non_blocking=True)
 
 
 class MusubiBlockSwapManager:
@@ -143,7 +217,10 @@ class MusubiBlockSwapManager:
         if _module_on_device(module, device):
             return
         with torch.no_grad():
-            module.to(device)
+            if _module_has_quanto_tensor(module):
+                _move_module_without_swapping_quanto_params(module, device)
+            else:
+                module.to(device)
 
 
 def apply_musubi_pretrained_defaults(config, pretrained_load_args: dict) -> dict:

--- a/tests/test_musubi_block_swap.py
+++ b/tests/test_musubi_block_swap.py
@@ -1,0 +1,56 @@
+import logging
+import unittest
+from unittest.mock import patch
+
+import torch
+from torch import nn
+
+from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager, _module_on_device
+
+
+class MusubiBlockSwapTests(unittest.TestCase):
+    def _accelerator_device(self):
+        if torch.cuda.is_available():
+            return torch.device("cuda")
+        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+            return torch.device("mps")
+        self.skipTest("No accelerator device available for block swap transfer tests")
+
+    def test_quanto_qlinear_streams_without_apply_swap(self):
+        try:
+            from optimum.quanto import freeze, qint8, quantize
+            from optimum.quanto.nn.qlinear import QLinear
+        except ImportError as exc:
+            self.skipTest(f"Quanto int8 quantization is unavailable: {exc}")
+
+        device = self._accelerator_device()
+        block = nn.Sequential(nn.Linear(4, 4), nn.SiLU(), nn.Linear(4, 4))
+        quantize(block, weights=qint8)
+        freeze(block)
+        qlinear = block[0]
+        self.assertIsInstance(qlinear, QLinear)
+
+        manager = MusubiBlockSwapManager(
+            block_indices=[0],
+            offload_device=torch.device("cpu"),
+            logger=logging.getLogger(__name__),
+        )
+
+        with patch.object(QLinear, "_apply", side_effect=RuntimeError("_apply(): Couldn't swap QLinear.weight")):
+            manager.stream_in(block, device)
+            self.assertTrue(_module_on_device(block, device))
+            self.assertEqual(qlinear.weight.device.type, device.type)
+            self.assertEqual(qlinear.weight._data.device.type, device.type)
+            self.assertEqual(qlinear.weight._scale.device.type, device.type)
+            output = block(torch.randn(2, 4, device=device))
+            self.assertEqual(output.device.type, device.type)
+
+            manager.stream_out(block)
+            self.assertTrue(_module_on_device(block, torch.device("cpu")))
+            self.assertEqual(qlinear.weight.device.type, "cpu")
+            self.assertEqual(qlinear.weight._data.device.type, "cpu")
+            self.assertEqual(qlinear.weight._scale.device.type, "cpu")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request enhances device management for quantized tensors in the Musubi block swap helper and introduces comprehensive tests for these scenarios. The main improvements are the addition of specialized logic to correctly detect, move, and verify "quanto" quantized tensors within modules, and the introduction of a test suite to ensure correct behavior, especially when standard PyTorch methods cannot be used.

**Device management for quantized tensors:**

* Added helper functions (`_same_device`, `_is_quanto_tensor`, `_tensor_on_device`, `_module_has_quanto_tensor`, `_move_quanto_tensor_to_device`, `_move_module_without_swapping_quanto_params`) to detect and recursively move "quanto" quantized tensors and their sub-tensors to the correct device, ensuring all relevant attributes are properly transferred.
* Modified the `_move_module` method to use the custom quanto-aware logic when quantized tensors are present, falling back to the default `.to(device)` otherwise.

**Testing improvements:**

* Added a new test suite in `tests/test_musubi_block_swap.py` to verify correct streaming of quantized modules, including handling of `QLinear` layers and fallback logic when the standard `_apply` method fails.

These changes ensure robust support for quantized models and improve test coverage for device transfer logic.