### PR TITLE
convrot: add loss comparison charts (Z-Image, Mage Flow)

### DIFF
--- a/documentation/quickstart/MAGEFLOW.es.md
+++ b/documentation/quickstart/MAGEFLOW.es.md
@@ -119,6 +119,15 @@ Usa 20 pasos para `default`, 30 para `base` y 4 para `turbo` / `edit-turbo`.
 }
 ```
 
-En pruebas rápidas de LoRA para Mage-Flow, la cuantización int8 produjo picos de loss sospechosos frente a FP8 weight-only TorchAO. Evita presets int8 para Mage-Flow salvo que valides la curva de loss en tu dataset. NF4 y otros presets de cuantización pueden seguir siendo útiles.
+Para SDNQ INT8 y ConvRot, prefiere buckets con crop cuadrado mientras validas Mage-Flow. Con buckets de aspecto arbitrario, SDNQ debe compilar y cachear muchas formas de activación, lo que puede dominar ejecuciones cortas. Un smoke LoRA Domokun en H100 80GB con crop cuadrado centrado usó un solo bucket `1.0` y produjo rangos de loss estables en 100 pasos:
+
+| Ruta de precisión | Rango de loss | Loss media | Loop s/step | Paso medio |
+| --- | ---: | ---: | ---: | ---: |
+| BF16 | `0.117..1.17` | `0.5689` | `0.189` | `0.177` |
+| FP8 weight-only TorchAO | `0.120..1.17` | `0.5696` | `0.234` | `0.222` |
+| SDNQ INT8 vanilla | `0.129..1.17` | `0.5736` | `1.113` | `0.277` |
+| SDNQ ConvRot 256 | `0.124..1.17` | `0.5696` | `0.436` | `0.299` |
+
+La misma carga con buckets de aspecto arbitrario paso mucho mas tiempo compilando formas de entrada SDNQ. Mantén el text encoder congelado; el cache inicial es costoso, pero no deberia entrenarse en ejecuciones LoRA normales. NF4 y otros presets de cuantización pueden seguir siendo útiles.
 
 SimpleTuner incluye una copia vendorizada del código MIT de Mage-Flow y lo envuelve en pipelines nativas de Diffusers para validación.

--- a/documentation/quickstart/MAGEFLOW.hi.md
+++ b/documentation/quickstart/MAGEFLOW.hi.md
@@ -119,6 +119,15 @@ Mage-Flow memory optimisation menu में RAMTorch और Musubi block swap p
 }
 ```
 
-Mage-Flow LoRA smoke tests में int8 quantisation ने FP8 weight-only TorchAO की तुलना में suspicious loss spikes दिखाए। अपने dataset पर loss curve validate किए बिना Mage-Flow int8 presets से बचें। NF4 और दूसरे quantisation presets फिर भी उपयोगी हो सकते हैं।
+SDNQ INT8 और ConvRot validate करते समय Mage-Flow के लिए पहले square-crop buckets prefer करें। Arbitrary aspect buckets में SDNQ को कई activation shapes compile/cache करने पड़ते हैं, जो short runs में dominant cost बन सकता है। H100 80GB Domokun LoRA smoke में center square crop ने सिर्फ एक `1.0` bucket इस्तेमाल किया और 100 steps पर stable loss ranges दिए:
+
+| Precision path | Loss range | Mean loss | Loop s/step | Mean step |
+| --- | ---: | ---: | ---: | ---: |
+| BF16 | `0.117..1.17` | `0.5689` | `0.189` | `0.177` |
+| FP8 weight-only TorchAO | `0.120..1.17` | `0.5696` | `0.234` | `0.222` |
+| SDNQ INT8 vanilla | `0.129..1.17` | `0.5736` | `1.113` | `0.277` |
+| SDNQ ConvRot 256 | `0.124..1.17` | `0.5696` | `0.436` | `0.299` |
+
+उसी workload को arbitrary aspect buckets पर चलाने से SDNQ input shapes compile करने में काफी अधिक समय लगा। Text encoder frozen रखें; initial cache pass महंगा है, लेकिन normal LoRA runs में इसे train नहीं करना चाहिए। NF4 और दूसरे quantisation presets फिर भी उपयोगी हो सकते हैं।
 
 SimpleTuner MIT-licensed Mage-Flow code को vendor करता है और validation consistency के लिए native Diffusers pipelines में wrap करता है।

