### PR TITLE
Fix automatic oversubscription scheduling with gradient accumulation

### DIFF
--- a/simpletuner/helpers/data_backend/factory.py
+++ b/simpletuner/helpers/data_backend/factory.py
@@ -3283,7 +3283,7 @@ class FactoryRegistry:
                     f" You have to reduce your batch size, or increase your dataset size (id={init_backend['id']})."
                 )
 
-        apply_padding = True if not self.args.max_train_steps or self.args.max_train_steps == 0 else False
+        apply_padding = not self.args.max_train_steps or self.args.allow_dataset_oversubscription
 
         if backend.get("auto_generated", False):
             # when we're duplicating a metadata set, it's already split between processes.

--- a/simpletuner/helpers/metadata/backends/base.py
+++ b/simpletuner/helpers/metadata/backends/base.py
@@ -778,10 +778,17 @@ class MetadataBackend:
         if self.bucket_report:
             self.bucket_report.set_constraints(effective_batch_size=effective_batch_size)
 
+        backend_config = StateTracker.get_data_backend_config(self.id) or {}
+        configured_repeats = int(backend_config.get("repeats") or 0)
+        user_set_repeats = configured_repeats > 0
+        auto_repeat_count = None
+
         # Early validation: check if configuration is mathematically impossible
         buckets_that_will_fail = []
         for bucket, images in self.aspect_ratio_bucket_indices.items():
             total_img_count_incl_repeats = len(images) * (self.repeats + 1)
