### PR TITLE
fix local gpu queue incomplete preferences

### DIFF
--- a/simpletuner/simpletuner_sdk/server/services/local_gpu_allocator.py
+++ b/simpletuner/simpletuner_sdk/server/services/local_gpu_allocator.py
@@ -20,6 +20,20 @@ logger = logging.getLogger(__name__)
 _allocator_instance: Optional["LocalGPUAllocator"] = None
 
 
+def dedupe_gpu_ids(gpu_ids: Optional[List[int]]) -> Optional[List[int]]:
+    """Return GPU IDs with duplicates removed in their original order."""
+    if not gpu_ids:
+        return gpu_ids
+    deduped = []
+    seen = set()
+    for gpu_id in gpu_ids:
+        if gpu_id in seen:
+            continue
+        seen.add(gpu_id)
+        deduped.append(gpu_id)
+    return deduped
+
+
 def get_gpu_allocator() -> "LocalGPUAllocator":
     """Get the singleton LocalGPUAllocator instance."""
     global _allocator_instance
@@ -460,11 +474,10 @@ class LocalGPUAllocator:
             # Get any_gpu setting from metadata
             metadata = job.metadata or {}
             any_gpu = metadata.get("any_gpu", False)
-            preferred_gpus = job.allocated_gpus if not any_gpu else None
+            preferred_gpus = dedupe_gpu_ids(job.allocated_gpus) if not any_gpu else None
             if preferred_gpus and len(preferred_gpus) < job.num_processes:
                 logger.warning(
-                    "Queued job %s needs %d GPU(s), but only has preferred GPUs %s; "
-                    "falling back to any available GPUs",
+                    "Queued job %s needs %d GPU(s), but only has preferred GPUs %s; " "falling back to any available GPUs",
                     job.job_id,
                     job.num_processes,
                     preferred_gpus,

--- a/simpletuner/simpletuner_sdk/server/services/local_gpu_allocator.py
+++ b/simpletuner/simpletuner_sdk/server/services/local_gpu_allocator.py
@@ -460,10 +460,20 @@ class LocalGPUAllocator:
             # Get any_gpu setting from metadata
             metadata = job.metadata or {}
             any_gpu = metadata.get("any_gpu", False)
+            preferred_gpus = job.allocated_gpus if not any_gpu else None
+            if preferred_gpus and len(preferred_gpus) < job.num_processes:
+                logger.warning(
+                    "Queued job %s needs %d GPU(s), but only has preferred GPUs %s; "
+                    "falling back to any available GPUs",
+                    job.job_id,
+                    job.num_processes,
+                    preferred_gpus,
+                )
+                preferred_gpus = None
 
             can_start, gpus, reason = await self.can_allocate(
                 required_count=job.num_processes,
-                preferred_gpus=job.allocated_gpus if not any_gpu else None,
+                preferred_gpus=preferred_gpus,
                 any_gpu=any_gpu,
             )
 

--- a/simpletuner/simpletuner_sdk/server/services/training_service.py
+++ b/simpletuner/simpletuner_sdk/server/services/training_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import concurrent.futures
 import copy
 import json
 import logging
@@ -30,13 +32,14 @@ from simpletuner.simpletuner_sdk.server.services.hardware_service import detect_
 from simpletuner.simpletuner_sdk.server.services.webui_state import WebUIDefaults, WebUIStateStore
 from simpletuner.simpletuner_sdk.server.utils.paths import resolve_config_path
 
-from .webhook_defaults import (
-    DEFAULT_WEBHOOK_CONFIG,
-    get_authenticated_webhook_config,
-    get_default_callback_url,
-)
+from .webhook_defaults import DEFAULT_WEBHOOK_CONFIG, get_authenticated_webhook_config, get_default_callback_url
 
 logger = logging.getLogger(__name__)
+
+_LOCAL_QUEUE_PROCESS_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+    max_workers=1,
+    thread_name_prefix="simpletuner-local-queue",
+)
 
 
 def _get_job_store():
