### PR TITLE
mage-flow: fix issue with rotary helper

### DIFF
--- a/simpletuner/helpers/models/mageflow/model.py
+++ b/simpletuner/helpers/models/mageflow/model.py
@@ -407,7 +407,12 @@ class MageFlow(ImageModelFoundation):
 
     @staticmethod
     def _ensure_qwen3vl_text_rotary_precision(text_encoder, device: torch.device) -> None:
-        rotary_emb = text_encoder.language_model.rotary_emb
+        language_model = getattr(text_encoder, "language_model", None)
+        if language_model is None and hasattr(text_encoder, "model"):
+            language_model = getattr(text_encoder.model, "language_model", None)
+        if language_model is None:
+            raise AttributeError(f"{text_encoder.__class__.__name__} does not expose a Qwen3-VL language_model")
+        rotary_emb = language_model.rotary_emb
         inv_freq = rotary_emb.inv_freq
         original_inv_freq = getattr(rotary_emb, "original_inv_freq", None)
         if (

--- a/simpletuner/helpers/models/mageflow/model.py
+++ b/simpletuner/helpers/models/mageflow/model.py
@@ -526,6 +526,7 @@ class MageFlow(ImageModelFoundation):
         target_tokens = rearrange(latents, "b c h w -> b (h w) c")
         sample_lens = []
         target_lens = []
+        target_shapes = []
         shape_seq = []
         target_indices = []
         parts = []
@@ -535,6 +536,7 @@ class MageFlow(ImageModelFoundation):
             parts.append(target)
             total_len = target.shape[1]
             target_lens.append(total_len)
+            target_shapes.append((height, width))
             shape_seq.append((1, height, width))
             if conditioning_latents is not None:
                 refs = conditioning_latents
@@ -556,8 +558,7 @@ class MageFlow(ImageModelFoundation):
             sample_lens,
             torch.cat(target_indices),
             target_lens,
-            height,
-            width,
+            target_shapes,
         )
 
     def model_predict(self, prepared_batch, custom_timesteps: list = None):
@@ -572,8 +573,7 @@ class MageFlow(ImageModelFoundation):
             img_lens,
             target_indices,
             target_lens,
-            latent_h,
-            latent_w,
+            target_shapes,
         ) = self._pack_latents_for_model(latents, conditioning_latents=conditioning_latents)
         txt, txt_cu = self._pack_text(prepared_batch)
         timestep = prepared_batch["timesteps"].to(device=self.accelerator.device, dtype=self.config.weight_dtype) / 1000.0
@@ -595,7 +595,7 @@ class MageFlow(ImageModelFoundation):
         model_pred = model_pred[:, target_indices]
         cursor = 0
         samples = []
-        for target_len in target_lens:
+        for target_len, (latent_h, latent_w) in zip(target_lens, target_shapes, strict=True):
             sample = model_pred[:, cursor : cursor + target_len]
             samples.append(rearrange(sample, "1 (h w) c -> c h w", h=latent_h, w=latent_w))
             cursor += target_len

--- a/simpletuner/helpers/models/mageflow/vendor/models/modules/mage_layers.py
+++ b/simpletuner/helpers/models/mageflow/vendor/models/modules/mage_layers.py
@@ -458,9 +458,19 @@ class MageDoubleStreamAttnProcessor:
         img_dest_indices = joint_cu_lens[img_sample_ids] + txt_lens[img_sample_ids] + img_intra_pos
 
         total_tokens = joint_cu_lens[-1]
-        joint_query = torch.empty((total_tokens, *txt_query.shape[1:]), dtype=txt_query.dtype, device=device)
-        joint_key = torch.empty((total_tokens, *txt_key.shape[1:]), dtype=txt_key.dtype, device=device)
-        joint_value = torch.empty((total_tokens, *txt_value.shape[1:]), dtype=txt_value.dtype, device=device)
+        attention_dtype = torch.promote_types(
+            torch.promote_types(torch.promote_types(img_query.dtype, img_key.dtype), img_value.dtype),
+            torch.promote_types(torch.promote_types(txt_query.dtype, txt_key.dtype), txt_value.dtype),
+        )
+        if attention_dtype == torch.float32:
+            device_type = hidden_states.device.type
+            if torch.is_autocast_enabled(device_type):
+                attention_dtype = torch.get_autocast_dtype(device_type)
+            elif hidden_states.dtype in {torch.float16, torch.bfloat16}:
+                attention_dtype = hidden_states.dtype
+        joint_query = torch.empty((total_tokens, *img_query.shape[1:]), dtype=attention_dtype, device=device)
+        joint_key = torch.empty((total_tokens, *img_key.shape[1:]), dtype=attention_dtype, device=device)
+        joint_value = torch.empty((total_tokens, *img_value.shape[1:]), dtype=attention_dtype, device=device)
 
         # logger.info(f"joint_query shape: {joint_query.shape}")
         # logger.info(f"joint_key shape: {joint_key.shape}")