+            if not images:
+                continue
             if total_img_count_incl_repeats < effective_batch_size:
                 buckets_that_will_fail.append(
                     {
@@ -799,25 +806,22 @@ class MetadataBackend:
                 needed_repeats = ceil(effective_batch_size / images) - 1
                 min_repeats_needed[bucket_info["bucket"]] = needed_repeats
 
+            # The documented repeat setting applies to the whole backend, so
+            # use the maximum requirement and apply it consistently to every
+            # bucket rather than assigning a different repeat count per bucket.
             max_needed_repeats = max(min_repeats_needed.values())
+            allow_oversubscription = StateTracker.get_args().allow_dataset_oversubscription
 
             # Check if dataset oversubscription is allowed
-            args = StateTracker.get_args()
-            allow_oversubscription = args.allow_dataset_oversubscription
-
-            # Check if user manually configured repeats in their backend config
-            backend_config = StateTracker.get_data_backend_config(self.id) or {}
-            user_set_repeats = "repeats" in backend_config
-
             if allow_oversubscription and not user_set_repeats:
                 # Automatically adjust repeats to make training possible
                 original_repeats = self.repeats
-                self.repeats = max_needed_repeats
+                auto_repeat_count = max_needed_repeats
                 logger.warning(
-                    f"(id={self.id}) Dataset oversubscription enabled: automatically increasing repeats from {original_repeats} to {self.repeats}\n"
+                    f"(id={self.id}) Dataset oversubscription enabled: automatically increasing repeats from {original_repeats} to {auto_repeat_count}\n"
                     f"  - This allows training with {total_samples} samples across {num_processes} GPUs\n"
                     f"  - Effective batch size: {effective_batch_size}\n"
-                    f"  - Each sample will be seen {self.repeats + 1} times per epoch"
+                    f"  - Logical repeat factor before per-bucket batch padding: {auto_repeat_count + 1}"
                 )
                 # Validation passed with adjustment, continue
             else:
@@ -874,10 +878,27 @@ class MetadataBackend:
             shuffle_seed = broadcast_object_from_main(shuffle_seed if self.accelerator.is_main_process else None)
 
         for bucket, images in self.aspect_ratio_bucket_indices.items():
+            if not images:
+                new_aspect_ratio_bucket_indices[bucket] = []
+                continue
             if should_shuffle_contents:
                 logger.debug(f"Shuffling bucket {bucket} contents.")
                 images = images.copy()
                 random.Random(f"{shuffle_seed}:{self.id}:{bucket}").shuffle(images)
+
+            if auto_repeat_count is not None:
+                logical_count = len(images) * (auto_repeat_count + 1)
+                scheduled_count = ceil(logical_count / effective_batch_size) * effective_batch_size
+                local_count = scheduled_count // effective_dp_size
+                start_idx = dp_rank * local_count
+                images_split = [images[(start_idx + offset) % len(images)] for offset in range(local_count)]
+                logger.debug(
+                    f"(id={self.id}) Bucket {bucket}: logical samples={logical_count}, "
+                    f"scheduled samples={scheduled_count}, local samples={local_count}"
+                )
+                new_aspect_ratio_bucket_indices[bucket] = images_split
+                continue
+
             total_img_count_incl_repeats = len(images) * (self.repeats + 1)
             num_batches = ceil(total_img_count_incl_repeats / effective_batch_size)
             trim_limit = num_batches * effective_batch_size

--- a/simpletuner/helpers/metadata/backends/base.py
+++ b/simpletuner/helpers/metadata/backends/base.py
@@ -903,33 +903,21 @@ class MetadataBackend:
                         effective_batch_size=effective_batch_size,
                     )
 
-            # Split data by DP rank (not global rank) when context parallelism is enabled.
-            # This ensures all ranks in a CP group get the same data shard.
-            if cp_size > 1:
-                # Custom CP-aware splitting: split by dp_rank instead of process_index
-                chunk_size = ceil(len(trimmed_images) / effective_dp_size) if effective_dp_size > 0 else len(trimmed_images)
-                start_idx = dp_rank * chunk_size
-                end_idx = min(start_idx + chunk_size, len(trimmed_images))
-                images_split = trimmed_images[start_idx:end_idx]
-
-                # Handle padding if requested (for uniform batch sizes)
-                if apply_padding and len(images_split) < chunk_size and len(images_split) > 0:
-                    padding_needed = chunk_size - len(images_split)
-                    # Pad by repeating elements from the split
-                    padding = (images_split * ((padding_needed // len(images_split)) + 1))[:padding_needed]
-                    images_split = images_split + padding
-
-                new_aspect_ratio_bucket_indices[bucket] = images_split
-            else:
-                # Standard splitting when CP is disabled
-                with self.accelerator.split_between_processes(trimmed_images, apply_padding=apply_padding) as images_split:
-                    new_aspect_ratio_bucket_indices[bucket] = images_split
+            samples_per_rank, extra_samples = divmod(len(trimmed_images), effective_dp_size)
+            start_idx = dp_rank * samples_per_rank + min(dp_rank, extra_samples)
+            local_size = samples_per_rank + int(dp_rank < extra_samples)
+            images_split = trimmed_images[start_idx : start_idx + local_size]
+            if apply_padding:
+                target_size = samples_per_rank + int(extra_samples > 0)
+                if trimmed_images and len(images_split) < target_size:
+                    images_split += [trimmed_images[-1]] * (target_size - len(images_split))
+            new_aspect_ratio_bucket_indices[bucket] = images_split
 
         self.aspect_ratio_bucket_indices = new_aspect_ratio_bucket_indices
         post_total = sum([len(bucket) for bucket in self.aspect_ratio_bucket_indices.values()])
         if self.bucket_report:
             self.bucket_report.record_bucket_snapshot("post_split", self.aspect_ratio_bucket_indices)
-        if total_samples != post_total:
+        if self.accelerator.num_processes > 1 or total_samples != post_total:
             self.read_only = True
 
         # Check if this backend has no samples after splitting (can happen with multi-GPU setups)
@@ -944,14 +932,28 @@ class MetadataBackend:
 
         logger.debug(f"Count of items after split: {post_total}")
 
+    def seen_occurrence_count(self, image_path) -> int:
+        """Return consumed occurrences, accepting boolean values from older checkpoints."""
+        value = self.seen_images.get(image_path, 0)
+        if isinstance(value, bool):
+            return int(value)
+        if not isinstance(value, int):
+            raise TypeError(f"Invalid seen occurrence count for {image_path!r}: {value!r}")
+        if value < 0:
+            raise ValueError(f"Seen occurrence count cannot be negative for {image_path!r}: {value}")
+        return int(value)
+
     def mark_as_seen(self, image_path):
-        self.seen_images[image_path] = True
+        self.seen_images[image_path] = self.seen_occurrence_count(image_path) + 1
 
     def mark_batch_as_seen(self, image_paths):
-        self.seen_images.update({image_path: True for image_path in image_paths})
+        for image_path in image_paths:
+            self.mark_as_seen(image_path)
 
-    def is_seen(self, image_path):
-        return self.seen_images.get(image_path, False)
+    def is_seen(self, image_path, occurrence_index: int = 0):
+        if isinstance(self.seen_images.get(image_path, 0), bool):
+            return self.seen_images[image_path]
+        return self.seen_occurrence_count(image_path) > occurrence_index
 
     def reset_seen_images(self):
         self.seen_images.clear()

--- a/simpletuner/helpers/metadata/utils/duplicator.py
+++ b/simpletuner/helpers/metadata/utils/duplicator.py
@@ -21,19 +21,7 @@ class DatasetDuplicator:
         if source_meta is None or target_meta is None:
             raise ValueError(f"Both backends must have metadata_backend defined. Received {source_meta} \n\n {target_meta}")
 
-        logger.debug("Reloading metadata caches...")
-        prior_source_buckets = {
-            bucket: list(paths) for bucket, paths in getattr(source_meta, "aspect_ratio_bucket_indices", {}).items()
-        }
-        prior_source_metadata = dict(source_meta.image_metadata) if getattr(source_meta, "image_metadata", None) else None
-        source_meta.reload_cache(set_config=False)
-        if not source_meta.aspect_ratio_bucket_indices and prior_source_buckets:
-            logger.warning(
-                "Source metadata cache reload returned no buckets; restoring in-memory snapshot to avoid data loss."
-            )
-            source_meta.aspect_ratio_bucket_indices = {bucket: list(paths) for bucket, paths in prior_source_buckets.items()}
-            if prior_source_metadata is not None:
-                source_meta.image_metadata = prior_source_metadata
+        logger.debug("Reloading target metadata cache...")
         target_meta.reload_cache(set_config=False)
 
         # Get the instance directories for path translation
@@ -88,7 +76,7 @@ class DatasetDuplicator:
         else:
             # Regular copy without path translation
             logger.info("Copying metadata without path translation")
-            target_meta.set_metadata(metadata_backend=source_meta, update_json=True)
+            target_meta.set_metadata(metadata_backend=source_meta, update_json=False)
 
         source_config = source_backend.get("config", {}) or {}
         target_config = target_backend.get("config", {}) or {}
@@ -131,10 +119,8 @@ class DatasetDuplicator:
 
         target_meta.config = target_config
 
-        # Save the updated metadata
-        target_meta.save_cache()
-
-        # IMPORTANT: save_cache() only saves bucket indices, we must also save the image_metadata
+        # Bucket indices may be rank-local here; do not overwrite the canonical target cache.
+        target_meta.set_readonly()
         if hasattr(target_meta, "save_image_metadata"):
             target_meta.save_image_metadata()
             logger.debug("Saved image_metadata to disk")
@@ -144,7 +130,6 @@ class DatasetDuplicator:
         logger.info("Metadata copied successfully.")
         source_meta.print_debug_info()
         target_meta.print_debug_info()
-        target_meta.set_readonly()
 
     @staticmethod
     def generate_conditioning_datasets(global_config, source_backend_config):

--- a/simpletuner/helpers/multiaspect/sampler.py
+++ b/simpletuner/helpers/multiaspect/sampler.py
@@ -134,10 +134,20 @@ class MultiAspectSampler(torch.utils.data.Sampler):
 
     def load_states(self, state_path: str):
         try:
-            self.buckets = self.load_buckets()
             previous_state = self.state_manager.load_state(state_path)
         except Exception as e:
             raise e
+
+        # Checkpoints contain the rank-local schedule. Restore it before seen
+        # state so legacy boolean flags can be expanded to all occurrences.
+        saved_schedule = previous_state.get("aspect_ratio_bucket_indices")
+        if isinstance(saved_schedule, dict):
+            self.metadata_backend.aspect_ratio_bucket_indices = saved_schedule
+            self._val_master_list = sorted(sum(saved_schedule.values(), []))
+        self.buckets = previous_state.get("buckets", self.load_buckets())
+        if "current_bucket" in previous_state:
+            self.current_bucket = previous_state["current_bucket"]
+
         self.exhausted_buckets = []
         if "exhausted_buckets" in previous_state:
             self.logger.info(f"Previous checkpoint had {len(previous_state['exhausted_buckets'])} exhausted buckets.")
@@ -149,7 +159,20 @@ class MultiAspectSampler(torch.utils.data.Sampler):
         # Merge seen_images into self.state_manager.seen_images Manager.dict:
         if "seen_images" in previous_state:
             self.logger.info(f"Previous checkpoint had {len(previous_state['seen_images'])} seen {self.sample_type_strs}.")
-            self.metadata_backend.seen_images.update(previous_state["seen_images"])
+            occurrence_counts = {}
+            for images in self.metadata_backend.aspect_ratio_bucket_indices.values():
+                for image_path in images:
+                    occurrence_counts[image_path] = occurrence_counts.get(image_path, 0) + 1
+            normalized_seen = {
+                image_path: (
+                    (occurrence_counts.get(image_path, True) if value else 0)
+                    if isinstance(value, bool)
+                    else value
+                )
+                for image_path, value in previous_state["seen_images"].items()
+            }
+            self.metadata_backend.seen_images.clear()
+            self.metadata_backend.seen_images.update(normalized_seen)
 
     def load_buckets(self):
         return list(self.metadata_backend.aspect_ratio_bucket_indices.keys())  # These keys are a float value, eg. 1.78.
@@ -389,6 +412,17 @@ class MultiAspectSampler(torch.utils.data.Sampler):
         # Bucket not found with either type
         return []
 
+    def _filter_unseen_occurrences(self, images):
+        """Filter consumed positions without collapsing duplicate filepaths."""
+        occurrence_indices = {}
+        unseen = []
+        for image in images:
+            occurrence_index = occurrence_indices.get(image, 0)
+            occurrence_indices[image] = occurrence_index + 1
+            if not self.metadata_backend.is_seen(image, occurrence_index):
+                unseen.append(image)
+        return unseen
+
     def _get_unseen_images(self, bucket=None):
         """
         Get unseen {self.sample_type_strs} from the specified bucket.
@@ -410,8 +444,7 @@ class MultiAspectSampler(torch.utils.data.Sampler):
 
             return [
                 (os.path.join(self.metadata_backend.instance_data_dir, image) if not image.startswith("http") else image)
-                for image in bucket_images
-                if not self.metadata_backend.is_seen(image)
+                for image in self._filter_unseen_occurrences(bucket_images)
             ]
         elif bucket is None:
             unseen_images = []
@@ -423,8 +456,7 @@ class MultiAspectSampler(torch.utils.data.Sampler):
                             if not image.startswith("http")
                             else image
                         )
-                        for image in images
-                        if not self.metadata_backend.is_seen(image)
+                        for image in self._filter_unseen_occurrences(images)
                     ]
                 )
             return unseen_images

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -5501,7 +5501,8 @@ class Trainer:
                 # we'll have to split the buckets between GPUs again now, so that the VAE cache distributes properly.
                 logger.info("Splitting buckets across GPUs")
                 backend["metadata_backend"].split_buckets_between_processes(
-                    gradient_accumulation_steps=self.config.gradient_accumulation_steps
+                    gradient_accumulation_steps=self.config.gradient_accumulation_steps,
+                    apply_padding=(self.config.overrode_max_train_steps or self.config.allow_dataset_oversubscription),
                 )
                 # we have to rebuild the VAE cache if it exists.
                 if "vaecache" in backend:

--- a/tests/test_audio_sampler.py
+++ b/tests/test_audio_sampler.py
@@ -19,9 +19,11 @@ class TestAudioSampler(unittest.TestCase):
         self.mock_metadata.id = "test_backend"
         self.mock_metadata.aspect_ratio_bucket_indices = {"10s": ["a.wav", "b.wav"], "20s": ["c.wav"]}
         self.mock_metadata.seen_images = {}
-        self.mock_metadata.is_seen = lambda x: x in self.mock_metadata.seen_images
+        self.mock_metadata.is_seen = (
+            lambda x, occurrence_index=0: int(self.mock_metadata.seen_images.get(x, 0)) > occurrence_index
+        )
         self.mock_metadata.mark_batch_as_seen = lambda batch: [
-            self.mock_metadata.seen_images.update({x: True}) for x in batch
+            self.mock_metadata.seen_images.update({x: int(self.mock_metadata.seen_images.get(x, 0)) + 1}) for x in batch
         ]
         self.mock_metadata.reset_seen_images = lambda: self.mock_metadata.seen_images.clear()
         self.mock_metadata.instance_data_dir = ""

--- a/tests/test_conditioning_split_alignment.py
+++ b/tests/test_conditioning_split_alignment.py
@@ -1,3 +1,4 @@
+import json
 import multiprocessing
 import os
 import unittest
@@ -423,6 +424,41 @@ class TestConditioningSplitAlignment(unittest.TestCase):
             total_conditioning_images,
             0,
             "Conditioning duplication should retain samples even when cache reload returns empty data.",
+        )
+
+    def test_rank_local_conditioning_schedule_does_not_overwrite_target_cache(self):
+        base_images = {"1.0": [f"/datasets/train/img_{i}.png" for i in range(16)]}
+        accelerator = self._init_state(num_processes=4, process_index=1, train_batch_size=8)
+        source_schedule = {}
+        source_sentinel = {"config": {}, "aspect_ratio_bucket_indices": {"1.0": ["canonical-source-cache"]}}
+        sentinel = {"config": {}, "aspect_ratio_bucket_indices": {"1.0": ["canonical-target-cache"]}}
+
+        def before_copy(train_meta, cond_meta, train_backend, cond_backend, *_args):
+            source_schedule.update({bucket: list(paths) for bucket, paths in train_meta.aspect_ratio_bucket_indices.items()})
+            train_backend.write(train_meta.cache_file, json.dumps(source_sentinel))
+            cond_backend.write(cond_meta.cache_file, json.dumps(sentinel))
+
+        train_meta, cond_meta = self._prepare_metadata_backends(
+            accelerator=accelerator,
+            base_buckets=base_images,
+            source_id="cache_source",
+            source_dir="/datasets/train",
+            conditioning_id="cache_conditioning",
+            conditioning_dir="/datasets/control",
+            before_copy_callback=before_copy,
+        )
+
+        self.assertTrue(train_meta.read_only)
+        self.assertTrue(cond_meta.read_only)
+        self.assertEqual(source_schedule, train_meta.aspect_ratio_bucket_indices)
+        self.assertEqual(json.loads(train_meta.data_backend.read(train_meta.cache_file)), source_sentinel)
+        self.assertEqual(
+            json.loads(cond_meta.data_backend.read(cond_meta.cache_file))["aspect_ratio_bucket_indices"],
+            sentinel["aspect_ratio_bucket_indices"],
+        )
+        self.assertEqual(
+            cond_meta.aspect_ratio_bucket_indices["1.0"],
+            [path.replace("/datasets/train", "/datasets/control", 1) for path in source_schedule["1.0"]],
         )
 
     def test_reference_strict_duplication_multi_process_reload(self):

--- a/tests/test_conditioning_split_alignment.py
+++ b/tests/test_conditioning_split_alignment.py
@@ -158,6 +158,7 @@ class TestConditioningSplitAlignment(unittest.TestCase):
         source_data_backend: InMemoryDataBackend | None = None,
         conditioning_data_backend: InMemoryDataBackend | None = None,
         before_copy_callback=None,
+        apply_padding: bool = False,
     ):
         source_config = {
             "resolution_type": "area",
@@ -196,7 +197,7 @@ class TestConditioningSplitAlignment(unittest.TestCase):
                 "dataset_type": "image",
             }
         )
-        training_metadata.split_buckets_between_processes()
+        training_metadata.split_buckets_between_processes(apply_padding=apply_padding)
 
         conditioning_config = {
             "resolution_type": "area",
@@ -460,6 +461,71 @@ class TestConditioningSplitAlignment(unittest.TestCase):
             cond_meta.aspect_ratio_bucket_indices["1.0"],
             [path.replace("/datasets/train", "/datasets/control", 1) for path in source_schedule["1.0"]],
         )
+
+    def test_duplication_preserves_the_padded_split_source_schedule(self):
+        # The main process persists the unsplit discovery list before the split, and the
+        # post-split save is a no-op because the split marks the backend read-only. Duplication
+        # must not reload that unsplit list back over the rank-local schedule.
+        source_dir = "/datasets/pad_train"
+        conditioning_dir = "/datasets/pad_control"
+        base_images = {"1.0": [f"{source_dir}/img_{index}.png" for index in range(4)]}
+        num_processes = 8
+        conditioning_backend = InMemoryDataBackend("pad_control")
+        conditioning_cache_path = f"{conditioning_dir}/aspect_ratio_bucket_indices.json"
+
+        source_shards = []
+        conditioning_cache_snapshots = []
+
+        def persist_unsplit_source_cache(train_meta, *_args):
+            split_view = {bucket: list(paths) for bucket, paths in train_meta.aspect_ratio_bucket_indices.items()}
+            original_read_only = train_meta.read_only
+            train_meta.read_only = False
+            train_meta.aspect_ratio_bucket_indices = deepcopy(base_images)
+            train_meta.save_cache()
+            train_meta.aspect_ratio_bucket_indices = split_view
+            train_meta.read_only = original_read_only
+
+        for process_index in range(num_processes):
+            with self.subTest(process=process_index):
+                accelerator = self._init_state(num_processes=num_processes, process_index=process_index)
+                source_backend = InMemoryDataBackend("pad_train")
+                train_meta, cond_meta = self._prepare_metadata_backends(
+                    accelerator=accelerator,
+                    base_buckets=base_images,
+                    source_id="pad_train",
+                    source_dir=source_dir,
+                    conditioning_id="pad_control",
+                    conditioning_dir=conditioning_dir,
+                    source_data_backend=source_backend,
+                    conditioning_data_backend=conditioning_backend,
+                    before_copy_callback=persist_unsplit_source_cache,
+                    apply_padding=True,
+                )
+
+                # The clobber source has to be present, or this test proves nothing.
+                self.assertIn(f"{source_dir}/aspect_ratio_bucket_indices.json", source_backend._storage)
+
+                # The clobber also coerces bucket keys to float, so do not index by "1.0".
+                (shard,) = (list(paths) for paths in train_meta.aspect_ratio_bucket_indices.values())
+                source_shards.append(shard)
+                conditioning_cache_snapshots.append(conditioning_backend._storage.get(conditioning_cache_path))
+
+                (conditioning_shard,) = (list(paths) for paths in cond_meta.aspect_ratio_bucket_indices.values())
+                self.assertEqual(
+                    conditioning_shard,
+                    [path.replace(source_dir, conditioning_dir, 1) for path in shard],
+                    msg=f"Conditioning dataset did not inherit the rank {process_index} shard.",
+                )
+
+        self.assertEqual([len(shard) for shard in source_shards], [1] * num_processes)
+        self.assertEqual(
+            sorted({path for shard in source_shards for path in shard}),
+            base_images["1.0"],
+            msg="The eight rank shards no longer cover the dataset.",
+        )
+        # Every rank writes the conditioning cache to the same path, so its contents must not
+        # depend on which rank wrote last.
+        self.assertEqual(len(set(conditioning_cache_snapshots)), 1)
 
     def test_reference_strict_duplication_multi_process_reload(self):
         manager = multiprocessing.Manager()

--- a/tests/test_factory_edge_cases.py
+++ b/tests/test_factory_edge_cases.py
@@ -977,6 +977,7 @@ class TestFactoryEdgeCases(unittest.TestCase):
         # Mock accelerator with 8 GPUs
         mock_accelerator = MagicMock()
         mock_accelerator.num_processes = 8
+        mock_accelerator.process_index = 0
         mock_backend.accelerator = mock_accelerator
 
         # Mock StateTracker.get_args() to return args with allow_dataset_oversubscription=False
@@ -1023,16 +1024,7 @@ class TestFactoryEdgeCases(unittest.TestCase):
         # Mock accelerator with 2 GPUs
         mock_accelerator = MagicMock()
         mock_accelerator.num_processes = 2
-
-        # Mock split_between_processes to distribute images properly
-        def split_side_effect(images, apply_padding=False):
-            mock_context = MagicMock()
-            # Each GPU gets half the images
-            mock_context.__enter__ = MagicMock(return_value=images[: len(images) // 2])
-            mock_context.__exit__ = MagicMock(return_value=False)
-            return mock_context
-
-        mock_accelerator.split_between_processes = MagicMock(side_effect=split_side_effect)
+        mock_accelerator.process_index = 0
         mock_backend.accelerator = mock_accelerator
 
         # Mock StateTracker.get_args() to return args with allow_dataset_oversubscription=False
@@ -1068,14 +1060,7 @@ class TestFactoryEdgeCases(unittest.TestCase):
 
         mock_accelerator = MagicMock()
         mock_accelerator.num_processes = 1
-
-        def split_side_effect(images, apply_padding=False):
-            mock_context = MagicMock()
-            mock_context.__enter__ = MagicMock(return_value=images)
-            mock_context.__exit__ = MagicMock(return_value=False)
-            return mock_context
-
-        mock_accelerator.split_between_processes = MagicMock(side_effect=split_side_effect)
+        mock_accelerator.process_index = 0
         mock_backend.accelerator = mock_accelerator
 
         with (
@@ -1091,8 +1076,6 @@ class TestFactoryEdgeCases(unittest.TestCase):
             except ValueError as e:
                 if "Dataset configuration will produce zero usable batches" in str(e):
                     self.fail(f"Eval dataset should not consider grad accumulation: {e}")
-
-        mock_accelerator.split_between_processes.assert_called_once()
 
     def test_oversubscription_auto_adjustment(self):
         """Test that --allow_dataset_oversubscription automatically adjusts repeats."""
@@ -1110,6 +1093,7 @@ class TestFactoryEdgeCases(unittest.TestCase):
         # Mock accelerator with 8 GPUs
         mock_accelerator = MagicMock()
         mock_accelerator.num_processes = 8
+        mock_accelerator.process_index = 0
         mock_backend.accelerator = mock_accelerator
 
         # Mock StateTracker to enable oversubscription and NO user-set repeats
@@ -1121,15 +1105,6 @@ class TestFactoryEdgeCases(unittest.TestCase):
             with patch.object(StateTracker, "get_data_backend_config") as mock_get_config:
                 # Return config WITHOUT 'repeats' key (not user-set)
                 mock_get_config.return_value = {"id": "test_auto_adjust"}
-
-                # Mock the split_between_processes to avoid actual splitting
-                def split_side_effect(images, apply_padding=False):
-                    mock_context = MagicMock()
-                    mock_context.__enter__ = MagicMock(return_value=images)
-                    mock_context.__exit__ = MagicMock(return_value=False)
-                    return mock_context
-
-                mock_accelerator.split_between_processes = MagicMock(side_effect=split_side_effect)
 
                 # Should NOT raise, should auto-adjust repeats
                 try:
@@ -1154,6 +1129,7 @@ class TestFactoryEdgeCases(unittest.TestCase):
 
         mock_accelerator = MagicMock()
         mock_accelerator.num_processes = 8
+        mock_accelerator.process_index = 0
         mock_backend.accelerator = mock_accelerator
 
         # Mock StateTracker with oversubscription enabled BUT user set repeats
@@ -1189,6 +1165,7 @@ class TestFactoryEdgeCases(unittest.TestCase):
 
         mock_accelerator = MagicMock()
         mock_accelerator.num_processes = 8
+        mock_accelerator.process_index = 0
         mock_backend.accelerator = mock_accelerator
 
         # Mock StateTracker with oversubscription DISABLED
@@ -1207,6 +1184,49 @@ class TestFactoryEdgeCases(unittest.TestCase):
                 error_msg = str(context.exception)
                 self.assertIn("Dataset configuration will produce zero usable batches", error_msg)
                 self.assertIn("Enable --allow_dataset_oversubscription", error_msg)
+
+    def test_bucket_split_padding_policy_matches_training_mode(self):
+        """Factory padding covers epoch and explicit oversubscription policies."""
+        from simpletuner.helpers.data_backend.factory import FactoryRegistry
+
+        factory = FactoryRegistry(
+            args=self.args,
+            accelerator=self.accelerator,
+            text_encoders=self.text_encoders,
+            tokenizers=self.tokenizers,
+            model=self.model,
+        )
+        factory._handle_config_versioning = MagicMock()
+
+        cases = (
+            ("fixed_steps", 100, False, False),
+            ("oversubscribed_fixed_steps", 100, True, True),
+            ("epoch_driven", 0, False, True),
+        )
+        for name, max_train_steps, allow_oversubscription, expected in cases:
+            with self.subTest(name=name):
+                factory.args.max_train_steps = max_train_steps
+                factory.args.allow_dataset_oversubscription = allow_oversubscription
+                factory.args.skip_file_discovery = "aspect"
+                factory.args.eval_dataset_id = None
+
+                metadata_backend = MagicMock()
+                init_backend = {
+                    "id": "train",
+                    "config": {},
+                    "dataset_type": "image",
+                    "metadata_backend": metadata_backend,
+                }
+                factory._handle_bucket_operations(
+                    backend={"id": "train", "skip_file_discovery": "aspect"},
+                    init_backend=init_backend,
+                    conditioning_type=None,
+                )
+
+                metadata_backend.split_buckets_between_processes.assert_called_once_with(
+                    gradient_accumulation_steps=factory.args.gradient_accumulation_steps,
+                    apply_padding=expected,
+                )
 
     def test_image_embeds_backend_configuration(self):
         """Image embed configuration should not instantiate VAE cache directly."""

--- a/tests/test_factory_edge_cases.py
+++ b/tests/test_factory_edge_cases.py
@@ -1109,8 +1109,8 @@ class TestFactoryEdgeCases(unittest.TestCase):
                 # Should NOT raise, should auto-adjust repeats
                 try:
                     MetadataBackend.split_buckets_between_processes(mock_backend, gradient_accumulation_steps=1)
-                    # Check that repeats was adjusted
-                    self.assertEqual(mock_backend.repeats, 7, "Repeats should be auto-adjusted to 7")
+                    self.assertEqual(mock_backend.repeats, 0)
+                    self.assertEqual(len(mock_backend.aspect_ratio_bucket_indices["1.0"]), 4)
                 except ValueError as e:
                     self.fail(f"Should not raise with oversubscription enabled: {e}")
 

--- a/tests/test_metadata_backend.py
+++ b/tests/test_metadata_backend.py
@@ -345,9 +345,6 @@ class TestSplitBucketsEvalDataset(unittest.TestCase):
         mock_accelerator = MagicMock()
         mock_accelerator.num_processes = 1
         mock_accelerator.process_index = 0
-        mock_accelerator.split_between_processes = MagicMock()
-        mock_accelerator.split_between_processes.return_value.__enter__ = MagicMock(return_value=["eval_img1.jpg"])
-        mock_accelerator.split_between_processes.return_value.__exit__ = MagicMock(return_value=False)
         mock_backend.accelerator = mock_accelerator
 
         with (
@@ -416,9 +413,6 @@ class TestSplitBucketsEvalDataset(unittest.TestCase):
         mock_accelerator = MagicMock()
         mock_accelerator.num_processes = 1
         mock_accelerator.process_index = 0
-        mock_accelerator.split_between_processes = MagicMock()
-        mock_accelerator.split_between_processes.return_value.__enter__ = MagicMock(return_value=["eval_img1.jpg"])
-        mock_accelerator.split_between_processes.return_value.__exit__ = MagicMock(return_value=False)
         mock_backend.accelerator = mock_accelerator
 
         with (
@@ -438,6 +432,86 @@ class TestSplitBucketsEvalDataset(unittest.TestCase):
             MetadataBackend.split_buckets_between_processes(mock_backend, gradient_accumulation_steps=8, apply_padding=False)
 
         self.assertIn("1.0", mock_backend.aspect_ratio_bucket_indices)
+
+
+class TestDistributedBucketPadding(unittest.TestCase):
+    """Regression coverage for PR #2897 distributed bucket policies."""
+
+    @staticmethod
+    def _backend(images, *, num_processes=8):
+        backend = MagicMock(spec=MetadataBackend)
+        backend.id = "distributed-padding"
+        backend.batch_size = 1
+        backend.repeats = 0
+        backend.bucket_report = None
+        backend.dataset_type = DatasetType.IMAGE
+        backend.aspect_ratio_bucket_indices = {"1.0": list(images)}
+        backend.read_only = False
+        backend.accelerator = MagicMock(
+            num_processes=num_processes,
+            process_index=0,
+            is_main_process=True,
+        )
+        return backend
+
+    def _split_rank(self, images, rank, *, cp_size, apply_padding):
+        backend = self._backend(images)
+        with (
+            patch.dict("os.environ", {"SIMPLETUNER_SHUFFLE_BUCKETS": "0"}),
+            patch.object(
+                StateTracker,
+                "get_args",
+                return_value=SimpleNamespace(allow_dataset_oversubscription=apply_padding),
+            ),
+            patch.object(StateTracker, "get_data_backend_config", return_value={}),
+            patch(
+                "simpletuner.helpers.metadata.backends.base.get_cp_aware_dp_info",
+                return_value=(8, rank, cp_size),
+            ),
+        ):
+            MetadataBackend.split_buckets_between_processes(
+                backend,
+                gradient_accumulation_steps=1,
+                apply_padding=apply_padding,
+            )
+        return backend.aspect_ratio_bucket_indices["1.0"]
+
+    def test_cp_padding_fills_empty_dp_shards_from_final_global_item(self):
+        images = ["img0", "img1", "img2", "img3"]
+        shards = [self._split_rank(images, rank, cp_size=2, apply_padding=True) for rank in range(8)]
+
+        self.assertEqual([len(shard) for shard in shards], [1] * 8)
+        self.assertEqual([item for shard in shards for item in shard], images + ["img3"] * 4)
+
+    def test_cp_no_padding_uses_balanced_qr_partition(self):
+        images = [f"img{index}" for index in range(9)]
+        shards = [self._split_rank(images, rank, cp_size=2, apply_padding=False) for rank in range(8)]
+
+        self.assertEqual([len(shard) for shard in shards], [2, 1, 1, 1, 1, 1, 1, 1])
+        self.assertEqual([item for shard in shards for item in shard], images)
+
+    def test_standard_split_preserves_balanced_qr_order(self):
+        images = [f"img{index}" for index in range(9)]
+        shards = [self._split_rank(images, rank, cp_size=1, apply_padding=False) for rank in range(8)]
+
+        self.assertEqual([len(shard) for shard in shards], [2, 1, 1, 1, 1, 1, 1, 1])
+        self.assertEqual([item for shard in shards for item in shard], images)
+
+    def test_standard_split_padding_exact_division_preserves_cardinality(self):
+        images = [f"img{index}" for index in range(8)]
+        shards = [self._split_rank(images, rank, cp_size=1, apply_padding=True) for rank in range(8)]
+
+        self.assertEqual([len(shard) for shard in shards], [1] * 8)
+        self.assertEqual([item for shard in shards for item in shard], images)
+
+    def test_padding_non_divisible_preserves_qr_boundaries(self):
+        images = [f"img{index}" for index in range(10)]
+        expected = [["img0", "img1"], ["img2", "img3"]] + [[f"img{index}", "img9"] for index in range(4, 10)]
+
+        for cp_size in (1, 2):
+            with self.subTest(cp_size=cp_size):
+                shards = [self._split_rank(images, rank, cp_size=cp_size, apply_padding=True) for rank in range(8)]
+                self.assertEqual(shards, expected)
 
 
 class TestFilteringStatistics(unittest.TestCase):

--- a/tests/test_metadata_backend.py
+++ b/tests/test_metadata_backend.py
@@ -454,8 +454,9 @@ class TestDistributedBucketPadding(unittest.TestCase):
         )
         return backend
 
-    def _split_rank(self, images, rank, *, cp_size, apply_padding):
+    def _split_rank(self, images, rank, *, cp_size, apply_padding, repeats=0):
         backend = self._backend(images)
+        backend.repeats = repeats
         with (
             patch.dict("os.environ", {"SIMPLETUNER_SHUFFLE_BUCKETS": "0"}),
             patch.object(
@@ -463,7 +464,11 @@ class TestDistributedBucketPadding(unittest.TestCase):
                 "get_args",
                 return_value=SimpleNamespace(allow_dataset_oversubscription=apply_padding),
             ),
-            patch.object(StateTracker, "get_data_backend_config", return_value={}),
+            patch.object(
+                StateTracker,
+                "get_data_backend_config",
+                return_value={"repeats": repeats} if repeats else {},
+            ),
             patch(
                 "simpletuner.helpers.metadata.backends.base.get_cp_aware_dp_info",
                 return_value=(8, rank, cp_size),
@@ -478,7 +483,10 @@ class TestDistributedBucketPadding(unittest.TestCase):
 
     def test_cp_padding_fills_empty_dp_shards_from_final_global_item(self):
         images = ["img0", "img1", "img2", "img3"]
-        shards = [self._split_rank(images, rank, cp_size=2, apply_padding=True) for rank in range(8)]
+        shards = [
+            self._split_rank(images, rank, cp_size=2, apply_padding=True, repeats=1)
+            for rank in range(8)
+        ]
 
         self.assertEqual([len(shard) for shard in shards], [1] * 8)
         self.assertEqual([item for shard in shards for item in shard], images + ["img3"] * 4)
@@ -512,6 +520,123 @@ class TestDistributedBucketPadding(unittest.TestCase):
             with self.subTest(cp_size=cp_size):
                 shards = [self._split_rank(images, rank, cp_size=cp_size, apply_padding=True) for rank in range(8)]
                 self.assertEqual(shards, expected)
+
+
+class TestAutomaticOversubscriptionLogicalSequence(unittest.TestCase):
+    """Automatic repeats are materialised into a rank-local cyclic schedule."""
+
+    @staticmethod
+    def _backend(images, dp_size, rank, cp_size=1, batch_size=1, repeats=0):
+        backend = object.__new__(MetadataBackend)
+        backend.id = "auto-oversubscription"
+        backend.batch_size = batch_size
+        backend.repeats = repeats
+        backend.bucket_report = None
+        backend.dataset_type = DatasetType.IMAGE
+        backend.read_only = False
+        backend._aspect_ratio_bucket_indices = {"1.0": list(images)}
+        backend.accelerator = SimpleNamespace(
+            num_processes=dp_size * cp_size,
+            process_index=rank,
+            is_main_process=True,
+        )
+        return backend
+
+    def _split(self, backend, dp_size, rank, cp_size, gradient_accumulation_steps, config=None):
+        with (
+            patch.dict("os.environ", {"SIMPLETUNER_SHUFFLE_BUCKETS": "0"}),
+            patch.object(
+                StateTracker,
+                "get_args",
+                return_value=SimpleNamespace(allow_dataset_oversubscription=True, seed=0),
+            ),
+            patch.object(StateTracker, "get_data_backend_config", return_value=config or {}),
+            patch(
+                "simpletuner.helpers.metadata.backends.base.get_cp_aware_dp_info",
+                return_value=(dp_size, rank, cp_size),
+            ),
+        ):
+            MetadataBackend.split_buckets_between_processes(
+                backend,
+                gradient_accumulation_steps=gradient_accumulation_steps,
+                apply_padding=True,
+            )
+
+    def test_standard_auto_repeat_provides_one_complete_ga_window_per_rank(self):
+        shards = []
+        for rank in range(8):
+            backend = self._backend(["img0"], dp_size=8, rank=rank)
+            self._split(backend, 8, rank, 1, gradient_accumulation_steps=4, config={"repeats": 0})
+            shards.append(backend.aspect_ratio_bucket_indices["1.0"])
+            self.assertEqual(backend.repeats, 0)
+
+        self.assertEqual([len(shard) for shard in shards], [4] * 8)
+        self.assertEqual(sum(map(len, shards)), 32)
+        self.assertEqual({item for shard in shards for item in shard}, {"img0"})
+
+    def test_context_parallel_auto_repeat_uses_effective_dp_and_cyclic_tail(self):
+        images = [f"img{index}" for index in range(5)]
+        shards = []
+        for rank in range(4):
+            backend = self._backend(images, dp_size=4, rank=rank, cp_size=2)
+            self._split(backend, 4, rank, 2, gradient_accumulation_steps=2, config={"repeats": 0})
+            shards.append(backend.aspect_ratio_bucket_indices["1.0"])
+
+        self.assertEqual([len(shard) for shard in shards], [4] * 4)
+        self.assertEqual(
+            [item for shard in shards for item in shard],
+            images + images + (images * 2)[:6],
+        )
+
+    def test_docs_style_auto_repeat_cardinality_is_padded_to_full_window(self):
+        images = [f"img{index}" for index in range(25)]
+        shards = []
+        for rank in range(8):
+            backend = self._backend(images, dp_size=8, rank=rank)
+            self._split(backend, 8, rank, 1, gradient_accumulation_steps=4, config={"repeats": 0})
+            shards.append(backend.aspect_ratio_bucket_indices["1.0"])
+
+        self.assertEqual([len(shard) for shard in shards], [8] * 8)
+        self.assertEqual(
+            [item for shard in shards for item in shard],
+            images + images + images[:14],
+        )
+
+    def test_auto_repeat_count_is_backend_wide_across_buckets(self):
+        backend = self._backend([], dp_size=2, rank=0, batch_size=4)
+        backend._aspect_ratio_bucket_indices = {
+            "small": ["s0", "s1", "s2"],
+            "large": ["l0", "l1", "l2", "l3", "l4", "l5", "l6"],
+        }
+        self._split(backend, 2, 0, 1, gradient_accumulation_steps=1, config={"repeats": 0})
+
+        self.assertEqual(backend.repeats, 0)
+        self.assertEqual(
+            {bucket: len(values) for bucket, values in backend.aspect_ratio_bucket_indices.items()},
+            {"small": 8, "large": 12},
+        )
+        self.assertEqual(
+            backend.aspect_ratio_bucket_indices["small"],
+            ["s0", "s1", "s2", "s0", "s1", "s2", "s0", "s1"],
+        )
+        self.assertEqual(
+            backend.aspect_ratio_bucket_indices["large"],
+            ["l0", "l1", "l2", "l3", "l4", "l5", "l6", "l0", "l1", "l2", "l3", "l4"],
+        )
+
+    def test_manual_repeats_are_not_materialised(self):
+        backend = self._backend(["img0"], dp_size=8, rank=0, repeats=31)
+        self._split(backend, 8, 0, 1, gradient_accumulation_steps=4, config={"repeats": 31})
+
+        self.assertEqual(backend.aspect_ratio_bucket_indices["1.0"], ["img0"])
+        self.assertEqual(backend.repeats, 31)
+
+    def test_empty_buckets_are_ignored_without_division_by_zero(self):
+        backend = self._backend([], dp_size=8, rank=0, batch_size=1)
+        backend._aspect_ratio_bucket_indices = {"empty": [], "full": ["img0"]}
+        self._split(backend, 8, 0, 1, gradient_accumulation_steps=1, config={"repeats": 0})
+        self.assertEqual(backend.aspect_ratio_bucket_indices["empty"], [])
+        self.assertEqual(len(backend.aspect_ratio_bucket_indices["full"]), 1)
 
 
 class TestFilteringStatistics(unittest.TestCase):

--- a/tests/test_metadata_backend.py
+++ b/tests/test_metadata_backend.py
@@ -639,6 +639,101 @@ class TestAutomaticOversubscriptionLogicalSequence(unittest.TestCase):
         self.assertEqual(len(backend.aspect_ratio_bucket_indices["full"]), 1)
 
 
+class TestEmptyBucketRepeatValidation(unittest.TestCase):
+    """An empty bucket key survives update_buckets_with_existing_files and reaches the split."""
+
+    @staticmethod
+    def _backend(buckets, *, repeats=0):
+        backend = MagicMock(spec=MetadataBackend)
+        backend.id = "empty-bucket"
+        backend.batch_size = 1
+        backend.repeats = repeats
+        backend.bucket_report = None
+        backend.dataset_type = DatasetType.IMAGE
+        backend.aspect_ratio_bucket_indices = {key: list(value) for key, value in buckets.items()}
+        backend.read_only = False
+        backend.accelerator = MagicMock(num_processes=1, process_index=0, is_main_process=True)
+        return backend
+
+    @staticmethod
+    def _split(backend, *, num_processes, allow_oversubscription, dp_rank=0):
+        with (
+            patch.dict("os.environ", {"SIMPLETUNER_SHUFFLE_BUCKETS": "0"}),
+            patch.object(
+                StateTracker,
+                "get_args",
+                return_value=SimpleNamespace(allow_dataset_oversubscription=allow_oversubscription),
+            ),
+            patch.object(StateTracker, "get_data_backend_config", return_value={}),
+            patch(
+                "simpletuner.helpers.metadata.backends.base.get_cp_aware_dp_info",
+                return_value=(num_processes, dp_rank, 1),
+            ),
+        ):
+            MetadataBackend.split_buckets_between_processes(
+                backend,
+                gradient_accumulation_steps=1,
+                apply_padding=allow_oversubscription,
+            )
+
+    def test_empty_bucket_does_not_divide_by_zero(self):
+        # The crash is not distribution-specific: effective_batch_size is at least 1, so an
+        # empty bucket always joins buckets_that_will_fail regardless of world size.
+        for num_processes in (1, 2, 8):
+            for allow_oversubscription in (True, False):
+                with self.subTest(num_processes=num_processes, allow_oversubscription=allow_oversubscription):
+                    backend = self._backend({"1.0": ["a.jpg", "b.jpg"], "1.5": []})
+                    try:
+                        self._split(backend, num_processes=num_processes, allow_oversubscription=allow_oversubscription)
+                    except ZeroDivisionError as error:
+                        self.fail(f"empty bucket divided by zero: {error}")
+                    except ValueError:
+                        # The pre-existing "zero usable batches" guard is allowed to fire; it is
+                        # asserted on its own below.
+                        pass
+
+    def test_oversubscription_ignores_the_empty_bucket_when_adjusting_repeats(self):
+        # The auto repeat factor ceil(8 / 2) - 1 = 3 is driven by the two-image bucket alone.
+        # Since #2918, repeats is left unmutated and the factor is materialised into the
+        # rank-local shard instead: logical 2 * (3 + 1) = 8 samples, batch-aligned to the
+        # effective batch size of 8, so every rank holds exactly 8 // 8 = 1 cyclic sample.
+        shards = []
+        for dp_rank in range(8):
+            backend = self._backend({"1.0": ["a.jpg", "b.jpg"], "1.5": []})
+            self._split(backend, num_processes=8, allow_oversubscription=True, dp_rank=dp_rank)
+            self.assertEqual(backend.repeats, 0, "auto oversubscription must not mutate repeats")
+            self.assertEqual(backend.aspect_ratio_bucket_indices["1.5"], [])
+            shards.append(backend.aspect_ratio_bucket_indices["1.0"])
+
+        self.assertEqual([len(shard) for shard in shards], [1] * 8)
+        self.assertEqual([shard[0] for shard in shards], ["a.jpg", "b.jpg"] * 4)
+
+    def test_empty_bucket_still_reports_zero_usable_batches_without_oversubscription(self):
+        backend = self._backend({"1.0": ["a.jpg", "b.jpg"], "1.5": []})
+        with self.assertRaises(ValueError) as raised:
+            self._split(backend, num_processes=8, allow_oversubscription=False)
+        self.assertIn("zero usable batches", str(raised.exception))
+
+    def test_bucket_without_empty_keys_is_unaffected(self):
+        backend = self._backend({"1.0": ["a.jpg", "b.jpg"]})
+        self._split(backend, num_processes=8, allow_oversubscription=True)
+
+        # Same materialised schedule as the empty-bucket case: repeats stays 0 and rank 0
+        # holds the first of the eight batch-aligned cyclic samples.
+        self.assertEqual(backend.repeats, 0, "auto oversubscription must not mutate repeats")
+        self.assertEqual(backend.aspect_ratio_bucket_indices["1.0"], ["a.jpg"])
+
+    def test_refresh_leaves_an_empty_bucket_key_behind(self):
+        # update_buckets_with_existing_files assigns [] rather than dropping the key, which is
+        # how the empty bucket reaches the split in the first place.
+        backend = MagicMock()
+        backend.aspect_ratio_bucket_indices = {"1.0": ["a.jpg"], "1.5": ["gone.jpg"]}
+        backend.bucket_report = None
+        MetadataBackend.update_buckets_with_existing_files(backend, {"a.jpg"})
+
+        self.assertEqual(backend.aspect_ratio_bucket_indices, {"1.0": ["a.jpg"], "1.5": []})
+
+
 class TestFilteringStatistics(unittest.TestCase):
     """Test filtering_statistics storage and retrieval in metadata backends (issue #2474)."""
 

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -68,6 +68,60 @@ class TestMultiAspectSampler(unittest.TestCase):
         buckets = self.sampler.load_buckets()
         self.assertEqual(buckets, ["1.0"])
 
+    def test_padded_occurrences_are_consumed_individually(self):
+        """A repeated filepath represents multiple scheduled samples, not one boolean item."""
+        metadata_backend = object.__new__(DiscoveryMetadataBackend)
+        metadata_backend.instance_data_dir = ""
+        metadata_backend.aspect_ratio_bucket_indices = {"1.0": ["same.jpg", "same.jpg"]}
+        metadata_backend.seen_images = {}
+
+        sampler = object.__new__(MultiAspectSampler)
+        sampler.metadata_backend = metadata_backend
+        sampler.logger = MagicMock()
+        sampler.debug_log = MagicMock()
+
+        self.assertEqual(sampler._get_unseen_images("1.0"), ["same.jpg", "same.jpg"])
+        metadata_backend.mark_as_seen("same.jpg")
+        self.assertEqual(sampler._get_unseen_images("1.0"), ["same.jpg"])
+
+        # Old checkpoints stored booleans. True means the filepath was
+        # exhausted, including every scheduled duplicate.
+        metadata_backend.seen_images = {"same.jpg": True}
+        self.assertEqual(sampler._get_unseen_images("1.0"), [])
+
+        metadata_backend.seen_images = {}
+        metadata_backend.mark_batch_as_seen(["same.jpg", "same.jpg"])
+        self.assertEqual(metadata_backend.seen_occurrence_count("same.jpg"), 2)
+        self.assertEqual(sampler._get_unseen_images("1.0"), [])
+
+        metadata_backend.seen_images = {"same.jpg": "corrupt"}
+        with self.assertRaisesRegex(TypeError, "Invalid seen occurrence count"):
+            metadata_backend.seen_occurrence_count("same.jpg")
+
+    def test_load_states_restores_schedule_before_normalizing_legacy_seen_flags(self):
+        self.sampler.state_manager.load_state.return_value = {
+            "aspect_ratio_bucket_indices": {"1.0": ["same.jpg", "same.jpg", "other.jpg"]},
+            "buckets": ["1.0"],
+            "current_bucket": 0,
+            "exhausted_buckets": ["old"],
+            "seen_images": {"same.jpg": True, "other.jpg": False, "legacy.jpg": True},
+        }
+
+        self.metadata_backend.aspect_ratio_bucket_indices = {"1.0": ["stale.jpg"]}
+        self.metadata_backend.seen_images = {}
+        self.sampler.load_states(self.state_path)
+
+        self.assertEqual(
+            self.metadata_backend.aspect_ratio_bucket_indices,
+            {"1.0": ["same.jpg", "same.jpg", "other.jpg"]},
+        )
+        self.assertEqual(self.sampler.buckets, ["1.0"])
+        self.assertEqual(self.sampler.current_bucket, 0)
+        self.assertEqual(self.sampler.exhausted_buckets, ["old"])
+        self.assertEqual(self.metadata_backend.seen_images["same.jpg"], 2)
+        self.assertEqual(self.metadata_backend.seen_images["other.jpg"], 0)
+        self.assertTrue(self.metadata_backend.seen_images["legacy.jpg"])
+
     def test_change_bucket(self):
         self.sampler.buckets = ["1.5"]
         self.sampler.exhausted_buckets = ["1.0"]

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1837,6 +1837,54 @@ class TestTrainer(unittest.TestCase):
             self.assertEqual(trainer.state["current_epoch"], 2)
             self.assertEqual(trainer.extra_lr_scheduler_kwargs["epoch"], 2)
 
+    def test_epoch_rollover_reuses_initial_bucket_padding_policy(self):
+        cases = (
+            ("fixed_steps", False, False, False),
+            ("epoch_driven", True, False, True),
+            ("oversubscribed_fixed_steps", False, True, True),
+        )
+
+        for name, overrode_max_train_steps, allow_oversubscription, expected in cases:
+            with self.subTest(name=name):
+                trainer = object.__new__(Trainer)
+                trainer.state = {"first_epoch": 1, "current_epoch": 1}
+                trainer.accelerator = MagicMock(is_main_process=True)
+                trainer.extra_lr_scheduler_kwargs = {}
+                trainer.get_steps_per_epoch_for_epoch = MagicMock(return_value=100)
+                trainer.config = SimpleNamespace(
+                    num_train_epochs=5,
+                    aspect_bucket_disable_rebuild=False,
+                    lr_scheduler="constant",
+                    num_update_steps_per_epoch=100,
+                    gradient_accumulation_steps=3,
+                    overrode_max_train_steps=overrode_max_train_steps,
+                    allow_dataset_oversubscription=allow_oversubscription,
+                )
+                metadata_backend = MagicMock(read_only=True)
+                backends = {"train": {"metadata_backend": metadata_backend}}
+                backend_config = {
+                    "crop": True,
+                    "crop_aspect": "random",
+                }
+
+                with (
+                    patch("simpletuner.helpers.training.trainer.StateTracker.set_epoch"),
+                    patch(
+                        "simpletuner.helpers.training.trainer.StateTracker.get_data_backends",
+                        return_value=backends,
+                    ),
+                    patch(
+                        "simpletuner.helpers.training.trainer.StateTracker.get_data_backend_config",
+                        return_value=backend_config,
+                    ),
+                ):
+                    trainer._epoch_rollover(2)
+
+                metadata_backend.split_buckets_between_processes.assert_called_once_with(
+                    gradient_accumulation_steps=3,
+                    apply_padding=expected,
+                )
+
     @patch(
         "simpletuner.helpers.training.trainer.Trainer.parse_arguments",
         return_value=Mock(),


### PR DESCRIPTION
## Dependency

Depends on #2897 for occurrence-aware sampler and resume semantics. This branch is stacked on #2897 and will be rebased after it merges.

## Additional issues found

- Automatic oversubscription increased the repeat count without constructing the repeated schedule, so gradient accumulation could still leave insufficient rank-local samples.
- `repeats: 0` was treated as a manual override.
- Empty buckets could enter repeat division.
- Mutating the backend repeat value could affect later splits.
- Conditioning metadata copying could discard the current rank-local source schedule and overwrite canonical target bucket state with rank-local data.

## Resolution

- Keep the automatic repeat calculation local to the split.
- Build a batch-aligned cyclic schedule directly at rank-local size.
- Treat only positive configured repeats as a manual override.
- Skip empty buckets.
- Preserve the source schedule and avoid persisting rank-local target bucket indices over canonical metadata.

Regression coverage for gradient accumulation, standard DP, Context Parallel, empty buckets, manual repeats, and conditioning metadata is included.
