### PR TITLE
krea2: switch quant backend to use SDNQ int8 ConvRot instead of int8-torchao

### DIFF
--- a/simpletuner/examples/krea2.peft-lora/config.json
+++ b/simpletuner/examples/krea2.peft-lora/config.json
@@ -1,5 +1,5 @@
 {
-    "base_model_precision": "int8-torchao",
+    "base_model_precision": "int8-sdnq",
     "caption_dropout_probability": 0.0,
     "checkpoint_step_interval": 50,
     "checkpoints_total_limit": 5,
@@ -38,6 +38,11 @@
     "resolution": 1024,
     "resolution_type": "pixel_area",
     "resume_from_checkpoint": null,
+    "sdnq_compile_mode": "compile",
+    "sdnq_group_size": -1,
+    "sdnq_hadamard_group_size": 128,
+    "sdnq_use_hadamard": true,
+    "sdnq_use_quantized_matmul": true,
     "seed": 42,
     "skip_file_discovery": false,
     "tracker_project_name": "lora-training",


### PR DESCRIPTION
This pull request updates the configuration for the Krea2 LoRA training example to use the SDNQ quantization method and introduces several new SDNQ-related parameters. The main focus is on improving quantization settings for the base model.

**Quantization method update:**

* Changed the `base_model_precision` from `"int8-torchao"` to `"int8-sdnq"` to switch the quantization backend to SDNQ.

**SDNQ-specific configuration additions:**

* Added new SDNQ parameters: `sdnq_compile_mode`, `sdnq_group_size`, `sdnq_hadamard_group_size`, `sdnq_use_hadamard`, and `sdnq_use_quantized_matmul` to the configuration file for finer control over SDNQ quantization behavior.