@@ -1524,6 +1527,9 @@ def _queue_training_job(
 
     position, status = _add_to_queue()
 
+    if not requires_approval:
+        _process_pending_local_jobs()
+
     if requires_approval:
         logger.info(
             "Queued training job %s for approval at position %d (reason: %s)",
@@ -1551,6 +1557,34 @@ def _queue_training_job(
         queue_position=position,
         reason=f"Waiting for {num_processes} GPU(s) to become available",
     )
+
+
+def _process_pending_local_jobs() -> None:
+    """Kick the local GPU allocator after a local job is queued."""
+    from .local_gpu_allocator import get_gpu_allocator
+
+    async def _async_process():
+        started = await get_gpu_allocator().process_pending_jobs()
+        if started:
+            logger.info("Started %d pending local job(s): %s", len(started), started)
+
+    def _log_process_result(future):
+        try:
+            future.result()
+        except asyncio.CancelledError:
+            logger.debug("Pending local job processing task was cancelled")
+        except Exception:
+            logger.exception("Failed to process pending local jobs after enqueue")
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        future = _LOCAL_QUEUE_PROCESS_EXECUTOR.submit(lambda: asyncio.run(_async_process()))
+        future.add_done_callback(_log_process_result)
+        return
+
+    task = loop.create_task(_async_process())
+    task.add_done_callback(_log_process_result)
 
 
 def terminate_training_job(job_id: Optional[str], *, status: str, clear_job_id: bool) -> bool:

--- a/simpletuner/simpletuner_sdk/server/services/training_service.py
+++ b/simpletuner/simpletuner_sdk/server/services/training_service.py
@@ -32,6 +32,7 @@ from simpletuner.simpletuner_sdk.server.services.hardware_service import detect_
 from simpletuner.simpletuner_sdk.server.services.webui_state import WebUIDefaults, WebUIStateStore
 from simpletuner.simpletuner_sdk.server.utils.paths import resolve_config_path
 
+from .local_gpu_allocator import dedupe_gpu_ids
 from .webhook_defaults import DEFAULT_WEBHOOK_CONFIG, get_authenticated_webhook_config, get_default_callback_url
 
 logger = logging.getLogger(__name__)
@@ -131,6 +132,7 @@ def _queued_preferred_gpus(preferred_gpus: Optional[List[int]], num_processes: i
     """
     if any_gpu or not preferred_gpus:
         return None
+    preferred_gpus = dedupe_gpu_ids(preferred_gpus)
     if len(preferred_gpus) < num_processes:
         logger.warning(
             "Ignoring incomplete GPU preference %s for queued job needing %d GPU(s)",

--- a/simpletuner/simpletuner_sdk/server/services/training_service.py
+++ b/simpletuner/simpletuner_sdk/server/services/training_service.py
@@ -31,7 +31,6 @@ from simpletuner.simpletuner_sdk.server.services.webui_state import WebUIDefault
 from simpletuner.simpletuner_sdk.server.utils.paths import resolve_config_path
 
 from .webhook_defaults import (
-    DEFAULT_CALLBACK_URL,
     DEFAULT_WEBHOOK_CONFIG,
     get_authenticated_webhook_config,
     get_default_callback_url,
@@ -118,6 +117,25 @@ def get_gpu_requirements(runtime_config: Dict[str, Any]) -> Tuple[int, Optional[
                 device_ids = parsed
 
     return (num_processes, device_ids)
+
+
+def _queued_preferred_gpus(preferred_gpus: Optional[List[int]], num_processes: int, any_gpu: bool) -> Optional[List[int]]:
+    """Return the hard GPU preference to persist for a queued local job.
+
+    ``allocated_gpus`` doubles as "preferred GPUs" while a local job is queued.
+    Persisting an incomplete preference, such as ``[0]`` for a two-process job,
+    makes the allocator wait forever even when enough other GPUs are idle.
+    """
+    if any_gpu or not preferred_gpus:
+        return None
+    if len(preferred_gpus) < num_processes:
+        logger.warning(
+            "Ignoring incomplete GPU preference %s for queued job needing %d GPU(s)",
+            preferred_gpus,
+            num_processes,
+        )
+        return None
+    return preferred_gpus
 
 
 _PROMPT_LIBRARY_RUNTIME_ROOT = Path(tempfile.gettempdir()) / "simpletuner_prompt_libraries"
@@ -1167,7 +1185,7 @@ def start_training_job(
             )
 
         try:
-            loop = asyncio.get_running_loop()
+            asyncio.get_running_loop()
             # We're in an async context, create a task
             import concurrent.futures
 
@@ -1274,7 +1292,7 @@ def start_training_job(
             return job
 
         try:
-            loop = asyncio.get_running_loop()
+            asyncio.get_running_loop()
             import concurrent.futures
 
             with concurrent.futures.ThreadPoolExecutor() as pool:
@@ -1397,7 +1415,7 @@ def start_training_job(
                     logger.debug("Stored PID %d for job %s", pid, job_id)
 
             try:
-                loop = asyncio.get_running_loop()
+                asyncio.get_running_loop()
                 import concurrent.futures
 
                 with concurrent.futures.ThreadPoolExecutor() as pool:
@@ -1466,6 +1484,7 @@ def _queue_training_job(
             stats = await job_repo.get_queue_stats()
             queue_depth = stats.get("queue_depth", 0)
 
+            queued_preferred_gpus = _queued_preferred_gpus(preferred_gpus, num_processes, any_gpu)
             job = UnifiedJob(
                 job_id=job_id,
                 job_type=JobType.LOCAL,
@@ -1477,7 +1496,7 @@ def _queue_training_job(
                 user_id=user_id,
                 org_id=org_id,
                 num_processes=num_processes,
-                allocated_gpus=preferred_gpus if not any_gpu else None,
+                allocated_gpus=queued_preferred_gpus,
                 requires_approval=requires_approval,
                 queue_position=queue_depth + 1,
                 output_url=output_url,
@@ -1494,7 +1513,7 @@ def _queue_training_job(
             return job.queue_position, status
 
         try:
-            loop = asyncio.get_running_loop()
+            asyncio.get_running_loop()
             import concurrent.futures
 
             with concurrent.futures.ThreadPoolExecutor() as pool:
@@ -1614,7 +1633,7 @@ def _release_job_gpus(job_id: str, *, process_pending: bool = True) -> None:
                     logger.info("Started %d pending jobs after GPU release", len(started))
 
         try:
-            loop = asyncio.get_running_loop()
+            asyncio.get_running_loop()
             import concurrent.futures
 
             with concurrent.futures.ThreadPoolExecutor() as pool:

--- a/tests/test_local_gpu_allocator.py
+++ b/tests/test_local_gpu_allocator.py
@@ -12,14 +12,10 @@ Tests cover:
 from __future__ import annotations
 
 import asyncio
-import json
-import sqlite3
-import tempfile
 import unittest
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 from simpletuner.simpletuner_sdk.server.services.cloud.queue.models import QueueEntry, QueuePriority, QueueStatus
 from simpletuner.simpletuner_sdk.server.services.local_gpu_allocator import LocalGPUAllocator
@@ -64,6 +60,7 @@ class MockQueueStore:
             self._allocated_gpus.pop(job_id, None)
         else:
             self._allocated_gpus[job_id] = gpus
+        self._entries[job_id].allocated_gpus = gpus
         return True
 
     async def mark_running(self, job_id: str) -> bool:
@@ -586,6 +583,43 @@ class TestLocalGPUAllocatorProcessPending(unittest.TestCase):
         started = asyncio.run(self.allocator.process_pending_jobs())
 
         self.assertEqual(started, ["job-1"])
+        mock_submit.assert_called_once()
+
+    @patch("simpletuner.simpletuner_sdk.server.services.local_gpu_allocator.detect_gpu_inventory")
+    @patch("simpletuner.simpletuner_sdk.server.services.webui_state.WebUIStateStore")
+    @patch("simpletuner.simpletuner_sdk.process_keeper.submit_job")
+    @patch("simpletuner.simpletuner_sdk.server.services.cloud.async_job_store.AsyncJobStore.get_instance")
+    def test_process_pending_falls_back_from_incomplete_gpu_preference(
+        self,
+        mock_job_store_instance,
+        mock_submit,
+        mock_state_store,
+        mock_detect,
+    ):
+        """A stale queued 2-GPU job with one preferred GPU should not deadlock."""
+        mock_detect.return_value = self.mock_inventory
+        mock_state_store.return_value.load_defaults.return_value = self.mock_defaults
+
+        mock_store = AsyncMock()
+        mock_store.update_job = AsyncMock(return_value=True)
+        mock_job_store_instance.return_value = mock_store
+
+        entry = self._create_entry(
+            "job-1",
+            num_processes=2,
+            allocated_gpus=[0],
+            metadata={
+                "runtime_config": {"--output_dir": "/tmp/test"},
+                "env_name": "test-env",
+                "any_gpu": False,
+            },
+        )
+        self.mock_queue_store.add_entry(entry)
+
+        started = asyncio.run(self.allocator.process_pending_jobs())
+
+        self.assertEqual(started, ["job-1"])
+        self.assertEqual(entry.allocated_gpus, [0, 1])
         mock_submit.assert_called_once()
 
     @patch("simpletuner.simpletuner_sdk.server.services.local_gpu_allocator.detect_gpu_inventory")

--- a/tests/test_local_gpu_allocator.py
+++ b/tests/test_local_gpu_allocator.py
@@ -624,6 +624,43 @@ class TestLocalGPUAllocatorProcessPending(unittest.TestCase):
 
     @patch("simpletuner.simpletuner_sdk.server.services.local_gpu_allocator.detect_gpu_inventory")
     @patch("simpletuner.simpletuner_sdk.server.services.webui_state.WebUIStateStore")
+    @patch("simpletuner.simpletuner_sdk.process_keeper.submit_job")
+    @patch("simpletuner.simpletuner_sdk.server.services.cloud.async_job_store.AsyncJobStore.get_instance")
+    def test_process_pending_falls_back_from_duplicate_gpu_preference(
+        self,
+        mock_job_store_instance,
+        mock_submit,
+        mock_state_store,
+        mock_detect,
+    ):
+        """Duplicate queued preferences should not allocate the same GPU twice."""
+        mock_detect.return_value = self.mock_inventory
+        mock_state_store.return_value.load_defaults.return_value = self.mock_defaults
+
+        mock_store = AsyncMock()
+        mock_store.update_job = AsyncMock(return_value=True)
+        mock_job_store_instance.return_value = mock_store
+
+        entry = self._create_entry(
+            "job-1",
+            num_processes=2,
+            allocated_gpus=[0, 0],
+            metadata={
+                "runtime_config": {"--output_dir": "/tmp/test"},
+                "env_name": "test-env",
+                "any_gpu": False,
+            },
+        )
+        self.mock_queue_store.add_entry(entry)
+
+        started = asyncio.run(self.allocator.process_pending_jobs())
+
+        self.assertEqual(started, ["job-1"])
+        self.assertEqual(entry.allocated_gpus, [0, 1])
+        mock_submit.assert_called_once()
+
+    @patch("simpletuner.simpletuner_sdk.server.services.local_gpu_allocator.detect_gpu_inventory")
+    @patch("simpletuner.simpletuner_sdk.server.services.webui_state.WebUIStateStore")
     def test_process_pending_no_pending(self, mock_state_store, mock_detect):
         """Test processing when no pending jobs."""
         mock_detect.return_value = self.mock_inventory

--- a/tests/test_training_service_gpu.py
+++ b/tests/test_training_service_gpu.py
@@ -11,9 +11,12 @@ Tests cover:
 from __future__ import annotations
 
 import unittest
-from typing import Any, Dict, List, Optional, Tuple
 
-from simpletuner.simpletuner_sdk.server.services.training_service import TrainingJobResult, get_gpu_requirements
+from simpletuner.simpletuner_sdk.server.services.training_service import (
+    TrainingJobResult,
+    _queued_preferred_gpus,
+    get_gpu_requirements,
+)
 
 
 class TestGetGPURequirements(unittest.TestCase):
@@ -221,6 +224,18 @@ class TestQueueTrainingJob(unittest.TestCase):
         # 1. test_queue_store_gpu.py - tests add_to_queue with GPU fields
         # 2. local_gpu.test.js - tests API submission behavior
         pass
+
+    def test_incomplete_preferred_gpus_are_not_persisted(self):
+        """A queued 2-GPU job should not hard-pin itself to one GPU forever."""
+        self.assertIsNone(_queued_preferred_gpus([0], num_processes=2, any_gpu=False))
+
+    def test_complete_preferred_gpus_are_persisted(self):
+        """Complete preferences remain hard preferences for queued jobs."""
+        self.assertEqual(_queued_preferred_gpus([0, 1], num_processes=2, any_gpu=False), [0, 1])
+
+    def test_any_gpu_drops_preferred_gpus(self):
+        """The any-GPU mode should let the allocator choose later."""
+        self.assertIsNone(_queued_preferred_gpus([0, 1], num_processes=2, any_gpu=True))
 
 
 class TestReleaseJobGPUs(unittest.TestCase):

--- a/tests/test_training_service_gpu.py
+++ b/tests/test_training_service_gpu.py
@@ -230,6 +230,14 @@ class TestQueueTrainingJob(unittest.TestCase):
         """A queued 2-GPU job should not hard-pin itself to one GPU forever."""
         self.assertIsNone(_queued_preferred_gpus([0], num_processes=2, any_gpu=False))
 
+    def test_duplicate_preferred_gpus_are_not_counted_as_complete(self):
+        """Duplicate GPU IDs should not satisfy a multi-GPU preference."""
+        self.assertIsNone(_queued_preferred_gpus([0, 0], num_processes=2, any_gpu=False))
+
+    def test_duplicate_complete_preferred_gpus_are_deduplicated(self):
+        """Complete preferences are persisted without duplicate GPU IDs."""
+        self.assertEqual(_queued_preferred_gpus([0, 1, 1], num_processes=2, any_gpu=False), [0, 1])
+
     def test_complete_preferred_gpus_are_persisted(self):
         """Complete preferences remain hard preferences for queued jobs."""
         self.assertEqual(_queued_preferred_gpus([0, 1], num_processes=2, any_gpu=False), [0, 1])

--- a/tests/test_training_service_gpu.py
+++ b/tests/test_training_service_gpu.py
@@ -14,6 +14,7 @@ import unittest
 
 from simpletuner.simpletuner_sdk.server.services.training_service import (
     TrainingJobResult,
+    _queue_training_job,
     _queued_preferred_gpus,
     get_gpu_requirements,
 )
@@ -236,6 +237,136 @@ class TestQueueTrainingJob(unittest.TestCase):
     def test_any_gpu_drops_preferred_gpus(self):
         """The any-GPU mode should let the allocator choose later."""
         self.assertIsNone(_queued_preferred_gpus([0, 1], num_processes=2, any_gpu=True))
+
+    def test_queued_job_processes_pending_when_approval_not_required(self):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_repo = MagicMock()
+        mock_repo.get_queue_stats = AsyncMock(return_value={"queue_depth": 0})
+        mock_repo.add = AsyncMock()
+
+        with (
+            patch(
+                "simpletuner.simpletuner_sdk.server.services.cloud.storage.job_repository.get_job_repository",
+                return_value=mock_repo,
+            ),
+            patch(
+                "simpletuner.simpletuner_sdk.server.services.training_service._process_pending_local_jobs"
+            ) as mock_process,
+            patch(
+                "simpletuner.simpletuner_sdk.server.services.training_service._detect_local_hardware",
+                return_value="local",
+            ),
+        ):
+            result = _queue_training_job(
+                job_id="queued-job",
+                runtime_config={"--output_dir": "/tmp/out"},
+                env_name="test-env",
+                num_processes=2,
+                preferred_gpus=None,
+                any_gpu=False,
+                org_id=None,
+                user_id=None,
+            )
+
+        self.assertEqual(result.status, "queued")
+        mock_repo.add.assert_awaited_once()
+        mock_process.assert_called_once_with()
+
+    def test_approval_queue_does_not_process_pending(self):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_repo = MagicMock()
+        mock_repo.get_queue_stats = AsyncMock(return_value={"queue_depth": 0})
+        mock_repo.add = AsyncMock()
+
+        with (
+            patch(
+                "simpletuner.simpletuner_sdk.server.services.cloud.storage.job_repository.get_job_repository",
+                return_value=mock_repo,
+            ),
+            patch(
+                "simpletuner.simpletuner_sdk.server.services.training_service._process_pending_local_jobs"
+            ) as mock_process,
+            patch(
+                "simpletuner.simpletuner_sdk.server.services.training_service._detect_local_hardware",
+                return_value="local",
+            ),
+        ):
+            result = _queue_training_job(
+                job_id="approval-job",
+                runtime_config={"--output_dir": "/tmp/out"},
+                env_name="test-env",
+                num_processes=2,
+                preferred_gpus=None,
+                any_gpu=False,
+                org_id=None,
+                user_id=None,
+                requires_approval=True,
+                approval_reason="quota review",
+            )
+
+        self.assertEqual(result.status, "blocked")
+        mock_repo.add.assert_awaited_once()
+        mock_process.assert_not_called()
+
+    def test_process_pending_local_jobs_schedules_on_running_loop(self):
+        import asyncio
+        from unittest.mock import MagicMock, patch
+
+        from simpletuner.simpletuner_sdk.server.services.training_service import _process_pending_local_jobs
+
+        async def run_check():
+            started = asyncio.Event()
+            release = asyncio.Event()
+            allocator = MagicMock()
+
+            async def process_pending_jobs():
+                started.set()
+                await release.wait()
+                return []
+
+            allocator.process_pending_jobs = process_pending_jobs
+
+            with patch(
+                "simpletuner.simpletuner_sdk.server.services.local_gpu_allocator.get_gpu_allocator",
+                return_value=allocator,
+            ):
+                _process_pending_local_jobs()
+                await asyncio.wait_for(started.wait(), timeout=1)
+                release.set()
+                await asyncio.sleep(0)
+
+        asyncio.run(run_check())
+
+    def test_process_pending_local_jobs_logs_async_failure(self):
+        import asyncio
+        from unittest.mock import MagicMock, patch
+
+        from simpletuner.simpletuner_sdk.server.services import training_service
+
+        async def run_check():
+            allocator = MagicMock()
+
+            async def process_pending_jobs():
+                raise RuntimeError("queue failed")
+
+            allocator.process_pending_jobs = process_pending_jobs
+
+            with (
+                patch(
+                    "simpletuner.simpletuner_sdk.server.services.local_gpu_allocator.get_gpu_allocator",
+                    return_value=allocator,
+                ),
+                patch.object(training_service.logger, "exception") as mock_exception,
+            ):
+                training_service._process_pending_local_jobs()
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+
+            mock_exception.assert_called_once_with("Failed to process pending local jobs after enqueue")
+
+        asyncio.run(run_check())
 
 
 class TestReleaseJobGPUs(unittest.TestCase):


### PR DESCRIPTION
## Summary

Ports the queued local GPU preference fix from whitejt2/SimpleTuner@53bc999aec9ebc39e3613c7ae9f4e8842720209b.

Queued local jobs store GPU preferences in `allocated_gpus` until the allocator starts them. When a multi-process job only has an incomplete preference, such as `[0]` for two processes, the pending-job processor can treat it as a hard constraint and leave the job queued even when enough other GPUs are available.

This change drops incomplete queued GPU preferences before persisting or reprocessing them, while preserving complete explicit preferences and `any_gpu` behavior.

## Validation

- `.venv/bin/python -m unittest tests.test_local_gpu_allocator tests.test_training_service_gpu -v`