### PR TITLE
fix krea2 validation lora loading

### DIFF
--- a/simpletuner/helpers/models/krea2/lora_pipeline.py
+++ b/simpletuner/helpers/models/krea2/lora_pipeline.py
@@ -7,6 +7,9 @@ import torch
 from diffusers.loaders.lora_base import LoraBaseMixin, _fetch_state_dict
 from diffusers.utils import (
     USE_PEFT_BACKEND,
+    convert_unet_state_dict_to_peft,
+    get_adapter_name,
+    get_peft_kwargs,
     is_peft_available,
     is_peft_version,
     is_torch_version,
@@ -15,6 +18,8 @@ from diffusers.utils import (
     logging,
 )
 from huggingface_hub.utils import validate_hf_hub_args
+
+from simpletuner.helpers.utils.offloading import restore_offload_state, unpack_offload_state
 
 _LOW_CPU_MEM_USAGE_DEFAULT_LORA = False
 if is_torch_version(">=", "1.9.0"):
@@ -27,8 +32,60 @@ if is_torch_version(">=", "1.9.0"):
         _LOW_CPU_MEM_USAGE_DEFAULT_LORA = True
 
 TRANSFORMER_NAME = "transformer"
+KREA2_LORA_TRANSFORMER_PREFIXES = ("transformer", "diffusion_model")
+KREA2_EXTERNAL_LORA_MODULE_MAP = (
+    ("blocks.", "transformer_blocks."),
+    (".attn.wq.", ".attn.to_q."),
+    (".attn.wk.", ".attn.to_k."),
+    (".attn.wv.", ".attn.to_v."),
+    (".attn.wo.", ".attn.to_out.0."),
+    (".attn.gate.", ".attn.to_gate."),
+    (".mlp.gate.", ".ff.gate."),
+    (".mlp.up.", ".ff.up."),
+    (".mlp.down.", ".ff.down."),
+)
 
 logger = logging.get_logger(__name__)
+
+
+def _normalize_krea2_lora_state_dict(
+    state_dict: dict[str, torch.Tensor],
+) -> tuple[dict[str, torch.Tensor], str | None]:
+    """Return KREA2 transformer LoRA keys without their serialization prefix."""
+    for prefix in KREA2_LORA_TRANSFORMER_PREFIXES:
+        prefix_with_dot = f"{prefix}."
+        matches = {
+            _translate_krea2_lora_module_key(key.removeprefix(prefix_with_dot)): value
+            for key, value in state_dict.items()
+            if key.startswith(prefix_with_dot)
+        }
+        if matches:
+            return matches, prefix
+
+    return {_translate_krea2_lora_module_key(key): value for key, value in state_dict.items()}, None
+
+
+def _translate_krea2_lora_module_key(key: str) -> str:
+    """Map external KREA LoRA module names onto SimpleTuner's KREA2 module graph."""
+    translated = key
+    for old, new in KREA2_EXTERNAL_LORA_MODULE_MAP:
+        if old == "blocks.":
+            if translated.startswith(old):
+                translated = translated.replace(old, new, 1)
+            continue
+        translated = translated.replace(old, new)
+    return translated
+
+
+def _infer_krea2_lora_target_modules(state_dict: dict[str, torch.Tensor]) -> list[str]:
+    """Infer exact model-relative module paths from PEFT-style LoRA tensor keys."""
+    target_modules: dict[str, None] = {}
+    for key in state_dict:
+        for marker in (".lora_A.", ".lora_B."):
+            if marker in key:
+                target_modules[key.split(marker, 1)[0]] = None
+                break
+    return list(target_modules)
 
 
 class Krea2LoraLoaderMixin(LoraBaseMixin):
@@ -156,17 +213,87 @@ class Krea2LoraLoaderMixin(LoraBaseMixin):
                 "`low_cpu_mem_usage=True` is not compatible with this `peft` version. Please update it with `pip install -U peft`."
             )
 
