### PR TITLE
FSDP2: handle footgun as a rejection case in pytorch issue 180666 (the mark of the beast)

### DIFF
--- a/simpletuner/helpers/configuration/cmd_args.py
+++ b/simpletuner/helpers/configuration/cmd_args.py
@@ -1239,6 +1239,20 @@ def parse_cmdline_args(input_args=None, exit_on_error: bool = False):
                 "FSDP v2 uses DTensor-sharded parameters, but Quanto kernels do not register DTensor sharding "
                 f"strategies. Disable Quanto precision for FSDP v2 runs ({field_list}), or use non-FSDP LoRA training."
             )
+        if args.fsdp_version == 2 and getattr(args, "fsdp_cpu_offload", False):
+            optimizer_name = str(getattr(args, "optimizer", "") or "").lower()
+            uses_optimi_gradient_release = bool(getattr(args, "optimizer_release_gradients", False)) and (
+                "optimi" in optimizer_name
+            )
+            uses_torchao_cpu_offload_optimizer = (
+                str(getattr(args, "optimizer_cpu_offload_method", "") or "").lower() == "torchao"
+            )
+            if uses_optimi_gradient_release or uses_torchao_cpu_offload_optimizer:
+                raise ValueError(
+                    "FSDP v2 CPU parameter offload is not compatible with post-accumulate gradient hook based "
+                    "optimizer paths. Disable --fsdp_cpu_offload, --optimizer_release_gradients, or "
+                    "--optimizer_cpu_offload_method=torchao."
+                )
     else:
         # When FSDP is disabled, normalise auxiliary options so downstream logic can rely on None/False.
         args.fsdp_transformer_layer_cls_to_wrap = None

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -1196,6 +1196,21 @@ class Trainer:
             )
             setattr(self.config, "gradient_checkpointing", False)
 
+        if fsdp_version == 2 and cpu_offload:
+            optimizer_name = str(getattr(self.config, "optimizer", "") or "").lower()
+            uses_optimi_gradient_release = bool(getattr(self.config, "optimizer_release_gradients", False)) and (
+                "optimi" in optimizer_name
+            )
+            uses_torchao_cpu_offload_optimizer = (
+                str(getattr(self.config, "optimizer_cpu_offload_method", "") or "").lower() == "torchao"
+            )
+            if uses_optimi_gradient_release or uses_torchao_cpu_offload_optimizer:
+                raise RuntimeError(
+                    "FSDP v2 CPU parameter offload is not compatible with post-accumulate gradient hook based "
+                    "optimizer paths. Disable fsdp_cpu_offload, optimizer_release_gradients, or "
+                    "optimizer_cpu_offload_method=torchao."
+                )
+
         plugin_kwargs = {
             "fsdp_version": fsdp_version,
             "reshard_after_forward": reshard_after_forward,

--- a/tests/test_fsdp_cmd_args.py
+++ b/tests/test_fsdp_cmd_args.py
@@ -215,6 +215,47 @@ class TestFSDPCmdArgs(unittest.TestCase):
                 exit_on_error=False,
             )
 
+    def test_fsdp2_cpu_offload_rejects_optimi_gradient_release(self):
+        tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(tmp_dir, ignore_errors=True))
+        base_args = [
+            "--model_family=sdxl",
+            "--model_type=full",
+            f"--output_dir={tmp_dir}",
+            "--optimizer=optimi-adamw",
+            "--data_backend_config=dummy",
+        ]
+        with self.assertRaisesRegex(ValueError, "post-accumulate gradient hook"):
+            parse_cmdline_args(
+                input_args=base_args
+                + [
+                    "--fsdp_enable",
+                    "--fsdp_version=2",
+                    "--fsdp_cpu_offload",
+                    "--optimizer_release_gradients",
+                ],
+                exit_on_error=False,
+            )
+
+    def test_fsdp2_cpu_offload_allows_standard_optimizer(self):
+        tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(tmp_dir, ignore_errors=True))
+        args = parse_cmdline_args(
+            input_args=[
+                "--model_family=sdxl",
+                "--model_type=full",
+                f"--output_dir={tmp_dir}",
+                "--optimizer=adamw_bf16",
+                "--data_backend_config=dummy",
+                "--fsdp_enable",
+                "--fsdp_version=2",
+                "--fsdp_cpu_offload",
+            ],
+            exit_on_error=False,
+        )
+
+        self.assertTrue(args.fsdp_cpu_offload)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1372,6 +1372,46 @@ class TestTrainer(unittest.TestCase):
         with self.assertRaises(ValueError):
             trainer._load_fsdp_plugin()
 
