### PR TITLE
Fix distributed padding and preserve padded occurrences

### DIFF
--- a/simpletuner/helpers/data_backend/factory.py
+++ b/simpletuner/helpers/data_backend/factory.py
@@ -3283,7 +3283,7 @@ class FactoryRegistry:
                     f" You have to reduce your batch size, or increase your dataset size (id={init_backend['id']})."
                 )
 
-        apply_padding = True if not self.args.max_train_steps or self.args.max_train_steps == 0 else False
+        apply_padding = not self.args.max_train_steps or self.args.allow_dataset_oversubscription
 
         if backend.get("auto_generated", False):
             # when we're duplicating a metadata set, it's already split between processes.

--- a/simpletuner/helpers/metadata/backends/base.py
+++ b/simpletuner/helpers/metadata/backends/base.py
@@ -903,33 +903,21 @@ class MetadataBackend:
                         effective_batch_size=effective_batch_size,
                     )
 
-            # Split data by DP rank (not global rank) when context parallelism is enabled.
-            # This ensures all ranks in a CP group get the same data shard.
-            if cp_size > 1:
-                # Custom CP-aware splitting: split by dp_rank instead of process_index
-                chunk_size = ceil(len(trimmed_images) / effective_dp_size) if effective_dp_size > 0 else len(trimmed_images)
-                start_idx = dp_rank * chunk_size
-                end_idx = min(start_idx + chunk_size, len(trimmed_images))
-                images_split = trimmed_images[start_idx:end_idx]
-
-                # Handle padding if requested (for uniform batch sizes)
-                if apply_padding and len(images_split) < chunk_size and len(images_split) > 0:
-                    padding_needed = chunk_size - len(images_split)
-                    # Pad by repeating elements from the split
-                    padding = (images_split * ((padding_needed // len(images_split)) + 1))[:padding_needed]
-                    images_split = images_split + padding
-
-                new_aspect_ratio_bucket_indices[bucket] = images_split
-            else:
-                # Standard splitting when CP is disabled
-                with self.accelerator.split_between_processes(trimmed_images, apply_padding=apply_padding) as images_split:
-                    new_aspect_ratio_bucket_indices[bucket] = images_split
+            samples_per_rank, extra_samples = divmod(len(trimmed_images), effective_dp_size)
+            start_idx = dp_rank * samples_per_rank + min(dp_rank, extra_samples)
+            local_size = samples_per_rank + int(dp_rank < extra_samples)
+            images_split = trimmed_images[start_idx : start_idx + local_size]
+            if apply_padding:
+                target_size = samples_per_rank + int(extra_samples > 0)
+                if trimmed_images and len(images_split) < target_size:
+                    images_split += [trimmed_images[-1]] * (target_size - len(images_split))
+            new_aspect_ratio_bucket_indices[bucket] = images_split
 
         self.aspect_ratio_bucket_indices = new_aspect_ratio_bucket_indices
         post_total = sum([len(bucket) for bucket in self.aspect_ratio_bucket_indices.values()])
         if self.bucket_report:
             self.bucket_report.record_bucket_snapshot("post_split", self.aspect_ratio_bucket_indices)
-        if total_samples != post_total:
+        if self.accelerator.num_processes > 1 or total_samples != post_total:
             self.read_only = True
 
         # Check if this backend has no samples after splitting (can happen with multi-GPU setups)
@@ -944,14 +932,28 @@ class MetadataBackend:
 
         logger.debug(f"Count of items after split: {post_total}")
 
+    def seen_occurrence_count(self, image_path) -> int:
+        """Return consumed occurrences, accepting boolean values from older checkpoints."""
+        value = self.seen_images.get(image_path, 0)
+        if isinstance(value, bool):
+            return int(value)
+        if not isinstance(value, int):
+            raise TypeError(f"Invalid seen occurrence count for {image_path!r}: {value!r}")
+        if value < 0:
+            raise ValueError(f"Seen occurrence count cannot be negative for {image_path!r}: {value}")
+        return int(value)
+
     def mark_as_seen(self, image_path):
-        self.seen_images[image_path] = True
+        self.seen_images[image_path] = self.seen_occurrence_count(image_path) + 1
 
     def mark_batch_as_seen(self, image_paths):
-        self.seen_images.update({image_path: True for image_path in image_paths})
+        for image_path in image_paths:
+            self.mark_as_seen(image_path)
 
-    def is_seen(self, image_path):
-        return self.seen_images.get(image_path, False)
+    def is_seen(self, image_path, occurrence_index: int = 0):
+        if isinstance(self.seen_images.get(image_path, 0), bool):
+            return self.seen_images[image_path]
+        return self.seen_occurrence_count(image_path) > occurrence_index
 
     def reset_seen_images(self):
         self.seen_images.clear()

--- a/simpletuner/helpers/multiaspect/sampler.py
+++ b/simpletuner/helpers/multiaspect/sampler.py
@@ -134,10 +134,20 @@ class MultiAspectSampler(torch.utils.data.Sampler):
 
     def load_states(self, state_path: str):
         try:
-            self.buckets = self.load_buckets()
             previous_state = self.state_manager.load_state(state_path)
         except Exception as e:
             raise e
+
+        # Checkpoints contain the rank-local schedule. Restore it before seen
+        # state so legacy boolean flags can be expanded to all occurrences.
+        saved_schedule = previous_state.get("aspect_ratio_bucket_indices")
+        if isinstance(saved_schedule, dict):
+            self.metadata_backend.aspect_ratio_bucket_indices = saved_schedule
+            self._val_master_list = sorted(sum(saved_schedule.values(), []))
+        self.buckets = previous_state.get("buckets", self.load_buckets())
+        if "current_bucket" in previous_state:
+            self.current_bucket = previous_state["current_bucket"]
+
         self.exhausted_buckets = []
         if "exhausted_buckets" in previous_state:
             self.logger.info(f"Previous checkpoint had {len(previous_state['exhausted_buckets'])} exhausted buckets.")
@@ -149,7 +159,20 @@ class MultiAspectSampler(torch.utils.data.Sampler):
         # Merge seen_images into self.state_manager.seen_images Manager.dict:
         if "seen_images" in previous_state:
             self.logger.info(f"Previous checkpoint had {len(previous_state['seen_images'])} seen {self.sample_type_strs}.")
-            self.metadata_backend.seen_images.update(previous_state["seen_images"])
+            occurrence_counts = {}
+            for images in self.metadata_backend.aspect_ratio_bucket_indices.values():
+                for image_path in images:
+                    occurrence_counts[image_path] = occurrence_counts.get(image_path, 0) + 1
+            normalized_seen = {
+                image_path: (
+                    (occurrence_counts.get(image_path, True) if value else 0)
+                    if isinstance(value, bool)
+                    else value
+                )
+                for image_path, value in previous_state["seen_images"].items()
+            }
+            self.metadata_backend.seen_images.clear()
+            self.metadata_backend.seen_images.update(normalized_seen)
 
     def load_buckets(self):
         return list(self.metadata_backend.aspect_ratio_bucket_indices.keys())  # These keys are a float value, eg. 1.78.
@@ -389,6 +412,17 @@ class MultiAspectSampler(torch.utils.data.Sampler):
         # Bucket not found with either type
         return []
 
+    def _filter_unseen_occurrences(self, images):
+        """Filter consumed positions without collapsing duplicate filepaths."""
+        occurrence_indices = {}
+        unseen = []
+        for image in images:
+            occurrence_index = occurrence_indices.get(image, 0)
+            occurrence_indices[image] = occurrence_index + 1
+            if not self.metadata_backend.is_seen(image, occurrence_index):
+                unseen.append(image)
+        return unseen
+
     def _get_unseen_images(self, bucket=None):
         """
         Get unseen {self.sample_type_strs} from the specified bucket.
@@ -410,8 +444,7 @@ class MultiAspectSampler(torch.utils.data.Sampler):
 
             return [
                 (os.path.join(self.metadata_backend.instance_data_dir, image) if not image.startswith("http") else image)
-                for image in bucket_images
-                if not self.metadata_backend.is_seen(image)
+                for image in self._filter_unseen_occurrences(bucket_images)
             ]
         elif bucket is None:
             unseen_images = []
@@ -423,8 +456,7 @@ class MultiAspectSampler(torch.utils.data.Sampler):
                             if not image.startswith("http")
                             else image
                         )
-                        for image in images
-                        if not self.metadata_backend.is_seen(image)
+                        for image in self._filter_unseen_occurrences(images)
                     ]
                 )
             return unseen_images

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -5501,7 +5501,8 @@ class Trainer:
                 # we'll have to split the buckets between GPUs again now, so that the VAE cache distributes properly.
                 logger.info("Splitting buckets across GPUs")
                 backend["metadata_backend"].split_buckets_between_processes(
-                    gradient_accumulation_steps=self.config.gradient_accumulation_steps
+                    gradient_accumulation_steps=self.config.gradient_accumulation_steps,
+                    apply_padding=(self.config.overrode_max_train_steps or self.config.allow_dataset_oversubscription),
                 )
                 # we have to rebuild the VAE cache if it exists.
                 if "vaecache" in backend:

--- a/tests/test_audio_sampler.py
+++ b/tests/test_audio_sampler.py
@@ -19,9 +19,11 @@ class TestAudioSampler(unittest.TestCase):
         self.mock_metadata.id = "test_backend"
         self.mock_metadata.aspect_ratio_bucket_indices = {"10s": ["a.wav", "b.wav"], "20s": ["c.wav"]}
         self.mock_metadata.seen_images = {}
-        self.mock_metadata.is_seen = lambda x: x in self.mock_metadata.seen_images
+        self.mock_metadata.is_seen = (
+            lambda x, occurrence_index=0: int(self.mock_metadata.seen_images.get(x, 0)) > occurrence_index
+        )
         self.mock_metadata.mark_batch_as_seen = lambda batch: [
-            self.mock_metadata.seen_images.update({x: True}) for x in batch
+            self.mock_metadata.seen_images.update({x: int(self.mock_metadata.seen_images.get(x, 0)) + 1}) for x in batch
         ]
         self.mock_metadata.reset_seen_images = lambda: self.mock_metadata.seen_images.clear()
         self.mock_metadata.instance_data_dir = ""

--- a/tests/test_factory_edge_cases.py
+++ b/tests/test_factory_edge_cases.py
@@ -977,6 +977,7 @@ class TestFactoryEdgeCases(unittest.TestCase):
         # Mock accelerator with 8 GPUs
         mock_accelerator = MagicMock()
         mock_accelerator.num_processes = 8
+        mock_accelerator.process_index = 0
         mock_backend.accelerator = mock_accelerator
 
         # Mock StateTracker.get_args() to return args with allow_dataset_oversubscription=False
@@ -1023,16 +1024,7 @@ class TestFactoryEdgeCases(unittest.TestCase):
         # Mock accelerator with 2 GPUs
         mock_accelerator = MagicMock()
         mock_accelerator.num_processes = 2
-
-        # Mock split_between_processes to distribute images properly
-        def split_side_effect(images, apply_padding=False):
-            mock_context = MagicMock()
-            # Each GPU gets half the images
-            mock_context.__enter__ = MagicMock(return_value=images[: len(images) // 2])
-            mock_context.__exit__ = MagicMock(return_value=False)
-            return mock_context
-
-        mock_accelerator.split_between_processes = MagicMock(side_effect=split_side_effect)
+        mock_accelerator.process_index = 0
         mock_backend.accelerator = mock_accelerator
 
         # Mock StateTracker.get_args() to return args with allow_dataset_oversubscription=False
@@ -1068,14 +1060,7 @@ class TestFactoryEdgeCases(unittest.TestCase):
 
         mock_accelerator = MagicMock()
         mock_accelerator.num_processes = 1
-
-        def split_side_effect(images, apply_padding=False):
-            mock_context = MagicMock()
-            mock_context.__enter__ = MagicMock(return_value=images)
-            mock_context.__exit__ = MagicMock(return_value=False)
-            return mock_context
-
-        mock_accelerator.split_between_processes = MagicMock(side_effect=split_side_effect)
+        mock_accelerator.process_index = 0
         mock_backend.accelerator = mock_accelerator
 
         with (
@@ -1091,8 +1076,6 @@ class TestFactoryEdgeCases(unittest.TestCase):
             except ValueError as e:
                 if "Dataset configuration will produce zero usable batches" in str(e):
                     self.fail(f"Eval dataset should not consider grad accumulation: {e}")
-
-        mock_accelerator.split_between_processes.assert_called_once()
 
     def test_oversubscription_auto_adjustment(self):
         """Test that --allow_dataset_oversubscription automatically adjusts repeats."""
@@ -1110,6 +1093,7 @@ class TestFactoryEdgeCases(unittest.TestCase):
         # Mock accelerator with 8 GPUs
         mock_accelerator = MagicMock()
         mock_accelerator.num_processes = 8
+        mock_accelerator.process_index = 0
         mock_backend.accelerator = mock_accelerator
 
         # Mock StateTracker to enable oversubscription and NO user-set repeats
@@ -1121,15 +1105,6 @@ class TestFactoryEdgeCases(unittest.TestCase):
             with patch.object(StateTracker, "get_data_backend_config") as mock_get_config:
                 # Return config WITHOUT 'repeats' key (not user-set)
                 mock_get_config.return_value = {"id": "test_auto_adjust"}
-
-                # Mock the split_between_processes to avoid actual splitting
-                def split_side_effect(images, apply_padding=False):
-                    mock_context = MagicMock()
-                    mock_context.__enter__ = MagicMock(return_value=images)
-                    mock_context.__exit__ = MagicMock(return_value=False)
-                    return mock_context
-
-                mock_accelerator.split_between_processes = MagicMock(side_effect=split_side_effect)
 
                 # Should NOT raise, should auto-adjust repeats
                 try:
@@ -1154,6 +1129,7 @@ class TestFactoryEdgeCases(unittest.TestCase):
 
         mock_accelerator = MagicMock()
         mock_accelerator.num_processes = 8
+        mock_accelerator.process_index = 0
         mock_backend.accelerator = mock_accelerator
 
         # Mock StateTracker with oversubscription enabled BUT user set repeats
@@ -1189,6 +1165,7 @@ class TestFactoryEdgeCases(unittest.TestCase):
 
         mock_accelerator = MagicMock()
         mock_accelerator.num_processes = 8
+        mock_accelerator.process_index = 0
         mock_backend.accelerator = mock_accelerator
 
         # Mock StateTracker with oversubscription DISABLED
@@ -1207,6 +1184,49 @@ class TestFactoryEdgeCases(unittest.TestCase):
                 error_msg = str(context.exception)
                 self.assertIn("Dataset configuration will produce zero usable batches", error_msg)
                 self.assertIn("Enable --allow_dataset_oversubscription", error_msg)
+
+    def test_bucket_split_padding_policy_matches_training_mode(self):
+        """Factory padding covers epoch and explicit oversubscription policies."""
+        from simpletuner.helpers.data_backend.factory import FactoryRegistry
+
+        factory = FactoryRegistry(
+            args=self.args,
+            accelerator=self.accelerator,
+            text_encoders=self.text_encoders,
+            tokenizers=self.tokenizers,
+            model=self.model,
+        )
+        factory._handle_config_versioning = MagicMock()
+
+        cases = (
+            ("fixed_steps", 100, False, False),
+            ("oversubscribed_fixed_steps", 100, True, True),
+            ("epoch_driven", 0, False, True),
+        )
+        for name, max_train_steps, allow_oversubscription, expected in cases:
+            with self.subTest(name=name):
+                factory.args.max_train_steps = max_train_steps
+                factory.args.allow_dataset_oversubscription = allow_oversubscription
+                factory.args.skip_file_discovery = "aspect"
+                factory.args.eval_dataset_id = None
+
+                metadata_backend = MagicMock()
+                init_backend = {
+                    "id": "train",
+                    "config": {},
+                    "dataset_type": "image",
+                    "metadata_backend": metadata_backend,
+                }
+                factory._handle_bucket_operations(
+                    backend={"id": "train", "skip_file_discovery": "aspect"},
+                    init_backend=init_backend,
+                    conditioning_type=None,
+                )
+
+                metadata_backend.split_buckets_between_processes.assert_called_once_with(
+                    gradient_accumulation_steps=factory.args.gradient_accumulation_steps,
+                    apply_padding=expected,
+                )
 
     def test_image_embeds_backend_configuration(self):
         """Image embed configuration should not instantiate VAE cache directly."""

--- a/tests/test_metadata_backend.py
+++ b/tests/test_metadata_backend.py
@@ -345,9 +345,6 @@ class TestSplitBucketsEvalDataset(unittest.TestCase):
         mock_accelerator = MagicMock()
         mock_accelerator.num_processes = 1
         mock_accelerator.process_index = 0
-        mock_accelerator.split_between_processes = MagicMock()
-        mock_accelerator.split_between_processes.return_value.__enter__ = MagicMock(return_value=["eval_img1.jpg"])
-        mock_accelerator.split_between_processes.return_value.__exit__ = MagicMock(return_value=False)
         mock_backend.accelerator = mock_accelerator
 
         with (
@@ -416,9 +413,6 @@ class TestSplitBucketsEvalDataset(unittest.TestCase):
         mock_accelerator = MagicMock()
         mock_accelerator.num_processes = 1
         mock_accelerator.process_index = 0
-        mock_accelerator.split_between_processes = MagicMock()
-        mock_accelerator.split_between_processes.return_value.__enter__ = MagicMock(return_value=["eval_img1.jpg"])
-        mock_accelerator.split_between_processes.return_value.__exit__ = MagicMock(return_value=False)
         mock_backend.accelerator = mock_accelerator
 
         with (
@@ -438,6 +432,86 @@ class TestSplitBucketsEvalDataset(unittest.TestCase):
             MetadataBackend.split_buckets_between_processes(mock_backend, gradient_accumulation_steps=8, apply_padding=False)
 
         self.assertIn("1.0", mock_backend.aspect_ratio_bucket_indices)
+
+
+class TestDistributedBucketPadding(unittest.TestCase):
+    """Regression coverage for PR #2897 distributed bucket policies."""
+
+    @staticmethod
+    def _backend(images, *, num_processes=8):
+        backend = MagicMock(spec=MetadataBackend)
+        backend.id = "distributed-padding"
+        backend.batch_size = 1
+        backend.repeats = 0
+        backend.bucket_report = None
+        backend.dataset_type = DatasetType.IMAGE
+        backend.aspect_ratio_bucket_indices = {"1.0": list(images)}
+        backend.read_only = False
+        backend.accelerator = MagicMock(
+            num_processes=num_processes,
+            process_index=0,
+            is_main_process=True,
+        )
+        return backend
+
+    def _split_rank(self, images, rank, *, cp_size, apply_padding):
+        backend = self._backend(images)
+        with (
+            patch.dict("os.environ", {"SIMPLETUNER_SHUFFLE_BUCKETS": "0"}),
+            patch.object(
+                StateTracker,
+                "get_args",
+                return_value=SimpleNamespace(allow_dataset_oversubscription=apply_padding),
+            ),
+            patch.object(StateTracker, "get_data_backend_config", return_value={}),
+            patch(
+                "simpletuner.helpers.metadata.backends.base.get_cp_aware_dp_info",
+                return_value=(8, rank, cp_size),
+            ),
+        ):
+            MetadataBackend.split_buckets_between_processes(
+                backend,
+                gradient_accumulation_steps=1,
+                apply_padding=apply_padding,
+            )
+        return backend.aspect_ratio_bucket_indices["1.0"]
+
+    def test_cp_padding_fills_empty_dp_shards_from_final_global_item(self):
+        images = ["img0", "img1", "img2", "img3"]
+        shards = [self._split_rank(images, rank, cp_size=2, apply_padding=True) for rank in range(8)]
+
+        self.assertEqual([len(shard) for shard in shards], [1] * 8)
+        self.assertEqual([item for shard in shards for item in shard], images + ["img3"] * 4)
+
+    def test_cp_no_padding_uses_balanced_qr_partition(self):
+        images = [f"img{index}" for index in range(9)]
+        shards = [self._split_rank(images, rank, cp_size=2, apply_padding=False) for rank in range(8)]
+
+        self.assertEqual([len(shard) for shard in shards], [2, 1, 1, 1, 1, 1, 1, 1])
+        self.assertEqual([item for shard in shards for item in shard], images)
+
+    def test_standard_split_preserves_balanced_qr_order(self):
+        images = [f"img{index}" for index in range(9)]
+        shards = [self._split_rank(images, rank, cp_size=1, apply_padding=False) for rank in range(8)]
+
+        self.assertEqual([len(shard) for shard in shards], [2, 1, 1, 1, 1, 1, 1, 1])
+        self.assertEqual([item for shard in shards for item in shard], images)
+
+    def test_standard_split_padding_exact_division_preserves_cardinality(self):
+        images = [f"img{index}" for index in range(8)]
+        shards = [self._split_rank(images, rank, cp_size=1, apply_padding=True) for rank in range(8)]
+
+        self.assertEqual([len(shard) for shard in shards], [1] * 8)
+        self.assertEqual([item for shard in shards for item in shard], images)
+
+    def test_padding_non_divisible_preserves_qr_boundaries(self):
+        images = [f"img{index}" for index in range(10)]
+        expected = [["img0", "img1"], ["img2", "img3"]] + [[f"img{index}", "img9"] for index in range(4, 10)]
+
+        for cp_size in (1, 2):
+            with self.subTest(cp_size=cp_size):
+                shards = [self._split_rank(images, rank, cp_size=cp_size, apply_padding=True) for rank in range(8)]
+                self.assertEqual(shards, expected)
 
 
 class TestFilteringStatistics(unittest.TestCase):

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -68,6 +68,60 @@ class TestMultiAspectSampler(unittest.TestCase):
         buckets = self.sampler.load_buckets()
         self.assertEqual(buckets, ["1.0"])
 
+    def test_padded_occurrences_are_consumed_individually(self):
+        """A repeated filepath represents multiple scheduled samples, not one boolean item."""
+        metadata_backend = object.__new__(DiscoveryMetadataBackend)
+        metadata_backend.instance_data_dir = ""
+        metadata_backend.aspect_ratio_bucket_indices = {"1.0": ["same.jpg", "same.jpg"]}
+        metadata_backend.seen_images = {}
+
+        sampler = object.__new__(MultiAspectSampler)
+        sampler.metadata_backend = metadata_backend
+        sampler.logger = MagicMock()
+        sampler.debug_log = MagicMock()
+
+        self.assertEqual(sampler._get_unseen_images("1.0"), ["same.jpg", "same.jpg"])
+        metadata_backend.mark_as_seen("same.jpg")
+        self.assertEqual(sampler._get_unseen_images("1.0"), ["same.jpg"])
+
+        # Old checkpoints stored booleans. True means the filepath was
+        # exhausted, including every scheduled duplicate.
+        metadata_backend.seen_images = {"same.jpg": True}
+        self.assertEqual(sampler._get_unseen_images("1.0"), [])
+
+        metadata_backend.seen_images = {}
+        metadata_backend.mark_batch_as_seen(["same.jpg", "same.jpg"])
+        self.assertEqual(metadata_backend.seen_occurrence_count("same.jpg"), 2)
+        self.assertEqual(sampler._get_unseen_images("1.0"), [])
+
+        metadata_backend.seen_images = {"same.jpg": "corrupt"}
+        with self.assertRaisesRegex(TypeError, "Invalid seen occurrence count"):
+            metadata_backend.seen_occurrence_count("same.jpg")
+
+    def test_load_states_restores_schedule_before_normalizing_legacy_seen_flags(self):
+        self.sampler.state_manager.load_state.return_value = {
+            "aspect_ratio_bucket_indices": {"1.0": ["same.jpg", "same.jpg", "other.jpg"]},
+            "buckets": ["1.0"],
+            "current_bucket": 0,
+            "exhausted_buckets": ["old"],
+            "seen_images": {"same.jpg": True, "other.jpg": False, "legacy.jpg": True},
+        }
+
+        self.metadata_backend.aspect_ratio_bucket_indices = {"1.0": ["stale.jpg"]}
+        self.metadata_backend.seen_images = {}
+        self.sampler.load_states(self.state_path)
+
+        self.assertEqual(
+            self.metadata_backend.aspect_ratio_bucket_indices,
+            {"1.0": ["same.jpg", "same.jpg", "other.jpg"]},
+        )
+        self.assertEqual(self.sampler.buckets, ["1.0"])
+        self.assertEqual(self.sampler.current_bucket, 0)
+        self.assertEqual(self.sampler.exhausted_buckets, ["old"])
+        self.assertEqual(self.metadata_backend.seen_images["same.jpg"], 2)
+        self.assertEqual(self.metadata_backend.seen_images["other.jpg"], 0)
+        self.assertTrue(self.metadata_backend.seen_images["legacy.jpg"])
+
     def test_change_bucket(self):
         self.sampler.buckets = ["1.5"]
         self.sampler.exhausted_buckets = ["1.0"]

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1837,6 +1837,54 @@ class TestTrainer(unittest.TestCase):
             self.assertEqual(trainer.state["current_epoch"], 2)
             self.assertEqual(trainer.extra_lr_scheduler_kwargs["epoch"], 2)
 
+    def test_epoch_rollover_reuses_initial_bucket_padding_policy(self):
+        cases = (
+            ("fixed_steps", False, False, False),
+            ("epoch_driven", True, False, True),
+            ("oversubscribed_fixed_steps", False, True, True),
+        )
+
+        for name, overrode_max_train_steps, allow_oversubscription, expected in cases:
+            with self.subTest(name=name):
+                trainer = object.__new__(Trainer)
+                trainer.state = {"first_epoch": 1, "current_epoch": 1}
+                trainer.accelerator = MagicMock(is_main_process=True)
+                trainer.extra_lr_scheduler_kwargs = {}
+                trainer.get_steps_per_epoch_for_epoch = MagicMock(return_value=100)
+                trainer.config = SimpleNamespace(
+                    num_train_epochs=5,
+                    aspect_bucket_disable_rebuild=False,
+                    lr_scheduler="constant",
+                    num_update_steps_per_epoch=100,
+                    gradient_accumulation_steps=3,
+                    overrode_max_train_steps=overrode_max_train_steps,
+                    allow_dataset_oversubscription=allow_oversubscription,
+                )
+                metadata_backend = MagicMock(read_only=True)
+                backends = {"train": {"metadata_backend": metadata_backend}}
+                backend_config = {
+                    "crop": True,
+                    "crop_aspect": "random",
+                }
+
+                with (
+                    patch("simpletuner.helpers.training.trainer.StateTracker.set_epoch"),
+                    patch(
+                        "simpletuner.helpers.training.trainer.StateTracker.get_data_backends",
+                        return_value=backends,
+                    ),
+                    patch(
+                        "simpletuner.helpers.training.trainer.StateTracker.get_data_backend_config",
+                        return_value=backend_config,
+                    ),
+                ):
+                    trainer._epoch_rollover(2)
+
+                metadata_backend.split_buckets_between_processes.assert_called_once_with(
+                    gradient_accumulation_steps=3,
+                    apply_padding=expected,
+                )
+
     @patch(
         "simpletuner.helpers.training.trainer.Trainer.parse_arguments",
         return_value=Mock(),


### PR DESCRIPTION
## Summary

Fix distributed bucket partitioning for standard DP and Context Parallel paths while preserving intentional padded occurrences across sampler progress and checkpoint resume.

## Additional issues found

- The original standard DDP/FSDP example overstated the empty-tail behavior; that bug was specific to the custom CP splitter.
- Non-divisible CP splits did not match standard DP partition boundaries when padding was disabled.
- Path-based sampler progress collapsed intentional padded occurrences.
- Resume applied progress without first restoring the saved rank-local schedule.

## Resolution

- Use the same balanced quotient/remainder partition for standard DP and CP.
- Apply padding only to short rank-local shards after their real boundaries are established.
- Track repeated paths by occurrence count.
- Restore the saved rank-local schedule before applying resume progress.
- Preserve the same padding policy during epoch rollover.

Persistent discovery/cache deduplication remains unchanged. The separate automatic oversubscription scheduling issue is handled in #2918.

Regression coverage for the affected partition, padding, rollover, duplicate-occurrence, and resume cases is included.
