### PR TITLE
Fix deterministic distributed bucket splitting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@
 - Problems should always be provable through tests, logging, or other means
 - Generally speaking, it's fine to run the full application end-to-end to verify a fix, "it's heavy" is not a valid excuse to avoid verification - we're on a ML development workstation that's designed to allow running these workloads
 - For the most part, things should not be marked as CUDA-only unless it relies on third-party compiled CUDA kernels or similar. Don't be afraid to use the available accelerator eg. mps, cuda, if available on the system opportunistically.
+- Do not assume checkpoint resume supports changing topology or dataset settings. Changing DDP/FSDP/CP layout, world size, batch sizing, gradient accumulation, repeats, bucket splitting, shuffling, or dataloader configuration between save and resume can produce unexpected behavior; avoid adding compatibility fallbacks unless support for that specific change is explicitly required and verified.
 
 ## Frontend testing
 

--- a/simpletuner/helpers/metadata/backends/base.py
+++ b/simpletuner/helpers/metadata/backends/base.py
@@ -7,7 +7,6 @@ import time
 from math import ceil, floor
 from multiprocessing import Process, Queue
 from pathlib import Path
-from random import shuffle
 
 # For semaphore
 from threading import Semaphore, Thread
@@ -22,7 +21,7 @@ from simpletuner.helpers.data_backend.base import BaseDataBackend
 from simpletuner.helpers.data_backend.dataset_types import DatasetType, ensure_dataset_type
 from simpletuner.helpers.data_backend.runtime.context_parallel_sync import get_cp_info
 from simpletuner.helpers.multiaspect.image import MultiaspectImage
-from simpletuner.helpers.training.multi_process import should_log
+from simpletuner.helpers.training.multi_process import broadcast_object_from_main, should_log
 from simpletuner.helpers.training.state_tracker import StateTracker
 
 logger = logging.getLogger("BaseMetadataBackend")
@@ -867,13 +866,22 @@ class MetadataBackend:
                 raise ValueError(error_msg)
 
         should_shuffle_contents = os.environ.get("SIMPLETUNER_SHUFFLE_BUCKETS", "1") == "1"
+        if should_shuffle_contents:
+            # Process-specific RNG seeding must not change the split input across ranks.
+            shuffle_seed = getattr(StateTracker.get_args(), "seed", None)
+            if self.accelerator.is_main_process and shuffle_seed is None:
+                shuffle_seed = random.SystemRandom().getrandbits(64)
+            shuffle_seed = broadcast_object_from_main(shuffle_seed if self.accelerator.is_main_process else None)
+
         for bucket, images in self.aspect_ratio_bucket_indices.items():
             if should_shuffle_contents:
                 logger.debug(f"Shuffling bucket {bucket} contents.")
-                shuffle(images)
+                images = images.copy()
+                random.Random(f"{shuffle_seed}:{self.id}:{bucket}").shuffle(images)
             total_img_count_incl_repeats = len(images) * (self.repeats + 1)
             num_batches = ceil(total_img_count_incl_repeats / effective_batch_size)
-            trimmed_images = images[: num_batches * effective_batch_size]
+            trim_limit = num_batches * effective_batch_size
+            trimmed_images = images[:trim_limit] if trim_limit < len(images) else images
             removed_for_trim = len(images) - len(trimmed_images)
             if removed_for_trim > 0 and self.bucket_report:
                 self.bucket_report.record_bucket_event(


### PR DESCRIPTION
# Fix deterministic distributed bucket splitting

## Summary

- Process-local RNG state could give ranks different permutations of the same bucket before splitting.
- When each rank slices a different permutation, distributed training can duplicate some samples and omit others in an epoch.
- Use a shared shuffle seed and a dataset/bucket-specific RNG so every rank slices the same bucket order.

## Changes

- `simpletuner/helpers/metadata/backends/base.py`: reuse the configured seed, or generate one on the main process and broadcast it; shuffle a bucket copy with a dataset-and-bucket-specific RNG before rank slicing.
- `simpletuner/helpers/metadata/backends/base.py`: avoid a second full-list copy when the trim limit keeps the complete bucket.
- `AGENTS.md`: document that checkpoint resume is not assumed to support topology or dataloader-setting changes between save and resume.

## Notes

- This intentionally does not restore saved sampler partitions or add compatibility handling for changed DDP/FSDP/CP topology, world size, batch sizing, gradient accumulation, repeats, bucket splitting, shuffling, or dataloader configuration. Those changes may produce unexpected behavior when resuming and need explicit support before being treated as safe.

## Verification

```bash
/Users/kash/src/SimpleTuner/.venv/bin/python -m unittest tests.test_factory_edge_cases.TestFactoryEdgeCases.test_early_validation_sufficient_repeats tests.test_factory_edge_cases.TestFactoryEdgeCases.test_eval_dataset_ignores_gradient_accumulation tests.test_factory_edge_cases.TestFactoryEdgeCases.test_oversubscription_auto_adjustment -v
```

Also verified with a focused 8-rank bucket split probe: 1,024 assigned, 1,024 unique, 0 missing, 0 duplicated entries.