### PR TITLE
Fix FSDP2 gradient norm/max reporting and clipping

### DIFF
--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -554,19 +554,24 @@ class Trainer:
         target_logs: Dict[str, float],
         *,
         require_value_method: bool = False,
+        clone_norm_value: bool = False,
         is_regularisation_data: bool = False,
     ):
-        grad_value = self._normalize_metric_value(self.grad_norm)
-        if grad_value is None:
+        if self.grad_norm is None:
             return
 
         prefix = "regularisation_" if is_regularisation_data else ""
         if self.config.grad_clip_method == "norm":
+            grad_value = self.grad_norm
+            if clone_norm_value:
+                grad_value = self._normalize_metric_value(self.grad_norm)
+                if grad_value is None:
+                    return
             target_logs[f"{prefix}grad_norm"] = grad_value
         elif (
             not require_value_method or self.config.grad_clip_method == "value"
         ) and not self.config.use_deepspeed_optimizer:
-            target_logs[f"{prefix}grad_absmax"] = grad_value
+            target_logs[f"{prefix}grad_absmax"] = self.grad_norm
 
     def _config_uses_bitsandbytes(self) -> bool:
         if not getattr(self, "config", None):
@@ -5299,7 +5304,11 @@ class Trainer:
             metrics.setdefault("total_batch_size", batch_size_value)
         metrics.update(self.iteration_tracker.iteration_metrics())
         # Add gradient metrics (same logic as _update_grad_metrics but for webhook payload)
-        self._update_grad_metrics(metrics, is_regularisation_data=parent_loss is not None)
+        self._update_grad_metrics(
+            metrics,
+            clone_norm_value=True,
+            is_regularisation_data=parent_loss is not None,
+        )
         if extra_metrics:
             for key, value in extra_metrics.items():
                 if value is None:

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -34,6 +34,7 @@ import huggingface_hub
 import wandb
 from torch.distributed.fsdp.api import ShardedOptimStateDictConfig, ShardedStateDictConfig
 from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
+from torch.distributed.tensor import DTensor
 
 from simpletuner.helpers import log_format  # noqa
 from simpletuner.helpers.caching.memory import reclaim_memory
@@ -553,22 +554,19 @@ class Trainer:
         target_logs: Dict[str, float],
         *,
         require_value_method: bool = False,
-        clone_norm_value: bool = False,
         is_regularisation_data: bool = False,
     ):
-        if self.grad_norm is None:
+        grad_value = self._normalize_metric_value(self.grad_norm)
+        if grad_value is None:
             return
 
         prefix = "regularisation_" if is_regularisation_data else ""
         if self.config.grad_clip_method == "norm":
-            grad_value = self.grad_norm
-            if clone_norm_value:
-                grad_value = float(self.grad_norm.clone().detach())
             target_logs[f"{prefix}grad_norm"] = grad_value
         elif (
             not require_value_method or self.config.grad_clip_method == "value"
         ) and not self.config.use_deepspeed_optimizer:
-            target_logs[f"{prefix}grad_absmax"] = self.grad_norm
+            target_logs[f"{prefix}grad_absmax"] = grad_value
 
     def _config_uses_bitsandbytes(self) -> bool:
         if not getattr(self, "config", None):
@@ -5301,7 +5299,7 @@ class Trainer:
             metrics.setdefault("total_batch_size", batch_size_value)
         metrics.update(self.iteration_tracker.iteration_metrics())
         # Add gradient metrics (same logic as _update_grad_metrics but for webhook payload)
-        self._update_grad_metrics(metrics, clone_norm_value=True, is_regularisation_data=parent_loss is not None)
+        self._update_grad_metrics(metrics, is_regularisation_data=parent_loss is not None)
         if extra_metrics:
             for key, value in extra_metrics.items():
                 if value is None:
@@ -5693,11 +5691,36 @@ class Trainer:
         return overridden_batch
 
     def _max_grad_value(self):
-        max_grad_value = float("-inf")  # Start with a very small number
+        gradients = []
+        device_mesh = None
+        empty_local_gradient = None
         for param in self._get_trainable_parameters():
-            if param.grad is not None:
-                max_grad_value = max(max_grad_value, param.grad.abs().max().item())
+            gradient = param.grad
+            if gradient is None:
+                continue
+            if isinstance(gradient, DTensor):
+                device_mesh = gradient.device_mesh
+                gradient = gradient.to_local()
+                if gradient.numel() == 0:
+                    empty_local_gradient = gradient
+                    continue
+            gradients.append(gradient)
 
