### PR TITLE
fix krea2 validation lora target alignment

### DIFF
--- a/simpletuner/helpers/models/krea2/lora_pipeline.py
+++ b/simpletuner/helpers/models/krea2/lora_pipeline.py
@@ -88,6 +88,70 @@ def _infer_krea2_lora_target_modules(state_dict: dict[str, torch.Tensor]) -> lis
     return list(target_modules)
 
 
+def _align_krea2_lora_state_dict_to_transformer(
+    state_dict: dict[str, torch.Tensor],
+    target_modules: list[str],
+    transformer,
+) -> tuple[dict[str, torch.Tensor], list[str]]:
+    """Rewrite LoRA keys to the live transformer module names PEFT will inspect.
+
+    PEFT 0.19 uses state-dict module names, not only ``target_modules``, when a
+    state dict is passed to ``inject_adapter_in_model``. Accelerate/DDP wrappers
+    can expose modules as ``module.transformer_blocks.*`` while external KREA2
+    LoRAs are serialized as ``transformer_blocks.*``. Aligning here keeps the
+    adapter exact without broad leaf-name targeting.
+    """
+    try:
+        live_module_names = [name for name, _ in transformer.named_modules() if name]
+    except Exception:
+        return state_dict, target_modules
+
+    live_module_set = set(live_module_names)
+    if target_modules and all(target in live_module_set for target in target_modules):
+        return state_dict, target_modules
+
+    remap: dict[str, str] = {}
+    ambiguous: dict[str, list[str]] = {}
+    for target in target_modules:
+        if target in live_module_set:
+            remap[target] = target
+            continue
+        suffix = f".{target}"
+        matches = [name for name in live_module_names if name.endswith(suffix)]
+        if len(matches) == 1:
+            remap[target] = matches[0]
+        elif len(matches) > 1:
+            ambiguous[target] = matches[:5]
+
+    if ambiguous:
+        preview = ", ".join(f"{target}: {matches}" for target, matches in list(ambiguous.items())[:3])
+        raise ValueError(f"Ambiguous KREA2 LoRA targets in wrapped transformer: {preview}")
+
+    missing = [target for target in target_modules if target not in remap]
+    if missing:
+        sample_modules = ", ".join(live_module_names[:12])
+        sample_missing = ", ".join(missing[:12])
+        raise ValueError(
+            "KREA2 LoRA target modules do not match the live transformer. "
+            f"Missing targets: {sample_missing}. Live module sample: {sample_modules}"
+        )
+
+    if all(remap[target] == target for target in target_modules):
+        return state_dict, target_modules
+
+    aligned_state_dict: dict[str, torch.Tensor] = {}
+    for key, value in state_dict.items():
+        rewritten = key
+        for target, live_target in remap.items():
+            prefix = f"{target}."
+            if key.startswith(prefix):
+                rewritten = f"{live_target}.{key[len(prefix):]}"
+                break
+        aligned_state_dict[rewritten] = value
+
+    return aligned_state_dict, list(dict.fromkeys(remap[target] for target in target_modules))
+
+
 class Krea2LoraLoaderMixin(LoraBaseMixin):
     r"""
     Load LoRA layers into [`Krea2Transformer2DModel`]. Specific to [`Krea2Pipeline`].
@@ -244,17 +308,22 @@ class Krea2LoraLoaderMixin(LoraBaseMixin):
                 f"Adapter name {adapter_name} already in use in the transformer - please select a new adapter name."
             )
 
-        rank = {}
-        for key, val in state_dict.items():
-            if "lora_B" in key and getattr(val, "ndim", 0) > 1:
-                rank[key] = val.shape[1]
-
         target_modules = _infer_krea2_lora_target_modules(state_dict)
         if not target_modules:
             raise ValueError(
                 "Could not infer KREA2 LoRA target modules from the adapter state dict. "
                 "Expected keys ending in .lora_A.weight and .lora_B.weight."
             )
+        state_dict, target_modules = _align_krea2_lora_state_dict_to_transformer(
+            state_dict,
+            target_modules,
+            transformer,
+        )
+
+        rank = {}
+        for key, val in state_dict.items():
+            if "lora_B" in key and getattr(val, "ndim", 0) > 1:
+                rank[key] = val.shape[1]
 
         lora_config_kwargs = get_peft_kwargs(rank, network_alpha_dict=None, peft_state_dict=state_dict)
         lora_config_kwargs["target_modules"] = target_modules

--- a/tests/test_krea2_model.py
+++ b/tests/test_krea2_model.py
@@ -156,7 +156,23 @@ class Krea2VendoredModelTests(unittest.TestCase):
         self.assertIn("transformer_blocks.0.attn.to_q", transformer.peft_config["krea2_turbo"].target_modules)
 
     def test_lora_loader_injects_without_state_dict_argument(self):
-        transformer = torch.nn.Module()
+        transformer = Krea2Transformer2DModel(
+            in_channels=4,
+            num_layers=1,
+            attention_head_dim=6,
+            num_attention_heads=1,
+            num_key_value_heads=1,
+            intermediate_size=8,
+            timestep_embed_dim=8,
+            text_hidden_dim=6,
+            num_text_layers=1,
+            text_num_attention_heads=1,
+            text_num_key_value_heads=1,
+            text_intermediate_size=8,
+            num_layerwise_text_blocks=1,
+            num_refiner_text_blocks=0,
+            axes_dims_rope=(2, 2, 2),
+        )
         state_dict = {
             "transformer.blocks.0.attn.wq.lora_A.weight": torch.ones(2, 6),
             "transformer.blocks.0.attn.wq.lora_B.weight": torch.ones(6, 2),
@@ -178,7 +194,23 @@ class Krea2VendoredModelTests(unittest.TestCase):
         self.assertNotIn("state_dict", mock_inject.call_args.kwargs)
 
     def test_lora_loader_restores_offload_state_when_injection_fails(self):
-        transformer = torch.nn.Module()
+        transformer = Krea2Transformer2DModel(
+            in_channels=4,
+            num_layers=1,
+            attention_head_dim=6,
+            num_attention_heads=1,
+            num_key_value_heads=1,
+            intermediate_size=8,
+            timestep_embed_dim=8,
+            text_hidden_dim=6,
+            num_text_layers=1,
+            text_num_attention_heads=1,
+            text_num_key_value_heads=1,
+            text_intermediate_size=8,
+            num_layerwise_text_blocks=1,
+            num_refiner_text_blocks=0,
+            axes_dims_rope=(2, 2, 2),
+        )
         pipeline = Mock()
         state_dict = {
             "transformer.blocks.0.attn.wq.lora_A.weight": torch.ones(2, 6),
@@ -200,6 +232,109 @@ class Krea2VendoredModelTests(unittest.TestCase):
                 )
 
         mock_restore.assert_called_once_with(pipeline, True, False, True)
+
+    def test_lora_loader_aligns_external_krea2_adapter_for_wrapped_transformer(self):
+        class WrappedTransformer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.module = Krea2Transformer2DModel(
+                    in_channels=4,
+                    num_layers=1,
+                    attention_head_dim=6,
+                    num_attention_heads=1,
+                    num_key_value_heads=1,
+                    intermediate_size=8,
+                    timestep_embed_dim=8,
+                    text_hidden_dim=6,
+                    num_text_layers=1,
+                    text_num_attention_heads=1,
+                    text_num_key_value_heads=1,
+                    text_intermediate_size=8,
+                    num_layerwise_text_blocks=1,
+                    num_refiner_text_blocks=0,
+                    axes_dims_rope=(2, 2, 2),
+                )
+
+        transformer = WrappedTransformer()
+        state_dict = {
+            "transformer.blocks.0.attn.wq.lora_A.weight": torch.ones(2, 6),
+            "transformer.blocks.0.attn.wq.lora_B.weight": torch.ones(6, 2),
+        }
+
+        Krea2LoraLoaderMixin.load_lora_into_transformer(
+            state_dict,
+            transformer=transformer,
+            adapter_name="krea2_turbo",
+        )
+
+        self.assertIn("krea2_turbo", transformer.peft_config)
+        self.assertIn("module.transformer_blocks.0.attn.to_q", transformer.peft_config["krea2_turbo"].target_modules)
+        self.assertTrue(hasattr(transformer.module.transformer_blocks[0].attn.to_q, "lora_A"))
+
+    def test_lora_loader_computes_rank_after_wrapped_transformer_alignment(self):
+        class DummyLoraConfig:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        class WrappedTransformer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.module = Krea2Transformer2DModel(
+                    in_channels=4,
+                    num_layers=1,
+                    attention_head_dim=6,
+                    num_attention_heads=1,
+                    num_key_value_heads=1,
+                    intermediate_size=8,
+                    timestep_embed_dim=8,
+                    text_hidden_dim=6,
+                    num_text_layers=1,
+                    text_num_attention_heads=1,
+                    text_num_key_value_heads=1,
+                    text_intermediate_size=8,
+                    num_layerwise_text_blocks=1,
+                    num_refiner_text_blocks=0,
+                    axes_dims_rope=(2, 2, 2),
+                )
+
+        captured = {}
+
+        def capture_peft_kwargs(rank, network_alpha_dict, peft_state_dict):
+            captured["rank"] = dict(rank)
+            captured["peft_state_dict"] = dict(peft_state_dict)
+            return {"r": 2, "lora_alpha": 2}
+
+        transformer = WrappedTransformer()
+        state_dict = {
+            "transformer.blocks.0.attn.wq.lora_A.weight": torch.ones(2, 6),
+            "transformer.blocks.0.attn.wq.lora_B.weight": torch.ones(6, 2),
+        }
+
+        with (
+            patch("peft.LoraConfig", DummyLoraConfig),
+            patch("peft.inject_adapter_in_model"),
+            patch("peft.set_peft_model_state_dict", return_value=None),
+            patch(
+                "simpletuner.helpers.models.krea2.lora_pipeline.get_peft_kwargs",
+                side_effect=capture_peft_kwargs,
+            ),
+            patch.object(Krea2LoraLoaderMixin, "_optionally_disable_offloading", return_value=False),
+            patch("simpletuner.helpers.models.krea2.lora_pipeline.restore_offload_state"),
+        ):
+            Krea2LoraLoaderMixin.load_lora_into_transformer(
+                state_dict,
+                transformer=transformer,
+                adapter_name="krea2_turbo",
+            )
+
+        self.assertEqual(captured["rank"], {"module.transformer_blocks.0.attn.to_q.lora_B.weight": 2})
+        self.assertEqual(
+            set(captured["peft_state_dict"]),
+            {
+                "module.transformer_blocks.0.attn.to_q.lora_A.weight",
+                "module.transformer_blocks.0.attn.to_q.lora_B.weight",
+            },
+        )
 
     def test_pipeline_accepts_reference_image_for_validation(self):
         parameters = inspect.signature(Krea2Pipeline.__call__).parameters


### PR DESCRIPTION
## Summary

Ports the Krea2 target alignment follow-up from whitejt2/SimpleTuner@ee98ee7bba4ac4c304cefe8a5cd06e04acc02a7a.

This is stacked on #2875. PEFT can inspect live module names when injecting an adapter from a state dict. Wrapped transformers may expose names such as `module.transformer_blocks.*` while external Krea2 LoRAs use unwrapped `transformer_blocks.*` keys.

This change aligns inferred LoRA target modules and state-dict keys with the live transformer module names, while failing clearly on ambiguous or missing targets.

## Validation

- `.venv/bin/python -m unittest tests.test_krea2_model -v`

## Stack

- Base: #2875 (`agent/krea2-validation-lora-loading`)
- This PR: target alignment follow-up