### PR TITLE
StateTracker: storing flat string vae cache paths

### DIFF
--- a/simpletuner/helpers/training/state_tracker.py
+++ b/simpletuner/helpers/training/state_tracker.py
@@ -634,10 +634,13 @@ class StateTracker:
             cls.all_vae_cache_files[data_backend_id].clear()
         else:
             cls.all_vae_cache_files[data_backend_id] = {}
-        for subdirectory_list in raw_file_list:
-            _, _, files = subdirectory_list
+        for entry in raw_file_list or []:
+            if isinstance(entry, (str, Path)):
+                files = [str(entry)]
+            else:
+                _, _, files = entry
             for image in files:
-                cls.all_vae_cache_files[data_backend_id][image] = False
+                cls.all_vae_cache_files[data_backend_id][str(image)] = False
         cls._save_to_disk(
             "all_vae_cache_files_{}".format(data_backend_id),
             cls.all_vae_cache_files[data_backend_id],


### PR DESCRIPTION
This pull request updates the `set_vae_cache_files` method in `state_tracker.py` to improve its robustness and flexibility when handling the `raw_file_list` input. The main change is to allow the method to accept both lists of directory entries as well as individual file paths, ensuring that the cache is set correctly regardless of the input format.

**Improvements to input handling:**

* Updated `set_vae_cache_files` to handle cases where `raw_file_list` contains either directory entry tuples or individual file paths, making the method more flexible and less error-prone.
* Ensured all file paths are consistently converted to strings before being added to the cache, improving reliability when working with different path types.