### PR TITLE
ConvRot documentation

### DIFF
--- a/documentation/experimental/CONVROT.es.md
+++ b/documentation/experimental/CONVROT.es.md
@@ -1,0 +1,48 @@
+# ConvRot / Hadamard SDNQ
+
+SimpleTuner expone una rotación estilo ConvRot mediante la ruta Hadamard de SDNQ. Es útil para trabajos PEFT grandes donde el modelo base congelado debe ejecutarse en int8 mientras los adaptadores LoRA o LyCORIS siguen entrenándose en bf16.
+
+Esto no carga directamente buffers de checkpoints ConvRot externos. Carga los pesos originales del modelo y deja que SimpleTuner cuantice el componente entrenado con SDNQ después de cargar el modelo.
+
+## Configuración rápida
+
+```json
+{
+  "base_model_precision": "int8-sdnq",
+  "gradient_checkpointing": true,
+  "sdnq_use_hadamard": true,
+  "sdnq_hadamard_group_size": 128,
+  "sdnq_group_size": -1,
+  "sdnq_use_quantized_matmul": true,
+  "sdnq_compile_mode": "compile"
+}
+```
+
+Para modelos grandes, mantén `quantize_via` en `cpu` salvo que la guía del modelo indique otra cosa. La cuantización en CPU reduce el pico de memoria del acelerador durante la preparación.
+
+## Qué hacen las opciones
+
+- `base_model_precision: int8-sdnq` selecciona cuantización SDNQ int8 posterior a la carga para el componente base entrenado.
+- `sdnq_use_hadamard: true` activa la ruta de rotación Hadamard.
+- `sdnq_hadamard_group_size: 128` define el tamaño de bloque de rotación usado por SDNQ.
+- `sdnq_group_size: -1` usa escalas estáticas por fila de pesos. Esto evita la ruta dinámica agrupada, orientada principalmente a full fine-tuning, que puede recuantizar pesos durante el entrenamiento.
+- `sdnq_use_quantized_matmul: true` mantiene activa la ruta SDNQ int8 matmul.
+- `sdnq_compile_mode: compile` compila helpers y kernels de cuantización donde SDNQ lo soporta.
+- `gradient_checkpointing: true` permite que SDNQ use la ruta de entrenamiento de menor overhead para cargas PEFT. SimpleTuner pasa esto a SDNQ como `use_grad_ckpt=True`; con gradient checkpointing habilitado, poner ese flag de SDNQ en false solo agrega trabajo para guardar entradas backward cuantizadas que checkpointing descarta de inmediato.
+
+## Comportamiento PEFT
+
+El transformer base se cuantiza con SDNQ. Los pesos del adaptador siguen siendo entrenables y usan el dtype normal de precisión mixta, normalmente bf16.
+
+Algunos modelos cargan adaptadores auxiliares fijos antes del entrenamiento. Z-Image Turbo, por ejemplo, tiene una assistant LoRA. SimpleTuner retrasa ese adaptador hasta después de la cuantización SDNQ para que SDNQ vea los módulos transformer originales en lugar de pesos proxy del wrapper PEFT.
+
+## Requisitos y límites
+
+- Usa un build de SDNQ con soporte Hadamard. La verificación en H100 usó SDNQ upstream `0.2.3`; PyPI `0.2.2` no incluye la misma corrección Hadamard para bf16.
+- Este preset está pensado para entrenamiento LoRA y LyCORIS de modelos grandes. Full fine-tuning con SDNQ Hadamard necesita validación separada.
+- Los primeros steps pueden ser lentos porque SDNQ y Torch compilan kernels durante la preparación y el inicio del entrenamiento.
+- Validación e inferencia usan el modelo base cuantizado más el adaptador activo, igual que el entrenamiento.
+
+## Modelos de ejemplo
+
+SimpleTuner incluye ejemplos SDNQ Hadamard para Z-Image Turbo, Krea 2, FLUX.2, Cosmos 3 y LTXVideo 2.3. Estos ejemplos usan `sdnq_group_size: -1` porque esa configuración encajó mejor con PEFT que el default dinámico agrupado de entrenamiento.