+        if gradients:
+            max_grad_value = torch.nn.utils.get_total_norm(gradients, norm_type=float("inf"))
+        elif empty_local_gradient is None:
+            return float("-inf")
+        else:
+            max_grad_value = empty_local_gradient.new_tensor(float("-inf"))
+
+        if device_mesh is not None:
+            if max_grad_value.device.type != device_mesh.device_type:
+                max_grad_value = max_grad_value.to(device_mesh.device_type)
+            torch.distributed.all_reduce(
+                max_grad_value,
+                op=torch.distributed.ReduceOp.MAX,
+                group=device_mesh.get_group(),
+            )
         return max_grad_value
 
     def prepare_batch(self, batch: dict):
@@ -6406,12 +6429,16 @@ class Trainer:
                                 if param.grad is not None:
                                     param.grad.data = param.grad.data.to(torch.float32)
 
-                        self.grad_norm = self._max_grad_value()
-                        if (
+                        should_clip_gradients = (
                             self.accelerator.sync_gradients
                             and self.config.optimizer not in ["optimi-stableadamw", "prodigy"]
                             and self.config.max_grad_norm > 0
+                        )
+                        if self.accelerator.sync_gradients and (
+                            self.config.grad_clip_method != "norm" or not should_clip_gradients
                         ):
+                            self.grad_norm = self._max_grad_value()
+                        if should_clip_gradients:
                             # StableAdamW/Prodigy do not need clipping, similar to Adafactor.
                             if self.config.fsdp_enable:
                                 # For FSDP, handle FSDP1/FSDP2 separately and surface failures instead of crashing.
@@ -6811,7 +6838,6 @@ class Trainer:
                 self._update_grad_metrics(
                     logs,
                     require_value_method=True,
-                    clone_norm_value=True,
                     is_regularisation_data=is_regularisation_data,
                 )
 


### PR DESCRIPTION
# Fix FSDP2 gradient norm/max reporting and clipping

## Summary

- **Max measurement:** rank-local DTensor maxima could under-report the logical
  gradient; empty local shards and CPU-offloaded gradients were unsafe cases.
- **Norm clipping:** the loop measured a max on every accumulation microstep even
  when norm clipping would recompute and overwrite it at the optimizer step.
- **Reporting:** logs and webhook payloads used separate tensor/float conversion
  paths and could receive inconsistent metric types.
- **Fix:** separate norm and max paths at synchronized steps, reduce max values
  across the FSDP2 mesh, reuse the norm returned by clipping, and preserve the
  existing logging API while normalizing structured progress payloads.

## Changes

- `Trainer._max_grad_value()`: compute the infinity norm from non-empty local
  gradients, contribute `-inf` for an empty DTensor shard, stage CPU scalars on
  the mesh device, and run one mesh-group `all_reduce(MAX)`.
- Post-backward dispatch: calculate metrics and clip only when
  `accelerator.sync_gradients` is true; use `clip_grad_norm_()`'s return value for
  norm mode instead of running a separate max traversal first.
- Clipping paths: keep FSDP2 norm clipping on `torch.nn.utils.clip_grad_norm_()`,
  FSDP1 on the wrapped model method, and non-FSDP clipping through Accelerate.
  Existing optimizer exclusions and the FSDP value-clipping limitation remain
  unchanged.
- `_update_grad_metrics()` and progress payloads: retain tensor objects for the
  existing accelerator log path, restore the `clone_norm_value` compatibility
  argument, and normalize norm values only for structured progress/webhook
  serialization.

| Mode | Measurement/report | Clipping |
|---|---|---|
| Norm with clipping active | Pre-clipping norm returned by `clip_grad_norm_()` | Norm clipping runs |
| Value/max path | Mesh-wide pre-clipping absolute maximum | Non-FSDP value clipping runs; FSDP warns and skips |
| Accumulation microstep | No metric | No clipping |

## Result

- Every FSDP2 rank reports the same mesh-wide absolute maximum when the max path
  is used.
- Norm clipping performs one gradient traversal and its returned pre-clipping
  norm is reported directly.
- Empty DTensor shards remain in the collective with `-inf`; CPU-offloaded scalar
  values are staged on the mesh device before reduction.
- Accumulation-only steps avoid incomplete metrics, clipping, and unnecessary
  collectives.
- **Example:** if rank 0 has local maximum `0.8`, rank 1 has `3.2`, and rank 2 has
  an empty shard, their contributions are `0.8`, `3.2`, and `-inf`; all ranks
  receive and report `3.2` after `all_reduce(MAX)`.
- **Verified:** 67/67 existing Trainer tests passed. A focused matrix covered
  metric contracts, norm/value clipping, empty DTensor shards, CPU-offload
  staging, and accumulation gating. A real two-GPU FSDP2 run also verified the
  mesh-wide max and post-clipping global norm.

## Environment

- Python: `3.13.14`
- PyTorch: `2.13.0+cu130`
- Accelerate: `1.14.0`
- Diffusers: `0.39.0`
- Transformers: `5.13.1`
- GPU: NVIDIA B200, driver `590.48.01`
