### PR TITLE
Export portable Diffusers pipelines after FSDP2 full-model training

### DIFF
--- a/simpletuner/helpers/training/save_hooks.py
+++ b/simpletuner/helpers/training/save_hooks.py
@@ -5,10 +5,12 @@ import os
 import shutil
 import types
 from contextlib import contextmanager
+from dataclasses import dataclass
 
 import torch
 import torch.distributed.checkpoint as dcp
 from accelerate.utils import DistributedType
+from accelerate.utils.versions import compare_versions
 from diffusers.training_utils import _collate_lora_metadata
 from diffusers.utils import convert_state_dict_to_diffusers, convert_unet_state_dict_to_peft
 from diffusers.utils.state_dict_utils import StateDictType
@@ -36,6 +38,14 @@ else:
 MODEL_SPEC_VERSION = "1.0.1"
 LORA_SAFETENSORS_FILENAME = "pytorch_lora_weights.safetensors"
 EMA_SAFETENSORS_FILENAME = "ema_model.safetensors"
+
+
+@dataclass(frozen=True)
+class _FSDP2PipelineExportSpec:
+    pipeline_type: PipelineTypes
+    component_name: str
+    model_class: type[torch.nn.Module]
+    model_config: object
 
 
 def merge_safetensors_files(directory, metadata=None):
@@ -123,6 +133,141 @@ def _materialize_state_dict_for_save(state_dict: dict[str, torch.Tensor]) -> dic
     return {name: _materialize_tensor_for_save(tensor) for name, tensor in state_dict.items()}
 
 