--- a/documentation/experimental/CONVROT.hi.md
+++ b/documentation/experimental/CONVROT.hi.md
@@ -1,0 +1,48 @@
+# ConvRot / Hadamard SDNQ
+
+SimpleTuner SDNQ के Hadamard path के जरिए ConvRot-style rotation उपलब्ध कराता है। यह बड़े PEFT jobs के लिए उपयोगी है, जहां frozen base model int8 में चले और LoRA या LyCORIS adapters bf16 जैसे mixed-precision dtype में trainable रहें।
+
+यह external ConvRot checkpoint buffers को सीधे load नहीं करता। Original model weights load करें, फिर model load के बाद SimpleTuner trained component को SDNQ से quantize करेगा।
+
+## Quick Setup
+
+```json
+{
+  "base_model_precision": "int8-sdnq",
+  "gradient_checkpointing": true,
+  "sdnq_use_hadamard": true,
+  "sdnq_hadamard_group_size": 128,
+  "sdnq_group_size": -1,
+  "sdnq_use_quantized_matmul": true,
+  "sdnq_compile_mode": "compile"
+}
+```
+
+बड़े models के लिए `quantize_via` को `cpu` पर रखें, जब तक model guide कुछ और न कहे। CPU quantization setup के दौरान accelerator memory peak को कम करता है।
+
+## Options क्या करती हैं
+
+- `base_model_precision: int8-sdnq` trained base component के लिए post-load SDNQ int8 quantization चुनता है।
+- `sdnq_use_hadamard: true` Hadamard rotation path enable करता है।
+- `sdnq_hadamard_group_size: 128` SDNQ का rotation block size सेट करता है।
+- `sdnq_group_size: -1` static full-row weight scales इस्तेमाल करता है। यह dynamic grouped path से बचता है, जो मुख्य रूप से full fine-tuning के लिए है और training के दौरान weights requantize कर सकता है।
+- `sdnq_use_quantized_matmul: true` SDNQ int8 matmul path active रखता है।
+- `sdnq_compile_mode: compile` जहां SDNQ support करता है, quantization helpers और kernels compile करता है।
+- `gradient_checkpointing: true` PEFT workloads में SDNQ को lower-overhead training path इस्तेमाल करने देता है। SimpleTuner इसे SDNQ को `use_grad_ckpt=True` के रूप में पास करता है; gradient checkpointing enabled होने पर इस SDNQ flag को false करने से सिर्फ quantized backward inputs save करने का extra काम जुड़ता है, जिन्हें checkpointing तुरंत discard कर देता है।
+
+## PEFT Behavior
+
+Base transformer SDNQ से quantize होता है। Adapter weights trainable रहते हैं और normal mixed-precision dtype इस्तेमाल करते हैं, आम तौर पर bf16।
+
+कुछ models training से पहले fixed helper adapters load करते हैं। Z-Image Turbo में assistant LoRA है। SimpleTuner उस assistant adapter को SDNQ quantization के बाद तक defer करता है, ताकि SDNQ PEFT wrapper proxy weights के बजाय original transformer modules देखे।
+
+## Requirements And Limits
+
+- Hadamard support वाला SDNQ build इस्तेमाल करें। H100 verification में upstream SDNQ `0.2.3` इस्तेमाल हुआ; PyPI `0.2.2` में वही bf16 Hadamard fix नहीं है।
+- यह preset बड़े models की LoRA और LyCORIS training के लिए है। SDNQ Hadamard के साथ full fine-tuning को अलग validation चाहिए।
+- शुरुआती steps धीमे हो सकते हैं, क्योंकि setup और early training में SDNQ और Torch kernels compile करते हैं।
+- Validation और inference quantized base model plus active adapter इस्तेमाल करते हैं, training की तरह।
+
+## Example Models
+
+SimpleTuner में Z-Image Turbo, Krea 2, FLUX.2, Cosmos 3, और LTXVideo 2.3 के लिए SDNQ Hadamard examples हैं। ये examples `sdnq_group_size: -1` इस्तेमाल करते हैं क्योंकि यह PEFT workload के लिए dynamic grouped training default से बेहतर fit हुआ।