-        # Load the layers corresponding to transformer.
-        logger.info(f"Loading {cls.transformer_name}.")
-        transformer.load_lora_adapter(
-            state_dict,
-            network_alphas=None,
-            adapter_name=adapter_name,
-            metadata=metadata,
-            _pipeline=_pipeline,
-            low_cpu_mem_usage=low_cpu_mem_usage,
-            hotswap=hotswap,
+        if hotswap:
+            # Keep the upstream hot-swap implementation for compiled pipelines. Normal validation
+            # adapter loading uses the explicit PEFT path below so KREA module names are targeted.
+            logger.info(f"Loading {cls.transformer_name}.")
+            transformer.load_lora_adapter(
+                state_dict,
+                network_alphas=None,
+                adapter_name=adapter_name,
+                metadata=metadata,
+                _pipeline=_pipeline,
+                low_cpu_mem_usage=low_cpu_mem_usage,
+                hotswap=hotswap,
+            )
+            return
+
+        from peft import LoraConfig, inject_adapter_in_model, set_peft_model_state_dict
+
+        state_dict, source_prefix = _normalize_krea2_lora_state_dict(state_dict)
+        if not state_dict:
+            supported = ", ".join(f"{prefix}.*" for prefix in KREA2_LORA_TRANSFORMER_PREFIXES)
+            raise ValueError(f"No KREA2 transformer LoRA keys were found. Expected one of: {supported}.")
+
+        first_key = next(iter(state_dict.keys()))
+        if "lora_A" not in first_key:
+            state_dict = convert_unet_state_dict_to_peft(state_dict)
+
+        if adapter_name in getattr(transformer, "peft_config", {}):
+            raise ValueError(
+                f"Adapter name {adapter_name} already in use in the transformer - please select a new adapter name."
+            )
+
+        rank = {}
+        for key, val in state_dict.items():
+            if "lora_B" in key and getattr(val, "ndim", 0) > 1:
+                rank[key] = val.shape[1]
+
+        target_modules = _infer_krea2_lora_target_modules(state_dict)
+        if not target_modules:
+            raise ValueError(
+                "Could not infer KREA2 LoRA target modules from the adapter state dict. "
+                "Expected keys ending in .lora_A.weight and .lora_B.weight."
+            )
+
+        lora_config_kwargs = get_peft_kwargs(rank, network_alpha_dict=None, peft_state_dict=state_dict)
+        lora_config_kwargs["target_modules"] = target_modules
+        if "use_dora" in lora_config_kwargs:
+            if lora_config_kwargs["use_dora"] and is_peft_version("<", "0.9.0"):
+                raise ValueError(
+                    "You need `peft` 0.9.0 at least to use DoRA-enabled LoRAs. "
+                    "Please upgrade your installation of `peft`."
+                )
+            if not lora_config_kwargs["use_dora"]:
+                lora_config_kwargs.pop("use_dora")
+        lora_config = LoraConfig(**lora_config_kwargs)
+
+        if adapter_name is None:
+            adapter_name = get_adapter_name(transformer)
+
+        logger.info(
+            f"Loading {cls.transformer_name} LoRA adapter '{adapter_name}' "
+            f"from {source_prefix or 'unprefixed'} keys with {len(target_modules)} target module(s)."
         )
+
+        offload_state = cls._optionally_disable_offloading(_pipeline)
+        (
+            is_model_cpu_offload,
+            is_sequential_cpu_offload,
+            is_group_offload,
+        ) = unpack_offload_state(offload_state)
+
+        peft_kwargs = {}
+        if is_peft_version(">=", "0.13.1"):
+            peft_kwargs["low_cpu_mem_usage"] = low_cpu_mem_usage
+
+        try:
+            inject_adapter_in_model(lora_config, transformer, adapter_name=adapter_name, **peft_kwargs)
+            incompatible_keys = set_peft_model_state_dict(transformer, state_dict, adapter_name, **peft_kwargs)
+            if incompatible_keys is not None:
+                logger.info(f"Loaded KREA2 LoRA with incompatible keys: {incompatible_keys}")
+        finally:
+            restore_offload_state(_pipeline, is_model_cpu_offload, is_sequential_cpu_offload, is_group_offload)
 
     @classmethod
     # Copied from diffusers.loaders.lora_pipeline.CogVideoXLoraLoaderMixin.save_lora_weights

--- a/tests/test_krea2_model.py
+++ b/tests/test_krea2_model.py
@@ -1,11 +1,13 @@
 import inspect
 import unittest
 from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import torch
 
 from simpletuner.helpers.models.common import TextEmbedCacheKey
 from simpletuner.helpers.models.krea2 import Krea2, Krea2LoraLoaderMixin, Krea2Pipeline, Krea2Transformer2DModel
+from simpletuner.helpers.models.krea2.lora_pipeline import _infer_krea2_lora_target_modules, _normalize_krea2_lora_state_dict
 from simpletuner.helpers.models.krea2.transformer import Krea2Attention, _krea2_rope_freqs_dtype
 from simpletuner.helpers.models.registry import ModelRegistry
 from simpletuner.helpers.training.tread import TREADRouter
@@ -77,6 +79,127 @@ class Krea2VendoredModelTests(unittest.TestCase):
     def test_lora_save_accepts_transformer_metadata(self):
         parameters = inspect.signature(Krea2LoraLoaderMixin.save_lora_weights).parameters
         self.assertIn("transformer_lora_adapter_metadata", parameters)
+
+    def test_lora_loader_normalizes_transformer_prefix_and_targets(self):
+        state_dict = {
+            "transformer.blocks.0.attn.wq.lora_A.weight": torch.ones(4, 8),
+            "transformer.blocks.0.attn.wq.lora_B.weight": torch.ones(8, 4),
+            "transformer.blocks.0.mlp.up.lora_A.weight": torch.ones(4, 8),
+            "transformer.blocks.0.mlp.up.lora_B.weight": torch.ones(8, 4),
+        }
+
+        normalized, prefix = _normalize_krea2_lora_state_dict(state_dict)
+
+        self.assertEqual(prefix, "transformer")
+        self.assertEqual(
+            list(normalized),
+            [
+                "transformer_blocks.0.attn.to_q.lora_A.weight",
+                "transformer_blocks.0.attn.to_q.lora_B.weight",
+                "transformer_blocks.0.ff.up.lora_A.weight",
+                "transformer_blocks.0.ff.up.lora_B.weight",
+            ],
+        )
+        self.assertEqual(
+            _infer_krea2_lora_target_modules(normalized),
+            ["transformer_blocks.0.attn.to_q", "transformer_blocks.0.ff.up"],
+        )
+
+    def test_lora_loader_accepts_comfyui_diffusion_model_prefix(self):
+        state_dict = {
+            "diffusion_model.blocks.1.attn.wv.lora_A.weight": torch.ones(2, 8),
+            "diffusion_model.blocks.1.attn.wv.lora_B.weight": torch.ones(8, 2),
+        }
+
+        normalized, prefix = _normalize_krea2_lora_state_dict(state_dict)
+
+        self.assertEqual(prefix, "diffusion_model")
+        self.assertEqual(
+            normalized,
+            {
+                "transformer_blocks.1.attn.to_v.lora_A.weight": state_dict["diffusion_model.blocks.1.attn.wv.lora_A.weight"],
+                "transformer_blocks.1.attn.to_v.lora_B.weight": state_dict["diffusion_model.blocks.1.attn.wv.lora_B.weight"],
+            },
+        )
+        self.assertEqual(_infer_krea2_lora_target_modules(normalized), ["transformer_blocks.1.attn.to_v"])
+
+    def test_lora_loader_injects_external_krea2_adapter_with_requested_name(self):
+        transformer = Krea2Transformer2DModel(
+            in_channels=4,
+            num_layers=1,
+            attention_head_dim=6,
+            num_attention_heads=1,
+            num_key_value_heads=1,
+            intermediate_size=8,
+            timestep_embed_dim=8,
+            text_hidden_dim=6,
+            num_text_layers=1,
+            text_num_attention_heads=1,
+            text_num_key_value_heads=1,
+            text_intermediate_size=8,
+            num_layerwise_text_blocks=1,
+            num_refiner_text_blocks=0,
+            axes_dims_rope=(2, 2, 2),
+        )
+        state_dict = {
+            "transformer.blocks.0.attn.wq.lora_A.weight": torch.ones(2, 6),
+            "transformer.blocks.0.attn.wq.lora_B.weight": torch.ones(6, 2),
+        }
+
+        Krea2LoraLoaderMixin.load_lora_into_transformer(
+            state_dict,
+            transformer=transformer,
+            adapter_name="krea2_turbo",
+        )
+
+        self.assertIn("krea2_turbo", transformer.peft_config)
+        self.assertIn("transformer_blocks.0.attn.to_q", transformer.peft_config["krea2_turbo"].target_modules)
+
+    def test_lora_loader_injects_without_state_dict_argument(self):
+        transformer = torch.nn.Module()
+        state_dict = {
+            "transformer.blocks.0.attn.wq.lora_A.weight": torch.ones(2, 6),
+            "transformer.blocks.0.attn.wq.lora_B.weight": torch.ones(6, 2),
+        }
+
+        with (
+            patch("peft.inject_adapter_in_model") as mock_inject,
+            patch("peft.set_peft_model_state_dict", return_value=None),
+            patch.object(Krea2LoraLoaderMixin, "_optionally_disable_offloading", return_value=False),
+            patch("simpletuner.helpers.models.krea2.lora_pipeline.restore_offload_state"),
+        ):
+            Krea2LoraLoaderMixin.load_lora_into_transformer(
+                state_dict,
+                transformer=transformer,
+                adapter_name="krea2_turbo",
+            )
+
+        mock_inject.assert_called_once()
+        self.assertNotIn("state_dict", mock_inject.call_args.kwargs)
+
+    def test_lora_loader_restores_offload_state_when_injection_fails(self):
+        transformer = torch.nn.Module()
+        pipeline = Mock()
+        state_dict = {
+            "transformer.blocks.0.attn.wq.lora_A.weight": torch.ones(2, 6),
+            "transformer.blocks.0.attn.wq.lora_B.weight": torch.ones(6, 2),
+        }
+
+        with (
+            patch("peft.inject_adapter_in_model", side_effect=RuntimeError("inject failed")),
+            patch("peft.set_peft_model_state_dict"),
+            patch.object(Krea2LoraLoaderMixin, "_optionally_disable_offloading", return_value=(True, False, True)),
+            patch("simpletuner.helpers.models.krea2.lora_pipeline.restore_offload_state") as mock_restore,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "inject failed"):
+                Krea2LoraLoaderMixin.load_lora_into_transformer(
+                    state_dict,
+                    transformer=transformer,
+                    adapter_name="krea2_turbo",
+                    _pipeline=pipeline,
+                )
+
+        mock_restore.assert_called_once_with(pipeline, True, False, True)
 
     def test_pipeline_accepts_reference_image_for_validation(self):
         parameters = inspect.signature(Krea2Pipeline.__call__).parameters


### PR DESCRIPTION
## Summary

Ports the Krea2 validation LoRA loading fix from whitejt2/SimpleTuner@fca592c638090deaa8bfbf193c5f093b35a2ead0.

Krea2 validation adapters can be serialized with external transformer prefixes and KREA module names such as `transformer.blocks.*` or `diffusion_model.blocks.*`. The current vendored loader passes those keys directly to the transformer adapter loader, which does not target SimpleTuner's Krea2 module graph correctly.

This change normalizes Krea2 LoRA keys, infers exact PEFT target modules, injects the adapter into the transformer, and preserves the existing hotswap path for compiled validation.

## Validation

- `.venv/bin/python -m unittest tests.test_krea2_model -v`

## Notes

The later fork commits for target alignment and compiled lifecycle are stacked on top of this loader rewrite and should be reviewed after this branch.