### PR TITLE
ConvRot: documentation additions and corrections (group size should be 256)

### DIFF
--- a/documentation/experimental/CONVROT.es.md
+++ b/documentation/experimental/CONVROT.es.md
@@ -2,7 +2,7 @@
 
 SimpleTuner expone una rotación estilo ConvRot mediante la ruta Hadamard de SDNQ. Es útil para trabajos PEFT grandes donde el modelo base congelado debe ejecutarse en int8 mientras los adaptadores LoRA o LyCORIS siguen entrenándose en bf16.
 
-Esto no carga directamente buffers de checkpoints ConvRot externos. Carga los pesos originales del modelo y deja que SimpleTuner cuantice el componente entrenado con SDNQ después de cargar el modelo.
+SimpleTuner no consume buffers sidecar ConvRot arbitrarios como una funcion separada. Para la ruta comun, carga los pesos originales del modelo y deja que SimpleTuner cuantice el componente entrenado con SDNQ despues de cargar el modelo. Los loaders que soportan pesos transformer cuantizados de archivo unico tambien pueden cargar safetensors transformer INT8 ConvRot compatibles y ejecutarlos mediante SDNQ Hadamard.
 
 ## Configuración rápida
 
@@ -11,7 +11,7 @@ Esto no carga directamente buffers de checkpoints ConvRot externos. Carga los pe
   "base_model_precision": "int8-sdnq",
   "gradient_checkpointing": true,
   "sdnq_use_hadamard": true,
-  "sdnq_hadamard_group_size": 128,
+  "sdnq_hadamard_group_size": 256,
   "sdnq_group_size": -1,
   "sdnq_use_quantized_matmul": true,
   "sdnq_compile_mode": "compile"
@@ -24,7 +24,7 @@ Para modelos grandes, mantén `quantize_via` en `cpu` salvo que la guía del mod
 
 - `base_model_precision: int8-sdnq` selecciona cuantización SDNQ int8 posterior a la carga para el componente base entrenado.
 - `sdnq_use_hadamard: true` activa la ruta de rotación Hadamard.
-- `sdnq_hadamard_group_size: 128` define el tamaño de bloque de rotación usado por SDNQ.
+- `sdnq_hadamard_group_size: 256` define el tamaño de bloque de rotación usado por SDNQ. Usa `256` para ConvRot; bloques mas pequenos seleccionan una ruta estilo QuaRot.
 - `sdnq_group_size: -1` usa escalas estáticas por fila de pesos. Esto evita la ruta dinámica agrupada, orientada principalmente a full fine-tuning, que puede recuantizar pesos durante el entrenamiento.
 - `sdnq_use_quantized_matmul: true` mantiene activa la ruta SDNQ int8 matmul.
 - `sdnq_compile_mode: compile` compila helpers y kernels de cuantización donde SDNQ lo soporta.
@@ -38,10 +38,28 @@ Algunos modelos cargan adaptadores auxiliares fijos antes del entrenamiento. Z-I
 
 ## Requisitos y límites
 
-- Usa un build de SDNQ con soporte Hadamard. La verificación en H100 usó SDNQ upstream `0.2.3`; PyPI `0.2.2` no incluye la misma corrección Hadamard para bf16.
+- SimpleTuner instala y configura la dependencia de entrenamiento SDNQ para los targets de instalacion soportados.
 - Este preset está pensado para entrenamiento LoRA y LyCORIS de modelos grandes. Full fine-tuning con SDNQ Hadamard necesita validación separada.
 - Los primeros steps pueden ser lentos porque SDNQ y Torch compilan kernels durante la preparación y el inicio del entrenamiento.
 - Validación e inferencia usan el modelo base cuantizado más el adaptador activo, igual que el entrenamiento.