--- a/documentation/experimental/CONVROT.ja.md
+++ b/documentation/experimental/CONVROT.ja.md
@@ -1,0 +1,48 @@
+# ConvRot / Hadamard SDNQ
+
+SimpleTuner は、SDNQ の Hadamard 経路で ConvRot 形式の回転量子化を提供します。凍結したベースモデルを int8 で実行し、LoRA や LyCORIS アダプターを bf16 などの混合精度 dtype のまま学習する大型 PEFT ジョブに向いています。
+
+これは外部 ConvRot checkpoint の独自 buffer を直接読み込む機能ではありません。元のモデル重みを読み込み、モデルロード後に SimpleTuner が SDNQ で学習対象コンポーネントを量子化します。
+
+## クイック設定
+
+```json
+{
+  "base_model_precision": "int8-sdnq",
+  "gradient_checkpointing": true,
+  "sdnq_use_hadamard": true,
+  "sdnq_hadamard_group_size": 128,
+  "sdnq_group_size": -1,
+  "sdnq_use_quantized_matmul": true,
+  "sdnq_compile_mode": "compile"
+}
+```
+
+大型モデルでは、モデルガイドで別指定がない限り `quantize_via` は `cpu` のままにしてください。CPU 量子化はセットアップ時のアクセラレータメモリのピークを抑えます。
+
+## オプション
+
+- `base_model_precision: int8-sdnq` は、学習対象のベースコンポーネントに SDNQ int8 のロード後量子化を選びます。
+- `sdnq_use_hadamard: true` は Hadamard 回転経路を有効にします。
+- `sdnq_hadamard_group_size: 128` は SDNQ が使う回転ブロックサイズです。
+- `sdnq_group_size: -1` は静的な行単位 weight scale を使います。主にフルファインチューニング向けの動的 grouped 経路で、学習中に重みが再量子化されるのを避けます。
+- `sdnq_use_quantized_matmul: true` は SDNQ int8 matmul 経路を有効に保ちます。
+- `sdnq_compile_mode: compile` は SDNQ が対応する量子化 helper と kernel をコンパイルします。
+- `gradient_checkpointing: true` は PEFT ワークロードで SDNQ の低オーバーヘッドな学習経路を使えるようにします。SimpleTuner はこれを `use_grad_ckpt=True` として SDNQ に渡します。gradient checkpointing が有効なときにこの SDNQ フラグを false にすると、checkpointing がすぐ破棄する量子化 backward 入力を保存するだけで遅くなります。
+
+## PEFT での動作
+
+ベース transformer は SDNQ で量子化されます。アダプター重みは学習可能なままで、通常は bf16 のような混合精度 dtype を使います。
+
+一部のモデルは学習前に固定の補助アダプターを読み込みます。たとえば Z-Image Turbo には assistant LoRA があります。SimpleTuner はこの assistant アダプターを SDNQ 量子化後まで遅延させるため、SDNQ は PEFT wrapper の proxy weight ではなく元の transformer module を処理できます。
+
+## 要件と制限
+
+- Hadamard サポートを含む SDNQ build を使ってください。H100 検証では upstream SDNQ `0.2.3` を使いました。PyPI `0.2.2` には同じ bf16 Hadamard 修正が含まれていません。
+- このプリセットは大型モデルの LoRA と LyCORIS 学習向けです。SDNQ Hadamard でのフルファインチューニングは別途検証が必要です。
+- 初期 step は遅くなることがあります。SDNQ と Torch がセットアップや初期学習中に kernel をコンパイルするためです。
+- 検証と推論は、学習時と同じく量子化済みベースモデルと有効なアダプターを使います。
+
+## サンプルモデル
+
+SimpleTuner には Z-Image Turbo、Krea 2、FLUX.2、Cosmos 3、LTXVideo 2.3 向けの SDNQ Hadamard サンプルがあります。これらは PEFT ワークロードにより合うため、動的 grouped 学習のデフォルトではなく `sdnq_group_size: -1` を使います。