+def _get_fsdp2_pipeline_export_spec(model) -> _FSDP2PipelineExportSpec:
+    is_controlnet = bool(getattr(model.config, "controlnet", False))
+    pipeline_type = PipelineTypes.CONTROLNET if is_controlnet else model.DEFAULT_PIPELINE_TYPE
+    pipeline_class = model.PIPELINE_CLASSES.get(pipeline_type)
+    if pipeline_class is None:
+        raise RuntimeError(
+            f"FSDP2 full-model export requires a {pipeline_type.value!r} pipeline for {type(model).__name__}."
+        )
+    if not callable(getattr(pipeline_class, "save_pretrained", None)):
+        raise RuntimeError(
+            f"FSDP2 full-model export is unavailable because {pipeline_class.__name__} "
+            "does not support save_pretrained()."
+        )
+
+    default_component_name = "controlnet" if is_controlnet else model.MODEL_TYPE.value
+    component_name_attr = f"{default_component_name}_name"
+    component_name = getattr(pipeline_class, component_name_attr, default_component_name)
+    if not isinstance(component_name, str) or not component_name:
+        raise RuntimeError(
+            f"FSDP2 full-model export requires {pipeline_class.__name__}.{component_name_attr} "
+            "to name a registered pipeline component."
+        )
+
+    component = _get_trained_component_for_save(model)
+    if component is None:
+        raise RuntimeError("FSDP2 full-model export requires a trained model component.")
+    model_class = type(component)
+    model_config = getattr(component, "config", None)
+    if model_config is None or not callable(getattr(model_class, "from_config", None)):
+        raise RuntimeError(
+            f"FSDP2 full-model export cannot use {model_class.__name__}: "
+            "the component cannot be reconstructed from its config."
+        )
+
+    try:
+        with torch.device("meta"):
+            rebuilt_component = model_class.from_config(model_config)
+        component_state = component.state_dict()
+        rebuilt_state = rebuilt_component.state_dict()
+    except Exception as exc:
+        raise RuntimeError(f"FSDP2 full-model export cannot reconstruct {model_class.__name__} from its config.") from exc
+
+    component_shapes = {name: tuple(value.shape) for name, value in component_state.items()}
+    rebuilt_shapes = {name: tuple(value.shape) for name, value in rebuilt_state.items()}
+    if component_shapes != rebuilt_shapes:
+        raise RuntimeError(
+            f"FSDP2 full-model export cannot use {model_class.__name__}: "
+            "the trained component cannot be reconstructed exactly from its config."
+        )
+
+    return _FSDP2PipelineExportSpec(
+        pipeline_type=pipeline_type,
+        component_name=component_name,
+        model_class=model_class,
+        model_config=model_config,
+    )
+
+
+def _materialize_fsdp2_tensor_for_save(accelerator, tensor: torch.Tensor) -> torch.Tensor | None:
+    if type(tensor).__name__ == "DTensor" and hasattr(tensor, "full_tensor"):
+        if tensor.device.type == "cpu":
+            tensor = tensor.to(accelerator.device)
+        tensor = tensor.full_tensor()
+    if not accelerator.is_main_process:
+        return None
+    return _materialize_tensor_for_save(tensor)
+
+
+def _materialize_fsdp2_state_dict_for_save(accelerator, component, ema_model=None) -> dict[str, torch.Tensor]:
+    prepared_component = component
+    component = unwrap_model(accelerator, component)
+    state_dict = accelerator.get_state_dict(prepared_component, unwrap=False)
+
+    if ema_model is not None:
+        trainable_parameters = [(name, param) for name, param in component.named_parameters() if param.requires_grad]
+        shadow_params = list(ema_model.shadow_params)
+        tracked_param_ids = list(getattr(ema_model, "_tracked_param_ids", ()))
+        if len(trainable_parameters) != len(shadow_params) or tracked_param_ids != [
+            id(param) for _, param in trainable_parameters
+        ]:
+            raise RuntimeError("FSDP2 EMA parameters do not match the trainable component parameters.")
+
+        component_state = component.state_dict()
+        for (name, parameter), shadow in zip(trainable_parameters, shadow_params):
+            if name not in component_state:
+                raise RuntimeError(f"FSDP2 EMA parameter {name!r} is absent from the component state dict.")
+            if shadow.shape != parameter.shape:
+                raise RuntimeError(
+                    f"FSDP2 EMA shape mismatch for {name!r}: expected {tuple(parameter.shape)}, "
+                    f"got {tuple(shadow.shape)}."
+                )
+            materialized = _materialize_fsdp2_tensor_for_save(accelerator, shadow)
+            if accelerator.is_main_process:
+                state_dict[name] = materialized
+
+    if not accelerator.is_main_process:
+        return {}
+    if not state_dict:
+        raise RuntimeError("FSDP2 full-state export returned an empty state dict on the main process.")
+    if any(type(tensor).__name__ == "DTensor" for tensor in state_dict.values()):
+        raise RuntimeError("FSDP2 full-state export left distributed tensors in the main-process state dict.")
+    if any(not isinstance(tensor, torch.Tensor) or tensor.device.type != "cpu" for tensor in state_dict.values()):
+        raise RuntimeError("FSDP2 full-state export did not produce only CPU tensors.")
+    return state_dict
+
+
+def _build_model_from_state_dict_for_save(model_class, model_config, state_dict: dict[str, torch.Tensor]):
+    if not state_dict:
+        raise RuntimeError("Cannot build a save-only model from an empty state dict.")
+    with torch.device("meta"):
+        model = model_class.from_config(model_config)
+    model.load_state_dict(state_dict, strict=True, assign=True)
+    return model
+
+
+def _save_pipeline_with_component_for_save(pipeline, component_name: str, component, output_dir: str) -> None:
+    save_pretrained = getattr(pipeline, "save_pretrained", None)
+    if not callable(save_pretrained):
+        raise RuntimeError(f"{type(pipeline).__name__} does not support save_pretrained().")
+
+    try:
+        components = pipeline.components
+    except (AttributeError, ValueError) as exc:
+        raise RuntimeError(f"Unable to inspect the registered components of {type(pipeline).__name__}.") from exc
+    if component_name not in components:
+        raise RuntimeError(f"{component_name!r} is not a registered pipeline component of {type(pipeline).__name__}.")
+
+    previous_component = components[component_name]
+    setattr(pipeline, component_name, component)
+    try:
+        save_pretrained(output_dir, safe_serialization=True)
+    finally:
+        setattr(pipeline, component_name, previous_component)
+
+
 class SaveHookManager:
     EMA_METADATA_KEYS = (
         "decay",
@@ -145,11 +290,13 @@ class SaveHookManager:
 
         self.args = args
         self.model = model
-        if self.model.get_trained_component() is None:
-            raise ValueError("No model was loaded?")
         self.ema_model = ema_model
         self.accelerator = accelerator
         self.use_deepspeed_optimizer = use_deepspeed_optimizer
+        if self.model.get_trained_component() is None:
+            raise ValueError("No model was loaded?")
+
+        self.fsdp2_pipeline_export_spec = None
 
         self.denoiser_class = self.model.MODEL_CLASS
         self.denoiser_subdir = self.model.MODEL_SUBFOLDER
@@ -172,6 +319,15 @@ class SaveHookManager:
             and fsdp_plugin is not None
             and getattr(fsdp_plugin, "fsdp_version", 1) == 2
         )
