### PR TITLE
Use cyclic distributed padding for oversubscribed datasets

### DIFF
--- a/simpletuner/helpers/data_backend/factory.py
+++ b/simpletuner/helpers/data_backend/factory.py
@@ -3283,7 +3283,7 @@ class FactoryRegistry:
                     f" You have to reduce your batch size, or increase your dataset size (id={init_backend['id']})."
                 )
 
-        apply_padding = True if not self.args.max_train_steps or self.args.max_train_steps == 0 else False
+        apply_padding = not self.args.max_train_steps or self.args.allow_dataset_oversubscription
 
         if backend.get("auto_generated", False):
             # when we're duplicating a metadata set, it's already split between processes.

--- a/simpletuner/helpers/metadata/backends/base.py
+++ b/simpletuner/helpers/metadata/backends/base.py
@@ -781,6 +781,9 @@ class MetadataBackend:
         # Early validation: check if configuration is mathematically impossible
         buckets_that_will_fail = []
         for bucket, images in self.aspect_ratio_bucket_indices.items():
+            if not images:
+                # Empty buckets do not require repeat calculation or padding.
+                continue
             total_img_count_incl_repeats = len(images) * (self.repeats + 1)
             if total_img_count_incl_repeats < effective_batch_size:
                 buckets_that_will_fail.append(
@@ -890,7 +893,7 @@ class MetadataBackend:
                     removed=removed_for_trim,
                     effective_batch_size=effective_batch_size,
                 )
-            if len(trimmed_images) == 0 and should_log():
+            if len(trimmed_images) == 0 and images and should_log():
                 logger.error(
                     f"Bucket {bucket} has no samples after trimming because {len(images)} samples are not enough to satisfy an effective batch size of {effective_batch_size}."
                     " Lower your batch size, increase repeat count, or increase data pool size."
@@ -903,6 +906,16 @@ class MetadataBackend:
                         effective_batch_size=effective_batch_size,
                     )
 
+            # Pad from the shuffled global bucket before splitting. This gives every
+            # effective-DP rank the same shard length without concentrating all
+            # duplicated samples on the final item.
+            if apply_padding and trimmed_images and effective_dp_size > 1:
+                padded_size = ceil(len(trimmed_images) / effective_dp_size) * effective_dp_size
+                padding_needed = padded_size - len(trimmed_images)
+                if padding_needed:
+                    cycle_count = ceil(padding_needed / len(trimmed_images))
+                    trimmed_images = trimmed_images + (trimmed_images * cycle_count)[:padding_needed]
+
             # Split data by DP rank (not global rank) when context parallelism is enabled.
             # This ensures all ranks in a CP group get the same data shard.
             if cp_size > 1:
@@ -912,15 +925,11 @@ class MetadataBackend:
                 end_idx = min(start_idx + chunk_size, len(trimmed_images))
                 images_split = trimmed_images[start_idx:end_idx]
 
-                # Match Accelerate's apply_padding behavior by repeating the
-                # final input item, including for otherwise empty DP shards.
-                if apply_padding and trimmed_images and len(images_split) < chunk_size:
-                    images_split = images_split + [trimmed_images[-1]] * (chunk_size - len(images_split))
-
                 new_aspect_ratio_bucket_indices[bucket] = images_split
             else:
-                # Standard splitting when CP is disabled
-                with self.accelerator.split_between_processes(trimmed_images, apply_padding=apply_padding) as images_split:
+                # Global padding has already made the bucket divisible by the DP
+                # world size, so per-rank tail padding must stay disabled.
+                with self.accelerator.split_between_processes(trimmed_images, apply_padding=False) as images_split:
                     new_aspect_ratio_bucket_indices[bucket] = images_split
 
         self.aspect_ratio_bucket_indices = new_aspect_ratio_bucket_indices

--- a/simpletuner/helpers/metadata/backends/base.py
+++ b/simpletuner/helpers/metadata/backends/base.py
@@ -904,12 +904,10 @@ class MetadataBackend:
                 end_idx = min(start_idx + chunk_size, len(trimmed_images))
                 images_split = trimmed_images[start_idx:end_idx]
 