--- a/documentation/experimental/CONVROT.md
+++ b/documentation/experimental/CONVROT.md
@@ -1,0 +1,48 @@
+# ConvRot / Hadamard SDNQ
+
+SimpleTuner exposes ConvRot-style rotation through SDNQ's Hadamard path. This is useful for large PEFT jobs where the frozen base model should run as int8 while LoRA or LyCORIS adapters stay trainable in bf16.
+
+This does not load external ConvRot checkpoint buffers directly. Load the original model weights, then let SimpleTuner quantize the trained component with SDNQ after model load.
+
+## Quick Setup
+
+```json
+{
+  "base_model_precision": "int8-sdnq",
+  "gradient_checkpointing": true,
+  "sdnq_use_hadamard": true,
+  "sdnq_hadamard_group_size": 128,
+  "sdnq_group_size": -1,
+  "sdnq_use_quantized_matmul": true,
+  "sdnq_compile_mode": "compile"
+}
+```
+
+For large models, keep `quantize_via` on `cpu` unless the model guide says otherwise. CPU quantization reduces peak accelerator memory during setup.
+
+## What The Options Do
+
+- `base_model_precision: int8-sdnq` selects SDNQ int8 post-load quantization for the trained base component.
+- `sdnq_use_hadamard: true` enables the Hadamard rotation path.
+- `sdnq_hadamard_group_size: 128` sets the rotation block size used by SDNQ.
+- `sdnq_group_size: -1` uses static full-row weight scales. This avoids the dynamic grouped path that is mainly targeted at full fine-tuning and can requantize weights during training.
+- `sdnq_use_quantized_matmul: true` keeps the SDNQ int8 matmul path active.
+- `sdnq_compile_mode: compile` compiles the SDNQ quantization helpers and kernels where SDNQ supports it.
+- `gradient_checkpointing: true` lets SDNQ use the lower-overhead training path for PEFT workloads. SimpleTuner passes this to SDNQ as `use_grad_ckpt=True`; with gradient checkpointing enabled, setting that SDNQ flag to false only adds work to save quantized backward inputs that checkpointing immediately discards.
+
+## PEFT Behavior
+
+The base transformer is quantized by SDNQ. The adapter weights remain trainable and use the normal mixed-precision dtype, usually bf16.
+
+Some models load fixed helper adapters before training. Z-Image Turbo, for example, has an assistant LoRA. SimpleTuner defers that assistant adapter until after SDNQ quantization so SDNQ sees the original transformer modules instead of PEFT wrapper proxy weights.
+
+## Requirements And Limits
+
+- Use an SDNQ build with Hadamard support. The H100 verification used upstream SDNQ `0.2.3`; PyPI `0.2.2` does not include the same bf16 Hadamard fix.
+- This preset is intended for LoRA and LyCORIS training of large models. Full fine-tuning with SDNQ Hadamard needs separate validation.
+- First steps can be slow because SDNQ and Torch compile kernels during setup and early training.
+- Validation and inference use the quantized base model plus the active adapter, the same as training.
+
+## Example Models
+
+SimpleTuner includes SDNQ Hadamard examples for Z-Image Turbo, Krea 2, FLUX.2, Cosmos 3, and LTXVideo 2.3. These examples use `sdnq_group_size: -1` because that setting matched the PEFT workload better than the dynamic grouped training default.