+
+    def validate_fsdp2_pipeline_export(self) -> None:
+        if self.args.model_type == "full" and self._is_fsdp2():
+            if not compare_versions("accelerate", ">=", "1.8.0"):
+                raise RuntimeError(
+                    "FSDP2 full-model pipeline export requires accelerate>=1.8.0 so the gathered state dict "
+                    "is offloaded to CPU before serialization."
+                )
+            self.fsdp2_pipeline_export_spec = _get_fsdp2_pipeline_export_spec(self.model)
 
     def _ema_checkpoint_dir(self, checkpoint_dir: str) -> str:
         return os.path.join(checkpoint_dir, self.ema_model_subdir)

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -379,6 +379,32 @@ class Trainer:
             num_processes = 1
         return num_processes > 1 and torch.distributed.is_available() and torch.distributed.is_initialized()
 
+    @contextmanager
+    def _fsdp2_full_export_failure_guard(self, enabled: bool):
+        if not enabled or not self._distributed_collectives_ready():
+            yield
+            return
+
+        assert self.accelerator is not None
+        status = torch.zeros((), dtype=torch.int32, device=self.accelerator.device)
+        try:
+            yield
+        finally:
+            original_exception_type = sys.exc_info()[0]
+            status.fill_(int(original_exception_type is not None))
+            try:
+                torch.distributed.all_reduce(status, op=torch.distributed.ReduceOp.MAX)
+            except Exception as collective_error:
+                if original_exception_type is not None:
+                    logger.error(
+                        "Failed to propagate FSDP2 final-export failure to peer ranks: %s",
+                        collective_error,
+                    )
+                else:
+                    raise
+            if original_exception_type is None and status.item():
+                raise RuntimeError("FSDP2 full-model export failed on another rank.")
+
     def _any_rank_reached_epoch_end(self, reached_epoch_end: bool) -> bool:
         if not self._distributed_collectives_ready():
             return reached_epoch_end
@@ -4115,6 +4141,7 @@ class Trainer:
         primary_model = self.model.get_trained_component(unwrap_model=False)
         if hasattr(self.model, "before_accelerator_prepare"):
             self.model.before_accelerator_prepare()
+        self.model_hooks.validate_fsdp2_pipeline_export()
         apply_standalone_context_parallel(self.accelerator, primary_model, self._context_parallel_topology)
         attach_shared_ramtorch_parameters = None
         if self._ramtorch_distributed() and primary_model is not None:
@@ -6873,6 +6900,14 @@ class Trainer:
             logger.info("Torch profiler stopped.")
         validation_images = None
         final_lora_save_kwargs = None
+        fsdp_plugin = getattr(getattr(self.accelerator, "state", None), "fsdp_plugin", None)
+        is_fsdp2_full_model_save = (
+            self.config.model_type == "full"
+            and self.accelerator.distributed_type == DistributedType.FSDP
+            and getattr(fsdp_plugin, "fsdp_version", 1) == 2
+        )
+        fsdp2_model_for_save = None
+        fsdp2_pipeline_export_spec = None
         if "lora" in self.config.model_type and "standard" == self.config.lora_type.lower():
             from simpletuner.helpers.training.save_hooks import _materialize_state_dict_for_save
 
@@ -6901,116 +6936,158 @@ class Trainer:
             if self.config.fsdp_enable:
                 self.accelerator.wait_for_everyone()
 
