### PR TITLE
z-image turbo: switch quant backend to use SDNQ int8 ConvRot

### DIFF
--- a/simpletuner/examples/z-image-turbo.peft-lora/config.json
+++ b/simpletuner/examples/z-image-turbo.peft-lora/config.json
@@ -1,5 +1,5 @@
 {
-    "base_model_precision": "int8-torchao",
+    "base_model_precision": "int8-sdnq",
     "caption_dropout_probability": 0.0,
     "checkpoint_step_interval": 50,
     "checkpoints_total_limit": 5,
@@ -32,6 +32,11 @@
     "resolution": 1024,
     "resolution_type": "pixel_area",
     "resume_from_checkpoint": "latest",
+    "sdnq_compile_mode": "compile",
+    "sdnq_group_size": -1,
+    "sdnq_hadamard_group_size": 128,
+    "sdnq_use_hadamard": true,
+    "sdnq_use_quantized_matmul": true,
     "seed": 42,
     "skip_file_discovery": false,
     "tracker_project_name": "lora-training",


### PR DESCRIPTION
This pull request updates the configuration for the `z-image-turbo.peft-lora` example to switch the base model precision method and introduce new settings for SDNQ quantization. The main focus is on enabling and customizing SDNQ quantization features.

**SDNQ quantization configuration:**
* Changed `base_model_precision` from `"int8-torchao"` to `"int8-sdnq"` to use the SDNQ quantization method instead of TorchAO.
* Added new SDNQ-specific parameters to the config:
  - `sdnq_compile_mode`: set to `"compile"`
  - `sdnq_group_size`: set to `-1`
  - `sdnq_hadamard_group_size`: set to `128`
  - `sdnq_use_hadamard`: set to `true`
  - [`sdnq_use_quantized_matmul`](diffhunk://#diff-378aa2036ebaf97d463589a64cf3e3ea3aa903a34f8ae9cbd64bea442671e991R35-R39): set to `true`