### PR TITLE
flux2: switch quant backend to use SDNQ int8 ConvRot instead of int8-torchao and quanto

### DIFF
--- a/simpletuner/examples/flux2.peft-lora+TREAD/config.json
+++ b/simpletuner/examples/flux2.peft-lora+TREAD/config.json
@@ -1,5 +1,5 @@
 {
-    "base_model_precision": "int8-quanto",
+    "base_model_precision": "int8-sdnq",
     "checkpoint_step_interval": 10,
     "controlnet": false,
     "data_backend_config": "config/examples/multidatabackend-small-dreambooth-512px.json",
@@ -26,6 +26,11 @@
     "push_to_hub": false,
     "quantize_via": "cpu",
     "report_to": "none",
+    "sdnq_compile_mode": "compile",
+    "sdnq_group_size": -1,
+    "sdnq_hadamard_group_size": 128,
+    "sdnq_use_hadamard": true,
+    "sdnq_use_quantized_matmul": true,
     "seed": 42,
     "tracker_project_name": "lora-training",
     "tracker_run_name": "example-training-run",

--- a/simpletuner/examples/flux2.peft-lora/config.json
+++ b/simpletuner/examples/flux2.peft-lora/config.json
@@ -1,5 +1,5 @@
 {
-    "base_model_precision": "int8-quanto",
+    "base_model_precision": "int8-sdnq",
     "checkpoint_step_interval": 10,
     "controlnet": false,
     "data_backend_config": "config/examples/multidatabackend-small-dreambooth-512px.json",
@@ -26,6 +26,11 @@
     "push_to_hub": false,
     "quantize_via": "cpu",
     "report_to": "none",
+    "sdnq_compile_mode": "compile",
+    "sdnq_group_size": -1,
+    "sdnq_hadamard_group_size": 128,
+    "sdnq_use_hadamard": true,
+    "sdnq_use_quantized_matmul": true,
     "seed": 42,
     "tracker_project_name": "lora-training",
     "tracker_run_name": "example-training-run",


### PR DESCRIPTION
This pull request updates the quantization configuration for two example LoRA training setups to use the SDNQ quantization method and introduces several new SDNQ-specific parameters to the configuration files. These changes are aimed at enabling and fine-tuning SDNQ quantization for improved performance and flexibility.

**Quantization method update:**

* Changed the `base_model_precision` from `"int8-quanto"` to `"int8-sdnq"` in both `flux2.peft-lora/config.json` and `flux2.peft-lora+TREAD/config.json`, switching the quantization backend to SDNQ. [[1]](diffhunk://#diff-46c620ad2e10e52f607eb3f1087365875d230ea0f3a7f8c292d2d6490ab09c4eL2-R2) [[2]](diffhunk://#diff-b01c9b9ff574ce0a3b5517729ba51b25c6896b54b0ce88b63c939b17d0277b2cL2-R2)

**Addition of SDNQ-specific configuration parameters:**

* Added new parameters to both configuration files to control SDNQ behavior:
  - `"sdnq_compile_mode"` set to `"compile"` to enable compilation mode.
  - `"sdnq_group_size"` set to `-1` (likely indicating auto or default grouping).
  - `"sdnq_hadamard_group_size"` set to `128` to configure Hadamard group size.
  - `"sdnq_use_hadamard"` set to `true` to enable Hadamard-based quantization.
  - `"sdnq_use_quantized_matmul"` set to `true` to use quantized matrix multiplication. [[1]](diffhunk://#diff-46c620ad2e10e52f607eb3f1087365875d230ea0f3a7f8c292d2d6490ab09c4eR29-R33) [[2]](diffhunk://#diff-b01c9b9ff574ce0a3b5517729ba51b25c6896b54b0ce88b63c939b17d0277b2cR29-R33)