--- a/documentation/experimental/CONVROT.pt-BR.md
+++ b/documentation/experimental/CONVROT.pt-BR.md
@@ -1,0 +1,48 @@
+# ConvRot / Hadamard SDNQ
+
+O SimpleTuner expõe uma rotação no estilo ConvRot pelo caminho Hadamard do SDNQ. Isso é útil para jobs PEFT grandes em que o modelo base congelado deve rodar em int8 enquanto adaptadores LoRA ou LyCORIS continuam treináveis em bf16.
+
+Isto não carrega diretamente buffers de checkpoints ConvRot externos. Carregue os pesos originais do modelo e deixe o SimpleTuner quantizar o componente treinado com SDNQ depois do carregamento.
+
+## Configuração rápida
+
+```json
+{
+  "base_model_precision": "int8-sdnq",
+  "gradient_checkpointing": true,
+  "sdnq_use_hadamard": true,
+  "sdnq_hadamard_group_size": 128,
+  "sdnq_group_size": -1,
+  "sdnq_use_quantized_matmul": true,
+  "sdnq_compile_mode": "compile"
+}
+```
+
+Para modelos grandes, mantenha `quantize_via` em `cpu`, a menos que o guia do modelo diga o contrário. A quantização em CPU reduz o pico de memória do acelerador durante a inicialização.
+
+## O que as opções fazem
+
+- `base_model_precision: int8-sdnq` seleciona quantização SDNQ int8 pós-carregamento para o componente base treinado.
+- `sdnq_use_hadamard: true` ativa o caminho de rotação Hadamard.
+- `sdnq_hadamard_group_size: 128` define o tamanho de bloco de rotação usado pelo SDNQ.
+- `sdnq_group_size: -1` usa scales estáticos por linha de peso. Isso evita o caminho dinâmico agrupado, mais voltado para full fine-tuning, que pode requantizar pesos durante o treino.
+- `sdnq_use_quantized_matmul: true` mantém ativo o caminho SDNQ int8 matmul.
+- `sdnq_compile_mode: compile` compila helpers e kernels de quantização onde o SDNQ oferece suporte.
+- `gradient_checkpointing: true` permite que o SDNQ use o caminho de treino de menor overhead para workloads PEFT. O SimpleTuner passa isso ao SDNQ como `use_grad_ckpt=True`; com gradient checkpointing habilitado, definir esse flag do SDNQ como false só adiciona trabalho para salvar entradas backward quantizadas que o checkpointing descarta imediatamente.
+
+## Comportamento PEFT
+
+O transformer base é quantizado pelo SDNQ. Os pesos do adaptador continuam treináveis e usam o dtype normal de precisão mista, geralmente bf16.
+
+Alguns modelos carregam adaptadores auxiliares fixos antes do treino. O Z-Image Turbo, por exemplo, tem uma assistant LoRA. O SimpleTuner adia esse adaptador até depois da quantização SDNQ, para que o SDNQ veja os módulos transformer originais em vez dos proxy weights do wrapper PEFT.
+
+## Requisitos e limites
+
+- Use um build do SDNQ com suporte a Hadamard. A verificação em H100 usou o SDNQ upstream `0.2.3`; PyPI `0.2.2` não inclui a mesma correção Hadamard para bf16.
+- Este preset é voltado para treino LoRA e LyCORIS em modelos grandes. Full fine-tuning com SDNQ Hadamard precisa de validação separada.
+- Os primeiros steps podem ser lentos porque SDNQ e Torch compilam kernels durante a inicialização e o início do treino.
+- Validação e inferência usam o modelo base quantizado mais o adaptador ativo, igual ao treino.
+
+## Modelos de exemplo
+
+O SimpleTuner inclui exemplos SDNQ Hadamard para Z-Image Turbo, Krea 2, FLUX.2, Cosmos 3 e LTXVideo 2.3. Esses exemplos usam `sdnq_group_size: -1` porque essa configuração combinou melhor com PEFT do que o padrão dinâmico agrupado de treino.