--- a/documentation/quickstart/MAGEFLOW.ja.md
+++ b/documentation/quickstart/MAGEFLOW.ja.md
@@ -119,6 +119,15 @@ Mage-Flow はメモリ最適化メニューに RAMTorch と Musubi block swap �
 }
 ```
 
-Mage-Flow LoRA のスモークテストでは、int8 量子化は FP8 weight-only TorchAO と比べて不自然な loss spike を出しました。自分の dataset で loss curve を確認するまでは、Mage-Flow の int8 preset は避けてください。NF4 など他の量子化 preset は引き続き有用な場合があります。
+SDNQ INT8 と ConvRot を検証する場合、Mage-Flow ではまず square crop bucket を推奨します。任意 aspect bucket では SDNQ が多くの activation shape を compile/cache する必要があり、短い run ではそれが支配的になります。H100 80GB の Domokun LoRA smoke では、center square crop により `1.0` bucket だけを使い、100 steps で安定した loss range になりました。
+
+| Precision path | Loss range | Mean loss | Loop s/step | Mean step |
+| --- | ---: | ---: | ---: | ---: |
+| BF16 | `0.117..1.17` | `0.5689` | `0.189` | `0.177` |
+| FP8 weight-only TorchAO | `0.120..1.17` | `0.5696` | `0.234` | `0.222` |
+| SDNQ INT8 vanilla | `0.129..1.17` | `0.5736` | `1.113` | `0.277` |
+| SDNQ ConvRot 256 | `0.124..1.17` | `0.5696` | `0.436` | `0.299` |
+
+同じ workload を任意 aspect bucket で実行すると、SDNQ input shape の compile にかなり多くの時間を使いました。Text encoder は凍結してください。初回 cache pass は高コストですが、通常の LoRA run で training 対象にするべきではありません。NF4 など他の量子化 preset も有用な場合があります。
 
 SimpleTuner は MIT ライセンスの Mage-Flow コードを vendored し、検証と save hook の一貫性のため Diffusers pipeline で包んでいます。

--- a/documentation/quickstart/MAGEFLOW.md
+++ b/documentation/quickstart/MAGEFLOW.md
@@ -171,7 +171,16 @@ Start with `bf16` when it fits. If it does not, prefer FP8 weight-only TorchAO o
 }
 ```
 
-In Mage-Flow LoRA smoke tests, int8 quantisation produced suspicious loss spikes compared with FP8 weight-only TorchAO. Avoid int8 Mage-Flow presets unless you validate the loss curve on your dataset. NF4 and other SimpleTuner quantisation presets may also be useful for LoRA training. Keep the text encoder frozen; the initial cache pass is expensive but it should not be trained for normal LoRA runs.
+For SDNQ INT8 and ConvRot, prefer square-crop buckets while validating Mage-Flow. With arbitrary aspect buckets, SDNQ has to compile and cache many activation shapes, which can dominate short runs. A H100 80GB Domokun LoRA smoke with center square crop used one `1.0` bucket and produced stable 100-step loss ranges:
+
+| Precision path | Loss range | Mean loss | Loop s/step | Mean step |
+| --- | ---: | ---: | ---: | ---: |
+| BF16 | `0.117..1.17` | `0.5689` | `0.189` | `0.177` |
+| FP8 weight-only TorchAO | `0.120..1.17` | `0.5696` | `0.234` | `0.222` |
+| SDNQ INT8 vanilla | `0.129..1.17` | `0.5736` | `1.113` | `0.277` |
+| SDNQ ConvRot 256 | `0.124..1.17` | `0.5696` | `0.436` | `0.299` |
+
+The same workload with arbitrary aspect buckets spent far more time compiling SDNQ input shapes. Keep the text encoder frozen; the initial cache pass is expensive but it should not be trained for normal LoRA runs. NF4 and other SimpleTuner quantisation presets may also be useful for LoRA training.
 
 ## Implementation notes
 

--- a/documentation/quickstart/MAGEFLOW.pt-BR.md
+++ b/documentation/quickstart/MAGEFLOW.pt-BR.md
@@ -119,6 +119,15 @@ Use cerca de 20 passos para `default`, 30 para `base` e 4 para `turbo` / `edit-t
 }
 ```
 