+    def test_load_fsdp_plugin_rejects_cpu_offload_with_torchao_optimizer_offload(self):
+        trainer = object.__new__(Trainer)
+        trainer.config = SimpleNamespace(
+            fsdp_enable=True,
+            fsdp_version=2,
+            fsdp_reshard_after_forward=True,
+            fsdp_cpu_ram_efficient_loading=False,
+            fsdp_cpu_offload=True,
+            fsdp_state_dict_type="SHARDED_STATE_DICT",
+            fsdp_auto_wrap_policy="transformer_based_wrap",
+            fsdp_transformer_layer_cls_to_wrap=None,
+            optimizer="adamw_bf16",
+            optimizer_cpu_offload_method="torchao",
+            optimizer_release_gradients=False,
+            deepspeed_config=None,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "post-accumulate gradient hook"):
+            trainer._load_fsdp_plugin()
+
+    def test_load_fsdp_plugin_rejects_cpu_offload_with_optimi_gradient_release(self):
+        trainer = object.__new__(Trainer)
+        trainer.config = SimpleNamespace(
+            fsdp_enable=True,
+            fsdp_version=2,
+            fsdp_reshard_after_forward=True,
+            fsdp_cpu_ram_efficient_loading=False,
+            fsdp_cpu_offload=True,
+            fsdp_state_dict_type="SHARDED_STATE_DICT",
+            fsdp_auto_wrap_policy="transformer_based_wrap",
+            fsdp_transformer_layer_cls_to_wrap=None,
+            optimizer="optimi-adamw",
+            optimizer_cpu_offload_method="none",
+            optimizer_release_gradients=True,
+            deepspeed_config=None,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "post-accumulate gradient hook"):
+            trainer._load_fsdp_plugin()
+
     def test_resume_and_prepare_initializes_ema_after_prepare(self):
         trainer = object.__new__(Trainer)
         trainer.ema_model = None


### PR DESCRIPTION
This pull request adds important validation logic to prevent incompatible configurations when using FSDP v2 with CPU parameter offload, and extends test coverage to ensure these checks work as intended. The main focus is to avoid runtime errors caused by using certain optimizer options that are not supported together.

### Validation logic for FSDP v2 CPU offload:

* Added checks in `_normalize_input_args` (`cmd_args.py`) and `_load_fsdp_plugin` (`trainer.py`) to raise errors if FSDP v2 CPU parameter offload is enabled together with either post-accumulate gradient hook based optimizers (e.g., `optimizer_release_gradients` with "optimi" optimizers) or the `torchao` optimizer CPU offload method. This prevents unsupported configurations and provides clear error messages to users. [[1]](diffhunk://#diff-2eb2bdca165b022325e9401eb998e8aa0f66d16deea3d8b7cd0fd68e5814ffa0R1242-R1255) [[2]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R1199-R1213)

### Test coverage improvements:

* Added new tests in `test_fsdp_cmd_args.py` to verify that invalid argument combinations are rejected and valid ones are allowed.
* Added new tests in `test_trainer.py` to ensure that the trainer correctly raises errors for incompatible FSDP v2 CPU offload and optimizer settings.

These changes improve the robustness of configuration handling and help users avoid hard-to-debug runtime failures.