### PR TITLE
VAE Cache: fix reporting of write counts

### DIFF
--- a/simpletuner/helpers/caching/vae.py
+++ b/simpletuner/helpers/caching/vae.py
@@ -233,6 +233,8 @@ class VAECache(WebhookMixin):
         self.vae_input_queue = Queue()
         self._local_unprocessed_files_set_source = None
         self._local_unprocessed_files_set = None
+        self._vae_cache_written_count = 0
+        self._vae_cache_written_lock = threading.Lock()
 
         # Initialize batch processing helper
         self.batch_processor = BatchedTrainingSamples()
@@ -1400,6 +1402,8 @@ class VAECache(WebhookMixin):
 
         if not self.vae_cache_disable:
             self.cache_data_backend.write_batch(filepaths, latents)
+            with self._vae_cache_written_lock:
+                self._vae_cache_written_count += len(filepaths)
 
         return latents
 
@@ -2009,6 +2013,8 @@ class VAECache(WebhookMixin):
                     }
                     last_reported_index = 0
                     local_unprocessed_files = self._local_unprocessed_file_set()
+                    with self._vae_cache_written_lock:
+                        written_before_bucket = self._vae_cache_written_count
 
                     for raw_filepath in tqdm(
                         relevant_files,
@@ -2045,7 +2051,6 @@ class VAECache(WebhookMixin):
                                 futures.append(future_to_process)
 
                             if self.vae_input_queue.qsize() >= self.vae_batch_size:
-                                statistics["cached"] += 1
                                 future_to_process = executor.submit(self._encode_images_in_batch)
                                 futures.append(future_to_process)
                                 if self.webhook_handler is not None:
@@ -2106,6 +2111,8 @@ class VAECache(WebhookMixin):
                             futures.append(future_to_write)
 
                         futures = self._process_futures(futures, executor)
+                        with self._vae_cache_written_lock:
+                            statistics["cached"] += max(0, self._vae_cache_written_count - written_before_bucket)
                         log_msg = f"(id={self.id}) Bucket {bucket} caching results: {statistics}"
                         if get_rank() == 0:
                             logger.debug(log_msg)
@@ -2128,6 +2135,15 @@ class VAECache(WebhookMixin):
         # Send completion event for VAE cache initialization
         self._finalize_deferred_metadata_filters()
         self._write_nsfw_scan_report()
+        if self.accelerator.is_local_main_process:
+            StateTracker.set_vae_cache_files(
+                self.cache_data_backend.list_files(
+                    instance_data_dir=self.cache_dir,
+                    file_extensions=["pt"],
+                ),
+                data_backend_id=self.id,
+            )
+        self.accelerator.wait_for_everyone()
         if self.webhook_handler is not None:
             event = lifecycle_stage_event(
                 key="init_vae_cache",


### PR DESCRIPTION
This pull request introduces improvements to how VAE cache statistics are tracked and reported during bucket processing in `simpletuner/helpers/caching/vae.py`. The main changes focus on making the cache write count thread-safe, ensuring accurate statistics, and updating the state after cache initialization.

**VAE cache write tracking and statistics:**

* Introduced a thread-safe counter (`_vae_cache_written_count`) with a lock to accurately track the number of files written to the VAE cache during batch operations (`__init__`, `_write_latents_in_batch`) [[1]](diffhunk://#diff-614668871ca0c481a8427daef01930a4dbbf640cd7c1b15e3fba9d8d2cbe4f4eR236-R237) [[2]](diffhunk://#diff-614668871ca0c481a8427daef01930a4dbbf640cd7c1b15e3fba9d8d2cbe4f4eR1405-R1406).
* Updated the `process_buckets` method to use the thread-safe counter for reporting how many files were cached in each bucket, replacing the previous increment on batch size with the actual number written (`process_buckets`) [[1]](diffhunk://#diff-614668871ca0c481a8427daef01930a4dbbf640cd7c1b15e3fba9d8d2cbe4f4eR2016-R2017) [[2]](diffhunk://#diff-614668871ca0c481a8427daef01930a4dbbf640cd7c1b15e3fba9d8d2cbe4f4eR2114-R2115) [[3]](diffhunk://#diff-614668871ca0c481a8427daef01930a4dbbf640cd7c1b15e3fba9d8d2cbe4f4eL2048).

**State tracking and reporting:**

* After VAE cache initialization, the list of cached files is now explicitly set in `StateTracker` for the main process, ensuring downstream components have up-to-date information (`process_buckets`).