### PR TITLE
fix local queue processing after enqueue

### DIFF
--- a/simpletuner/simpletuner_sdk/server/services/training_service.py
+++ b/simpletuner/simpletuner_sdk/server/services/training_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import concurrent.futures
 import copy
 import json
 import logging
@@ -30,13 +32,14 @@ from simpletuner.simpletuner_sdk.server.services.hardware_service import detect_
 from simpletuner.simpletuner_sdk.server.services.webui_state import WebUIDefaults, WebUIStateStore
 from simpletuner.simpletuner_sdk.server.utils.paths import resolve_config_path
 
-from .webhook_defaults import (
-    DEFAULT_WEBHOOK_CONFIG,
-    get_authenticated_webhook_config,
-    get_default_callback_url,
-)
+from .webhook_defaults import DEFAULT_WEBHOOK_CONFIG, get_authenticated_webhook_config, get_default_callback_url
 
 logger = logging.getLogger(__name__)
+
+_LOCAL_QUEUE_PROCESS_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+    max_workers=1,
+    thread_name_prefix="simpletuner-local-queue",
+)
 
 
 def _get_job_store():
@@ -1524,6 +1527,9 @@ def _queue_training_job(
 
     position, status = _add_to_queue()
 
+    if not requires_approval:
+        _process_pending_local_jobs()
+
     if requires_approval:
         logger.info(
             "Queued training job %s for approval at position %d (reason: %s)",
@@ -1551,6 +1557,34 @@ def _queue_training_job(
         queue_position=position,
         reason=f"Waiting for {num_processes} GPU(s) to become available",
     )
+
+
+def _process_pending_local_jobs() -> None:
+    """Kick the local GPU allocator after a local job is queued."""
+    from .local_gpu_allocator import get_gpu_allocator
+
+    async def _async_process():
+        started = await get_gpu_allocator().process_pending_jobs()
+        if started:
+            logger.info("Started %d pending local job(s): %s", len(started), started)
+
+    def _log_process_result(future):
+        try:
+            future.result()
+        except asyncio.CancelledError:
+            logger.debug("Pending local job processing task was cancelled")
+        except Exception:
+            logger.exception("Failed to process pending local jobs after enqueue")
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        future = _LOCAL_QUEUE_PROCESS_EXECUTOR.submit(lambda: asyncio.run(_async_process()))
+        future.add_done_callback(_log_process_result)
+        return
+
+    task = loop.create_task(_async_process())
+    task.add_done_callback(_log_process_result)
 
 
 def terminate_training_job(job_id: Optional[str], *, status: str, clear_job_id: bool) -> bool:

--- a/tests/test_training_service_gpu.py
+++ b/tests/test_training_service_gpu.py
@@ -14,6 +14,7 @@ import unittest
 
 from simpletuner.simpletuner_sdk.server.services.training_service import (
     TrainingJobResult,
+    _queue_training_job,
     _queued_preferred_gpus,
     get_gpu_requirements,
 )
@@ -236,6 +237,136 @@ class TestQueueTrainingJob(unittest.TestCase):
     def test_any_gpu_drops_preferred_gpus(self):
         """The any-GPU mode should let the allocator choose later."""
         self.assertIsNone(_queued_preferred_gpus([0, 1], num_processes=2, any_gpu=True))
+
+    def test_queued_job_processes_pending_when_approval_not_required(self):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_repo = MagicMock()
+        mock_repo.get_queue_stats = AsyncMock(return_value={"queue_depth": 0})
+        mock_repo.add = AsyncMock()
+
+        with (
+            patch(
+                "simpletuner.simpletuner_sdk.server.services.cloud.storage.job_repository.get_job_repository",
+                return_value=mock_repo,
+            ),
+            patch(
+                "simpletuner.simpletuner_sdk.server.services.training_service._process_pending_local_jobs"
+            ) as mock_process,
+            patch(
+                "simpletuner.simpletuner_sdk.server.services.training_service._detect_local_hardware",
+                return_value="local",
+            ),
+        ):
+            result = _queue_training_job(
+                job_id="queued-job",
+                runtime_config={"--output_dir": "/tmp/out"},
+                env_name="test-env",
+                num_processes=2,
+                preferred_gpus=None,
+                any_gpu=False,
+                org_id=None,
+                user_id=None,
+            )
+
+        self.assertEqual(result.status, "queued")
+        mock_repo.add.assert_awaited_once()
+        mock_process.assert_called_once_with()
+
+    def test_approval_queue_does_not_process_pending(self):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_repo = MagicMock()
+        mock_repo.get_queue_stats = AsyncMock(return_value={"queue_depth": 0})
+        mock_repo.add = AsyncMock()
+
+        with (
+            patch(
+                "simpletuner.simpletuner_sdk.server.services.cloud.storage.job_repository.get_job_repository",
+                return_value=mock_repo,
+            ),
+            patch(
+                "simpletuner.simpletuner_sdk.server.services.training_service._process_pending_local_jobs"
+            ) as mock_process,
+            patch(
+                "simpletuner.simpletuner_sdk.server.services.training_service._detect_local_hardware",
+                return_value="local",
+            ),
+        ):
+            result = _queue_training_job(
+                job_id="approval-job",
+                runtime_config={"--output_dir": "/tmp/out"},
+                env_name="test-env",
+                num_processes=2,
+                preferred_gpus=None,
+                any_gpu=False,
+                org_id=None,
+                user_id=None,
+                requires_approval=True,
+                approval_reason="quota review",
+            )
+
+        self.assertEqual(result.status, "blocked")
+        mock_repo.add.assert_awaited_once()
+        mock_process.assert_not_called()
+
+    def test_process_pending_local_jobs_schedules_on_running_loop(self):
+        import asyncio
+        from unittest.mock import MagicMock, patch
+
+        from simpletuner.simpletuner_sdk.server.services.training_service import _process_pending_local_jobs
+
+        async def run_check():
+            started = asyncio.Event()
+            release = asyncio.Event()
+            allocator = MagicMock()
+
+            async def process_pending_jobs():
+                started.set()
+                await release.wait()
+                return []
+
+            allocator.process_pending_jobs = process_pending_jobs
+
+            with patch(
+                "simpletuner.simpletuner_sdk.server.services.local_gpu_allocator.get_gpu_allocator",
+                return_value=allocator,
+            ):
+                _process_pending_local_jobs()
+                await asyncio.wait_for(started.wait(), timeout=1)
+                release.set()
+                await asyncio.sleep(0)
+
+        asyncio.run(run_check())
+
+    def test_process_pending_local_jobs_logs_async_failure(self):
+        import asyncio
+        from unittest.mock import MagicMock, patch
+
+        from simpletuner.simpletuner_sdk.server.services import training_service
+
+        async def run_check():
+            allocator = MagicMock()
+
+            async def process_pending_jobs():
+                raise RuntimeError("queue failed")
+
+            allocator.process_pending_jobs = process_pending_jobs
+
+            with (
+                patch(
+                    "simpletuner.simpletuner_sdk.server.services.local_gpu_allocator.get_gpu_allocator",
+                    return_value=allocator,
+                ),
+                patch.object(training_service.logger, "exception") as mock_exception,
+            ):
+                training_service._process_pending_local_jobs()
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+
+            mock_exception.assert_called_once_with("Failed to process pending local jobs after enqueue")
+
+        asyncio.run(run_check())
 
 
 class TestReleaseJobGPUs(unittest.TestCase):


### PR DESCRIPTION
## Summary

Ports the queue-start portion of whitejt2/SimpleTuner@afc7319ac4642cce646f61466cd904bcb791d9ae as a focused follow-up to #2877.

After #2877, an incomplete queued GPU preference is no longer persisted as a hard pin. However, the submit path can still return a queued result and wait for a later release/callback to process the pending job. This change kicks the local GPU allocator immediately after non-approval local jobs are queued, so jobs that became startable during queue normalization can start without waiting for unrelated queue activity.

Approval-held jobs intentionally do not process pending jobs.

## Validation

- `.venv/bin/python -m unittest tests.test_training_service_gpu tests.test_local_gpu_allocator -v`

## Notes

The original fork commit also changed checkpoint replacement behavior, validation adapter deletion, and one-based GPU normalization. Those pieces were not included here: checkpoint destination deletion needs a separate data-loss review, validation cleanup is partially superseded by current `main`, and the current WebUI submits detected `device.index` values rather than one-based IDs.

## Stack

- Base: #2877 (`agent/local-gpu-incomplete-queue-preferences`)
- This PR: process queued local jobs immediately after enqueue