+- ConvRot puede reducir el dano de cuantizacion, pero no garantiza que INT8 iguale a BF16 o FP8 en todos los modelos. Valida tanto la curva de loss como las muestras generadas antes de comprometerte con un run largo.
+- La inferencia standalone con SDNQ ConvRot queda fuera de esta guia de entrenamiento. Para APIs directas de inferencia SDNQ, sigue la [documentacion upstream de SDNQ](https://github.com/Disty0/sdnq) porque esa API cambia con mas frecuencia que la configuracion de entrenamiento de SimpleTuner.
+
+## Resultados medidos
+
+Estas son mediciones del trainer real de SimpleTuner por modelo, no resultados sinteticos solo de GEMM. `Loop s/step` es el tiempo de pared del loop de entrenamiento por paso. `Paso medio` excluye los primeros cinco pasos de warmup.
+
+| Modelo | GPU | Pasos | Ruta de pesos | Loop s/step | Paso medio | p50 | p95 | VRAM maxima asignada |
+| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| Z-Image Turbo LoRA | H100 80GB | 1000 | cuantizacion post-load SDNQ Hadamard | 1.107 | 1.087 | 1.071 | 1.109 | 9.70 GiB |
+| Z-Image Turbo LoRA | L40S | 1000 | cuantizacion post-load SDNQ Hadamard | 1.026 | 1.018 | 1.002 | 1.040 | 9.66 GiB |
+| Z-Image Turbo LoRA | L40S | 1000 | baseline SDNQ Hadamard | 1.131 | 1.072 | 1.055 | 1.102 | 9.66 GiB |
+| Krea 2 Raw LoRA | H100 80GB | 100 | pesos transformer `lilcheaty/Krea2-INT8-ConvRot`, atencion diffusers | 0.787 | 0.399 | 0.397 | 0.411 | 32.15 GiB |
+| Krea 2 Raw LoRA | L40S | 100 | pesos transformer `lilcheaty/Krea2-INT8-ConvRot`, atencion cuDNN | 0.945 | 0.794 | 0.793 | 0.799 | 31.89 GiB |
+| Mage-Flow LoRA, crop cuadrado | H100 80GB | 100 | cuantizacion post-load SDNQ INT8 vanilla | 1.113 | 0.277 | 0.276 | 0.286 | 20.12 GiB |
+| Mage-Flow LoRA, crop cuadrado | H100 80GB | 100 | cuantizacion post-load SDNQ ConvRot 256 | 0.436 | 0.299 | 0.297 | 0.308 | 20.15 GiB |
+
+En la comparacion Z-Image con caches calientes en L40S, la ruta actual fue 10.3% mas rapida por tiempo de loop y 5.2% mas rapida por media de paso medida que el baseline SDNQ Hadamard. Las filas de Krea 2 verifican la ruta de pesos transformer INT8 ConvRot de Hugging Face en ejecuciones reales de entrenamiento de 100 pasos. Las filas de Mage-Flow muestran por que la validacion por modelo importa: el crop cuadrado elimino la mayor parte del churn de compilacion por formas, ConvRot redujo el tiempo total del loop frente a INT8 vanilla, pero el paso medido ya caliente fue un poco mas lento que INT8 vanilla.
 
 ## Modelos de ejemplo
 

--- a/documentation/experimental/CONVROT.hi.md
+++ b/documentation/experimental/CONVROT.hi.md
@@ -2,7 +2,7 @@
 
 SimpleTuner SDNQ के Hadamard path के जरिए ConvRot-style rotation उपलब्ध कराता है। यह बड़े PEFT jobs के लिए उपयोगी है, जहां frozen base model int8 में चले और LoRA या LyCORIS adapters bf16 जैसे mixed-precision dtype में trainable रहें।
 
-यह external ConvRot checkpoint buffers को सीधे load नहीं करता। Original model weights load करें, फिर model load के बाद SimpleTuner trained component को SDNQ से quantize करेगा।
+SimpleTuner arbitrary ConvRot sidecar buffers को अलग feature की तरह consume नहीं करता। Common path में original model weights load करें, फिर model load के बाद SimpleTuner trained component को SDNQ से quantize करेगा। Single-file quantized transformer weights support करने वाले model loaders compatible INT8 ConvRot transformer safetensors भी load कर सकते हैं और उन्हें SDNQ Hadamard के जरिए चला सकते हैं।
 
 ## Quick Setup
 
@@ -11,7 +11,7 @@ SimpleTuner SDNQ के Hadamard path के जरिए ConvRot-style rotation
   "base_model_precision": "int8-sdnq",
   "gradient_checkpointing": true,
   "sdnq_use_hadamard": true,
-  "sdnq_hadamard_group_size": 128,
+  "sdnq_hadamard_group_size": 256,
   "sdnq_group_size": -1,
   "sdnq_use_quantized_matmul": true,
   "sdnq_compile_mode": "compile"
@@ -24,7 +24,7 @@ SimpleTuner SDNQ के Hadamard path के जरिए ConvRot-style rotation
 
 - `base_model_precision: int8-sdnq` trained base component के लिए post-load SDNQ int8 quantization चुनता है।
 - `sdnq_use_hadamard: true` Hadamard rotation path enable करता है।
-- `sdnq_hadamard_group_size: 128` SDNQ का rotation block size सेट करता है।
+- `sdnq_hadamard_group_size: 256` SDNQ का rotation block size सेट करता है। ConvRot के लिए `256` इस्तेमाल करें; छोटे blocks QuaRot-style path चुनते हैं।
 - `sdnq_group_size: -1` static full-row weight scales इस्तेमाल करता है। यह dynamic grouped path से बचता है, जो मुख्य रूप से full fine-tuning के लिए है और training के दौरान weights requantize कर सकता है।
 - `sdnq_use_quantized_matmul: true` SDNQ int8 matmul path active रखता है।
 - `sdnq_compile_mode: compile` जहां SDNQ support करता है, quantization helpers और kernels compile करता है।
@@ -38,10 +38,28 @@ Base transformer SDNQ से quantize होता है। Adapter weights tra
 
 ## Requirements And Limits
 
-- Hadamard support वाला SDNQ build इस्तेमाल करें। H100 verification में upstream SDNQ `0.2.3` इस्तेमाल हुआ; PyPI `0.2.2` में वही bf16 Hadamard fix नहीं है।
+- SimpleTuner supported install targets के लिए SDNQ training dependency install और configure करता है।
 - यह preset बड़े models की LoRA और LyCORIS training के लिए है। SDNQ Hadamard के साथ full fine-tuning को अलग validation चाहिए।
 - शुरुआती steps धीमे हो सकते हैं, क्योंकि setup और early training में SDNQ और Torch kernels compile करते हैं।
 - Validation और inference quantized base model plus active adapter इस्तेमाल करते हैं, training की तरह।
+- ConvRot quantization damage कम कर सकता है, लेकिन यह guarantee नहीं है कि INT8 हर model पर BF16 या FP8 जैसा होगा। Long run शुरू करने से पहले loss curve और generated samples दोनों validate करें।
+- SDNQ ConvRot के साथ standalone inference इस training guide के scope से बाहर है। Direct SDNQ inference APIs के लिए [SDNQ upstream documentation](https://github.com/Disty0/sdnq) follow करें, क्योंकि वह API SimpleTuner training configuration से ज्यादा अक्सर बदलती है।
+
+## Measured Results
+
+ये model-specific SimpleTuner trainer measurements हैं, synthetic GEMM-only results नहीं। `Loop s/step` wrapper का train-loop wall time per step है। `Mean step` पहले पांच warmup steps को exclude करता है।
+
+| Model | GPU | Steps | Weight path | Loop s/step | Mean step | p50 | p95 | Peak allocated VRAM |
+| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| Z-Image Turbo LoRA | H100 80GB | 1000 | SDNQ Hadamard post-load quantization | 1.107 | 1.087 | 1.071 | 1.109 | 9.70 GiB |
+| Z-Image Turbo LoRA | L40S | 1000 | SDNQ Hadamard post-load quantization | 1.026 | 1.018 | 1.002 | 1.040 | 9.66 GiB |
+| Z-Image Turbo LoRA | L40S | 1000 | baseline SDNQ Hadamard path | 1.131 | 1.072 | 1.055 | 1.102 | 9.66 GiB |
+| Krea 2 Raw LoRA | H100 80GB | 100 | `lilcheaty/Krea2-INT8-ConvRot` transformer weights, diffusers attention | 0.787 | 0.399 | 0.397 | 0.411 | 32.15 GiB |
+| Krea 2 Raw LoRA | L40S | 100 | `lilcheaty/Krea2-INT8-ConvRot` transformer weights, cuDNN attention | 0.945 | 0.794 | 0.793 | 0.799 | 31.89 GiB |
+| Mage-Flow LoRA, square crop | H100 80GB | 100 | SDNQ INT8 vanilla post-load quantization | 1.113 | 0.277 | 0.276 | 0.286 | 20.12 GiB |
+| Mage-Flow LoRA, square crop | H100 80GB | 100 | SDNQ ConvRot 256 post-load quantization | 0.436 | 0.299 | 0.297 | 0.308 | 20.15 GiB |
+
+Warm-cache L40S Z-Image comparison में current path train-loop wall time से 10.3% और measured train-step mean से 5.2% baseline SDNQ Hadamard path से तेज था। Krea 2 rows Hugging Face INT8 ConvRot transformer-weight path को real 100-step training runs में verify करती हैं। Mage-Flow rows दिखाती हैं कि model-specific validation क्यों जरूरी है: square crop ने shape-compile churn का बड़ा हिस्सा हटाया, ConvRot ने vanilla INT8 की तुलना में total train-loop time कम किया, लेकिन warmed measured step vanilla INT8 से थोड़ा धीमा था।
 
 ## Example Models
 

--- a/documentation/experimental/CONVROT.ja.md
+++ b/documentation/experimental/CONVROT.ja.md
@@ -2,7 +2,7 @@
 
 SimpleTuner は、SDNQ の Hadamard 経路で ConvRot 形式の回転量子化を提供します。凍結したベースモデルを int8 で実行し、LoRA や LyCORIS アダプターを bf16 などの混合精度 dtype のまま学習する大型 PEFT ジョブに向いています。
 
-これは外部 ConvRot checkpoint の独自 buffer を直接読み込む機能ではありません。元のモデル重みを読み込み、モデルロード後に SimpleTuner が SDNQ で学習対象コンポーネントを量子化します。
+SimpleTuner は任意の ConvRot sidecar buffer を独立した機能として消費するものではありません。通常の path では元のモデル重みを読み込み、モデルロード後に SimpleTuner が SDNQ で学習対象コンポーネントを量子化します。single-file の quantized transformer weight に対応した loader では、互換性のある INT8 ConvRot transformer safetensors を読み込み、SDNQ Hadamard 経由で実行することもできます。
 
 ## クイック設定
 
@@ -11,7 +11,7 @@ SimpleTuner は、SDNQ の Hadamard 経路で ConvRot 形式の回転量子化�
   "base_model_precision": "int8-sdnq",
   "gradient_checkpointing": true,
   "sdnq_use_hadamard": true,
-  "sdnq_hadamard_group_size": 128,
+  "sdnq_hadamard_group_size": 256,
   "sdnq_group_size": -1,
   "sdnq_use_quantized_matmul": true,
   "sdnq_compile_mode": "compile"
@@ -24,7 +24,7 @@ SimpleTuner は、SDNQ の Hadamard 経路で ConvRot 形式の回転量子化�
 
 - `base_model_precision: int8-sdnq` は、学習対象のベースコンポーネントに SDNQ int8 のロード後量子化を選びます。
 - `sdnq_use_hadamard: true` は Hadamard 回転経路を有効にします。
-- `sdnq_hadamard_group_size: 128` は SDNQ が使う回転ブロックサイズです。
+- `sdnq_hadamard_group_size: 256` は SDNQ が使う回転ブロックサイズです。ConvRot には `256` を使います。より小さいブロックは QuaRot 風の path を選択します。
 - `sdnq_group_size: -1` は静的な行単位 weight scale を使います。主にフルファインチューニング向けの動的 grouped 経路で、学習中に重みが再量子化されるのを避けます。
 - `sdnq_use_quantized_matmul: true` は SDNQ int8 matmul 経路を有効に保ちます。
 - `sdnq_compile_mode: compile` は SDNQ が対応する量子化 helper と kernel をコンパイルします。
@@ -38,10 +38,28 @@ SimpleTuner は、SDNQ の Hadamard 経路で ConvRot 形式の回転量子化�
 
 ## 要件と制限
 
-- Hadamard サポートを含む SDNQ build を使ってください。H100 検証では upstream SDNQ `0.2.3` を使いました。PyPI `0.2.2` には同じ bf16 Hadamard 修正が含まれていません。
+- SimpleTuner は、対応している install target では SDNQ training dependency をインストールして設定します。
 - このプリセットは大型モデルの LoRA と LyCORIS 学習向けです。SDNQ Hadamard でのフルファインチューニングは別途検証が必要です。
 - 初期 step は遅くなることがあります。SDNQ と Torch がセットアップや初期学習中に kernel をコンパイルするためです。
 - 検証と推論は、学習時と同じく量子化済みベースモデルと有効なアダプターを使います。
+- ConvRot は量子化による劣化を減らせますが、すべての model で INT8 が BF16 や FP8 と一致する保証ではありません。長い run の前に loss curve と生成 sample の両方を検証してください。
+- SDNQ ConvRot の standalone inference は、この training guide の範囲外です。直接 SDNQ inference API を使う場合は、SimpleTuner の training 設定より API 変更が多いため、[SDNQ upstream documentation](https://github.com/Disty0/sdnq) に従ってください。
+
+## 測定結果
+
+これは synthetic な GEMM-only 結果ではなく、モデル別の SimpleTuner 実 trainer 測定です。`Loop s/step` は wrapper の training loop wall time/step です。`Mean step` は最初の 5 warmup step を除外しています。
+
+| Model | GPU | Steps | Weight path | Loop s/step | Mean step | p50 | p95 | Peak allocated VRAM |
+| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| Z-Image Turbo LoRA | H100 80GB | 1000 | SDNQ Hadamard post-load quantization | 1.107 | 1.087 | 1.071 | 1.109 | 9.70 GiB |
+| Z-Image Turbo LoRA | L40S | 1000 | SDNQ Hadamard post-load quantization | 1.026 | 1.018 | 1.002 | 1.040 | 9.66 GiB |
+| Z-Image Turbo LoRA | L40S | 1000 | baseline SDNQ Hadamard path | 1.131 | 1.072 | 1.055 | 1.102 | 9.66 GiB |
+| Krea 2 Raw LoRA | H100 80GB | 100 | `lilcheaty/Krea2-INT8-ConvRot` transformer weights、diffusers attention | 0.787 | 0.399 | 0.397 | 0.411 | 32.15 GiB |
+| Krea 2 Raw LoRA | L40S | 100 | `lilcheaty/Krea2-INT8-ConvRot` transformer weights、cuDNN attention | 0.945 | 0.794 | 0.793 | 0.799 | 31.89 GiB |
+| Mage-Flow LoRA, square crop | H100 80GB | 100 | SDNQ INT8 vanilla post-load quantization | 1.113 | 0.277 | 0.276 | 0.286 | 20.12 GiB |
+| Mage-Flow LoRA, square crop | H100 80GB | 100 | SDNQ ConvRot 256 post-load quantization | 0.436 | 0.299 | 0.297 | 0.308 | 20.15 GiB |
+
+warm cache の L40S Z-Image 比較では、現行 path は baseline SDNQ Hadamard path より train-loop wall time で 10.3%、測定 train-step 平均で 5.2% 高速でした。Krea 2 の各行は、Hugging Face の INT8 ConvRot transformer weight path を実際の 100 step training run で検証したものです。Mage-Flow の行は model-specific validation が重要であることを示します。Square crop は shape compile churn の大半を取り除き、ConvRot は vanilla INT8 より総 train-loop time を短くしましたが、warm 後の measured step は vanilla INT8 より少し遅くなりました。
 
 ## サンプルモデル
 

--- a/documentation/experimental/CONVROT.md
+++ b/documentation/experimental/CONVROT.md
@@ -2,7 +2,7 @@
 
 SimpleTuner exposes ConvRot-style rotation through SDNQ's Hadamard path. This is useful for large PEFT jobs where the frozen base model should run as int8 while LoRA or LyCORIS adapters stay trainable in bf16.
 
-This does not load external ConvRot checkpoint buffers directly. Load the original model weights, then let SimpleTuner quantize the trained component with SDNQ after model load.
+SimpleTuner does not consume arbitrary ConvRot sidecar buffers as a separate feature. For the common path, load the original model weights and let SimpleTuner quantize the trained component with SDNQ after model load. Model loaders that support single-file quantized transformer weights can also load compatible INT8 ConvRot transformer safetensors and run them through SDNQ Hadamard.
 
 ## Quick Setup
 
@@ -11,7 +11,7 @@ This does not load external ConvRot checkpoint buffers directly. Load the origin
   "base_model_precision": "int8-sdnq",
   "gradient_checkpointing": true,
   "sdnq_use_hadamard": true,
-  "sdnq_hadamard_group_size": 128,
+  "sdnq_hadamard_group_size": 256,
   "sdnq_group_size": -1,
   "sdnq_use_quantized_matmul": true,
   "sdnq_compile_mode": "compile"
@@ -24,7 +24,7 @@ For large models, keep `quantize_via` on `cpu` unless the model guide says other
 
 - `base_model_precision: int8-sdnq` selects SDNQ int8 post-load quantization for the trained base component.
 - `sdnq_use_hadamard: true` enables the Hadamard rotation path.
-- `sdnq_hadamard_group_size: 128` sets the rotation block size used by SDNQ.
+- `sdnq_hadamard_group_size: 256` sets the rotation block size used by SDNQ. Use `256` for ConvRot; smaller blocks select a QuaRot-style path.
 - `sdnq_group_size: -1` uses static full-row weight scales. This avoids the dynamic grouped path that is mainly targeted at full fine-tuning and can requantize weights during training.
 - `sdnq_use_quantized_matmul: true` keeps the SDNQ int8 matmul path active.
 - `sdnq_compile_mode: compile` compiles the SDNQ quantization helpers and kernels where SDNQ supports it.
@@ -38,10 +38,28 @@ Some models load fixed helper adapters before training. Z-Image Turbo, for examp
 
 ## Requirements And Limits
 
-- Use an SDNQ build with Hadamard support. The H100 verification used upstream SDNQ `0.2.3`; PyPI `0.2.2` does not include the same bf16 Hadamard fix.
+- SimpleTuner installs and configures the SDNQ training dependency for supported install targets.
 - This preset is intended for LoRA and LyCORIS training of large models. Full fine-tuning with SDNQ Hadamard needs separate validation.
 - First steps can be slow because SDNQ and Torch compile kernels during setup and early training.
 - Validation and inference use the quantized base model plus the active adapter, the same as training.
+- ConvRot can reduce quantization damage, but it is not a guarantee that INT8 will match BF16 or FP8 for every model. Validate both loss curves and generated samples before committing to a long run.
+- Standalone inference with SDNQ ConvRot is outside this training guide. For direct SDNQ inference APIs, follow the [upstream SDNQ documentation](https://github.com/Disty0/sdnq) because that API changes more often than SimpleTuner's training configuration.
+
+## Measured Results
+
+These are model-specific SimpleTuner trainer measurements, not synthetic GEMM-only results. `Loop s/step` is the wrapper's train-loop wall time per step. `Mean step` excludes the first five warmup steps.
+
+| Model | GPU | Steps | Weight path | Loop s/step | Mean step | p50 | p95 | Peak allocated VRAM |
+| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| Z-Image Turbo LoRA | H100 80GB | 1000 | SDNQ Hadamard post-load quantization | 1.107 | 1.087 | 1.071 | 1.109 | 9.70 GiB |
+| Z-Image Turbo LoRA | L40S | 1000 | SDNQ Hadamard post-load quantization | 1.026 | 1.018 | 1.002 | 1.040 | 9.66 GiB |
+| Z-Image Turbo LoRA | L40S | 1000 | baseline SDNQ Hadamard path | 1.131 | 1.072 | 1.055 | 1.102 | 9.66 GiB |
+| Krea 2 Raw LoRA | H100 80GB | 100 | `lilcheaty/Krea2-INT8-ConvRot` transformer weights, diffusers attention | 0.787 | 0.399 | 0.397 | 0.411 | 32.15 GiB |
+| Krea 2 Raw LoRA | L40S | 100 | `lilcheaty/Krea2-INT8-ConvRot` transformer weights, cuDNN attention | 0.945 | 0.794 | 0.793 | 0.799 | 31.89 GiB |
+| Mage-Flow LoRA, square crop | H100 80GB | 100 | SDNQ INT8 vanilla post-load quantization | 1.113 | 0.277 | 0.276 | 0.286 | 20.12 GiB |
+| Mage-Flow LoRA, square crop | H100 80GB | 100 | SDNQ ConvRot 256 post-load quantization | 0.436 | 0.299 | 0.297 | 0.308 | 20.15 GiB |
+
+On the warmed L40S Z-Image comparison, the current path was 10.3% faster by train-loop wall time and 5.2% faster by measured train-step mean than the baseline SDNQ Hadamard path. The Krea 2 rows verify the Hugging Face INT8 ConvRot transformer-weight path in real 100-step training runs. The Mage-Flow rows show why model-specific validation matters: square crop removed most shape-compile churn, ConvRot reduced total train-loop time versus vanilla INT8, but the warmed measured step was slightly slower than vanilla INT8.
 
 ## Example Models
 

--- a/documentation/experimental/CONVROT.pt-BR.md
+++ b/documentation/experimental/CONVROT.pt-BR.md
@@ -2,7 +2,7 @@
 
 O SimpleTuner expõe uma rotação no estilo ConvRot pelo caminho Hadamard do SDNQ. Isso é útil para jobs PEFT grandes em que o modelo base congelado deve rodar em int8 enquanto adaptadores LoRA ou LyCORIS continuam treináveis em bf16.
 
-Isto não carrega diretamente buffers de checkpoints ConvRot externos. Carregue os pesos originais do modelo e deixe o SimpleTuner quantizar o componente treinado com SDNQ depois do carregamento.
+O SimpleTuner não consome buffers sidecar ConvRot arbitrários como um recurso separado. No caminho comum, carregue os pesos originais do modelo e deixe o SimpleTuner quantizar o componente treinado com SDNQ depois do carregamento. Loaders que aceitam pesos transformer quantizados em arquivo único também podem carregar safetensors transformer INT8 ConvRot compatíveis e executá-los via SDNQ Hadamard.
 
 ## Configuração rápida
 
@@ -11,7 +11,7 @@ Isto não carrega diretamente buffers de checkpoints ConvRot externos. Carregue 
   "base_model_precision": "int8-sdnq",
   "gradient_checkpointing": true,
   "sdnq_use_hadamard": true,
-  "sdnq_hadamard_group_size": 128,
+  "sdnq_hadamard_group_size": 256,
   "sdnq_group_size": -1,
   "sdnq_use_quantized_matmul": true,
   "sdnq_compile_mode": "compile"
@@ -24,7 +24,7 @@ Para modelos grandes, mantenha `quantize_via` em `cpu`, a menos que o guia do mo
 
 - `base_model_precision: int8-sdnq` seleciona quantização SDNQ int8 pós-carregamento para o componente base treinado.
 - `sdnq_use_hadamard: true` ativa o caminho de rotação Hadamard.
-- `sdnq_hadamard_group_size: 128` define o tamanho de bloco de rotação usado pelo SDNQ.
+- `sdnq_hadamard_group_size: 256` define o tamanho de bloco de rotação usado pelo SDNQ. Use `256` para ConvRot; blocos menores selecionam um caminho no estilo QuaRot.
 - `sdnq_group_size: -1` usa scales estáticos por linha de peso. Isso evita o caminho dinâmico agrupado, mais voltado para full fine-tuning, que pode requantizar pesos durante o treino.
 - `sdnq_use_quantized_matmul: true` mantém ativo o caminho SDNQ int8 matmul.
 - `sdnq_compile_mode: compile` compila helpers e kernels de quantização onde o SDNQ oferece suporte.
@@ -38,10 +38,28 @@ Alguns modelos carregam adaptadores auxiliares fixos antes do treino. O Z-Image 
 
 ## Requisitos e limites
 
-- Use um build do SDNQ com suporte a Hadamard. A verificação em H100 usou o SDNQ upstream `0.2.3`; PyPI `0.2.2` não inclui a mesma correção Hadamard para bf16.
+- O SimpleTuner instala e configura a dependência de treinamento SDNQ para os targets de instalação suportados.
 - Este preset é voltado para treino LoRA e LyCORIS em modelos grandes. Full fine-tuning com SDNQ Hadamard precisa de validação separada.
 - Os primeiros steps podem ser lentos porque SDNQ e Torch compilam kernels durante a inicialização e o início do treino.
 - Validação e inferência usam o modelo base quantizado mais o adaptador ativo, igual ao treino.
+- ConvRot pode reduzir o dano de quantização, mas não garante que INT8 iguale BF16 ou FP8 em todos os modelos. Valide a curva de loss e as amostras geradas antes de iniciar um run longo.
+- Inferência standalone com SDNQ ConvRot fica fora deste guia de treinamento. Para APIs diretas de inferência SDNQ, siga a [documentação upstream do SDNQ](https://github.com/Disty0/sdnq) porque essa API muda com mais frequência do que a configuração de treinamento do SimpleTuner.
+
+## Resultados medidos
+
+Estas são medições do trainer real do SimpleTuner por modelo, não resultados sintéticos apenas de GEMM. `Loop s/step` é o tempo de parede do loop de treinamento por passo. `Passo médio` exclui os cinco primeiros passos de warmup.
+
+| Modelo | GPU | Passos | Caminho dos pesos | Loop s/step | Passo médio | p50 | p95 | VRAM alocada máxima |
+| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| Z-Image Turbo LoRA | H100 80GB | 1000 | quantização post-load SDNQ Hadamard | 1.107 | 1.087 | 1.071 | 1.109 | 9.70 GiB |
+| Z-Image Turbo LoRA | L40S | 1000 | quantização post-load SDNQ Hadamard | 1.026 | 1.018 | 1.002 | 1.040 | 9.66 GiB |
+| Z-Image Turbo LoRA | L40S | 1000 | baseline SDNQ Hadamard | 1.131 | 1.072 | 1.055 | 1.102 | 9.66 GiB |
+| Krea 2 Raw LoRA | H100 80GB | 100 | pesos transformer `lilcheaty/Krea2-INT8-ConvRot`, atenção diffusers | 0.787 | 0.399 | 0.397 | 0.411 | 32.15 GiB |
+| Krea 2 Raw LoRA | L40S | 100 | pesos transformer `lilcheaty/Krea2-INT8-ConvRot`, atenção cuDNN | 0.945 | 0.794 | 0.793 | 0.799 | 31.89 GiB |
+| Mage-Flow LoRA, crop quadrado | H100 80GB | 100 | quantização post-load SDNQ INT8 vanilla | 1.113 | 0.277 | 0.276 | 0.286 | 20.12 GiB |
+| Mage-Flow LoRA, crop quadrado | H100 80GB | 100 | quantização post-load SDNQ ConvRot 256 | 0.436 | 0.299 | 0.297 | 0.308 | 20.15 GiB |
+
+Na comparação Z-Image com cache quente na L40S, o caminho atual foi 10.3% mais rápido pelo tempo de loop e 5.2% mais rápido pela média medida de passo do que o baseline SDNQ Hadamard. As linhas Krea 2 verificam o caminho de pesos transformer INT8 ConvRot do Hugging Face em execuções reais de treinamento de 100 passos. As linhas Mage-Flow mostram por que a validação por modelo importa: o crop quadrado removeu a maior parte do churn de compilação por formas, ConvRot reduziu o tempo total do loop frente ao INT8 vanilla, mas o passo medido ja quente foi um pouco mais lento que INT8 vanilla.
 
 ## Modelos de exemplo
 

--- a/documentation/experimental/CONVROT.zh.md
+++ b/documentation/experimental/CONVROT.zh.md
@@ -2,7 +2,7 @@
 
 SimpleTuner 通过 SDNQ 的 Hadamard 路径提供 ConvRot 风格的旋转量化。它适合大型 PEFT 训练：冻结的基础模型使用 int8 计算，LoRA 或 LyCORIS 适配器继续以 bf16 等混合精度 dtype 训练。
 
-这不会直接读取外部 ConvRot checkpoint 中的自定义 buffer。请加载原始模型权重，然后让 SimpleTuner 在模型加载后用 SDNQ 量化训练组件。
+SimpleTuner 不会把任意 ConvRot sidecar buffer 当作独立功能读取。常见路径是加载原始模型权重，然后让 SimpleTuner 在模型加载后用 SDNQ 量化训练组件。支持单文件量化 transformer 权重的模型 loader 也可以加载兼容的 INT8 ConvRot transformer safetensors，并通过 SDNQ Hadamard 执行。
 
 ## 快速配置
 
@@ -11,7 +11,7 @@ SimpleTuner 通过 SDNQ 的 Hadamard 路径提供 ConvRot 风格的旋转量化�
   "base_model_precision": "int8-sdnq",
   "gradient_checkpointing": true,
   "sdnq_use_hadamard": true,
-  "sdnq_hadamard_group_size": 128,
+  "sdnq_hadamard_group_size": 256,
   "sdnq_group_size": -1,
   "sdnq_use_quantized_matmul": true,
   "sdnq_compile_mode": "compile"
@@ -24,7 +24,7 @@ SimpleTuner 通过 SDNQ 的 Hadamard 路径提供 ConvRot 风格的旋转量化�
 
 - `base_model_precision: int8-sdnq` 为训练的基础组件选择 SDNQ int8 后加载量化。
 - `sdnq_use_hadamard: true` 启用 Hadamard 旋转路径。
-- `sdnq_hadamard_group_size: 128` 设置 SDNQ 使用的旋转块大小。
+- `sdnq_hadamard_group_size: 256` 设置 SDNQ 使用的旋转块大小。ConvRot 使用 `256`；更小的块会选择类似 QuaRot 的路径。
 - `sdnq_group_size: -1` 使用静态的按行权重 scale，避免主要面向全量微调的动态分组路径在训练中重新量化权重。
 - `sdnq_use_quantized_matmul: true` 保持 SDNQ int8 matmul 路径启用。
 - `sdnq_compile_mode: compile` 在 SDNQ 支持的位置编译量化 helper 和 kernel。
@@ -38,10 +38,28 @@ SimpleTuner 通过 SDNQ 的 Hadamard 路径提供 ConvRot 风格的旋转量化�
 
 ## 要求与限制
 
-- 使用带 Hadamard 支持的 SDNQ 构建。H100 验证使用的是上游 SDNQ `0.2.3`；PyPI `0.2.2` 不包含相同的 bf16 Hadamard 修复。
+- SimpleTuner 会为支持的安装目标安装并配置 SDNQ 训练依赖。
 - 该预设面向大型模型的 LoRA 和 LyCORIS 训练。SDNQ Hadamard 的全量微调需要单独验证。
 - 初始 step 可能较慢，因为 SDNQ 和 Torch 会在初始化和早期训练时编译 kernel。
 - 验证和推理使用量化后的基础模型加当前适配器，和训练一致。
+- ConvRot 可以降低量化损伤，但不保证 INT8 在每个模型上都能匹配 BF16 或 FP8。开始长训练前，请同时验证 loss curve 和生成样本。
+- 使用 SDNQ ConvRot 做 standalone inference 不属于本训练指南范围。若要直接使用 SDNQ inference API，请参考 [SDNQ 上游文档](https://github.com/Disty0/sdnq)，因为该 API 比 SimpleTuner 训练配置变化更频繁。
+
+## 实测结果
+
+这些是按模型测得的 SimpleTuner 真实 trainer 数据，不是只测 GEMM 的合成结果。`Loop s/step` 是 wrapper 记录的训练循环 wall time 每步。`Mean step` 排除了前五个 warmup step。
+
+| 模型 | GPU | 步数 | 权重路径 | Loop s/step | Mean step | p50 | p95 | 峰值已分配 VRAM |
+| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| Z-Image Turbo LoRA | H100 80GB | 1000 | SDNQ Hadamard post-load quantization | 1.107 | 1.087 | 1.071 | 1.109 | 9.70 GiB |
+| Z-Image Turbo LoRA | L40S | 1000 | SDNQ Hadamard post-load quantization | 1.026 | 1.018 | 1.002 | 1.040 | 9.66 GiB |
+| Z-Image Turbo LoRA | L40S | 1000 | baseline SDNQ Hadamard 路径 | 1.131 | 1.072 | 1.055 | 1.102 | 9.66 GiB |
+| Krea 2 Raw LoRA | H100 80GB | 100 | `lilcheaty/Krea2-INT8-ConvRot` transformer 权重，diffusers attention | 0.787 | 0.399 | 0.397 | 0.411 | 32.15 GiB |
+| Krea 2 Raw LoRA | L40S | 100 | `lilcheaty/Krea2-INT8-ConvRot` transformer 权重，cuDNN attention | 0.945 | 0.794 | 0.793 | 0.799 | 31.89 GiB |
+| Mage-Flow LoRA，square crop | H100 80GB | 100 | SDNQ INT8 vanilla post-load quantization | 1.113 | 0.277 | 0.276 | 0.286 | 20.12 GiB |
+| Mage-Flow LoRA，square crop | H100 80GB | 100 | SDNQ ConvRot 256 post-load quantization | 0.436 | 0.299 | 0.297 | 0.308 | 20.15 GiB |
+
+在 warm cache 的 L40S Z-Image 对比中，当前路径按 train-loop wall time 比 baseline SDNQ Hadamard 路径快 10.3%，按实测 train-step 平均快 5.2%。Krea 2 各行验证了 Hugging Face INT8 ConvRot transformer 权重路径在真实 100 步训练运行中的可用性。Mage-Flow 各行说明为什么必须按模型验证：square crop 去掉了大部分 shape compile churn，ConvRot 相比 vanilla INT8 降低了总 train-loop 时间，但 warm 后的实测单步略慢于 vanilla INT8。
 
 ## 示例模型
 

--- a/documentation/index.es.md
+++ b/documentation/index.es.md
@@ -72,9 +72,9 @@
 
     ---
 
-    Funciones de investigación como AnyFlow, cuantización SDNQ Hadamard estilo ConvRot, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention y Video CREPA
+    Funciones de investigación como AnyFlow, cuantización SDNQ Hadamard estilo ConvRot, checkpointing estilo Unsloth, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention y Video CREPA
 
-    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
+    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Unsloth Checkpointing](experimental/UNSLOTH_CHECKPOINTING.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
 
 </div>
 

--- a/documentation/index.hi.md
+++ b/documentation/index.hi.md
@@ -72,9 +72,9 @@
 
     ---
 
-    AnyFlow, ConvRot-style SDNQ Hadamard quantization, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention और Video CREPA जैसी research features
+    AnyFlow, ConvRot-style SDNQ Hadamard quantization, Unsloth-style checkpointing, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention और Video CREPA जैसी research features
 
-    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
+    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Unsloth Checkpointing](experimental/UNSLOTH_CHECKPOINTING.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
 
 </div>
 

--- a/documentation/index.ja.md
+++ b/documentation/index.ja.md
@@ -72,9 +72,9 @@
 
     ---
 
-    AnyFlow、ConvRot 形式の SDNQ Hadamard 量子化、Prompt2Effect、Self-Flow、Flow-DPO、LayerSync、Diff2Flow、Metal Flash Attention、Video CREPA などの研究向け機能
+    AnyFlow、ConvRot 形式の SDNQ Hadamard 量子化、Unsloth 形式 checkpointing、Prompt2Effect、Self-Flow、Flow-DPO、LayerSync、Diff2Flow、Metal Flash Attention、Video CREPA などの研究向け機能
 
-    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
+    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Unsloth Checkpointing](experimental/UNSLOTH_CHECKPOINTING.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
 
 </div>
 

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -72,9 +72,9 @@
 
     ---
 
-    Research features such as AnyFlow, ConvRot-style SDNQ Hadamard quantization, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention, and Video CREPA
+    Research features such as AnyFlow, ConvRot-style SDNQ Hadamard quantization, Unsloth-style checkpointing, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention, and Video CREPA
 
-    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
+    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Unsloth Checkpointing](experimental/UNSLOTH_CHECKPOINTING.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
 
 </div>
 

--- a/documentation/index.pt-BR.md
+++ b/documentation/index.pt-BR.md
@@ -72,9 +72,9 @@
 
     ---
 
-    Recursos de pesquisa como AnyFlow, quantização SDNQ Hadamard no estilo ConvRot, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention e Video CREPA
+    Recursos de pesquisa como AnyFlow, quantização SDNQ Hadamard no estilo ConvRot, checkpointing estilo Unsloth, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention e Video CREPA
 
-    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
+    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Unsloth Checkpointing](experimental/UNSLOTH_CHECKPOINTING.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
 
 </div>
 

--- a/documentation/index.zh.md
+++ b/documentation/index.zh.md
@@ -72,9 +72,9 @@
 
     ---
 
-    AnyFlow、ConvRot 风格的 SDNQ Hadamard 量化、Prompt2Effect、Self-Flow、Flow-DPO、LayerSync、Diff2Flow、Metal Flash Attention、Video CREPA 等研究功能
+    AnyFlow、ConvRot 风格的 SDNQ Hadamard 量化、Unsloth 风格 checkpointing、Prompt2Effect、Self-Flow、Flow-DPO、LayerSync、Diff2Flow、Metal Flash Attention、Video CREPA 等研究功能
 
-    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
+    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Unsloth Checkpointing](experimental/UNSLOTH_CHECKPOINTING.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
 
 </div>
 

--- a/simpletuner/examples/cosmos3-edge-image-24g.lycoris-lokr/config.json
+++ b/simpletuner/examples/cosmos3-edge-image-24g.lycoris-lokr/config.json
@@ -37,7 +37,7 @@
     "report_to": "none",
     "sdnq_compile_mode": "compile",
     "sdnq_group_size": -1,
-    "sdnq_hadamard_group_size": 128,
+    "sdnq_hadamard_group_size": 256,
     "sdnq_use_hadamard": true,
     "sdnq_use_quantized_matmul": true,
     "seed": 42,

--- a/simpletuner/examples/cosmos3-nano-image-24g.lycoris-lokr/config.json
+++ b/simpletuner/examples/cosmos3-nano-image-24g.lycoris-lokr/config.json
@@ -38,7 +38,7 @@
     "report_to": "none",
     "sdnq_compile_mode": "compile",
     "sdnq_group_size": -1,
-    "sdnq_hadamard_group_size": 128,
+    "sdnq_hadamard_group_size": 256,
     "sdnq_use_hadamard": true,
     "sdnq_use_quantized_matmul": true,
     "seed": 42,

--- a/simpletuner/examples/cosmos3-nano-image-32g.lycoris-lokr/config.json
+++ b/simpletuner/examples/cosmos3-nano-image-32g.lycoris-lokr/config.json
@@ -38,7 +38,7 @@
     "report_to": "none",
     "sdnq_compile_mode": "compile",
     "sdnq_group_size": -1,
-    "sdnq_hadamard_group_size": 128,
+    "sdnq_hadamard_group_size": 256,
     "sdnq_use_hadamard": true,
     "sdnq_use_quantized_matmul": true,
     "seed": 42,

--- a/simpletuner/examples/cosmos3-super-image-48g.lycoris-lokr/config.json
+++ b/simpletuner/examples/cosmos3-super-image-48g.lycoris-lokr/config.json
@@ -37,7 +37,7 @@
     "report_to": "none",
     "sdnq_compile_mode": "compile",
     "sdnq_group_size": -1,
-    "sdnq_hadamard_group_size": 128,
+    "sdnq_hadamard_group_size": 256,
     "sdnq_use_hadamard": true,
     "sdnq_use_quantized_matmul": true,
     "seed": 42,

--- a/simpletuner/examples/cosmos3-super-image-80g.lycoris-lokr/config.json
+++ b/simpletuner/examples/cosmos3-super-image-80g.lycoris-lokr/config.json
@@ -38,7 +38,7 @@
     "report_to": "none",
     "sdnq_compile_mode": "compile",
     "sdnq_group_size": -1,
-    "sdnq_hadamard_group_size": 128,
+    "sdnq_hadamard_group_size": 256,
     "sdnq_use_hadamard": true,
     "sdnq_use_quantized_matmul": true,
     "seed": 42,

--- a/simpletuner/examples/flux2.peft-lora+TREAD/config.json
+++ b/simpletuner/examples/flux2.peft-lora+TREAD/config.json
@@ -28,7 +28,7 @@
     "report_to": "none",
     "sdnq_compile_mode": "compile",
     "sdnq_group_size": -1,
-    "sdnq_hadamard_group_size": 128,
+    "sdnq_hadamard_group_size": 256,
     "sdnq_use_hadamard": true,
     "sdnq_use_quantized_matmul": true,
     "seed": 42,

--- a/simpletuner/examples/flux2.peft-lora/config.json
+++ b/simpletuner/examples/flux2.peft-lora/config.json
@@ -28,7 +28,7 @@
     "report_to": "none",
     "sdnq_compile_mode": "compile",
     "sdnq_group_size": -1,
-    "sdnq_hadamard_group_size": 128,
+    "sdnq_hadamard_group_size": 256,
     "sdnq_use_hadamard": true,
     "sdnq_use_quantized_matmul": true,
     "seed": 42,


### PR DESCRIPTION
This pull request updates the experimental ConvRot documentation in all supported languages to clarify loader compatibility, recommend a new default Hadamard group size, and add real-world training benchmarks. The most important changes are grouped below.

**Loader and Quantization Path Clarifications**
* All docs now clarify that `SimpleTuner` does not consume arbitrary ConvRot sidecar buffers as a standalone feature, but supports compatible single-file INT8 ConvRot transformer safetensors via SDNQ Hadamard if the loader supports it. [[1]](diffhunk://#diff-8558ca2d92b0c8f908e32e16d9fdad4b57bc017287bd6333df78702d8e2c2c2dL5-R5) [[2]](diffhunk://#diff-e6428317e0316c2e6bbd50d10b7425b859dc97242598c9bcd6fa473423cc2450L5-R5) [[3]](diffhunk://#diff-92fa37945f98d1e6ac1ce6cc3197d444f5f634e9671118a635b1680e57218a27L5-R5) [[4]](diffhunk://#diff-d46f6ea4e5745e3f0cdeac35434200525f41ccb734088128a99b1c118c9e9b04L5-R5) [[5]](diffhunk://#diff-b7c365c71e8d13e57492291d6f1232b980e878dab2f84948778b89b3b6856c1bL5-R5)

**Configuration Recommendations**
* The recommended default for `sdnq_hadamard_group_size` is changed from `128` to `256` in both code snippets and option explanations, with notes that smaller blocks select a QuaRot-style path. [[1]](diffhunk://#diff-8558ca2d92b0c8f908e32e16d9fdad4b57bc017287bd6333df78702d8e2c2c2dL14-R14) [[2]](diffhunk://#diff-8558ca2d92b0c8f908e32e16d9fdad4b57bc017287bd6333df78702d8e2c2c2dL27-R27) [[3]](diffhunk://#diff-92fa37945f98d1e6ac1ce6cc3197d444f5f634e9671118a635b1680e57218a27L14-R14) [[4]](diffhunk://#diff-92fa37945f98d1e6ac1ce6cc3197d444f5f634e9671118a635b1680e57218a27L27-R27) [[5]](diffhunk://#diff-d46f6ea4e5745e3f0cdeac35434200525f41ccb734088128a99b1c118c9e9b04L14-R14) [[6]](diffhunk://#diff-d46f6ea4e5745e3f0cdeac35434200525f41ccb734088128a99b1c118c9e9b04L27-R27) [[7]](diffhunk://#diff-b7c365c71e8d13e57492291d6f1232b980e878dab2f84948778b89b3b6856c1bL14-R14) [[8]](diffhunk://#diff-b7c365c71e8d13e57492291d6f1232b980e878dab2f84948778b89b3b6856c1bL27-R27)

**Requirements and Dependency Handling**
* Documentation now states that `SimpleTuner` installs and configures the SDNQ training dependency automatically for supported install targets, replacing the prior manual SDNQ build instructions. [[1]](diffhunk://#diff-8558ca2d92b0c8f908e32e16d9fdad4b57bc017287bd6333df78702d8e2c2c2dL41-R62) [[2]](diffhunk://#diff-92fa37945f98d1e6ac1ce6cc3197d444f5f634e9671118a635b1680e57218a27L41-R62) [[3]](diffhunk://#diff-d46f6ea4e5745e3f0cdeac35434200525f41ccb734088128a99b1c118c9e9b04L41-R62) [[4]](diffhunk://#diff-b7c365c71e8d13e57492291d6f1232b980e878dab2f84948778b89b3b6856c1bL41-R62)

**Quantization Guidance and Caveats**
* New warnings are added that ConvRot can reduce quantization damage, but INT8 performance is not guaranteed to match BF16/FP8 for all models; users are advised to validate loss curves and generated samples before long training runs. [[1]](diffhunk://#diff-8558ca2d92b0c8f908e32e16d9fdad4b57bc017287bd6333df78702d8e2c2c2dL41-R62) [[2]](diffhunk://#diff-92fa37945f98d1e6ac1ce6cc3197d444f5f634e9671118a635b1680e57218a27L41-R62) [[3]](diffhunk://#diff-d46f6ea4e5745e3f0cdeac35434200525f41ccb734088128a99b1c118c9e9b04L41-R62) [[4]](diffhunk://#diff-b7c365c71e8d13e57492291d6f1232b980e878dab2f84948778b89b3b6856c1bL41-R62)
* Standalone inference with SDNQ ConvRot is explicitly out of scope for these guides, with pointers to upstream SDNQ documentation for direct inference API usage. [[1]](diffhunk://#diff-8558ca2d92b0c8f908e32e16d9fdad4b57bc017287bd6333df78702d8e2c2c2dL41-R62) [[2]](diffhunk://#diff-92fa37945f98d1e6ac1ce6cc3197d444f5f634e9671118a635b1680e57218a27L41-R62) [[3]](diffhunk://#diff-d46f6ea4e5745e3f0cdeac35434200525f41ccb734088128a99b1c118c9e9b04L41-R62) [[4]](diffhunk://#diff-b7c365c71e8d13e57492291d6f1232b980e878dab2f84948778b89b3b6856c1bL41-R62)

**Benchmark Results**
* All language versions now include a new "Measured Results" section with real SimpleTuner training loop timings and VRAM usage for several models and configurations, illustrating the performance impact of ConvRot and the importance of model-specific validation. [[1]](diffhunk://#diff-8558ca2d92b0c8f908e32e16d9fdad4b57bc017287bd6333df78702d8e2c2c2dL41-R62) [[2]](diffhunk://#diff-92fa37945f98d1e6ac1ce6cc3197d444f5f634e9671118a635b1680e57218a27L41-R62) [[3]](diffhunk://#diff-d46f6ea4e5745e3f0cdeac35434200525f41ccb734088128a99b1c118c9e9b04L41-R62) [[4]](diffhunk://#diff-b7c365c71e8d13e57492291d6f1232b980e878dab2f84948778b89b3b6856c1bL41-R62)