-        if self.accelerator.is_main_process:
-            event = lifecycle_stage_event(
-                key="model_save",
-                label="Saving Final Model",
-                status="running",
-                message=f"Finalizing model and saving to {self.config.output_dir}",
-                job_id=self.job_id,
-            )
-            self._emit_event(event)
-            self.mark_optimizer_eval()
-            if self.validation is not None:
-                AttentionBackendController.apply(self.config, AttentionPhase.EVAL)
-                self.disable_gradient_checkpointing()
-                # Emit validation start lifecycle event for final validations
-                validation_start_event = lifecycle_stage_event(
-                    key="final_validation",
-                    label="Running Final Validations",
-                    status="running",
-                    message="Generating final validation images...",
-                    job_id=self.job_id,
+        with self._fsdp2_full_export_failure_guard(is_fsdp2_full_model_save):
+            if is_fsdp2_full_model_save:
+                from simpletuner.helpers.training.save_hooks import (
+                    _build_model_from_state_dict_for_save,
+                    _materialize_fsdp2_state_dict_for_save,
                 )
-                self._emit_event(validation_start_event)
-                validation_images = self.validation.run_validations(
-                    validation_type="final",
-                    step=self.state["global_step"],
-                    force_evaluation=True,
-                    skip_execution=True,
-                ).validation_images
-                # Emit validation completed lifecycle event
-                validation_completed_event = lifecycle_stage_event(
-                    key="final_validation",
-                    label="Running Final Validations",
-                    status="completed",
-                    message="Final validation images completed",
-                    job_id=self.job_id,
+
+                fsdp2_pipeline_export_spec = getattr(
+                    getattr(self, "model_hooks", None),
+                    "fsdp2_pipeline_export_spec",
+                    None,
                 )
-                self._emit_event(validation_completed_event)
-                # we don't have to do this but we will anyway.
-                AttentionBackendController.apply(self.config, AttentionPhase.TRAIN)
-            if self.model.get_trained_component() is not None:
-                self.model.model = unwrap_model(self.accelerator, self.model.model)
-            if "lora" in self.config.model_type and "standard" == self.config.lora_type.lower():
-                if final_lora_save_kwargs is None:
-                    raise RuntimeError("Final LoRA save kwargs were not materialized before the main-process save.")
-                self.model.save_lora_weights(
-                    **final_lora_save_kwargs,
+                if fsdp2_pipeline_export_spec is None:
+                    raise RuntimeError("FSDP2 full-model pipeline export was not validated before training.")
+                trained_component = self.model.get_trained_component(unwrap_model=False)
+                fsdp2_state_dict = _materialize_fsdp2_state_dict_for_save(
+                    self.accelerator,
+                    trained_component,
+                    ema_model=self.ema_model if self.config.use_ema else None,
                 )
-                del final_lora_save_kwargs
-                reclaim_memory()
-            elif "lora" in self.config.model_type and "lycoris" == self.config.lora_type.lower():
-                if self.accelerator.is_main_process or self.config.use_deepspeed_optimizer:
-                    logger.info(f"Saving final LyCORIS checkpoint to {self.config.output_dir}")
-                    # Save final LyCORIS checkpoint.
-                    if getattr(self.accelerator, "_lycoris_wrapped_network", None) is not None:
-                        from simpletuner.helpers.publishing.huggingface import LORA_SAFETENSORS_FILENAME
-
-                        self.accelerator._lycoris_wrapped_network.save_weights(
-                            os.path.join(self.config.output_dir, LORA_SAFETENSORS_FILENAME),
-                            list(self.accelerator._lycoris_wrapped_network.parameters())[0].dtype,
-                            {"lycoris_config": json.dumps(self.lycoris_config)},  # metadata
-                        )
-                        shutil.copy2(
-                            self.config.lycoris_config,
-                            os.path.join(self.config.output_dir, "lycoris_config.json"),
-                        )
-
-            elif self.config.use_ema:
-                if self.model.get_trained_component() is not None:
-                    self.ema_model.copy_to(self.model.get_trained_component().parameters())
-
-            if self.config.model_type == "full":
-                if self.config.save_text_encoder:
-                    self.model.load_text_encoder()
-                self.model.load_vae()
-                pipeline = self.model.get_pipeline()
-                pipeline.save_pretrained(
-                    os.path.join(self.config.output_dir, "pipeline"),
-                    safe_serialization=True,
-                )
-                logger.info(f"Wrote pipeline to disk: {self.config.output_dir}/pipeline")
-
-            if self.hub_manager is not None and self.accelerator.is_main_process:
-                captured_step = self.state["global_step"]
-                captured_epoch = self.state["current_epoch"]
-
-                def _upload_final_model():
-                    repo_url = self.hub_manager.upload_model(
-                        validation_images,
-                        self.webhook_handler,
-                        global_step=captured_step,
-                        epoch=captured_epoch,
+                if self.accelerator.is_main_process:
+                    fsdp2_model_for_save = _build_model_from_state_dict_for_save(
+                        fsdp2_pipeline_export_spec.model_class,
+                        fsdp2_pipeline_export_spec.model_config,
+                        fsdp2_state_dict,
                     )
-                    return repo_url, self.config.output_dir, repo_url
+                del fsdp2_state_dict
 
-                try:
-                    self._schedule_hub_upload("final model upload", _upload_final_model)
-                except Exception as e:
-                    logger.error(f"Error uploading final model to hub: {e}")
-                self._finish_hub_uploads()
-            else:
-                self._run_post_upload_script(local_path=self.config.output_dir, remote_path=None)
-            # Mark model_save as completed
-            event = lifecycle_stage_event(
-                key="model_save",
-                label="Saving Final Model",
-                status="completed",
-                message=f"Model saved to {self.config.output_dir}",
-                job_id=self.job_id,
-            )
-            self._emit_event(event)
+            if self.accelerator.is_main_process:
+                event = lifecycle_stage_event(
+                    key="model_save",
+                    label="Saving Final Model",
+                    status="running",
+                    message=f"Finalizing model and saving to {self.config.output_dir}",
+                    job_id=self.job_id,
+                )
+                self._emit_event(event)
+                self.mark_optimizer_eval()
+                if self.validation is not None:
+                    AttentionBackendController.apply(self.config, AttentionPhase.EVAL)
+                    self.disable_gradient_checkpointing()
+                    # Emit validation start lifecycle event for final validations
+                    validation_start_event = lifecycle_stage_event(
+                        key="final_validation",
+                        label="Running Final Validations",
+                        status="running",
+                        message="Generating final validation images...",
+                        job_id=self.job_id,
+                    )
+                    self._emit_event(validation_start_event)
+                    validation_images = self.validation.run_validations(
+                        validation_type="final",
+                        step=self.state["global_step"],
+                        force_evaluation=True,
+                        skip_execution=True,
+                    ).validation_images
+                    # Emit validation completed lifecycle event
+                    validation_completed_event = lifecycle_stage_event(
+                        key="final_validation",
+                        label="Running Final Validations",
+                        status="completed",
+                        message="Final validation images completed",
+                        job_id=self.job_id,
+                    )
+                    self._emit_event(validation_completed_event)
+                    # we don't have to do this but we will anyway.
+                    AttentionBackendController.apply(self.config, AttentionPhase.TRAIN)
+                if self.model.get_trained_component() is not None and not is_fsdp2_full_model_save:
+                    self.model.model = unwrap_model(self.accelerator, self.model.model)
+                if "lora" in self.config.model_type and "standard" == self.config.lora_type.lower():
+                    if final_lora_save_kwargs is None:
+                        raise RuntimeError("Final LoRA save kwargs were not materialized before the main-process save.")
+                    self.model.save_lora_weights(
+                        **final_lora_save_kwargs,
+                    )
+                    del final_lora_save_kwargs
+                    reclaim_memory()
+                elif "lora" in self.config.model_type and "lycoris" == self.config.lora_type.lower():
+                    if self.accelerator.is_main_process or self.config.use_deepspeed_optimizer:
+                        logger.info(f"Saving final LyCORIS checkpoint to {self.config.output_dir}")
+                        # Save final LyCORIS checkpoint.
+                        if getattr(self.accelerator, "_lycoris_wrapped_network", None) is not None:
+                            from simpletuner.helpers.publishing.huggingface import LORA_SAFETENSORS_FILENAME
+
+                            self.accelerator._lycoris_wrapped_network.save_weights(
+                                os.path.join(self.config.output_dir, LORA_SAFETENSORS_FILENAME),
+                                list(self.accelerator._lycoris_wrapped_network.parameters())[0].dtype,
+                                {"lycoris_config": json.dumps(self.lycoris_config)},  # metadata
+                            )
+                            shutil.copy2(
+                                self.config.lycoris_config,
+                                os.path.join(self.config.output_dir, "lycoris_config.json"),
+                            )
+
+                elif self.config.use_ema and not is_fsdp2_full_model_save:
+                    if self.model.get_trained_component() is not None:
+                        self.ema_model.copy_to(self.model.get_trained_component().parameters())
+
+                if self.config.model_type == "full":
+                    if self.config.save_text_encoder:
+                        self.model.load_text_encoder()
+                    self.model.load_vae()
+                    if is_fsdp2_full_model_save:
+                        from simpletuner.helpers.training.save_hooks import _save_pipeline_with_component_for_save
+
+                        pipeline = self.model.get_pipeline(pipeline_type=fsdp2_pipeline_export_spec.pipeline_type)
+                        _save_pipeline_with_component_for_save(
+                            pipeline,
+                            fsdp2_pipeline_export_spec.component_name,
+                            fsdp2_model_for_save,
+                            os.path.join(self.config.output_dir, "pipeline"),
+                        )
+                    else:
+                        pipeline = self.model.get_pipeline()
+                        pipeline.save_pretrained(
+                            os.path.join(self.config.output_dir, "pipeline"),
+                            safe_serialization=True,
+                        )
+                    logger.info(f"Wrote pipeline to disk: {self.config.output_dir}/pipeline")
+                    if is_fsdp2_full_model_save:
+                        del fsdp2_model_for_save
+                        reclaim_memory()
+
+                if self.hub_manager is not None and self.accelerator.is_main_process:
+                    captured_step = self.state["global_step"]
+                    captured_epoch = self.state["current_epoch"]
+
+                    def _upload_final_model():
+                        repo_url = self.hub_manager.upload_model(
+                            validation_images,
+                            self.webhook_handler,
+                            global_step=captured_step,
+                            epoch=captured_epoch,
+                        )
+                        return repo_url, self.config.output_dir, repo_url
+
+                    try:
+                        self._schedule_hub_upload("final model upload", _upload_final_model)
+                    except Exception as e:
+                        logger.error(f"Error uploading final model to hub: {e}")
+                    self._finish_hub_uploads()
+                else:
+                    self._run_post_upload_script(local_path=self.config.output_dir, remote_path=None)
+                # Mark model_save as completed
+                event = lifecycle_stage_event(
+                    key="model_save",
+                    label="Saving Final Model",
+                    status="completed",
+                    message=f"Model saved to {self.config.output_dir}",
+                    job_id=self.job_id,
+                )
+                self._emit_event(event)
         self.accelerator.end_training()
         # Emit training_complete event after all model saving and validation is complete
         event = lifecycle_stage_event(

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -385,7 +385,8 @@ class Trainer:
             yield
             return
 
-        assert self.accelerator is not None
+        if self.accelerator is None:
+            raise RuntimeError("Accelerator must be initialized before running FSDP2 export collectives.")
         status = torch.zeros((), dtype=torch.int32, device=self.accelerator.device)
         try:
             yield


### PR DESCRIPTION
# Export portable Diffusers pipelines after FSDP2 full-model training

## Summary

- **Problem:** unwrapping an FSDP2 component on rank 0 does not reconstruct its
  full DTensor state, so final Diffusers export can be incomplete or fail.
- **Distributed risk:** one-rank export failure can leave peers reporting a
  different finalization result.
- **Fix:** collectively materialize a CPU non-DTensor state, serialize a temporary
  full component on the main rank, and synchronize export failure.

## Changes

- `save_hooks.py` — preflight: identify the trained component and registered
  pipeline slot, verify exact config reconstruction, and require Accelerate 1.8+
  before FSDP2 preparation.
- `save_hooks.py` — materialization: gather a CPU non-DTensor state collectively,
  validate EMA parameter correspondence, and retain the full state only on the
  main rank.
- `save_hooks.py` — save-only component: rebuild on `meta`, strict-load the full
  state, swap it into the pipeline only for `save_pretrained()`, and restore the
  live component in `finally`.
- `trainer.py` — preparation and save: run preflight before FSDP2 wrapping; make
  every rank join `Accelerator.get_state_dict(..., unwrap=False)` while keeping
  file output main-rank-only.
- `trainer.py` — failure guard: use one scalar `all_reduce(MAX)` so the originating
  rank preserves its local exception and peer ranks receive a remote-failure
  exception.

## Result

- The main rank exports a complete Diffusers pipeline with a CPU-materialized
  trained component.
- Non-main ranks join required collectives without retaining the full state.
- The live sharded component is restored after save success or failure.
- **Example:** with logical weight `W` split into `W0` and `W1`, rank 0 previously
  still owned only `W0` after unwrap. Now both ranks join reconstruction, rank 0
  strict-loads full `W` into a save-only component, and only rank 0 serializes the
  pipeline.
- **Failure behavior:** the rank that raises keeps the original exception; peers
  receive an explicit remote-export failure, and all ranks restore the live
  component.
- **Verified:** all 430 model weights were materialized into six safetensor shards;
  a fresh one-GPU reload found 430 weights, zero DTensors, and finite latents.
  Fresh, resume, and DCP save paths passed.

## Environment

- Python: `3.13.14`
- PyTorch: `2.13.0+cu130`
- Accelerate: `1.14.0`
- Diffusers: `0.39.0`
- Transformers: `5.13.1`
- GPU: NVIDIA B200, driver `590.48.01`