-Em smoke tests de LoRA para Mage-Flow, a quantização int8 produziu picos suspeitos de loss quando comparada com FP8 weight-only TorchAO. Evite presets int8 para Mage-Flow a menos que você valide a curva de loss no seu dataset. NF4 e outros presets de quantização ainda podem ser úteis.
+Para SDNQ INT8 e ConvRot, prefira buckets com crop quadrado enquanto valida Mage-Flow. Com buckets de aspecto arbitrario, o SDNQ precisa compilar e cachear muitas formas de ativacao, o que pode dominar runs curtos. Um smoke LoRA Domokun em H100 80GB com crop quadrado centralizado usou um unico bucket `1.0` e produziu ranges de loss estaveis em 100 passos:
+
+| Caminho de precisão | Range de loss | Loss media | Loop s/step | Passo medio |
+| --- | ---: | ---: | ---: | ---: |
+| BF16 | `0.117..1.17` | `0.5689` | `0.189` | `0.177` |
+| FP8 weight-only TorchAO | `0.120..1.17` | `0.5696` | `0.234` | `0.222` |
+| SDNQ INT8 vanilla | `0.129..1.17` | `0.5736` | `1.113` | `0.277` |
+| SDNQ ConvRot 256 | `0.124..1.17` | `0.5696` | `0.436` | `0.299` |
+
+A mesma carga com buckets de aspecto arbitrario passou muito mais tempo compilando formas de entrada SDNQ. Mantenha o text encoder congelado; o cache inicial e caro, mas ele nao deve ser treinado em runs LoRA normais. NF4 e outros presets de quantização ainda podem ser úteis.
 
 O SimpleTuner vendoriza o código MIT do Mage-Flow e o envolve em pipelines Diffusers nativas para validação.

