### PR TITLE
Normalize configured API base URLs

### DIFF
--- a/simpletuner/static/js/utils/api.js
+++ b/simpletuner/static/js/utils/api.js
@@ -12,18 +12,22 @@
         return path.startsWith("/") ? path : `/${path}`;
     }
 
+    function normalizeBaseUrl(url) {
+        return typeof url === "string" ? url.replace(/\/+$/, "") : "";
+    }
+
     function getBaseOrigin() {
         return global.location ? global.location.origin : "";
     }
 
     const ApiClient = {
         get apiBaseUrl() {
-            return (global.ServerConfig && global.ServerConfig.apiBaseUrl) || getBaseOrigin();
+            return normalizeBaseUrl((global.ServerConfig && global.ServerConfig.apiBaseUrl) || getBaseOrigin());
         },
 
         get callbackBaseUrl() {
             if (global.ServerConfig && global.ServerConfig.callbackUrl) {
-                return global.ServerConfig.callbackUrl;
+                return normalizeBaseUrl(global.ServerConfig.callbackUrl);
             }
             return this.apiBaseUrl;
         },

--- a/tests/js/api_client.test.js
+++ b/tests/js/api_client.test.js
@@ -84,6 +84,22 @@ describe('ApiClient', () => {
         });
     });
 
+    describe('base URL normalization', () => {
+        test('removes trailing slashes from configured base URLs', () => {
+            global.ServerConfig = {
+                apiBaseUrl: 'https://api.example.com/',
+                callbackUrl: 'https://callback.example.com///',
+            };
+
+            expect(window.ApiClient.apiBaseUrl).toBe('https://api.example.com');
+            expect(window.ApiClient.callbackBaseUrl).toBe('https://callback.example.com');
+            expect(window.ApiClient.resolve('/api/jobs', { forceApi: true }))
+                .toBe('https://api.example.com/api/jobs');
+            expect(window.ApiClient.resolve('/notify', { forceCallback: true }))
+                .toBe('https://callback.example.com/notify');
+        });
+    });
+
     describe('resolve', () => {
         test('resolves path with default options', () => {
             const result = window.ApiClient.resolve('/api/jobs');


### PR DESCRIPTION
Configured API and callback base URLs may include a trailing slash in split deployments. Since `ApiClient` also normalizes endpoint paths with a leading slash, direct concatenation produces URLs such as `https://api.example.com//api/jobs`.

Normalize trailing slashes in the two base URL getters so existing `resolve`, websocket, and fetch paths keep a single separator. The test covers both API and callback URLs, including multiple trailing slashes.

Tests:
- `npx jest --config tests/js/jest.config.js tests/js/api_client.test.js --runInBand`
- `npm test -- --runInBand`
- `node --check simpletuner/static/js/utils/api.js`