### PR TITLE
convrot: add a hook to run post-quant custom setup when needed

### DIFF
--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -3186,6 +3186,13 @@ class ModelFoundation(ABC):
         """
         self._init_layersync_regularizer()
 
+    def post_quantization_setup(self):
+        """
+        Hook for model families that need setup after manual quantization.
+
+        """
+        return
+
     def fuse_qkv_projections(self):
         if not self.config.fuse_qkv_projections or self._qkv_projections_fused:
             return

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -2969,6 +2969,9 @@ class Trainer:
                     )
                     self.model.set_prepared_model(q_model, base_model=False)
 
+        if not preprocessing_models_only and not ema_only:
+            self.model.post_quantization_setup()
+
         if (
             getattr(self.config, "ramtorch", False)
             and not preprocessing_models_only


### PR DESCRIPTION
This pull request introduces a new extensibility hook to support additional setup steps after manual quantization of models. The main changes involve adding a `post_quantization_setup` method to the base model class and invoking this hook in the training process after quantization is applied.

**Model extensibility improvements:**

* Added a `post_quantization_setup` method to the base model class in `common.py` as a hook for model families that require extra setup after manual quantization.

**Training process integration:**

* Updated the training pipeline in `trainer.py` to call `post_quantization_setup` on the model after quantization is performed, ensuring any necessary post-quantization steps are executed.