### PR TITLE
z-image: switch group size for sdnq to 256 to enable convrot correctly

### DIFF
--- a/simpletuner/examples/z-image-turbo.peft-lora/config.json
+++ b/simpletuner/examples/z-image-turbo.peft-lora/config.json
@@ -34,7 +34,7 @@
     "resume_from_checkpoint": "latest",
     "sdnq_compile_mode": "compile",
     "sdnq_group_size": -1,
-    "sdnq_hadamard_group_size": 128,
+    "sdnq_hadamard_group_size": 256,
     "sdnq_use_hadamard": true,
     "sdnq_use_quantized_matmul": true,
     "seed": 42,


### PR DESCRIPTION
This pull request makes a configuration adjustment to the `simpletuner/examples/z-image-turbo.peft-lora/config.json` file. The most important change is an update to the `sdnq_hadamard_group_size` parameter, increasing its value from 128 to 256.

Configuration update:

* Increased the `sdnq_hadamard_group_size` parameter from 128 to 256 in `config.json` to modify the Hadamard group size used during training.