--- a/documentation/experimental/CONVROT.zh.md
+++ b/documentation/experimental/CONVROT.zh.md
@@ -1,0 +1,48 @@
+# ConvRot / Hadamard SDNQ
+
+SimpleTuner 通过 SDNQ 的 Hadamard 路径提供 ConvRot 风格的旋转量化。它适合大型 PEFT 训练：冻结的基础模型使用 int8 计算，LoRA 或 LyCORIS 适配器继续以 bf16 等混合精度 dtype 训练。
+
+这不会直接读取外部 ConvRot checkpoint 中的自定义 buffer。请加载原始模型权重，然后让 SimpleTuner 在模型加载后用 SDNQ 量化训练组件。
+
+## 快速配置
+
+```json
+{
+  "base_model_precision": "int8-sdnq",
+  "gradient_checkpointing": true,
+  "sdnq_use_hadamard": true,
+  "sdnq_hadamard_group_size": 128,
+  "sdnq_group_size": -1,
+  "sdnq_use_quantized_matmul": true,
+  "sdnq_compile_mode": "compile"
+}
+```
+
+对于大型模型，除非模型指南另有说明，建议保留 `quantize_via` 为 `cpu`。CPU 量化可以降低初始化阶段的显存峰值。
+
+## 选项说明
+
+- `base_model_precision: int8-sdnq` 为训练的基础组件选择 SDNQ int8 后加载量化。
+- `sdnq_use_hadamard: true` 启用 Hadamard 旋转路径。
+- `sdnq_hadamard_group_size: 128` 设置 SDNQ 使用的旋转块大小。
+- `sdnq_group_size: -1` 使用静态的按行权重 scale，避免主要面向全量微调的动态分组路径在训练中重新量化权重。
+- `sdnq_use_quantized_matmul: true` 保持 SDNQ int8 matmul 路径启用。
+- `sdnq_compile_mode: compile` 在 SDNQ 支持的位置编译量化 helper 和 kernel。
+- `gradient_checkpointing: true` 让 SDNQ 在 PEFT 训练中使用开销更低的训练路径。SimpleTuner 会把它作为 `use_grad_ckpt=True` 传给 SDNQ；启用梯度 checkpointing 时，如果把该 SDNQ 标志设为 false，只会额外保存会被 checkpointing 立即丢弃的量化 backward 输入。
+
+## PEFT 行为
+
+基础 transformer 由 SDNQ 量化。适配器权重仍然可训练，并使用普通混合精度 dtype，通常是 bf16。
+
+部分模型会在训练前加载固定辅助适配器。例如 Z-Image Turbo 有 assistant LoRA。SimpleTuner 会把该 assistant 适配器延后到 SDNQ 量化之后加载，这样 SDNQ 看到的是原始 transformer module，而不是 PEFT wrapper 的代理权重。
+
+## 要求与限制
+
+- 使用带 Hadamard 支持的 SDNQ 构建。H100 验证使用的是上游 SDNQ `0.2.3`；PyPI `0.2.2` 不包含相同的 bf16 Hadamard 修复。
+- 该预设面向大型模型的 LoRA 和 LyCORIS 训练。SDNQ Hadamard 的全量微调需要单独验证。
+- 初始 step 可能较慢，因为 SDNQ 和 Torch 会在初始化和早期训练时编译 kernel。
+- 验证和推理使用量化后的基础模型加当前适配器，和训练一致。
+
+## 示例模型
+
+SimpleTuner 为 Z-Image Turbo、Krea 2、FLUX.2、Cosmos 3 和 LTXVideo 2.3 提供 SDNQ Hadamard 示例。这些示例使用 `sdnq_group_size: -1`，因为它比动态分组训练默认值更符合 PEFT 工作负载。

--- a/documentation/index.es.md
+++ b/documentation/index.es.md
@@ -72,9 +72,9 @@
 
     ---
 
-    Funciones de investigación como AnyFlow, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention y Video CREPA
+    Funciones de investigación como AnyFlow, cuantización SDNQ Hadamard estilo ConvRot, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention y Video CREPA
 
-    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
+    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
 
 </div>
 

--- a/documentation/index.hi.md
+++ b/documentation/index.hi.md
@@ -72,9 +72,9 @@
 
     ---
 
-    AnyFlow, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention और Video CREPA जैसी research features
+    AnyFlow, ConvRot-style SDNQ Hadamard quantization, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention और Video CREPA जैसी research features
 
-    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
+    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
 
 </div>
 

--- a/documentation/index.ja.md
+++ b/documentation/index.ja.md
@@ -72,9 +72,9 @@
 
     ---
 
-    AnyFlow、Prompt2Effect、Self-Flow、Flow-DPO、LayerSync、Diff2Flow、Metal Flash Attention、Video CREPA などの研究向け機能
+    AnyFlow、ConvRot 形式の SDNQ Hadamard 量子化、Prompt2Effect、Self-Flow、Flow-DPO、LayerSync、Diff2Flow、Metal Flash Attention、Video CREPA などの研究向け機能
 
-    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
+    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
 
 </div>
 

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -72,9 +72,9 @@
 
     ---
 
-    Research features such as AnyFlow, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention, and Video CREPA
+    Research features such as AnyFlow, ConvRot-style SDNQ Hadamard quantization, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention, and Video CREPA
 
-    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
+    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
 
 </div>
 

--- a/documentation/index.pt-BR.md
+++ b/documentation/index.pt-BR.md
@@ -72,9 +72,9 @@
 
     ---
 
-    Recursos de pesquisa como AnyFlow, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention e Video CREPA
+    Recursos de pesquisa como AnyFlow, quantização SDNQ Hadamard no estilo ConvRot, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention e Video CREPA
 
