### PR TITLE
fix webui trainer callable globals

### DIFF
--- a/simpletuner/simpletuner_sdk/process_keeper.py
+++ b/simpletuner/simpletuner_sdk/process_keeper.py
@@ -367,7 +367,7 @@ mode = func_payload.get("mode")
 
 if mode == "callable":
     try:
-        globals_dict = {{"__builtins__": __builtins__}}
+        globals_dict = {{"__builtins__": __builtins__, "sys": sys}}
         globals_meta = func_payload.get("globals", {{}}) or {{}}
         modules_meta = globals_meta.get("modules", {{}}) or {{}}
         values_meta = globals_meta.get("values", {{}}) or {{}}

--- a/tests/test_process_keeper.py
+++ b/tests/test_process_keeper.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 import threading
 import time
+import types
 import unittest
 from contextlib import suppress
 from unittest.mock import MagicMock, Mock, patch
@@ -162,6 +163,10 @@ def crashing_task(config):
     os._exit(1)
 
 
+def sys_global_task(config):
+    return sys.version_info.major
+
+
 def slow_shutdown(config):
     # slow shutdown handler for testing timeouts
     signal.signal(signal.SIGTERM, lambda s, f: time.sleep(10))
@@ -299,6 +304,23 @@ class TestProcessLifecycle(ProcessKeeperTestCase):
         events = get_process_events(job_id)
         error_events = [event for event in events if (event.get("type") or "").lower() == "error"]
         self.assertTrue(error_events, f"Expected error event, received: {events}")
+
+    def test_callable_payload_reconstruction_provides_sys_global(self):
+        job_id = "test_callable_sys_global"
+        self.test_jobs.append(job_id)
+        target = types.FunctionType(sys_global_task.__code__, {"__builtins__": __builtins__}, sys_global_task.__name__)
+
+        submit_job(job_id, target, {})
+
+        deadline = time.time() + 5
+        status = None
+        while time.time() < deadline:
+            status = get_process_status(job_id)
+            if status not in {"pending", "running"}:
+                break
+            time.sleep(0.1)
+
+        self.assertEqual(status, "completed")
 
     def test_log_extraction_prefers_cuda_oom_message(self):
         """Synthetic log extraction should highlight CUDA OOM failures."""


### PR DESCRIPTION
## Summary

Ports the callable globals fix from whitejt2/SimpleTuner@2041c0181fa410403641ba55cdc3a044eb202674 and adds a regression test.

The subprocess callable reconstruction path can rebuild a function with a globals dictionary that lacks `sys`. The generated runner script imports and uses `sys`, so providing it in the reconstructed callable globals prevents valid callables from failing when their serialized globals do not carry `sys` explicitly.

## Validation

- `.venv/bin/python -m unittest tests.test_process_keeper.TestProcessLifecycle.test_callable_payload_reconstruction_provides_sys_global -v`
- `.venv/bin/python -m unittest tests.test_process_keeper -v`