### PR TITLE
cosmos3: unload VAE during training when not needed

### DIFF
--- a/simpletuner/helpers/models/cosmos3/model.py
+++ b/simpletuner/helpers/models/cosmos3/model.py
@@ -678,13 +678,13 @@ class Cosmos3Image(Cosmos2Image):
             self._training_pipeline_adapter = Cosmos3OmniPipeline(
                 transformer=self.unwrap_model(self.model),
                 text_tokenizer=self.text_tokenizer,
-                vae=self.get_vae(),
+                vae=None,
                 scheduler=self.noise_schedule,
                 sound_tokenizer=self.sound_tokenizer,
             )
         else:
             self._training_pipeline_adapter.transformer = self.unwrap_model(self.model)
-            self._training_pipeline_adapter.vae = self.get_vae()
+            self._training_pipeline_adapter.vae = None
             self._training_pipeline_adapter.sound_tokenizer = self.sound_tokenizer
         return self._training_pipeline_adapter
 

--- a/simpletuner/helpers/models/cosmos3/pipeline.py
+++ b/simpletuner/helpers/models/cosmos3/pipeline.py
@@ -353,7 +353,7 @@ class Cosmos3OmniPipeline(DiffusionPipeline):
         self,
         transformer: Cosmos3OmniTransformer,
         text_tokenizer: AutoTokenizer,
-        vae: AutoencoderKLWan,
+        vae: AutoencoderKLWan | None,
         scheduler: UniPCMultistepScheduler,
         sound_tokenizer: Cosmos3AVAEAudioTokenizer | None = None,
         default_use_system_prompt: bool = True,
@@ -371,9 +371,15 @@ class Cosmos3OmniPipeline(DiffusionPipeline):
             scheduler=scheduler,
             sound_tokenizer=sound_tokenizer,
         )
-        # VAE latent normalization stats
-        self._vae_latents_mean = torch.tensor(vae.config.latents_mean, dtype=vae.dtype)
-        self._vae_latents_inv_std = 1.0 / torch.tensor(vae.config.latents_std, dtype=vae.dtype)
+        # VAE latent normalization stats. The training adapter can be constructed
+        # without a live VAE because it consumes precomputed latents and only
+        # needs scale factors for prompt/mRoPE metadata.
+        if vae is not None:
+            self._vae_latents_mean = torch.tensor(vae.config.latents_mean, dtype=vae.dtype)
+            self._vae_latents_inv_std = 1.0 / torch.tensor(vae.config.latents_std, dtype=vae.dtype)
+        else:
+            self._vae_latents_mean = torch.zeros(1, dtype=torch.float32)
+            self._vae_latents_inv_std = torch.ones(1, dtype=torch.float32)
 
         # Image preprocessor for caller-supplied conditioning frames (PIL / tensor / numpy).
         self.vae_scale_factor_spatial = int(self.vae.config.scale_factor_spatial) if getattr(self, "vae", None) else 16


### PR DESCRIPTION
This pull request updates the Cosmos3 model pipeline to allow for the training adapter to be constructed without requiring a live VAE (Variational Autoencoder). This is useful because, during training, precomputed latents are used and only the VAE's scale factors are needed for prompt metadata. The main changes involve making the VAE argument optional and handling cases where it is not provided.

**Pipeline construction and VAE handling:**

* Changed the `vae` parameter in the `Cosmos3OmniPipeline` constructor to accept `None`, making it optional (`vae: AutoencoderKLWan | None`) (`simpletuner/helpers/models/cosmos3/pipeline.py`).
* Updated the initialization logic to handle cases where `vae` is `None` by setting default values for latent normalization statistics (`_vae_latents_mean` and `_vae_latents_inv_std`) (`simpletuner/helpers/models/cosmos3/pipeline.py`).

**Training pipeline adapter:**

* Modified `_get_training_pipeline_adapter` to pass `vae=None` instead of a live VAE, since precomputed latents are used during training (`simpletuner/helpers/models/cosmos3/model.py`).

These changes make the training pipeline more flexible and robust when a live VAE is not required.