--- a/documentation/quickstart/MAGEFLOW.zh.md
+++ b/documentation/quickstart/MAGEFLOW.zh.md
@@ -119,6 +119,15 @@ Mage-Flow 在内存优化菜单中提供 RAMTorch 和 Musubi block swap 预设�
 }
 ```
 
-在 Mage-Flow LoRA 快速测试中，int8 量化相比 FP8 weight-only TorchAO 出现了可疑的 loss 峰值。除非你已经在自己的数据集上验证 loss 曲线，否则请避免使用 Mage-Flow 的 int8 预设。NF4 和其他量化预设仍可能有用。
+验证 SDNQ INT8 和 ConvRot 时，Mage-Flow 建议先使用 square crop bucket。任意宽高比 bucket 会让 SDNQ 编译并缓存很多 activation shape，短跑时这些编译开销可能占主导。H100 80GB 上的 Domokun LoRA smoke 使用 center square crop 后只有一个 `1.0` bucket，100 步 loss range 稳定：
+
+| 精度路径 | Loss range | Mean loss | Loop s/step | Mean step |
+| --- | ---: | ---: | ---: | ---: |
+| BF16 | `0.117..1.17` | `0.5689` | `0.189` | `0.177` |
+| FP8 weight-only TorchAO | `0.120..1.17` | `0.5696` | `0.234` | `0.222` |
+| SDNQ INT8 vanilla | `0.129..1.17` | `0.5736` | `1.113` | `0.277` |
+| SDNQ ConvRot 256 | `0.124..1.17` | `0.5696` | `0.436` | `0.299` |
+
+同一 workload 使用任意宽高比 bucket 时，SDNQ input shape 编译耗时明显更多。保持 text encoder 冻结；初始 cache pass 很贵，但普通 LoRA 训练不应训练它。NF4 和其他量化预设仍可能有用。
 
 SimpleTuner vendored 了 MIT 许可的 Mage-Flow 代码，并用原生 Diffusers pipeline 包装以便验证和保存流程一致。

--- a/documentation/quickstart/ZIMAGE.es.md
+++ b/documentation/quickstart/ZIMAGE.es.md
@@ -20,6 +20,18 @@ Necesitarás:
 
 Las GPUs de Apple no se recomiendan para entrenamiento.
 
+### Rendimiento medido con SDNQ Hadamard
+
+Estas mediciones usaron el ejemplo `z-image-turbo.peft-lora` de Domokun durante 1000 pasos con validacion activada, `base_model_precision=int8-sdnq`, `sdnq_use_hadamard=true`, `sdnq_group_size=-1`, `sdnq_hadamard_group_size=256` y gradient checkpointing activado. Consulta la [configuracion rapida de ConvRot / Hadamard SDNQ](../experimental/CONVROT.md#quick-setup) para las opciones que activan esta ruta. Usalas como puntos de comparacion para esta receta, no como garantias de hardware.
+
+| GPU | Ejecucion | s/paso del loop | Paso medio | p50 | p95 | VRAM maxima asignada |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| H100 80GB | ruta SDNQ Hadamard actual | 1.107 | 1.087 | 1.071 | 1.109 | 9.70 GiB |
+| L40S | ruta SDNQ Hadamard actual | 1.026 | 1.018 | 1.002 | 1.040 | 9.66 GiB |
+| L40S | baseline SDNQ Hadamard | 1.131 | 1.072 | 1.055 | 1.102 | 9.66 GiB |
+
+En la comparacion con caches calientes en L40S, la ruta actual fue 10.3% mas rapida por tiempo de loop y 5.2% mas rapida por media de paso medida que el baseline SDNQ Hadamard.
+
 ### Offloading de memoria (opcional)
 
 El offloading agrupado de módulos reduce drásticamente la presión de VRAM cuando el cuello de botella son los pesos del transformer. Puedes habilitarlo agregando los siguientes flags a `TRAINER_EXTRA_ARGS` (o en la página Hardware de la WebUI):

--- a/documentation/quickstart/ZIMAGE.hi.md
+++ b/documentation/quickstart/ZIMAGE.hi.md
@@ -20,6 +20,18 @@ Z‑Image को Flux से कम मेमोरी चाहिए, ले�
 
 Apple GPUs पर प्रशिक्षण अनुशंसित नहीं है।
 
+### SDNQ Hadamard की मापी गई performance
+
+ये measurements `z-image-turbo.peft-lora` Domokun example पर 1000 steps, validation enabled, `base_model_precision=int8-sdnq`, `sdnq_use_hadamard=true`, `sdnq_group_size=-1`, `sdnq_hadamard_group_size=256`, और gradient checkpointing enabled के साथ लिए गए। इस path को enable करने वाले options के लिए [ConvRot / Hadamard SDNQ quick setup](../experimental/CONVROT.md#quick-setup) देखें। इन्हें इस recipe के comparison points मानें, hardware guarantee नहीं।
+
+| GPU | Run | Train loop s/step | Mean train step | p50 | p95 | Peak allocated VRAM |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| H100 80GB | current SDNQ Hadamard path | 1.107 | 1.087 | 1.071 | 1.109 | 9.70 GiB |
+| L40S | current SDNQ Hadamard path | 1.026 | 1.018 | 1.002 | 1.040 | 9.66 GiB |
+| L40S | baseline SDNQ Hadamard path | 1.131 | 1.072 | 1.055 | 1.102 | 9.66 GiB |
+
+Warm-cache L40S comparison में current path train-loop wall time से 10.3% और measured train-step mean से 5.2% baseline SDNQ Hadamard path से तेज था।
+
 ### मेमोरी ऑफ़लोडिंग (वैकल्पिक)
 
 Grouped module offloading transformer weights bottleneck होने पर VRAM दबाव काफी कम करता है। इसे `TRAINER_EXTRA_ARGS` (या WebUI Hardware page) में निम्न flags जोड़कर सक्षम करें:

--- a/documentation/quickstart/ZIMAGE.ja.md
+++ b/documentation/quickstart/ZIMAGE.ja.md
@@ -20,6 +20,18 @@ Z-Image は Flux よりメモリが少ないものの、強力な GPU が有利�
 
 Apple GPU は学習に推奨されません。
 
+### SDNQ Hadamard の測定性能
+
+これらの測定は、`z-image-turbo.peft-lora` の Domokun 例を 1000 step、validation 有効、`base_model_precision=int8-sdnq`、`sdnq_use_hadamard=true`、`sdnq_group_size=-1`、`sdnq_hadamard_group_size=256`、gradient checkpointing 有効で実行したものです。この path を有効化する option は [ConvRot / Hadamard SDNQ quick setup](../experimental/CONVROT.md#quick-setup) を参照してください。このレシピの比較値として扱い、ハードウェア保証とは見なさないでください。
+
+| GPU | 実行 | train loop 秒/step | 平均 train step | p50 | p95 | peak allocated VRAM |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| H100 80GB | 現行 SDNQ Hadamard path | 1.107 | 1.087 | 1.071 | 1.109 | 9.70 GiB |
+| L40S | 現行 SDNQ Hadamard path | 1.026 | 1.018 | 1.002 | 1.040 | 9.66 GiB |
+| L40S | baseline SDNQ Hadamard path | 1.131 | 1.072 | 1.055 | 1.102 | 9.66 GiB |
+
+warm cache の L40S 比較では、現行 path は baseline SDNQ Hadamard path より train-loop wall time で 10.3%、測定 train-step 平均で 5.2% 高速でした。
+
 ### メモリオフロード（オプション）
 
 Transformer 重みがボトルネックの場合、グループオフロードで VRAM を大幅に削減できます。`TRAINER_EXTRA_ARGS`（または WebUI の Hardware ページ）に以下を追加します:

--- a/documentation/quickstart/ZIMAGE.md
+++ b/documentation/quickstart/ZIMAGE.md
@@ -20,6 +20,18 @@ You'll need:
 
 Apple GPUs are not recommended for training.
 
+### Measured SDNQ Hadamard performance
+
+These measurements used the `z-image-turbo.peft-lora` Domokun example for 1000 steps with validation enabled, `base_model_precision=int8-sdnq`, `sdnq_use_hadamard=true`, `sdnq_group_size=-1`, `sdnq_hadamard_group_size=256`, and gradient checkpointing enabled. See the [ConvRot / Hadamard SDNQ quick setup](../experimental/CONVROT.md#quick-setup) for the options that enable this path. Treat these numbers as comparison points for this recipe, not as hardware guarantees.
+
+| GPU | Run | Train loop s/step | Mean train step | p50 | p95 | Peak allocated VRAM |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| H100 80GB | current SDNQ Hadamard path | 1.107 | 1.087 | 1.071 | 1.109 | 9.70 GiB |
+| L40S | current SDNQ Hadamard path | 1.026 | 1.018 | 1.002 | 1.040 | 9.66 GiB |
+| L40S | baseline SDNQ Hadamard path | 1.131 | 1.072 | 1.055 | 1.102 | 9.66 GiB |
+
+On the warmed L40S comparison, the current path was 10.3% faster by train-loop wall time and 5.2% faster by measured train-step mean than the baseline SDNQ Hadamard path.
+
 ### Memory offloading (optional)
 
 Grouped module offloading dramatically reduces VRAM pressure when you are bottlenecked by the transformer weights. You can enable it by adding the following flags to `TRAINER_EXTRA_ARGS` (or the WebUI Hardware page):

--- a/documentation/quickstart/ZIMAGE.pt-BR.md
+++ b/documentation/quickstart/ZIMAGE.pt-BR.md
@@ -20,6 +20,18 @@ Você vai precisar:
 
 GPUs Apple não são recomendadas para treino.
 
+### Desempenho medido com SDNQ Hadamard
+
+Estas medições usaram o exemplo Domokun `z-image-turbo.peft-lora` por 1000 passos com validação ativada, `base_model_precision=int8-sdnq`, `sdnq_use_hadamard=true`, `sdnq_group_size=-1`, `sdnq_hadamard_group_size=256` e gradient checkpointing ativado. Veja a [configuração rápida de ConvRot / Hadamard SDNQ](../experimental/CONVROT.md#quick-setup) para as opções que ativam este caminho. Trate estes valores como pontos de comparação para esta receita, não como garantias de hardware.
+
+| GPU | Execução | s/passo do loop | Passo médio | p50 | p95 | VRAM alocada máxima |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| H100 80GB | caminho SDNQ Hadamard atual | 1.107 | 1.087 | 1.071 | 1.109 | 9.70 GiB |
+| L40S | caminho SDNQ Hadamard atual | 1.026 | 1.018 | 1.002 | 1.040 | 9.66 GiB |
+| L40S | baseline SDNQ Hadamard | 1.131 | 1.072 | 1.055 | 1.102 | 9.66 GiB |
+
+Na comparação com cache quente na L40S, o caminho atual foi 10.3% mais rápido pelo tempo de loop e 5.2% mais rápido pela média medida de passo do que o baseline SDNQ Hadamard.
+
 ### Offload de memória (opcional)
 
 Offload agrupado de módulos reduz drasticamente a pressão de VRAM quando o gargalo são os pesos do transformer. Você pode habilitar adicionando as seguintes flags ao `TRAINER_EXTRA_ARGS` (ou na página Hardware da WebUI):

--- a/documentation/quickstart/ZIMAGE.zh.md
+++ b/documentation/quickstart/ZIMAGE.zh.md
@@ -20,6 +20,18 @@ Z-Image 比 Flux 省显存，但仍受益于高性能 GPU。训练 rank-16 LoRA 
 
 不建议使用 Apple GPU 训练。
 
+### SDNQ Hadamard 实测性能
+
+这些数据使用 `z-image-turbo.peft-lora` Domokun 示例训练 1000 步，启用验证、`base_model_precision=int8-sdnq`、`sdnq_use_hadamard=true`、`sdnq_group_size=-1`、`sdnq_hadamard_group_size=256` 和 gradient checkpointing。启用该路径的选项见 [ConvRot / Hadamard SDNQ quick setup](../experimental/CONVROT.md#quick-setup)。请把它们作为该配方的比较数据，不要当作硬件保证。
+
+| GPU | 运行 | train loop 秒/步 | 平均 train step | p50 | p95 | 峰值已分配 VRAM |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| H100 80GB | 当前 SDNQ Hadamard 路径 | 1.107 | 1.087 | 1.071 | 1.109 | 9.70 GiB |
+| L40S | 当前 SDNQ Hadamard 路径 | 1.026 | 1.018 | 1.002 | 1.040 | 9.66 GiB |
+| L40S | baseline SDNQ Hadamard 路径 | 1.131 | 1.072 | 1.055 | 1.102 | 9.66 GiB |
+
+在 warm cache 的 L40S 对比中，当前路径按 train-loop wall time 比 baseline SDNQ Hadamard 路径快 10.3%，按实测 train-step 平均快 5.2%。
+
 ### 内存卸载（可选）
 
 组模块卸载能显著降低 transformer 权重带来的 VRAM 压力。可在 `TRAINER_EXTRA_ARGS`（或 WebUI 硬件页面）中添加：


### PR DESCRIPTION
This pull request updates the Mage-Flow and Z-Image quickstart documentation across all supported languages with improved guidance and new benchmarking data for SDNQ INT8/ConvRot and SDNQ Hadamard quantization. The changes clarify recommended validation practices, provide concrete performance metrics, and explain the impact of bucket aspect ratio on compilation time and training efficiency.

**Mage-Flow documentation improvements:**

* Added recommendations to prefer square-crop buckets for SDNQ INT8 and ConvRot validation, with a detailed table of loss and timing results from a 100-step LoRA smoke test on H100 and L40S GPUs. Warns about compilation overhead with arbitrary aspect buckets and advises keeping the text encoder frozen. [[1]](diffhunk://#diff-87786a7e6a93b5065c121dcc7a21c73ad6b8476278f482e69e74903c7834ad63L174-R183) [[2]](diffhunk://#diff-3513c146d7e6e3c20ba207c02224c4fc8024d78f51738df628951676faa80b97L122-R131) [[3]](diffhunk://#diff-c5e053702edc8d8141b7d44d2394ee1dccc250b1fb9b86fd3c3ba8b7ac8531feL122-R131) [[4]](diffhunk://#diff-4b12eb185ada8a28efbb359b988e2029d9c0fcf0d3f0805e6f1c2db3adcde6d2L122-R131) [[5]](diffhunk://#diff-c573361f17b5a92f3b52ccfd76518e21f1f0c4868bbd5e608d148e5f212530e6L122-R131) [[6]](diffhunk://#diff-dbab62925dfbdc2caf5f3f796a8d313298bc8938c60b651b2970949f020f45faL122-R131)

**Z-Image documentation improvements:**

* Added new sections reporting measured SDNQ Hadamard training performance for H100 and L40S GPUs, including benchmark tables and comparison to baseline. Instructs users to treat results as reference points, not guarantees, and links to quick setup instructions. [[1]](diffhunk://#diff-3b26d75ca3f4d59720f7e4f101dee734d04fe9de492fb4618b72a8eb3e39cec6R23-R34) [[2]](diffhunk://#diff-6cdea4032f58b656e8bd9c6e4ef7013f26b260b54a7f6c7fa66905865230cdd6R23-R34) [[3]](diffhunk://#diff-d7ed79f9e44790724bf5755e021ac651e2cd8fca08dcaeef1a540307edd47a49R23-R34) [[4]](diffhunk://#diff-daabb6b4133d67ebb4d836e5f790738f2593346d8f97553796bb4333fcbb334fR23-R34) [[5]](diffhunk://#diff-d511ebf0a7c752c84898ec8141e22bd57a6dbbd788eff774f016c1e9269bf7afR23-R34) [[6]](diffhunk://#diff-910f86e32c7585010aa07cb5d989b5f88a4b0f1fa490d3a4dc602a3879cde180R23-R34)

No code changes were made; all updates are to documentation for clarity, reproducibility, and user guidance.