### PR TITLE
Fix per-rank sampler state resume path

### DIFF
--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -4687,16 +4687,13 @@ class Trainer:
             job_id=self.job_id,
         )
         self._emit_event(event)
-        training_state_filename = f"training_state.json"
-        if get_rank() > 0:
-            training_state_filename = f"training_state-{get_rank()}.json"
         for _, backend in StateTracker.get_data_backends().items():
             if "sampler" in backend:
                 backend["sampler"].load_states(
                     state_path=os.path.join(
                         self.config.output_dir,
                         path,
-                        training_state_filename,
+                        self.model_hooks.training_state_path,
                     ),
                 )
         self.state["global_resume_step"] = self.state["global_step"] = StateTracker.get_global_step()

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -2255,6 +2255,51 @@ class TestTrainer(unittest.TestCase):
             self.assertEqual(group["running_d_denom"].device, group["params"][0].device)
             self.assertFalse(group["use_focus"])
 
+    @patch("simpletuner.helpers.training.trainer.get_rank", return_value=1)
+    @patch("simpletuner.helpers.training.trainer.AttentionBackendController.on_load_checkpoint")
+    def test_init_resume_checkpoint_loads_sampler_from_hook_training_state_path(self, mock_attention_backend, mock_get_rank):
+        trainer = object.__new__(Trainer)
+        trainer.model = Mock()
+        trainer.config = SimpleNamespace(
+            output_dir="/path/to/output",
+            resume_from_checkpoint="checkpoint-100",
+            num_train_epochs=1,
+            max_train_steps=100,
+            strict_epoch_limit=True,
+            optimizer="adamw",
+            lr_scheduler="constant",
+            is_schedulefree=False,
+            learning_rate=0.001,
+            musubi_blocks_to_swap=0,
+        )
+        trainer.config.total_steps_remaining_at_start = 100
+        trainer.accelerator = Mock(num_processes=2)
+        trainer.accelerator.wait_for_everyone = Mock()
+        trainer.accelerator.load_state = Mock()
+        trainer.state = {"global_step": 0, "first_epoch": 1, "current_epoch": 1, "global_resume_step": 0}
+        trainer.distiller = None
+        trainer.optimizer = Mock()
+        trainer.optimizer.param_groups = [{"lr": 0.1}]
+        trainer._emit_event = Mock()
+        trainer.job_id = "test-job"
+        trainer.model_hooks = SimpleNamespace(training_state_path="training_state-rank1.json")
+        sampler = Mock()
+        lr_scheduler = Mock()
+        lr_scheduler.state_dict.return_value = {"base_lrs": [0.1], "_last_lr": [0.1]}
+
+        with patch(
+            "simpletuner.helpers.training.trainer.StateTracker.get_data_backends",
+            return_value={"foo": {"sampler": sampler}},
+        ):
+            with patch("simpletuner.helpers.training.trainer.StateTracker.get_global_step", return_value=10):
+                with patch("simpletuner.helpers.training.trainer.StateTracker.set_global_resume_step"):
+                    with patch("simpletuner.helpers.training.trainer.StateTracker.get_training_state", return_value={}):
+                        with patch("simpletuner.helpers.training.trainer.StateTracker.get_epoch", return_value=1):
+                            with patch("simpletuner.helpers.training.trainer.StateTracker.set_epoch"):
+                                trainer.init_resume_checkpoint(lr_scheduler=lr_scheduler)
+
+        sampler.load_states.assert_called_once_with(state_path="/path/to/output/checkpoint-100/training_state-rank1.json")
+
     def test_epoch_checkpoint_persists_next_epoch_without_state_mutation(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             checkpoint_dir = Path(tmpdir) / "checkpoint-10"


### PR DESCRIPTION
# Fix per-rank sampler state resume path

## Summary

- Resume rebuilt the per-rank sampler state filename independently from the save hook.
- Nonzero ranks saved through `SaveHookManager.training_state_path`, e.g. `training_state-rank1.json`, but sampler resume looked for `training_state-1.json` before backend state path mangling.
- Load sampler state from the hook-owned `self.model_hooks.training_state_path` instead.

## Changes

- `simpletuner/helpers/training/trainer.py`: use `SaveHookManager.training_state_path` when loading sampler state on checkpoint resume.
- `tests/test_trainer.py`: add a regression test for nonzero-rank sampler resume loading `training_state-rank1.json`.

## Notes

- This intentionally leaves completed-partition sampler rollover behavior unchanged. A fully consumed sampler state can be the epoch-end signal used to coordinate ranks before the next training step.
- Model, optimizer, and scheduler resume behavior is unchanged.

## Verification

```bash
/Users/kash/src/SimpleTuner/.venv/bin/python -m unittest tests.test_trainer.TestTrainer.test_init_resume_checkpoint tests.test_trainer.TestTrainer.test_init_resume_checkpoint_loads_sampler_from_hook_training_state_path -v
```