-    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
+    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
 
 </div>
 

--- a/documentation/index.zh.md
+++ b/documentation/index.zh.md
@@ -72,9 +72,9 @@
 
     ---
 
-    AnyFlow、Prompt2Effect、Self-Flow、Flow-DPO、LayerSync、Diff2Flow、Metal Flash Attention、Video CREPA 等研究功能
+    AnyFlow、ConvRot 风格的 SDNQ Hadamard 量化、Prompt2Effect、Self-Flow、Flow-DPO、LayerSync、Diff2Flow、Metal Flash Attention、Video CREPA 等研究功能
 
-    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
+    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
 
 </div>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -345,6 +345,7 @@ nav:
       - Sliding Window (SLA): attention/SLA.md
     - Experimental:
       - AnyFlow: experimental/ANYFLOW.md
+      - ConvRot / Hadamard SDNQ: experimental/CONVROT.md
       - Diff2Flow: experimental/DIFF2FLOW.md
       - Flow-DPO: experimental/FLOW_DPO.md
       - LayerSync: experimental/LAYERSYNC.md


### PR DESCRIPTION
This pull request adds comprehensive documentation for the new ConvRot / Hadamard SDNQ quantization feature in SimpleTuner, including quick setup instructions, explanations of configuration options, usage notes, and example models. The documentation is provided in multiple languages and is integrated into both the navigation and feature lists of the documentation site.

**Key changes:**

**1. New Feature Documentation:**
- Added detailed guides for ConvRot / Hadamard SDNQ quantization in `documentation/experimental/CONVROT.md` and localized versions in Spanish, Hindi, Japanese, Portuguese (Brazil), and Chinese. These guides cover setup, configuration, behavior, requirements, and example models for using SDNQ Hadamard quantization in PEFT workloads. [[1]](diffhunk://#diff-8558ca2d92b0c8f908e32e16d9fdad4b57bc017287bd6333df78702d8e2c2c2dR1-R48) [[2]](diffhunk://#diff-92fa37945f98d1e6ac1ce6cc3197d444f5f634e9671118a635b1680e57218a27R1-R48) [[3]](diffhunk://#diff-d46f6ea4e5745e3f0cdeac35434200525f41ccb734088128a99b1c118c9e9b04R1-R48) [[4]](diffhunk://#diff-b7c365c71e8d13e57492291d6f1232b980e878dab2f84948778b89b3b6856c1bR1-R48) [[5]](diffhunk://#diff-e6428317e0316c2e6bbd50d10b7425b859dc97242598c9bcd6fa473423cc2450R1-R48) [[6]](diffhunk://#diff-d051eecac5e6cbb10897f8ce65ea204a3af011cb55a403b58cf724ea9c3b6ef5R1-R48)

**2. Navigation and Index Integration:**
- Added "ConvRot / Hadamard SDNQ" to the experimental section of the documentation navigation by updating `mkdocs.yml`.
- Updated all index files (`index.md` and localized versions) to mention ConvRot / Hadamard SDNQ as a research feature and to include a direct link to the new documentation page. [[1]](diffhunk://#diff-8a992fc8a61d84dc7e49e3b126235f05599212988c01f9b712517995b9a59531L75-R77) [[2]](diffhunk://#diff-a40cb6e65021f9604fd67fa7247b9982bdf1cdee2fd6accf2dd892e33bc913b3L75-R77) [[3]](diffhunk://#diff-e30660701a4425b908d3e6dd221cd3c23718e43c66a36228c5bf56274a973098L75-R77) [[4]](diffhunk://#diff-539c5c3d049f9d54a186a14d85871ff35dbb058c2b960dc908f8d0450bca7e33L75-R77) [[5]](diffhunk://#diff-ce437b1c0a6c29f78f5e30a8847509bdf8f2ba1973fa5deb3eab8479e31057faL75-R77) [[6]](diffhunk://#diff-b543d392e2d57bb456fb6d7dcd43d4e266d5b1b7d2a23902178f8c18333dee52L75-R77)

These changes ensure that users can easily find and understand how to use the new ConvRot / Hadamard SDNQ quantization feature in SimpleTuner, with clear instructions and examples in multiple languages.