-                # Handle padding if requested (for uniform batch sizes)
-                if apply_padding and len(images_split) < chunk_size and len(images_split) > 0:
-                    padding_needed = chunk_size - len(images_split)
-                    # Pad by repeating elements from the split
-                    padding = (images_split * ((padding_needed // len(images_split)) + 1))[:padding_needed]
-                    images_split = images_split + padding
+                # Match Accelerate's apply_padding behavior by repeating the
+                # final input item, including for otherwise empty DP shards.
+                if apply_padding and trimmed_images and len(images_split) < chunk_size:
+                    images_split = images_split + [trimmed_images[-1]] * (chunk_size - len(images_split))
 
                 new_aspect_ratio_bucket_indices[bucket] = images_split
             else:

--- a/simpletuner/helpers/metadata/backends/base.py
+++ b/simpletuner/helpers/metadata/backends/base.py
@@ -7,7 +7,6 @@ import time
 from math import ceil, floor
 from multiprocessing import Process, Queue
 from pathlib import Path
-from random import shuffle
 
 # For semaphore
 from threading import Semaphore, Thread
@@ -22,7 +21,7 @@ from simpletuner.helpers.data_backend.base import BaseDataBackend
 from simpletuner.helpers.data_backend.dataset_types import DatasetType, ensure_dataset_type
 from simpletuner.helpers.data_backend.runtime.context_parallel_sync import get_cp_info
 from simpletuner.helpers.multiaspect.image import MultiaspectImage
-from simpletuner.helpers.training.multi_process import should_log
+from simpletuner.helpers.training.multi_process import broadcast_object_from_main, should_log
 from simpletuner.helpers.training.state_tracker import StateTracker
 
 logger = logging.getLogger("BaseMetadataBackend")
@@ -867,13 +866,22 @@ class MetadataBackend:
                 raise ValueError(error_msg)
 
         should_shuffle_contents = os.environ.get("SIMPLETUNER_SHUFFLE_BUCKETS", "1") == "1"
+        if should_shuffle_contents:
+            # Process-specific RNG seeding must not change the split input across ranks.
+            shuffle_seed = getattr(StateTracker.get_args(), "seed", None)
+            if self.accelerator.is_main_process and shuffle_seed is None:
+                shuffle_seed = random.SystemRandom().getrandbits(64)
+            shuffle_seed = broadcast_object_from_main(shuffle_seed if self.accelerator.is_main_process else None)
+
         for bucket, images in self.aspect_ratio_bucket_indices.items():
             if should_shuffle_contents:
                 logger.debug(f"Shuffling bucket {bucket} contents.")
-                shuffle(images)
+                images = images.copy()
+                random.Random(f"{shuffle_seed}:{self.id}:{bucket}").shuffle(images)
             total_img_count_incl_repeats = len(images) * (self.repeats + 1)
             num_batches = ceil(total_img_count_incl_repeats / effective_batch_size)
-            trimmed_images = images[: num_batches * effective_batch_size]
+            trim_limit = num_batches * effective_batch_size
+            trimmed_images = images[:trim_limit] if trim_limit < len(images) else images
             removed_for_trim = len(images) - len(trimmed_images)
             if removed_for_trim > 0 and self.bucket_report:
                 self.bucket_report.record_bucket_event(

--- a/simpletuner/helpers/metadata/backends/base.py
+++ b/simpletuner/helpers/metadata/backends/base.py
@@ -22,7 +22,7 @@ from simpletuner.helpers.data_backend.base import BaseDataBackend
 from simpletuner.helpers.data_backend.dataset_types import DatasetType, ensure_dataset_type
 from simpletuner.helpers.data_backend.runtime.context_parallel_sync import get_cp_info
 from simpletuner.helpers.multiaspect.image import MultiaspectImage
-from simpletuner.helpers.training.multi_process import should_log
+from simpletuner.helpers.training.multi_process import broadcast_object_from_main, should_log
 from simpletuner.helpers.training.state_tracker import StateTracker
 
 logger = logging.getLogger("BaseMetadataBackend")
@@ -782,6 +782,9 @@ class MetadataBackend:
         # Early validation: check if configuration is mathematically impossible
         buckets_that_will_fail = []
         for bucket, images in self.aspect_ratio_bucket_indices.items():
+            if not images:
+                # Empty buckets are harmless and are handled below without padding.
+                continue
             total_img_count_incl_repeats = len(images) * (self.repeats + 1)
             if total_img_count_incl_repeats < effective_batch_size:
                 buckets_that_will_fail.append(
@@ -867,10 +870,29 @@ class MetadataBackend:
                 raise ValueError(error_msg)
 
         should_shuffle_contents = os.environ.get("SIMPLETUNER_SHUFFLE_BUCKETS", "1") == "1"
+        shuffle_seed = None
+        if should_shuffle_contents and apply_padding:
+            # A single rank-independent seed is required before padding. Keep the
+            # no-seed contract (random per launch) while avoiding process-local RNG.
+            args = StateTracker.get_args()
+            shuffle_seed = getattr(args, "seed", None) if args is not None else None
+            is_main_process = getattr(self.accelerator, "is_main_process", True)
+            if is_main_process and shuffle_seed is None:
+                shuffle_seed = random.SystemRandom().getrandbits(64)
+            shuffle_seed = broadcast_object_from_main(shuffle_seed if is_main_process else None)
+
         for bucket, images in self.aspect_ratio_bucket_indices.items():
             if should_shuffle_contents:
                 logger.debug(f"Shuffling bucket {bucket} contents.")
-                shuffle(images)
+                if apply_padding:
+                    # Derive a stable per-dataset/bucket order without mutating global RNG.
+                    shuffled_images = list(images)
+                    random.Random(f"{shuffle_seed}:{self.id}:{bucket}").shuffle(shuffled_images)
+                    images = shuffled_images
+                else:
+                    # Preserve the existing process-local shuffle semantics when padding
+                    # is disabled; this branch does not participate in global padding.
+                    shuffle(images)
             total_img_count_incl_repeats = len(images) * (self.repeats + 1)
             num_batches = ceil(total_img_count_incl_repeats / effective_batch_size)
             trimmed_images = images[: num_batches * effective_batch_size]
@@ -882,7 +904,7 @@ class MetadataBackend:
                     removed=removed_for_trim,
                     effective_batch_size=effective_batch_size,
                 )
-            if len(trimmed_images) == 0 and should_log():
+            if len(trimmed_images) == 0 and images and should_log():
                 logger.error(
                     f"Bucket {bucket} has no samples after trimming because {len(images)} samples are not enough to satisfy an effective batch size of {effective_batch_size}."
                     " Lower your batch size, increase repeat count, or increase data pool size."
@@ -895,6 +917,16 @@ class MetadataBackend:
                         effective_batch_size=effective_batch_size,
                     )
 
+            # Pad the shuffled global bucket with a cyclic prefix before splitting so every
+            # effective-DP rank receives the same number of samples. This mirrors the
+            # training sampler policy and avoids concentrating all padding on one sample.
+            if apply_padding and trimmed_images and effective_dp_size > 1:
+                padded_size = ceil(len(trimmed_images) / effective_dp_size) * effective_dp_size
+                padding_needed = padded_size - len(trimmed_images)
+                if padding_needed:
+                    cycle_count = ceil(padding_needed / len(trimmed_images))
+                    trimmed_images = trimmed_images + (trimmed_images * cycle_count)[:padding_needed]
+
             # Split data by DP rank (not global rank) when context parallelism is enabled.
             # This ensures all ranks in a CP group get the same data shard.
             if cp_size > 1:
@@ -904,17 +936,11 @@ class MetadataBackend:
                 end_idx = min(start_idx + chunk_size, len(trimmed_images))
                 images_split = trimmed_images[start_idx:end_idx]
 
-                # Handle padding if requested (for uniform batch sizes)
-                if apply_padding and len(images_split) < chunk_size and len(images_split) > 0:
-                    padding_needed = chunk_size - len(images_split)
-                    # Pad by repeating elements from the split
-                    padding = (images_split * ((padding_needed // len(images_split)) + 1))[:padding_needed]
-                    images_split = images_split + padding
-
                 new_aspect_ratio_bucket_indices[bucket] = images_split
             else:
-                # Standard splitting when CP is disabled
-                with self.accelerator.split_between_processes(trimmed_images, apply_padding=apply_padding) as images_split:
+                # The bucket is already globally padded when requested; disable
+                # Accelerate's last-item padding so DDP/FSDP2 use the same policy.
+                with self.accelerator.split_between_processes(trimmed_images, apply_padding=False) as images_split:
                     new_aspect_ratio_bucket_indices[bucket] = images_split
 
         self.aspect_ratio_bucket_indices = new_aspect_ratio_bucket_indices

--- a/simpletuner/helpers/multiaspect/sampler.py
+++ b/simpletuner/helpers/multiaspect/sampler.py
@@ -9,7 +9,7 @@ from PIL import Image
 
 from simpletuner.helpers.data_backend.base import BaseDataBackend
 from simpletuner.helpers.image_manipulation.training_sample import TrainingSample
-from simpletuner.helpers.metadata.backends.base import MetadataBackend
+from simpletuner.helpers.metadata.backends.base import MetadataBackend, get_cp_aware_dp_info
 from simpletuner.helpers.multiaspect.image import MultiaspectImage
 from simpletuner.helpers.multiaspect.state import BucketStateManager
 from simpletuner.helpers.prompts import PromptHandler
@@ -116,6 +116,16 @@ class MultiAspectSampler(torch.utils.data.Sampler):
         self.state_manager = BucketStateManager(self.id)
         self._val_master_list = sorted(sum(self.metadata_backend.aspect_ratio_bucket_indices.values(), []))
 
+    def _partition_topology(self):
+        effective_dp_size, dp_rank, cp_size = get_cp_aware_dp_info(self.accelerator)
+        return {
+            "world_size": self.accelerator.num_processes,
+            "rank": self.accelerator.process_index,
+            "effective_dp_size": effective_dp_size,
+            "dp_rank": dp_rank,
+            "cp_size": cp_size,
+        }
+
     def save_state(self, state_path: str):
         """
         This method should be called when the accelerator save hook is called,
@@ -129,15 +139,31 @@ class MultiAspectSampler(torch.utils.data.Sampler):
             "current_bucket": self.current_bucket,
             "seen_images": self.metadata_backend.seen_images,
             "current_epoch": self.current_epoch,
+            "partition_topology": self._partition_topology(),
         }
         self.state_manager.save_state(state, state_path)
 
     def load_states(self, state_path: str):
-        try:
-            self.buckets = self.load_buckets()
-            previous_state = self.state_manager.load_state(state_path)
-        except Exception as e:
-            raise e
+        previous_state = self.state_manager.load_state(state_path)
+        saved_partition = previous_state.get("aspect_ratio_bucket_indices")
+        if saved_partition is not None:
+            saved_topology = previous_state.get("partition_topology")
+            current_topology = self._partition_topology()
+            if saved_topology is None and current_topology["world_size"] > 1:
+                raise ValueError(
+                    "Cannot safely restore distributed sampler state because the checkpoint does not record its "
+                    f"data-partition topology; current={current_topology}."
+                )
+            else:
+                if saved_topology is not None and saved_topology != current_topology:
+                    raise ValueError(
+                        "Cannot restore sampler state with a different distributed data-partition topology: "
+                        f"checkpoint={saved_topology}, current={current_topology}."
+                    )
+                self.metadata_backend.aspect_ratio_bucket_indices = saved_partition
+                self._val_master_list = sorted(sum(saved_partition.values(), []))
+
+        self.buckets = self.load_buckets()
         self.exhausted_buckets = []
         if "exhausted_buckets" in previous_state:
             self.logger.info(f"Previous checkpoint had {len(previous_state['exhausted_buckets'])} exhausted buckets.")

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -5451,7 +5451,8 @@ class Trainer:
                 # we'll have to split the buckets between GPUs again now, so that the VAE cache distributes properly.
                 logger.info("Splitting buckets across GPUs")
                 backend["metadata_backend"].split_buckets_between_processes(
-                    gradient_accumulation_steps=self.config.gradient_accumulation_steps
+                    gradient_accumulation_steps=self.config.gradient_accumulation_steps,
+                    apply_padding=(self.config.overrode_max_train_steps or self.config.allow_dataset_oversubscription),
                 )
                 # we have to rebuild the VAE cache if it exists.
                 if "vaecache" in backend:


### PR DESCRIPTION
# Use cyclic distributed padding for oversubscribed datasets

## Dependencies

- Submit this PR as a draft alongside the prerequisite PRs so the complete
  series can be reviewed together.
- Depends on:
  - [#2897 Fix distributed padding for oversubscribed step-bounded datasets](https://github.com/bghira/SimpleTuner/pull/2897)
  - [#2898 Fix deterministic distributed bucket splitting and sampler restore](https://github.com/bghira/SimpleTuner/pull/2898)
- The branch is stacked with the exact prerequisite commits. Keep #2903 as a
  draft until both prerequisite PRs are merged.
- After they merge, the author will update this branch onto the latest `main`
  and verify that `Files changed` contains only the cyclic-padding delta before
  marking #2903 ready for review.

## Summary

- **Problem:** last-item padding prevents empty shards but concentrates all added
  entries on one sample; Context Parallel and non-CP paths also padded at
  different stages.
- **Enhancement:** cyclically extend one shared shuffled global bucket before
  DDP/FSDP2 or Context Parallel splitting.

## Prerequisite behavior

- `simpletuner/helpers/data_backend/factory.py`: enable padding for epoch-driven
  runs or explicit oversubscription while preserving ordinary step-bounded
  behavior.
- `simpletuner/helpers/metadata/backends/base.py`: establish one deterministic
  dataset-and-bucket order shared by every rank.
- `simpletuner/helpers/training/trainer.py`: forward the same padding policy after
  epoch-rollover bucket rebuilds.

## Changes in this PR

- `simpletuner/helpers/metadata/backends/base.py`: preserve empty buckets without
  entering repeat or padding arithmetic.
- Cyclically extend the shared shuffled bucket to a multiple of effective DP
  size before splitting.
- Remove CP tail padding and disable Accelerate per-rank padding after the global
  list is already padded.

| Training mode | Padding |
|---|---|
| Epoch-driven | Cyclic prefix padding |
| Step-bounded with oversubscription | Cyclic prefix padding |
| Step-bounded without oversubscription | Disabled |

## Result

- A non-empty undersized bucket keeps every effective DP rank non-empty when
  padding is enabled.
- Added entries are distributed across the shuffled prefix instead of one final
  sample; CP and non-CP use the same global policy.
- Ordinary step-bounded behavior remains unchanged.
- **Example:** with eight effective DP ranks and `[A, B, C, D]`, final-item
  padding produces `[A, B, C, D, D, D, D, D]`: four added copies of `D`, five
  `D` occurrences total. A shared shuffled order such as `[C, A, D, B]` now
  becomes `[C, A, D, B, C, A, D, B]`, spreading the four added entries across
  the bucket prefix.
- **Verified:** the focused matrix covered CP and non-CP paths, eight effective
  DP ranks, CP size 2, epoch rollover, empty buckets, and seed reproducibility;
  the related 110-test regression suite passed. PR01 through PR06 followed by
  this stacked PR merged without conflicts, and the two-rank distributed
  integration smoke passed.

## Environment

- Python: `3.13.14`
- PyTorch: `2.13.0+cu130`
- Accelerate: `1.14.0`
- Diffusers: `0.39.0`
- Transformers: `5.13.1`
- GPU: NVIDIA B200, driver `590.48.01`