@@ -468,14 +478,14 @@ class MageDoubleStreamAttnProcessor:
         # logger.info(f"txt_dest_indices shape: {txt_dest_indices.shape}")
         # logger.info(f"img_dest_indices shape: {img_dest_indices.shape}")
 
-        joint_query[txt_dest_indices] = txt_query
-        joint_query[img_dest_indices] = img_query
+        joint_query[txt_dest_indices] = txt_query.to(joint_query.dtype)
+        joint_query[img_dest_indices] = img_query.to(joint_query.dtype)
 
-        joint_key[txt_dest_indices] = txt_key
-        joint_key[img_dest_indices] = img_key
+        joint_key[txt_dest_indices] = txt_key.to(joint_key.dtype)
+        joint_key[img_dest_indices] = img_key.to(joint_key.dtype)
 
-        joint_value[txt_dest_indices] = txt_value
-        joint_value[img_dest_indices] = img_value
+        joint_value[txt_dest_indices] = txt_value.to(joint_value.dtype)
+        joint_value[img_dest_indices] = img_value.to(joint_value.dtype)
 
         max_seqlen = joint_lens.max().item()
         joint_attn_output = flash_attn_varlen_func(

--- a/tests/test_mageflow_model.py
+++ b/tests/test_mageflow_model.py
@@ -238,6 +238,35 @@ class MageFlowModelTests(unittest.TestCase):
         self.assertTrue(torch.equal(rotary_emb.original_inv_freq, rotary_emb.inv_freq))
         self.assertEqual(rotary_emb.attention_scaling, 1.0)
 
+    def test_mageflow_restores_nested_qwen_text_rotary_inv_freq_to_fp32(self):
+        model_cls = _mageflow_class()
+
+        class RotaryEmbedding(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = SimpleNamespace()
+                self.attention_scaling = 0.25
+                rounded = torch.tensor([1.0, 0.1001], dtype=torch.bfloat16)
+                self.register_buffer("inv_freq", rounded, persistent=False)
+                self.register_buffer("original_inv_freq", rounded.clone(), persistent=False)
+
+            @staticmethod
+            def compute_default_rope_parameters(config, device):
+                del config
+                return torch.tensor([1.0, 0.100123], device=device, dtype=torch.float32), 1.0
+
+        language_model = SimpleNamespace(rotary_emb=RotaryEmbedding())
+        text_encoder = SimpleNamespace(model=SimpleNamespace(language_model=language_model))
+
+        model_cls._ensure_qwen3vl_text_rotary_precision(text_encoder, torch.device("cpu"))
+
+        rotary_emb = language_model.rotary_emb
+        self.assertEqual(rotary_emb.inv_freq.dtype, torch.float32)
+        self.assertEqual(rotary_emb.original_inv_freq.dtype, torch.float32)
+        self.assertTrue(torch.equal(rotary_emb.inv_freq, torch.tensor([1.0, 0.100123], dtype=torch.float32)))
+        self.assertTrue(torch.equal(rotary_emb.original_inv_freq, rotary_emb.inv_freq))
+        self.assertEqual(rotary_emb.attention_scaling, 1.0)
+
     def test_pretrained_load_args_enable_twinflow_time_sign_embedding(self):
         model_cls = _mageflow_class()
         model = object.__new__(model_cls)


### PR DESCRIPTION
This pull request enhances the robustness of the `_ensure_qwen3vl_text_rotary_precision` method in the MageFlow model code and adds a new test to ensure correct handling of nested Qwen3-VL text encoders. The changes improve compatibility with different model structures and increase test coverage for rotary embedding precision restoration.

**Improvements to model robustness:**

* Updated `_ensure_qwen3vl_text_rotary_precision` in `model.py` to support text encoders where `language_model` may be nested under a `model` attribute, raising a clear error if not found.

**Testing enhancements:**

* Added `test_mageflow_restores_nested_qwen_text_rotary_inv_freq_to_fp32` to verify that rotary embedding precision is correctly restored to float32 for nested Qwen3-VL text encoders.