### PR TITLE
Improve audio validation metadata handling (ACE-Step, HeartMuLa, OmniGen and Wan S2V)

### DIFF
--- a/simpletuner/helpers/caching/vae.py
+++ b/simpletuner/helpers/caching/vae.py
@@ -1034,6 +1034,7 @@ class VAECache(WebhookMixin):
             "wan_s2v",
             "sanavideo",
             "kandinsky5-video",
+            "kandinsky5_video",
             "hunyuanvideo",
             "longcat_video",
         ]:
@@ -1313,14 +1314,24 @@ class VAECache(WebhookMixin):
 
                 if self.dataset_type_enum is DatasetType.AUDIO:
                     debug_filepaths = [filepaths[i] for i in uncached_image_indices]
+                    debug_latents = (
+                        latents_uncached["latents"]
+                        if isinstance(latents_uncached, dict) and "latents" in latents_uncached
+                        else latents_uncached
+                    )
                     for idx, fp in enumerate(debug_filepaths):
-                        self._log_audio_tensor_stats("audio_latents_processed", latents_uncached[idx], fp)
+                        self._log_audio_tensor_stats("audio_latents_processed", debug_latents[idx], fp)
 
                 latents_uncached = self.model.scale_vae_latents_for_cache(latents_uncached, self.vae)
                 if self.dataset_type_enum is DatasetType.AUDIO:
                     debug_filepaths = [filepaths[i] for i in uncached_image_indices]
+                    debug_latents = (
+                        latents_uncached["latents"]
+                        if isinstance(latents_uncached, dict) and "latents" in latents_uncached
+                        else latents_uncached
+                    )
                     for idx, fp in enumerate(debug_filepaths):
-                        self._log_audio_tensor_stats("audio_latents_scaled", latents_uncached[idx], fp)
+                        self._log_audio_tensor_stats("audio_latents_scaled", debug_latents[idx], fp)
             if isinstance(latents_uncached, dict) and "latents" in latents_uncached:
                 raw_latents = latents_uncached["latents"]
                 num_samples = raw_latents.shape[0]
@@ -1604,6 +1615,12 @@ class VAECache(WebhookMixin):
         waveform, sample_rate = self._coerce_audio_waveform(raw_sample, metadata, filepath)
         if waveform is None:
             return None
+        waveform, metadata = self._truncate_audio_waveform_to_max_duration(
+            waveform=waveform,
+            sample_rate=sample_rate,
+            metadata=metadata,
+            filepath=filepath,
+        )
         waveform, metadata = self._align_audio_waveform_to_video(
             waveform=waveform,
             sample_rate=sample_rate,
@@ -1660,6 +1677,44 @@ class VAECache(WebhookMixin):
         metadata = dict(metadata)
         metadata["num_samples"] = waveform.shape[-1]
         metadata["duration_seconds"] = float(waveform.shape[-1]) / float(sample_rate)
+        return waveform, metadata
+
+    def _truncate_audio_waveform_to_max_duration(self, waveform, sample_rate, metadata: dict, filepath: str):
+        if sample_rate is None:
+            return waveform, metadata
+        backend_config = StateTracker.get_data_backend_config(data_backend_id=self.id) or {}
+        audio_config = backend_config.get("audio") or {}
+        max_duration = audio_config.get("max_duration_seconds")
+        if max_duration is None:
+            return waveform, metadata
+        try:
+            max_duration = float(max_duration)
+        except (TypeError, ValueError):
+            return waveform, metadata
+        if max_duration <= 0:
+            return waveform, metadata
+
+        target_samples = int(round(max_duration * float(sample_rate)))
+        if target_samples <= 0 or waveform.shape[-1] <= target_samples:
+            return waveform, metadata
+
+        truncation_mode = (metadata.get("truncation_mode") or audio_config.get("truncation_mode") or "beginning").lower()
+        if truncation_mode == "end":
+            start = waveform.shape[-1] - target_samples
+        elif truncation_mode == "random":
+            start = random.randint(0, waveform.shape[-1] - target_samples)
+        else:
+            start = 0
+        waveform = waveform[:, start : start + target_samples].contiguous()
+        metadata = dict(metadata)
+        metadata["num_samples"] = waveform.shape[-1]
+        metadata["duration_seconds"] = float(waveform.shape[-1]) / float(sample_rate)
+        metadata["truncated_duration_seconds"] = metadata["duration_seconds"]
+        logger.debug(
+            "Truncated audio sample %s to %.2fs for audio.max_duration_seconds.",
+            filepath,
+            metadata["duration_seconds"],
+        )
         return waveform, metadata
 
     def _coerce_audio_waveform(self, sample, metadata: dict, filepath: str):

--- a/simpletuner/helpers/data_backend/factory.py
+++ b/simpletuner/helpers/data_backend/factory.py
@@ -809,7 +809,7 @@ def init_backend_config(backend: dict, args: dict, accelerator) -> dict:
         is_i2v_flavour = model_flavour.startswith("i2v")
         force_i2v = (
             (model_family == "wan" and model_flavour.startswith("i2v-"))
-            or (model_family == "kandinsky5-video" and is_i2v_flavour)
+            or (model_family in ("kandinsky5-video", "kandinsky5_video") and is_i2v_flavour)
             or (model_family == "hunyuanvideo" and is_i2v_flavour)
         )
 
@@ -1907,7 +1907,7 @@ class FactoryRegistry:
         matching conditioning-image-embed backends when none were supplied explicitly.
         """
         model_family = str(getattr(self.args, "model_family", "") or "")
-        if model_family.lower() not in ["wan", "kandinsky5-video", "hunyuanvideo"]:
+        if model_family.lower() not in ["wan", "kandinsky5-video", "kandinsky5_video", "hunyuanvideo"]:
             return data_backend_config
 
         auto_embed_configs: List[Dict[str, Any]] = []

--- a/simpletuner/helpers/metadata/backends/huggingface.py
+++ b/simpletuner/helpers/metadata/backends/huggingface.py
@@ -165,6 +165,7 @@ class HuggingfaceMetadataBackend(MetadataBackend):
             except Exception as e:
                 logger.warning(f"Error loading caption cache, will regenerate: {e}")
         logger.info("Extracting captions from Hugging Face dataset...")
+        indices = self._limited_dataset_indices()
 
         def process_item(idx):
             item = self.data_backend.dataset[idx]
@@ -179,13 +180,12 @@ class HuggingfaceMetadataBackend(MetadataBackend):
             return None
 
         captions = {}
-        total_items = len(self.data_backend.dataset)
         with concurrent.futures.ThreadPoolExecutor() as executor:
             results = list(
                 tqdm(
-                    executor.map(process_item, range(total_items)),
+                    executor.map(process_item, indices),
                     desc="Extracting captions",
-                    total=total_items,
+                    total=len(indices),
                     ncols=100,
                     mininterval=0.5,
                     ascii=True,
@@ -205,6 +205,18 @@ class HuggingfaceMetadataBackend(MetadataBackend):
 
         logger.info(f"Extracted {len(captions)} captions from dataset")
         return captions
+
+    def _limited_dataset_indices(self) -> List[int]:
+        total_items = len(self.data_backend.dataset)
+        all_files = [f"{idx}.{self.file_extension}" for idx in range(total_items)]
+        limited_files = self._apply_max_num_samples_limit(all_files)
+        indices = []
+        for virtual_path in limited_files:
+            try:
+                indices.append(int(str(virtual_path).rsplit(".", 1)[0]))
+            except (TypeError, ValueError):
+                continue
+        return indices
 
     def _extract_caption_from_item(self, item: Dict) -> Optional[Union[str, List[str]]]:
         caption = None
@@ -758,23 +770,25 @@ class HuggingfaceMetadataBackend(MetadataBackend):
         aspect_ratio_bucket_updates = {}
         metadata_updates = {}
 
-        total_items = len(self.data_backend.dataset)
+        indices = self._limited_dataset_indices()
         if self.bucket_report:
-            pending_items = max(total_items - len(existing_files), 0)
+            pending_items = max(len(indices) - len(existing_files), 0)
             self.bucket_report.record_stage(
                 "new_files_to_process",
                 sample_count=pending_items,
                 ignore_existing_cache=ignore_existing_cache,
             )
-        for idx in tqdm(
-            range(total_items),
-            desc="Processing HF dataset items",
-            total=total_items,
-            leave=False,
-            ncols=100,
+        for progress_index, idx in enumerate(
+            tqdm(
+                indices,
+                desc="Processing HF dataset items",
+                total=len(indices),
+                leave=False,
+                ncols=100,
+            )
         ):
             if progress_callback is not None:
-                progress_callback(idx + 1, total_items)
+                progress_callback(progress_index + 1, len(indices))
 
             virtual_path = f"{idx}.{self.file_extension}"
 

--- a/simpletuner/helpers/metadata/backends/parquet.py
+++ b/simpletuner/helpers/metadata/backends/parquet.py
@@ -280,6 +280,10 @@ class ParquetMetadataBackend(MetadataBackend):
                     )
             # Load filtering statistics if present
             self.filtering_statistics = cache_data.get("filtering_statistics")
+            try:
+                self.load_image_metadata()
+            except Exception as e:
+                logger.warning(f"Error loading parquet metadata cache, continuing with empty metadata: {e}")
         else:
             logger.warning("No cache file found, starting a fresh one.")
 
@@ -344,9 +348,15 @@ class ParquetMetadataBackend(MetadataBackend):
                 ignore_existing_cache=ignore_existing_cache,
             )
         if not new_files:
+            if not self.image_metadata_loaded:
+                try:
+                    self.load_image_metadata()
+                except Exception as e:
+                    raise Exception(f"Error loading image metadata. Consider removing the metadata file manually: {e}")
             if self.bucket_report:
                 self.bucket_report.update_statistics(statistics)
                 self.bucket_report.record_bucket_snapshot("post_refresh", self.aspect_ratio_bucket_indices)
+            self._ensure_metadata_for_cached_buckets()
             return
 
         if ignore_existing_cache:
@@ -421,14 +431,17 @@ class ParquetMetadataBackend(MetadataBackend):
         if isinstance(series_or_scalar, pd.Series):
             series_or_scalar = series_or_scalar.iloc[0]  # Just unwrap the first value
         elif isinstance(series_or_scalar, str):
-            series_or_scalar = float(series_or_scalar) if "." in series_or_scalar else int(series_or_scalar)
+            try:
+                series_or_scalar = float(series_or_scalar) if "." in series_or_scalar else int(series_or_scalar)
+            except ValueError:
+                return series_or_scalar
 
         # After unwrapping, if it's an np.int* or np.float*, cast to python int/float
         if isinstance(series_or_scalar, np.integer):
             return int(series_or_scalar)
         elif isinstance(series_or_scalar, np.floating):
             return float(series_or_scalar)
-        elif isinstance(series_or_scalar, (int, float)):
+        elif isinstance(series_or_scalar, (int, float, str, list, tuple, dict)):
             return series_or_scalar
         elif series_or_scalar is None:
             return None
@@ -708,6 +721,11 @@ class ParquetMetadataBackend(MetadataBackend):
                     duration_seconds = None
 
             overrides = {}
+            caption_column = self.parquet_config.get("caption_column")
+            caption_value = self._extract_audio_value(database_row, caption_column)
+            if caption_value:
+                overrides["tags"] = caption_value
+                overrides["prompt"] = caption_value
             lyrics_column = self.parquet_config.get("lyrics_column")
             if lyrics_column:
                 lyrics_value = self._extract_audio_value(database_row, lyrics_column)

--- a/simpletuner/helpers/models/ace_step/model.py
+++ b/simpletuner/helpers/models/ace_step/model.py
@@ -244,7 +244,8 @@ class ACEStep(AudioModelFoundation):
 
     def __init__(self, config: dict, accelerator):
         super().__init__(config, accelerator)
-        self.text_tokenizer_max_length = getattr(self.config, "tokenizer_max_length", 256)
+        default_text_length = 77 if str(getattr(self.config, "model_flavour", "")).startswith("v15") else 256
+        self.text_tokenizer_max_length = int(getattr(self.config, "tokenizer_max_length", None) or default_text_length)
         self.mert_model = None
         self.hubert_model = None
         self.resampler_mert = None
@@ -261,6 +262,7 @@ class ACEStep(AudioModelFoundation):
         self._v15_layout: Optional[Dict[str, str]] = None
         self._v15_layout_probe_base: Optional[str] = None
         self.silence_latent: Optional[torch.Tensor] = None
+        self.v15_condition_model_dtype = getattr(self.config, "weight_dtype", torch.float32)
 
     def get_lora_target_layers(self):
         manual_targets = self._get_peft_lora_target_modules()
@@ -434,6 +436,27 @@ class ACEStep(AudioModelFoundation):
 
     def _load_v15_hf_component(self, loader_cls, *, component_name: str, pretrained_model_name_or_path: str, **kwargs):
         trust_remote_code = self._trust_remote_code_enabled()
+        force_cpu_init_without_meta = bool(kwargs.pop("force_cpu_init_without_meta", False))
+        original_get_init_context = None
+        if force_cpu_init_without_meta:
+            from transformers.modeling_utils import PreTrainedModel
+
+            original_get_init_context = PreTrainedModel.get_init_context
+            original_get_init_context_func = original_get_init_context.__func__
+
+            def get_cpu_init_context(cls, dtype, is_quantized, _is_ds_init_called, allow_all_kernels):
+                contexts = original_get_init_context_func(
+                    cls,
+                    dtype,
+                    is_quantized,
+                    _is_ds_init_called,
+                    allow_all_kernels,
+                )
+                return [
+                    context for context in contexts if not (isinstance(context, torch.device) and context.type == "meta")
+                ]
+
+            PreTrainedModel.get_init_context = classmethod(get_cpu_init_context)
         try:
             return loader_cls.from_pretrained(
                 pretrained_model_name_or_path=pretrained_model_name_or_path,
@@ -448,6 +471,9 @@ class ACEStep(AudioModelFoundation):
                     "`trust_remote_code=true` in the SimpleTuner configuration and retry."
                 ) from exc
             raise
+        finally:
+            if original_get_init_context is not None:
+                PreTrainedModel.get_init_context = original_get_init_context
 
     def _build_v15_text_prompt(self, prompt: str, prompt_context: Optional[dict]) -> str:
         metadata = prompt_context or {}
@@ -475,6 +501,18 @@ class ACEStep(AudioModelFoundation):
         if embedding_layer is None:
             raise AttributeError("ACE-Step v1.5 text encoder does not expose an input embedding layer.")
         return embedding_layer
+
+    def _ensure_v15_condition_model_dtype(self):
+        model = getattr(self, "model", None)
+        if not self._is_v15_layout_active() or model is None:
+            return
+        component = self.unwrap_model(model=model)
+        try:
+            first_param = next(component.parameters())
+        except StopIteration:
+            return
+        if first_param.dtype != self.v15_condition_model_dtype:
+            component.to(device=self.accelerator.device, dtype=self.v15_condition_model_dtype)
 
     def _get_v15_silence_latent_slice(self, length: int, device, dtype) -> torch.Tensor:
         if self.silence_latent is None:
@@ -540,15 +578,79 @@ class ACEStep(AudioModelFoundation):
         )
         refer_audio_order_mask = torch.zeros(text_hidden_states.shape[0], device=text_hidden_states.device, dtype=torch.long)
         full_model.encoder.eval()
+        model_config = getattr(full_model, "config", None)
+        original_attn_implementation = getattr(model_config, "_attn_implementation", None)
         with torch.no_grad():
-            return full_model.encoder(
-                text_hidden_states=text_hidden_states,
-                text_attention_mask=text_attention_mask,
-                lyric_hidden_states=lyric_hidden_states,
-                lyric_attention_mask=lyric_attention_mask,
-                refer_audio_acoustic_hidden_states_packed=refer_audio_hidden,
-                refer_audio_order_mask=refer_audio_order_mask,
+            try:
+                if model_config is not None:
+                    model_config._attn_implementation = "eager"
+                return full_model.encoder(
+                    text_hidden_states=text_hidden_states,
+                    text_attention_mask=text_attention_mask,
+                    lyric_hidden_states=lyric_hidden_states,
+                    lyric_attention_mask=lyric_attention_mask,
+                    refer_audio_acoustic_hidden_states_packed=refer_audio_hidden,
+                    refer_audio_order_mask=refer_audio_order_mask,
+                )
+            finally:
+                if model_config is not None:
+                    model_config._attn_implementation = original_attn_implementation
+
+    def _configure_v15_flash_attention(self) -> None:
+        if not torch.cuda.is_available() or not hasattr(self.model, "config"):
+            return
+
+        attn_implementation = "kernels-community/flash-attn2"
+        try:
+            import transformers.modeling_flash_attention_utils as flash_utils
+            from huggingface_hub import constants as hf_hub_constants
+            from transformers.integrations import hub_kernels
+            from transformers.integrations.flash_attention import flash_attention_forward
+            from transformers.masking_utils import ALL_MASK_ATTENTION_FUNCTIONS
+            from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+            original_disable_telemetry = hf_hub_constants.HF_HUB_DISABLE_TELEMETRY
+            try:
+                # huggingface_hub 1.26 can emit an illegal trailing-semicolon
+                # User-Agent when telemetry is disabled and `kernels` downloads
+                # hub kernels. Keep the environment unchanged and only patch the
+                # cached constant for this direct kernel load.
+                hf_hub_constants.HF_HUB_DISABLE_TELEMETRY = False
+                kernel = hub_kernels.get_kernel_hub(
+                    attn_implementation,
+                    version=1,
+                    trust_remote_code=True,
+                )
+            finally:
+                hf_hub_constants.HF_HUB_DISABLE_TELEMETRY = original_disable_telemetry
+            flash_utils._loaded_implementation = attn_implementation
+            flash_utils._flash_fn = getattr(kernel, "flash_attn_func", None)
+            flash_utils._flash_varlen_fn = getattr(kernel, "flash_attn_varlen_func", None)
+            flash_utils._flash_with_kvcache_fn = getattr(kernel, "flash_attn_with_kvcache", None)
+            flash_utils._pad_fn = flash_utils._pad_input
+            flash_utils._unpad_fn = flash_utils._unpad_input
+            flash_utils._process_flash_kwargs_fn = flash_utils._lazy_define_process_function(flash_utils._flash_varlen_fn)
+            ALL_ATTENTION_FUNCTIONS.register(attn_implementation, flash_attention_forward)
+            ALL_MASK_ATTENTION_FUNCTIONS.register(
+                attn_implementation,
+                ALL_MASK_ATTENTION_FUNCTIONS["flash_attention_2"],
             )
+            self.model.config._attn_implementation_internal = attn_implementation
+        except Exception as exc:
+            logger.warning(
+                "Could not register ACE-Step v1.5 FlashAttention 2 fallback kernel; falling back to eager attention: %s",
+                exc,
+            )
+            self.model.config._attn_implementation = "eager"
+
+    def _v15_flash_attention_mask(self, mask: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
+        if mask is None:
+            return None
+        full_model = self.unwrap_model(model=self.model)
+        attn_implementation = getattr(getattr(full_model, "config", None), "_attn_implementation", None)
+        if attn_implementation != "eager" and torch.is_tensor(mask):
+            return None
+        return mask
 
     def _sample_v15_timesteps(self, batch_size: int, device, dtype) -> torch.Tensor:
         full_model = self.unwrap_model(model=self.model)
@@ -643,6 +745,8 @@ class ACEStep(AudioModelFoundation):
                     [
                         f"{v15_variant_subdir}/*",
                         f"{v15_variant_subdir}/{self.V15_SILENCE_LATENT_FILENAME}",
+                        "acestep-v15-*/*",
+                        "acestep-v15-*/silence_latent.pt",
                     ]
                 )
             else:
@@ -765,10 +869,14 @@ class ACEStep(AudioModelFoundation):
                 AutoModel,
                 component_name="condition model",
                 pretrained_model_name_or_path=v15_layout["variant_path"],
-                torch_dtype=self.config.weight_dtype,
+                torch_dtype=self.v15_condition_model_dtype,
+                low_cpu_mem_usage=False,
+                allow_all_kernels=True,
+                force_cpu_init_without_meta=True,
             )
             if move_to_device:
-                self.model.to(self.accelerator.device, dtype=self.config.weight_dtype)
+                self.model.to(self.accelerator.device, dtype=self.v15_condition_model_dtype)
+            self._configure_v15_flash_attention()
             for module_name in ("encoder", "tokenizer", "detokenizer"):
                 module = getattr(self.model, module_name, None)
                 if module is None:
@@ -1398,7 +1506,7 @@ class ACEStep(AudioModelFoundation):
     def get_trained_component(self, base_model: bool = False, unwrap_model: bool = True):
         if not self._is_v15_layout_active():
             return super().get_trained_component(base_model=base_model, unwrap_model=unwrap_model)
-        component = self.model if base_model else getattr(self.model, "decoder", None)
+        component = self.model
         if unwrap_model:
             return self.unwrap_model(model=component)
         return component
@@ -1444,11 +1552,11 @@ class ACEStep(AudioModelFoundation):
         if self._ramtorch_enabled():
             ramtorch_utils.register_lora_custom_module(self.lora_config)
 
-        self.model.decoder = get_peft_model(self.model.decoder, self.lora_config)
+        self.model = get_peft_model(self.model, self.lora_config)
 
         if getattr(self.config, "init_lora", None):
             addkeys, misskeys = load_lora_weights(
-                {self.MODEL_TYPE.value: self.model.decoder},
+                {self.MODEL_TYPE.value: self.model},
                 self.config.init_lora,
                 use_dora=getattr(self.config, "use_dora", False),
             )
@@ -1488,13 +1596,15 @@ class ACEStep(AudioModelFoundation):
                 batch["encoder_attention_mask"] = torch.ones(mask_shape, dtype=torch.long)
 
             device = self.accelerator.device
-            dtype = getattr(self.config, "weight_dtype", torch.float32)
+            dtype = self.v15_condition_model_dtype
             latents = latent_batch.to(device=device, dtype=dtype)
             batch_size = latents.shape[0]
-            normalized_lyrics = self._normalize_v15_lyrics_inputs(lyrics, batch_size=batch_size)
             attention_mask = batch["latent_attention_mask"].to(device=device, dtype=dtype)
             text_hidden_states = batch["prompt_embeds"].to(device=device, dtype=dtype)
             text_attention_mask = batch["encoder_attention_mask"].to(device=device, dtype=torch.long)
+
+            self._ensure_v15_condition_model_dtype()
+            normalized_lyrics = self._normalize_v15_lyrics_inputs(lyrics, batch_size=batch_size)
             lyric_hidden_states, lyric_attention_mask = self._embed_v15_lyrics_batch(normalized_lyrics)
             encoder_hidden_states, encoder_attention_mask = self._run_v15_encoder(
                 text_hidden_states=text_hidden_states,
@@ -1523,6 +1633,8 @@ class ACEStep(AudioModelFoundation):
                     null_condition_emb = null_condition_emb.to(device=device, dtype=dtype).expand_as(encoder_hidden_states)
                     encoder_hidden_states = torch.where(keep_mask > 0, encoder_hidden_states, null_condition_emb)
 
+            context_latents = self._build_v15_context_latents(latents.shape[1], latents.shape[0], device, dtype)
+
             return {
                 "latents": latents,
                 "noise": noise,
@@ -1531,7 +1643,7 @@ class ACEStep(AudioModelFoundation):
                 "attention_mask": attention_mask,
                 "encoder_hidden_states": encoder_hidden_states,
                 "encoder_attention_mask": encoder_attention_mask,
-                "context_latents": self._build_v15_context_latents(latents.shape[1], latents.shape[0], device, dtype),
+                "context_latents": context_latents,
                 "flow_target": noise - latents,
             }
 
@@ -1647,31 +1759,63 @@ class ACEStep(AudioModelFoundation):
             raise ValueError("ACE-Step transformer has not been loaded before model_predict was invoked.")
 
         if self._is_v15_layout_active():
+            self._ensure_v15_condition_model_dtype()
+            full_model = self.unwrap_model(model=self.model)
+            decoder = getattr(full_model, "decoder", None)
+            if decoder is None and hasattr(full_model, "base_model"):
+                base_model = getattr(full_model.base_model, "model", full_model.base_model)
+                decoder = getattr(base_model, "decoder", None)
+            if decoder is None:
+                raise ValueError("ACE-Step v1.5 condition model does not expose a decoder module.")
             call_kwargs = {
                 "hidden_states": prepared_batch["noisy_latents"],
                 "timestep": prepared_batch["timesteps"],
-                "attention_mask": prepared_batch["attention_mask"],
+                "attention_mask": self._v15_flash_attention_mask(prepared_batch["attention_mask"]),
                 "encoder_hidden_states": prepared_batch["encoder_hidden_states"],
-                "encoder_attention_mask": prepared_batch.get("encoder_attention_mask"),
+                "encoder_attention_mask": self._v15_flash_attention_mask(prepared_batch.get("encoder_attention_mask")),
                 "context_latents": prepared_batch["context_latents"],
                 "timestep_r": prepared_batch["timesteps"],
             }
             call_kwargs.update(
                 self._get_flowmap_r_timestep_forward_kwargs(
                     prepared_batch,
-                    target=getattr(transformer, "forward", transformer),
+                    target=getattr(decoder, "forward", decoder),
                     kwarg_name="timestep_r",
                 )
             )
-            output = transformer(**call_kwargs)
+            output = decoder(**call_kwargs)
             flow_pred = output[0] if isinstance(output, (tuple, list)) else getattr(output, "sample", None)
             if flow_pred is None and hasattr(output, "__getitem__"):
                 flow_pred = output[0]
             if flow_pred is None:
                 raise ValueError("ACE-Step v1.5 decoder did not return a flow prediction tensor.")
             if not torch.isfinite(flow_pred).all():
+
+                def _tensor_summary(name: str, tensor: Optional[torch.Tensor]) -> str:
+                    if not torch.is_tensor(tensor):
+                        return f"{name}=None"
+                    finite = torch.isfinite(tensor)
+                    if not finite.any():
+                        return f"{name}=shape{tuple(tensor.shape)} dtype={tensor.dtype} all_nonfinite"
+                    sample = tensor.detach()[finite].float()
+                    return (
+                        f"{name}=shape{tuple(tensor.shape)} dtype={tensor.dtype} "
+                        f"min={sample.min().item()} max={sample.max().item()} mean={sample.mean().item()}"
+                    )
+
                 raise ValueError(
-                    f"Non-finite model_prediction detected (min={flow_pred.min().item()}, max={flow_pred.max().item()})"
+                    "Non-finite model_prediction detected: "
+                    + "; ".join(
+                        [
+                            _tensor_summary("noisy_latents", prepared_batch.get("noisy_latents")),
+                            _tensor_summary("timesteps", prepared_batch.get("timesteps")),
+                            _tensor_summary("attention_mask", prepared_batch.get("attention_mask")),
+                            _tensor_summary("encoder_hidden_states", prepared_batch.get("encoder_hidden_states")),
+                            _tensor_summary("encoder_attention_mask", prepared_batch.get("encoder_attention_mask")),
+                            _tensor_summary("context_latents", prepared_batch.get("context_latents")),
+                            _tensor_summary("flow_pred", flow_pred),
+                        ]
+                    )
                 )
             return {
                 "model_prediction": flow_pred,
@@ -1736,6 +1880,11 @@ class ACEStep(AudioModelFoundation):
         """
         import torch.nn.functional as F
 
+        if self._is_v15_layout_active():
+            diffusion_loss = model_output.get("diffusion_loss") if isinstance(model_output, dict) else None
+            if diffusion_loss is not None:
+                return diffusion_loss
+
         model_pred = model_output.get("model_prediction")
         if model_pred is None:
             model_pred = model_output.get("sample")
@@ -1770,6 +1919,12 @@ class ACEStep(AudioModelFoundation):
         return loss
 
     def auxiliary_loss(self, model_output, prepared_batch: dict, loss: torch.Tensor, **kwargs):
+        if (
+            self._is_v15_layout_active()
+            and isinstance(model_output, dict)
+            and model_output.get("diffusion_loss") is not None
+        ):
+            return loss, None
         loss, base_logs = super().auxiliary_loss(model_output=model_output, prepared_batch=prepared_batch, loss=loss)
         proj_losses = model_output.get("proj_losses")
         if not proj_losses:

--- a/simpletuner/helpers/models/heartmula/model.py
+++ b/simpletuner/helpers/models/heartmula/model.py
@@ -50,6 +50,7 @@ class HeartMuLa(AudioModelFoundation):
     def __init__(self, config, accelerator):
         super().__init__(config, accelerator)
         self.model = None
+        self.vae = None
         self.tokenizer: Optional[Tokenizer] = None
         self.gen_config: Optional[HeartMuLaGenConfig] = None
         self._gen_asset_path: Optional[str] = None
@@ -96,6 +97,10 @@ class HeartMuLa(AudioModelFoundation):
                 )
             ]
         return []
+
+    def check_user_config(self):
+        super().check_user_config()
+        self.DEFAULT_PIPELINE_TYPE = PipelineTypes.TEXT2AUDIO
 
     def uses_audio_latents(self) -> bool:
         return False
@@ -173,6 +178,26 @@ class HeartMuLa(AudioModelFoundation):
             self.model.to(self.accelerator.device)
         return self.model
 
+    def get_pipeline(self, pipeline_type: str = PipelineTypes.TEXT2AUDIO, load_base_model: bool = True):
+        if isinstance(pipeline_type, str):
+            pipeline_type = PipelineTypes(pipeline_type)
+        if pipeline_type != PipelineTypes.TEXT2AUDIO:
+            raise NotImplementedError(f"Pipeline type {pipeline_type} not defined in {self.__class__.__name__}.")
+        cached_pipeline = self.pipelines.get(pipeline_type)
+        transformer = self.unwrap_model(model=self.model) if self.model is not None else None
+        if cached_pipeline is not None:
+            if transformer is not None:
+                cached_pipeline.transformer = transformer
+            return cached_pipeline
+
+        pipeline = self.PIPELINE_CLASSES[pipeline_type].from_pretrained(
+            self._resolve_pretrained_path(),
+            transformer=transformer,
+            torch_dtype=self.config.weight_dtype,
+        )
+        self.pipelines[pipeline_type] = pipeline
+        return pipeline
+
     def add_lora_adapter(self):
         from peft import LoraConfig, get_peft_model
 
@@ -221,6 +246,23 @@ class HeartMuLa(AudioModelFoundation):
             )
 
         return addkeys, misskeys
+
+    def save_lora_weights(self, *args, **kwargs):
+        if args:
+            save_directory = args[0]
+        else:
+            save_directory = kwargs.get("save_directory")
+        if save_directory is None:
+            raise ValueError("save_directory is required to save LoRA weights.")
+
+        os.makedirs(save_directory, exist_ok=True)
+        trained_component = self.get_trained_component()
+        if trained_component is None:
+            raise ValueError("No HeartMuLa component is available to save LoRA weights.")
+        trained_component = self.unwrap_model(model=trained_component)
+        if not hasattr(trained_component, "save_pretrained"):
+            raise NotImplementedError("HeartMuLa LoRA saving requires a PEFT-wrapped component.")
+        trained_component.save_pretrained(save_directory, safe_serialization=True)
 
     def prepare_batch(self, batch: dict, state: dict) -> dict:
         if not batch:

--- a/simpletuner/helpers/models/omnigen/model.py
+++ b/simpletuner/helpers/models/omnigen/model.py
@@ -161,6 +161,9 @@ class OmniGen(ImageModelFoundation):
     def supports_crepa_self_flow(self) -> bool:
         return True
 
+    def uses_text_embeddings_cache(self) -> bool:
+        return False
+
     def get_transforms(self, dataset_type: str = "image"):
         from torchvision import transforms
 

--- a/simpletuner/helpers/models/wan_s2v/model.py
+++ b/simpletuner/helpers/models/wan_s2v/model.py
@@ -6,7 +6,9 @@ from typing import Dict, Optional
 import torch
 import torchaudio
 from diffusers import AutoencoderKLWan, FlowMatchEulerDiscreteScheduler
-from transformers import T5TokenizerFast, UMT5EncoderModel, Wav2Vec2Model, Wav2Vec2Processor
+from huggingface_hub import hf_hub_download
+from safetensors import safe_open
+from transformers import T5TokenizerFast, UMT5EncoderModel, Wav2Vec2FeatureExtractor, Wav2Vec2Model
 
 from simpletuner.helpers.models.common import ModelTypes, PipelineTypes, PredictionTypes, VideoModelFoundation
 from simpletuner.helpers.models.tae.types import VideoTAESpec
@@ -100,7 +102,7 @@ class WanS2V(VideoModelFoundation):
                 return
 
             logger.info(f"Loading Wav2Vec2 audio encoder from {self.AUDIO_ENCODER_MODEL}")
-            self._audio_processor = Wav2Vec2Processor.from_pretrained(self.AUDIO_ENCODER_MODEL)
+            self._audio_processor = Wav2Vec2FeatureExtractor.from_pretrained(self.AUDIO_ENCODER_MODEL)
             self._audio_encoder = Wav2Vec2Model.from_pretrained(
                 self.AUDIO_ENCODER_MODEL,
                 torch_dtype=torch.float32,  # Wav2Vec2 needs fp32
@@ -246,9 +248,12 @@ class WanS2V(VideoModelFoundation):
         if self.config.t5_padding == "zero":
             prompt_embeds = prompt_embeds * masks.to(device=prompt_embeds.device).unsqueeze(-1).expand(prompt_embeds.shape)
 
-        return prompt_embeds, masks
+        return {
+            "prompt_embeds": prompt_embeds,
+            "attention_masks": masks,
+        }
 
-    def prepare_batch_conditions(self, batch: dict) -> dict:
+    def prepare_batch_conditions(self, batch: dict, state: Optional[dict] = None) -> dict:
         """
         Prepare batch with audio conditioning.
 
@@ -445,11 +450,6 @@ class WanS2V(VideoModelFoundation):
         self.config.vae_enable_tiling = True
         self.config.vae_enable_slicing = True
 
-    def pretrained_load_args(self, pretrained_load_args: dict) -> dict:
-        """Arguments for loading pretrained model."""
-        load_args = super().pretrained_load_args(pretrained_load_args)
-        return load_args
-
     def get_pipeline(self, pipeline_type: PipelineTypes, load_base_model: bool = True):
         """Get inference pipeline for validation."""
         if pipeline_type not in self.PIPELINE_CLASSES:
@@ -463,8 +463,14 @@ class WanS2V(VideoModelFoundation):
         else:
             transformer = None
 
-        tokenizer = self.get_tokenizer()
-        text_encoder = self.get_text_encoder()
+        if self.tokenizers is None:
+            self.load_text_tokenizer()
+        tokenizer = self.tokenizers[0] if self.tokenizers else None
+
+        text_encoder = self.get_text_encoder(0)
+        if text_encoder is None:
+            self.load_text_encoder()
+            text_encoder = self.get_text_encoder(0)
         vae = self.get_vae()
         scheduler = FlowMatchEulerDiscreteScheduler()
 
@@ -529,3 +535,98 @@ class WanS2V(VideoModelFoundation):
             self.config.pretrained_model_name_or_path = self.HUGGINGFACE_PATHS[flavour]
 
         logger.info(f"Configured {self.NAME} with flavour: {flavour}")
+
+    def pretrained_load_args(self, pretrained_load_args: dict) -> dict:
+        args = super().pretrained_load_args(pretrained_load_args)
+        args["low_cpu_mem_usage"] = True
+        return args
+
+    @staticmethod
+    def _get_parameter(module: torch.nn.Module, name: str) -> torch.nn.Parameter | None:
+        target = module
+        for part in name.split(".")[:-1]:
+            target = getattr(target, part, None)
+            if target is None:
+                return None
+        parameter = getattr(target, name.split(".")[-1], None)
+        return parameter if isinstance(parameter, torch.nn.Parameter) else None
+
+    @staticmethod
+    def _set_parameter(module: torch.nn.Module, name: str, tensor: torch.Tensor, requires_grad: bool) -> None:
+        target = module
+        parts = name.split(".")
+        for part in parts[:-1]:
+            target = getattr(target, part)
+        setattr(target, parts[-1], torch.nn.Parameter(tensor, requires_grad=requires_grad))
+
+    @staticmethod
+    def _checkpoint_file(model_path: str, model_subfolder: str | None, filename: str, load_kwargs: dict) -> str:
+        relpath = f"{model_subfolder}/{filename}" if model_subfolder else filename
+        if os.path.isdir(model_path):
+            return os.path.join(model_path, relpath)
+        return hf_hub_download(
+            model_path,
+            relpath,
+            revision=load_kwargs.get("revision"),
+            local_files_only=bool(load_kwargs.get("local_files_only", False)),
+        )
+
+    def _load_checkpoint_tensor(
+        self,
+        model_path: str,
+        model_subfolder: str | None,
+        tensor_name: str,
+        load_kwargs: dict,
+    ) -> torch.Tensor | None:
+        import json
+
+        index_path = self._checkpoint_file(
+            model_path,
+            model_subfolder,
+            "diffusion_pytorch_model.safetensors.index.json",
+            load_kwargs,
+        )
+        with open(index_path, "r") as handle:
+            weight_map = json.load(handle).get("weight_map", {})
+        shard_name = weight_map.get(tensor_name)
+        if shard_name is None:
+            return None
+        shard_path = self._checkpoint_file(model_path, model_subfolder, shard_name, load_kwargs)
+        with safe_open(shard_path, framework="pt", device="cpu") as shard:
+            return shard.get_tensor(tensor_name)
+
+    def materialize_meta_tensors_after_load(
+        self,
+        model: torch.nn.Module,
+        model_path: str,
+        model_subfolder: str | None,
+        load_kwargs: dict,
+    ) -> bool:
+        aliases = {
+            "condition_embedder.causal_audio_encoder.weighted_avg.weights": "condition_embedder.causal_audio_encoder.weights",
+            "condition_embedder.causal_audio_encoder.encoder.conv2.conv.conv.weight": "condition_embedder.causal_audio_encoder.encoder.conv2.conv.weight",
+            "condition_embedder.causal_audio_encoder.encoder.conv2.conv.conv.bias": "condition_embedder.causal_audio_encoder.encoder.conv2.conv.bias",
+            "condition_embedder.causal_audio_encoder.encoder.conv3.conv.conv.weight": "condition_embedder.causal_audio_encoder.encoder.conv3.conv.weight",
+            "condition_embedder.causal_audio_encoder.encoder.conv3.conv.conv.bias": "condition_embedder.causal_audio_encoder.encoder.conv3.conv.bias",
+        }
+        materialized = False
+        for target_name, source_name in aliases.items():
+            target_parameter = self._get_parameter(model, target_name)
+            if target_parameter is None or target_parameter.device.type != "meta":
+                continue
+            source_tensor = self._load_checkpoint_tensor(model_path, model_subfolder, source_name, load_kwargs)
+            if source_tensor is None:
+                continue
+            if tuple(source_tensor.shape) != tuple(target_parameter.shape):
+                logger.warning(
+                    "Skipping WanS2V checkpoint alias %s -> %s because shapes differ: %s != %s",
+                    source_name,
+                    target_name,
+                    tuple(source_tensor.shape),
+                    tuple(target_parameter.shape),
+                )
+                continue
+            source_tensor = source_tensor.to(dtype=target_parameter.dtype, device="cpu")
+            self._set_parameter(model, target_name, source_tensor, requires_grad=target_parameter.requires_grad)
+            materialized = True
+        return materialized

--- a/simpletuner/helpers/models/wan_s2v/model.py
+++ b/simpletuner/helpers/models/wan_s2v/model.py
@@ -7,7 +7,8 @@ import torch
 import torchaudio
 from diffusers import AutoencoderKLWan, FlowMatchEulerDiscreteScheduler
 from huggingface_hub import hf_hub_download
-from safetensors import safe_open
+from huggingface_hub.errors import EntryNotFoundError, HfHubHTTPError, LocalEntryNotFoundError
+from safetensors import SafetensorError, safe_open
 from transformers import T5TokenizerFast, UMT5EncoderModel, Wav2Vec2FeatureExtractor, Wav2Vec2Model
 
 from simpletuner.helpers.models.common import ModelTypes, PipelineTypes, PredictionTypes, VideoModelFoundation
@@ -580,20 +581,28 @@ class WanS2V(VideoModelFoundation):
     ) -> torch.Tensor | None:
         import json
 
-        index_path = self._checkpoint_file(
-            model_path,
-            model_subfolder,
-            "diffusion_pytorch_model.safetensors.index.json",
-            load_kwargs,
-        )
-        with open(index_path, "r") as handle:
-            weight_map = json.load(handle).get("weight_map", {})
+        try:
+            index_path = self._checkpoint_file(
+                model_path,
+                model_subfolder,
+                "diffusion_pytorch_model.safetensors.index.json",
+                load_kwargs,
+            )
+            with open(index_path, "r", encoding="utf-8") as handle:
+                weight_map = json.load(handle).get("weight_map", {})
+        except (OSError, json.JSONDecodeError, EntryNotFoundError, HfHubHTTPError, LocalEntryNotFoundError) as exc:
+            logger.debug("Skipping WanS2V checkpoint alias materialization; could not read safetensors index: %s", exc)
+            return None
         shard_name = weight_map.get(tensor_name)
         if shard_name is None:
             return None
-        shard_path = self._checkpoint_file(model_path, model_subfolder, shard_name, load_kwargs)
-        with safe_open(shard_path, framework="pt", device="cpu") as shard:
-            return shard.get_tensor(tensor_name)
+        try:
+            shard_path = self._checkpoint_file(model_path, model_subfolder, shard_name, load_kwargs)
+            with safe_open(shard_path, framework="pt", device="cpu") as shard:
+                return shard.get_tensor(tensor_name)
+        except (OSError, SafetensorError, KeyError, EntryNotFoundError, HfHubHTTPError, LocalEntryNotFoundError) as exc:
+            logger.debug("Skipping WanS2V checkpoint alias %s; could not read tensor: %s", tensor_name, exc)
+            return None
 
     def materialize_meta_tensors_after_load(
         self,

--- a/simpletuner/helpers/prompts.py
+++ b/simpletuner/helpers/prompts.py
@@ -588,9 +588,17 @@ class PromptHandler:
         captions = []
         caption_image_paths = []
         images_missing_captions = []
-        all_image_files = StateTracker.get_image_files(data_backend_id=data_backend.id) or data_backend.list_files(
-            instance_data_dir=instance_data_dir, file_extensions=image_file_extensions
-        )
+        metadata_backend = (StateTracker.get_data_backend(data_backend.id) or {}).get("metadata_backend")
+        bucket_indices = getattr(metadata_backend, "aspect_ratio_bucket_indices", None)
+        max_num_samples = getattr(metadata_backend, "max_num_samples", None) or backend_config.get("max_num_samples")
+        if max_num_samples and isinstance(bucket_indices, dict) and bucket_indices:
+            all_image_files = []
+            for bucket in sorted(bucket_indices.keys(), key=str):
+                all_image_files.extend(bucket_indices[bucket])
+        else:
+            all_image_files = StateTracker.get_image_files(data_backend_id=data_backend.id) or data_backend.list_files(
+                instance_data_dir=instance_data_dir, file_extensions=image_file_extensions
+            )
         if isinstance(all_image_files, list) and len(all_image_files) > 0 and isinstance(all_image_files[0], tuple):
             all_image_files = all_image_files[0][2]
         from tqdm import tqdm

--- a/simpletuner/helpers/prompts.py
+++ b/simpletuner/helpers/prompts.py
@@ -588,7 +588,11 @@ class PromptHandler:
         captions = []
         caption_image_paths = []
         images_missing_captions = []
-        metadata_backend = (StateTracker.get_data_backend(data_backend.id) or {}).get("metadata_backend")
+        try:
+            data_backend_state = StateTracker.get_data_backend(data_backend.id) or {}
+        except KeyError:
+            data_backend_state = {}
+        metadata_backend = data_backend_state.get("metadata_backend")
         bucket_indices = getattr(metadata_backend, "aspect_ratio_bucket_indices", None)
         max_num_samples = getattr(metadata_backend, "max_num_samples", None) or backend_config.get("max_num_samples")
         if max_num_samples and isinstance(bucket_indices, dict) and bucket_indices:

--- a/simpletuner/helpers/training/collate.py
+++ b/simpletuner/helpers/training/collate.py
@@ -396,6 +396,7 @@ def compute_prompt_embeddings(prompt_entries, text_embed_cache, model):
         - If tensors are 3D [1, seq, dim], concatenate along dim=0 to get [batch, seq, dim]
         - If tensors have inconsistent dimensions, normalize them first
         """
+        tensors = [tensor for tensor in tensors if tensor is not None]
         if not tensors:
             return None
 
@@ -644,6 +645,13 @@ def collate_fn(batch):
         token_payload["is_regularisation_data"] = is_regularisation_data
         token_payload["is_i2v_data"] = is_i2v_data
         return token_payload
+
+    uses_text_embeddings_cache = True
+    if model is not None:
+        try:
+            uses_text_embeddings_cache = bool(model.uses_text_embeddings_cache())
+        except AttributeError:
+            uses_text_embeddings_cache = True
 
     debug_log("Compute latents")
     batch_data = compute_latents(filepaths, batch_backend_id, model)
@@ -1026,17 +1034,16 @@ def collate_fn(batch):
         # If the caption is empty, we use the instance prompt text.
         captions = [caption if caption else example["instance_prompt_text"] for caption, example in zip(captions, examples)]
         debug_log(f"Pull cached text embeds. conditioning captions: {captions}")
-
-        # Get the appropriate text_embed_cache
-        if conditioning_backends:
-            text_embed_cache = conditioning_backends[0]["text_embed_cache"]
-        else:
-            text_embed_cache = StateTracker.get_data_backend(data_backend_id)["text_embed_cache"]
     else:
         # Use training captions (default behavior)
         captions = [example["instance_prompt_text"] for example in examples]
         debug_log(f"Pull cached text embeds. Using training set captions: {captions}")
-        text_embed_cache = StateTracker.get_data_backend(data_backend_id)["text_embed_cache"]
+    text_embed_cache = None
+    if uses_text_embeddings_cache:
+        if has_conditioning_captions and is_random_mode and conditioning_backends:
+            text_embed_cache = conditioning_backends[0]["text_embed_cache"]
+        else:
+            text_embed_cache = StateTracker.get_data_backend(data_backend_id)["text_embed_cache"]
     prompt_requests = []
     key_type = TextEmbedCacheKey.CAPTION
     getter = getattr(model, "text_embed_cache_key", None)
@@ -1046,53 +1053,54 @@ def collate_fn(batch):
         except Exception as exc:
             debug_log(f"text_embed_cache_key() lookup failed on model {type(model)}: {exc}")
 
-    for idx, caption in enumerate(captions):
-        example = examples[idx]
-        example_path = example.get("image_path")
-        example_backend_id = example.get("data_backend_id")
-        backend_config = StateTracker.get_data_backend_config(example_backend_id) if example_backend_id else {}
-        backend_config = backend_config or {}
-        dataset_root = backend_config.get("instance_data_dir")
-        normalized_identifier = normalize_data_path(example_path, dataset_root)
-        metadata = {
-            "image_path": example_path,
-            "data_backend_id": example_backend_id,
-            "prompt": caption,
-            "dataset_relative_path": normalized_identifier,
-        }
-        metadata_builder = getattr(model, "text_embed_cache_metadata_for_sample", None)
-        if callable(metadata_builder):
-            metadata.update(
-                metadata_builder(
-                    example=example,
-                    latent=latent_batch[idx],
-                    prompt=caption,
-                    data_backend_id=example_backend_id,
-                    dataset_relative_path=normalized_identifier,
+    if uses_text_embeddings_cache:
+        for idx, caption in enumerate(captions):
+            example = examples[idx]
+            example_path = example.get("image_path")
+            example_backend_id = example.get("data_backend_id")
+            backend_config = StateTracker.get_data_backend_config(example_backend_id) if example_backend_id else {}
+            backend_config = backend_config or {}
+            dataset_root = backend_config.get("instance_data_dir")
+            normalized_identifier = normalize_data_path(example_path, dataset_root)
+            metadata = {
+                "image_path": example_path,
+                "data_backend_id": example_backend_id,
+                "prompt": caption,
+                "dataset_relative_path": normalized_identifier,
+            }
+            metadata_builder = getattr(model, "text_embed_cache_metadata_for_sample", None)
+            if callable(metadata_builder):
+                metadata.update(
+                    metadata_builder(
+                        example=example,
+                        latent=latent_batch[idx],
+                        prompt=caption,
+                        data_backend_id=example_backend_id,
+                        dataset_relative_path=normalized_identifier,
+                    )
                 )
-            )
-        # Only include conditioning pixels for text embedding when using a single
-        # conditioning image. With multiple backends in combined mode, skip image
-        # context in embeddings and rely solely on latent references.
-        # (In random mode with multiple backends, only one image is selected, so
-        # we can still use it for text embedding context.)
-        has_multiple_combined_refs = len(conditioning_backends) > 1 and is_combined_mode
-        if not has_multiple_combined_refs:
-            pixel_value = _conditioning_pixel_value_for_example(idx)
-            if pixel_value is not None:
-                metadata["conditioning_pixel_values"] = pixel_value
-        if key_type is TextEmbedCacheKey.DATASET_AND_FILENAME and example_backend_id and example_path:
-            key_value = f"{example_backend_id}:{normalized_identifier}"
-        elif key_type is TextEmbedCacheKey.FILENAME and example_path:
-            key_value = normalize_data_path(example_path, None)
-        else:
-            key_value = caption
-        key_builder = getattr(model, "text_embed_cache_key_value", None)
-        if callable(key_builder):
-            key_value = key_builder(prompt=caption, default_key=key_value, metadata=metadata)
-        prompt_requests.append({"prompt": caption, "key": key_value, "metadata": metadata})
+            # Only include conditioning pixels for text embedding when using a single
+            # conditioning image. With multiple backends in combined mode, skip image
+            # context in embeddings and rely solely on latent references.
+            # (In random mode with multiple backends, only one image is selected, so
+            # we can still use it for text embedding context.)
+            has_multiple_combined_refs = len(conditioning_backends) > 1 and is_combined_mode
+            if not has_multiple_combined_refs:
+                pixel_value = _conditioning_pixel_value_for_example(idx)
+                if pixel_value is not None:
+                    metadata["conditioning_pixel_values"] = pixel_value
+            if key_type is TextEmbedCacheKey.DATASET_AND_FILENAME and example_backend_id and example_path:
+                key_value = f"{example_backend_id}:{normalized_identifier}"
+            elif key_type is TextEmbedCacheKey.FILENAME and example_path:
+                key_value = normalize_data_path(example_path, None)
+            else:
+                key_value = caption
+            key_builder = getattr(model, "text_embed_cache_key_value", None)
+            if callable(key_builder):
+                key_value = key_builder(prompt=caption, default_key=key_value, metadata=metadata)
+            prompt_requests.append({"prompt": caption, "key": key_value, "metadata": metadata})
 
-    if not text_embed_cache.disabled:
+    if text_embed_cache is not None and not text_embed_cache.disabled:
         all_text_encoder_outputs = compute_prompt_embeddings(prompt_requests, text_embed_cache, StateTracker.get_model())
     else:
         all_text_encoder_outputs = {}
@@ -1132,6 +1140,19 @@ def collate_fn(batch):
     if not any(s2v_audio_paths):
         backend_config = StateTracker.get_data_backend_config(batch_backend_id) or {}
         dataset_type = backend_config.get("dataset_type")
+
+        def resolve_local_source_audio_path(path: str | None) -> str | None:
+            if not path:
+                return None
+            candidates = [path]
+            instance_data_dir = backend_config.get("instance_data_dir")
+            if instance_data_dir and not os.path.isabs(path):
+                candidates.insert(0, os.path.join(instance_data_dir, path.lstrip(os.sep)))
+            for candidate in candidates:
+                if os.path.exists(candidate):
+                    return candidate
+            return None
+
         if dataset_type == "video":
             s2v_datasets = StateTracker.get_s2v_datasets(batch_backend_id)
             if len(s2v_datasets) == 1:
@@ -1142,17 +1163,20 @@ def collate_fn(batch):
                     if audio_backend_id is not None:
                         metadata_backend = s2v_datasets[0].get("metadata_backend")
                         if metadata_backend is None:
-                            s2v_audio_paths = list(filepaths)
-                            s2v_audio_backend_ids = [audio_backend_id] * len(s2v_audio_paths)
+                            s2v_audio_paths = [resolve_local_source_audio_path(path) for path in filepaths]
+                            s2v_audio_backend_ids = [
+                                audio_backend_id if path is not None else None for path in s2v_audio_paths
+                            ]
                         else:
                             s2v_audio_paths = []
                             s2v_audio_backend_ids = []
                             for path in filepaths:
-                                if metadata_backend.get_metadata_by_filepath(path) is None:
+                                audio_path = resolve_local_source_audio_path(path)
+                                if metadata_backend.get_metadata_by_filepath(path) is None or audio_path is None:
                                     s2v_audio_paths.append(None)
                                     s2v_audio_backend_ids.append(None)
                                 else:
-                                    s2v_audio_paths.append(path)
+                                    s2v_audio_paths.append(audio_path)
                                     s2v_audio_backend_ids.append(audio_backend_id)
 
     audio_latent_batch = None
@@ -1228,6 +1252,8 @@ def collate_fn(batch):
     grounding_batch = None
     max_grounding_entities = getattr(StateTracker.get_args(), "max_grounding_entities", None)
     if max_grounding_entities and max_grounding_entities > 0:
+        if text_embed_cache is None:
+            raise ValueError("Grounding annotations require a text embedding cache.")
         from simpletuner.helpers.training.grounding.collate import GroundingCollate
 
         grounding_image_cache = StateTracker.get_grounding_image_embed_cache(data_backend_id)

--- a/simpletuner/helpers/training/save_hooks.py
+++ b/simpletuner/helpers/training/save_hooks.py
@@ -300,7 +300,7 @@ class SaveHookManager:
 
         self.denoiser_class = self.model.MODEL_CLASS
         self.denoiser_subdir = self.model.MODEL_SUBFOLDER
-        pipeline_type = self.model.DEFAULT_PIPELINE_TYPE
+        pipeline_type = getattr(self.model, "DEFAULT_PIPELINE_TYPE", PipelineTypes.TEXT2IMG)
         if args.validation_using_datasets and PipelineTypes.IMG2IMG in self.model.PIPELINE_CLASSES:
             pipeline_type = PipelineTypes.IMG2IMG
         self.pipeline_class = self.model.PIPELINE_CLASSES[pipeline_type]

--- a/simpletuner/helpers/training/save_hooks.py
+++ b/simpletuner/helpers/training/save_hooks.py
@@ -300,9 +300,10 @@ class SaveHookManager:
 
         self.denoiser_class = self.model.MODEL_CLASS
         self.denoiser_subdir = self.model.MODEL_SUBFOLDER
-        self.pipeline_class = self.model.PIPELINE_CLASSES[
-            (PipelineTypes.IMG2IMG if args.validation_using_datasets else PipelineTypes.TEXT2IMG)
-        ]
+        pipeline_type = self.model.DEFAULT_PIPELINE_TYPE
+        if args.validation_using_datasets and PipelineTypes.IMG2IMG in self.model.PIPELINE_CLASSES:
+            pipeline_type = PipelineTypes.IMG2IMG
+        self.pipeline_class = self.model.PIPELINE_CLASSES[pipeline_type]
 
         self.ema_model_cls = self.model.get_trained_component().__class__
         self.ema_model_subdir = f"{self.model.MODEL_SUBFOLDER}_ema"

--- a/simpletuner/helpers/training/save_hooks.py
+++ b/simpletuner/helpers/training/save_hooks.py
@@ -301,9 +301,29 @@ class SaveHookManager:
         self.denoiser_class = self.model.MODEL_CLASS
         self.denoiser_subdir = self.model.MODEL_SUBFOLDER
         pipeline_type = getattr(self.model, "DEFAULT_PIPELINE_TYPE", PipelineTypes.TEXT2IMG)
+        if isinstance(pipeline_type, str):
+            try:
+                pipeline_type = PipelineTypes(pipeline_type)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Unsupported DEFAULT_PIPELINE_TYPE for {type(self.model).__name__}: {pipeline_type!r}"
+                ) from exc
         if args.validation_using_datasets and PipelineTypes.IMG2IMG in self.model.PIPELINE_CLASSES:
             pipeline_type = PipelineTypes.IMG2IMG
-        self.pipeline_class = self.model.PIPELINE_CLASSES[pipeline_type]
+        if not isinstance(pipeline_type, PipelineTypes):
+            raise ValueError(
+                f"DEFAULT_PIPELINE_TYPE for {type(self.model).__name__} must be a PipelineTypes value, "
+                f"got {pipeline_type!r}."
+            )
+        self.pipeline_class = self.model.PIPELINE_CLASSES.get(pipeline_type)
+        if self.pipeline_class is None:
+            available_pipeline_types = ", ".join(
+                key.value if isinstance(key, PipelineTypes) else repr(key) for key in self.model.PIPELINE_CLASSES
+            )
+            raise ValueError(
+                f"{type(self.model).__name__} does not register a save pipeline for {pipeline_type.value!r}. "
+                f"Available pipeline types: {available_pipeline_types or 'none'}."
+            )
 
         self.ema_model_cls = self.model.get_trained_component().__class__
         self.ema_model_subdir = f"{self.model.MODEL_SUBFOLDER}_ema"

--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -696,6 +696,26 @@ def retrieve_validation_s2v_samples() -> list[ValidationPrompt]:
     args = StateTracker.get_args()
     validation_set = []
 
+    def resolve_video_sample_path(sample_path: str, backend_config: dict, sampler: Any) -> str:
+        if not sample_path:
+            return sample_path
+        if Path(sample_path).is_absolute():
+            return sample_path
+
+        sample_root = backend_config.get("instance_data_dir")
+        if not sample_root:
+            metadata_backend = getattr(sampler, "metadata_backend", None)
+            sample_root = getattr(metadata_backend, "instance_data_dir", None)
+        if not sample_root:
+            return sample_path
+
+        return os.path.join(sample_root, sample_path.lstrip(os.sep))
+
+    def local_audio_path_or_none(audio_path: str | None) -> str | None:
+        if not audio_path:
+            return None
+        return audio_path if Path(audio_path).exists() else None
+
     # Get video backends that have s2v_datasets linked
     video_backends = StateTracker.get_data_backends(_type="video")
     selected_eval_backend_ids = _assert_eval_dataset_exists(args.eval_dataset_id, video_backends, "video validation")
@@ -732,15 +752,14 @@ def retrieve_validation_s2v_samples() -> list[ValidationPrompt]:
             # Find matching audio from s2v_datasets
             audio_path = None
             if sample_path is not None:
-                from pathlib import Path
-
+                resolved_sample_path = resolve_video_sample_path(sample_path, backend_config, sampler)
                 video_stem = Path(sample_path).stem
 
                 for s2v_dataset in s2v_datasets:
                     s2v_config = s2v_dataset.get("config", {})
                     audio_config = s2v_config.get("audio", {})
                     if audio_config.get("source_from_video", False):
-                        audio_path = sample_path
+                        audio_path = local_audio_path_or_none(resolved_sample_path)
                         break
                     audio_root = s2v_config.get("instance_data_dir")
                     if not audio_root:
@@ -791,12 +810,15 @@ def _validation_text_cache_key(args, shortname: str, prompt: str) -> str:
 
 
 def prepare_validation_prompt_list(args, embed_cache, model):
-    precompute_text_embeddings = not getattr(embed_cache, "text_cache_ondemand", False)
+    model_uses_text_cache = True
+    if hasattr(model, "uses_text_embeddings_cache"):
+        model_uses_text_cache = model.uses_text_embeddings_cache()
+    precompute_text_embeddings = model_uses_text_cache and not getattr(embed_cache, "text_cache_ondemand", False)
     validation_prompts: list[PromptLibraryEntry] = (
         [PromptLibraryEntry(prompt="")] if not StateTracker.get_args().validation_disable_unconditional else []
     )
     validation_shortnames = ["unconditional"] if not StateTracker.get_args().validation_disable_unconditional else []
-    if not hasattr(embed_cache, "model_type"):
+    if model_uses_text_cache and not hasattr(embed_cache, "model_type"):
         raise ValueError(
             f"The default text embed cache backend was not found. You must specify 'default: true' on your text embed data backend via {StateTracker.get_args().data_backend_config}."
         )
@@ -810,7 +832,7 @@ def prepare_validation_prompt_list(args, embed_cache, model):
         }
         if precompute_text_embeddings:
             embed_cache.compute_embeddings_for_prompts([prompt_record], is_validation=True, load_from_cache=False)
-    model_type = embed_cache.model_type
+    model_type = getattr(embed_cache, "model_type", None)
     validation_sample_images = None
     deepfloyd_stage2_needs_validation_images = (
         "deepfloyd" in args.model_family
@@ -2095,7 +2117,10 @@ class Validation:
 
     def _pipeline_cls(self):
         if self.model is not None:
-            if self.config.validation_using_datasets:
+            if isinstance(self.model, AudioModelFoundation):
+                if PipelineTypes.TEXT2AUDIO not in self.model.PIPELINE_CLASSES:
+                    raise ValueError(f"Cannot run {self.model.MODEL_CLASS} in Text2Audio mode for validation.")
+            if self.config.validation_using_datasets and not isinstance(self.model, AudioModelFoundation):
                 if PipelineTypes.IMG2IMG not in self.model.PIPELINE_CLASSES:
                     raise ValueError(f"Cannot run {self.model.MODEL_CLASS} in Img2Img mode for validation.")
             if self.config.controlnet:
@@ -2111,6 +2136,8 @@ class Validation:
             return self.model.PIPELINE_CLASSES[PipelineTypes.CONTROLNET]
         if self.config.control:
             return self.model.PIPELINE_CLASSES[PipelineTypes.CONTROL]
+        if isinstance(self.model, AudioModelFoundation):
+            return self.model.PIPELINE_CLASSES[PipelineTypes.TEXT2AUDIO]
         return self.model.PIPELINE_CLASSES[PipelineTypes.TEXT2IMG]
 
     def _gather_prompt_embeds(
@@ -2857,6 +2884,9 @@ class Validation:
             if getattr(self.model, "requires_s2v_validation_inputs", lambda: False)():
                 if PipelineTypes.IMG2VIDEO in self.model.PIPELINE_CLASSES:
                     pipeline_type = PipelineTypes.IMG2VIDEO
+            elif isinstance(self.model, AudioModelFoundation):
+                if PipelineTypes.TEXT2AUDIO in self.model.PIPELINE_CLASSES:
+                    pipeline_type = PipelineTypes.TEXT2AUDIO
             elif self.config.validation_using_datasets:
                 if PipelineTypes.IMG2IMG in self.model.PIPELINE_CLASSES:
                     pipeline_type = PipelineTypes.IMG2IMG
@@ -4333,6 +4363,26 @@ class Validation:
                     "image": validation_input_image_for_resolution,
                     "audio_path": s2v_audio_path,
                 }
+                if resolution[0] > 0 and resolution[1] > 0:
+                    if isinstance(extra_validation_kwargs["image"], list):
+                        extra_validation_kwargs["image"] = [
+                            img.resize(resolution, Image.Resampling.LANCZOS)
+                            for img in extra_validation_kwargs["image"]
+                            if isinstance(img, Image.Image)
+                        ]
+                    elif isinstance(extra_validation_kwargs["image"], Image.Image):
+                        extra_validation_kwargs["image"] = extra_validation_kwargs["image"].resize(
+                            resolution, Image.Resampling.LANCZOS
+                        )
+                    validation_input_image_for_resolution = extra_validation_kwargs["image"]
+                    extra_validation_kwargs["_s2v_conditioning"]["image"] = validation_input_image_for_resolution
+                    validation_resolution_width, validation_resolution_height = resolution
+                elif isinstance(validation_input_image_for_resolution, list) and validation_input_image_for_resolution:
+                    validation_resolution_width, validation_resolution_height = validation_input_image_for_resolution[0].size
+                elif isinstance(validation_input_image_for_resolution, Image.Image):
+                    validation_resolution_width, validation_resolution_height = validation_input_image_for_resolution.size
+                else:
+                    validation_resolution_width, validation_resolution_height = 0, 0
             elif validation_input_image is not None:
                 validation_input_image_for_resolution = _coerce_validation_image_input(validation_input_image)
                 extra_validation_kwargs["image"] = validation_input_image_for_resolution

--- a/tests/helpers/metadata/test_audio_backends.py
+++ b/tests/helpers/metadata/test_audio_backends.py
@@ -218,6 +218,45 @@ class TestAudioMetadataBackends(unittest.TestCase):
         self.assertEqual(audio_metadata["num_channels"], 2)
         self.assertEqual(audio_metadata["truncation_mode"], "beginning")
 
+    def test_parquet_audio_bucket_preserves_lyrics_and_token_path(self):
+        dataset_id = "audio_parquet_tokens"
+        audio_path = os.path.join(self.tempdir.name, "tokenized.wav")
+        sample_rate, num_samples = _write_test_wav(audio_path)
+
+        manifest_path = os.path.join(self.tempdir.name, "tokens.jsonl")
+        record = {
+            "filepath": os.path.basename(audio_path),
+            "description": "bright synth pop",
+            "sample_rate": sample_rate,
+            "num_samples": num_samples,
+            "duration": round(num_samples / sample_rate, 2),
+            "channels": 1,
+            "lyrics": "hello from heartmula",
+            "audio_tokens_path": "tokenized.tokens.npy",
+        }
+        with open(manifest_path, "w", encoding="utf-8") as manifest_file:
+            manifest_file.write(json.dumps(record) + "\n")
+
+        backend = self._build_backend(dataset_id)
+        self._register_dataset_config(dataset_id)
+        parquet_backend = self._parquet_backend(dataset_id, backend, manifest_path)
+        parquet_backend.parquet_config["caption_column"] = "description"
+        parquet_backend.parquet_config["lyrics_column"] = "lyrics"
+
+        metadata_updates = {}
+        parquet_backend._process_for_bucket(
+            image_path_str=audio_path,
+            aspect_ratio_bucket_indices={},
+            metadata_updates=metadata_updates,
+            statistics={},
+        )
+
+        audio_metadata = metadata_updates[audio_path]
+        self.assertEqual(audio_metadata["tags"], "bright synth pop")
+        self.assertEqual(audio_metadata["prompt"], "bright synth pop")
+        self.assertEqual(audio_metadata["lyrics"], "hello from heartmula")
+        self.assertEqual(audio_metadata["audio_tokens_path"], "tokenized.tokens.npy")
+
     def test_parquet_audio_bucket_reads_from_audio_when_manifest_missing_values(self):
         dataset_id = "audio_parquet_fallback"
         audio_path = os.path.join(self.tempdir.name, "fallback.wav")

--- a/tests/test_collate.py
+++ b/tests/test_collate.py
@@ -26,12 +26,14 @@ class _StubModel:
         requires_conditioning_latents: bool = False,
         requires_conditioning_dataset: bool = False,
         requires_text_embed_image_context: bool = False,
+        uses_text_embeddings_cache: bool = True,
     ):
         self._requires_conditioning = requires_conditioning
         self._use_reference_embeds = use_reference_embeds
         self._requires_conditioning_latents = requires_conditioning_latents
         self._requires_conditioning_dataset = requires_conditioning_dataset
         self._requires_text_embed_context = requires_text_embed_image_context
+        self._uses_text_embeddings_cache = uses_text_embeddings_cache
 
     def requires_conditioning_image_embeds(self):
         return self._requires_conditioning
@@ -53,6 +55,9 @@ class _StubModel:
 
     def requires_text_embed_image_context(self):
         return self._requires_text_embed_context
+
+    def uses_text_embeddings_cache(self):
+        return self._uses_text_embeddings_cache
 
 
 class _StubConditioningSample:
@@ -179,6 +184,25 @@ class CollateFunctionTests(unittest.TestCase):
         self.assertTrue(torch.equal(result["add_text_embeds"], text_outputs["pooled_prompt_embeds"]))
         backend_mock = active_mocks[5]
         backend_mock.assert_called()
+
+    def test_collate_fn_preserves_prompts_without_text_cache(self):
+        backend_dict = {
+            "data_backend": _make_stub_data_backend(),
+            "config": {"instance_data_dir": "/train"},
+        }
+
+        model = _StubModel(requires_conditioning=False, uses_text_embeddings_cache=False)
+        patchers, _ = self._patch_state_tracker(
+            model=model, data_backend=backend_dict, text_outputs={}, backend_lookup={"backend-1": backend_dict}
+        )
+        with ExitStack() as stack:
+            active_mocks = [stack.enter_context(patcher) for patcher in patchers]
+            result = collate_fn(self.base_batch)
+
+        self.assertEqual(result["prompts"], ["caption"])
+        self.assertEqual(result["text_encoder_output"], {})
+        self.assertIsNone(result["prompt_embeds"])
+        active_mocks[9].assert_not_called()
 
     def test_compute_latents_uses_backend_ondemand_mode(self):
         vae_cache = SimpleNamespace(

--- a/tests/test_lora_metadata.py
+++ b/tests/test_lora_metadata.py
@@ -196,6 +196,27 @@ class SaveHookMetadataTests(unittest.TestCase):
         )
         return manager, model, trained_component
 
+    def test_manager_rejects_invalid_default_pipeline_type(self):
+        args = SimpleNamespace(
+            use_ema=False,
+            model_type="lora",
+            lora_type="standard",
+            controlnet=False,
+            validation_using_datasets=False,
+        )
+        trained_component = _DummyTrainedComponent("transformer")
+        model = _DummyModel(trained_component=trained_component)
+        model.DEFAULT_PIPELINE_TYPE = None
+
+        with self.assertRaisesRegex(ValueError, "DEFAULT_PIPELINE_TYPE"):
+            SaveHookManager(
+                args=args,
+                model=model,
+                ema_model=_ema_stub,
+                accelerator=_DummyAccelerator(),
+                use_deepspeed_optimizer=False,
+            )
+
     def test_materialize_state_dict_for_save_expands_dtensor_like_values(self):
         class DTensor:
             def __init__(self):

--- a/tests/test_omnigen_model.py
+++ b/tests/test_omnigen_model.py
@@ -35,6 +35,9 @@ class OmniGenModelTests(unittest.TestCase):
     def test_model_supports_crepa_self_flow(self):
         self.assertTrue(self.model.supports_crepa_self_flow())
 
+    def test_model_does_not_use_text_embedding_cache(self):
+        self.assertFalse(self.model.uses_text_embeddings_cache())
+
     def test_prepare_crepa_self_flow_batch_creates_tokenwise_timesteps(self):
         self.model.config.crepa_self_flow_mask_ratio = 0.5
         batch = {

--- a/tests/test_pipelines/test_wan_s2v_pipeline.py
+++ b/tests/test_pipelines/test_wan_s2v_pipeline.py
@@ -1,5 +1,7 @@
 """Tests for WanS2V (Speech-to-Video) pipeline components."""
 
+import os
+import tempfile
 import unittest
 from unittest import mock
 
@@ -83,6 +85,24 @@ class TestWanS2VModelClass(unittest.TestCase):
             WanS2V.HUGGINGFACE_PATHS["s2v-14b-2.2"],
             "tolgacangoz/Wan2.2-S2V-14B-Diffusers",
         )
+
+    def test_checkpoint_tensor_loader_returns_none_for_missing_or_unreadable_index(self):
+        from simpletuner.helpers.models.wan_s2v.model import WanS2V
+
+        model = WanS2V.__new__(WanS2V)
+        with tempfile.TemporaryDirectory() as tempdir:
+            self.assertIsNone(model._load_checkpoint_tensor(tempdir, "transformer", "missing.weight", {}))
+
+            transformer_dir = os.path.join(tempdir, "transformer")
+            os.makedirs(transformer_dir, exist_ok=True)
+            with open(
+                os.path.join(transformer_dir, "diffusion_pytorch_model.safetensors.index.json"),
+                "w",
+                encoding="utf-8",
+            ) as index_file:
+                index_file.write("{")
+
+            self.assertIsNone(model._load_checkpoint_tensor(tempdir, "transformer", "missing.weight", {}))
 
 
 class TestWanS2VModelMetadata(unittest.TestCase):

--- a/tests/test_validation_audio_mock.py
+++ b/tests/test_validation_audio_mock.py
@@ -1,12 +1,13 @@
 import unittest
 from io import BytesIO
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
 
 from simpletuner.helpers.models.common import AudioModelFoundation, ModelTypes, PipelineTypes, PredictionTypes
 from simpletuner.helpers.training import validation_audio
-from simpletuner.helpers.training.validation import Validation, ValidationPrompt
+from simpletuner.helpers.training.validation import Validation, ValidationPrompt, prepare_validation_prompt_list
 
 
 class MockAudioModel(AudioModelFoundation):
@@ -74,6 +75,38 @@ class MockAudioModel(AudioModelFoundation):
 
 
 class TestAudioValidation(unittest.TestCase):
+    def test_raw_validation_prompts_do_not_require_text_embed_cache(self):
+        class NoTextCacheModel:
+            def uses_text_embeddings_cache(self):
+                return False
+
+            def requires_conditioning_validation_inputs(self):
+                return False
+
+            def should_precompute_validation_negative_prompt(self):
+                return False
+
+        args = SimpleNamespace(
+            model_family="heartmula",
+            model_flavour="3b",
+            controlnet=False,
+            control=False,
+            validation_using_datasets=False,
+            validation_input=None,
+            validation_prompt_library=False,
+            user_prompt_library=None,
+            validation_prompt="driving pop, bright synths",
+            validation_negative_prompt="None",
+            validation_disable_unconditional=True,
+            data_backend_config="config/examples/heartmula-audio.json",
+        )
+
+        with patch("simpletuner.helpers.training.validation.StateTracker.get_args", return_value=args):
+            metadata = prepare_validation_prompt_list(args, embed_cache=None, model=NoTextCacheModel())
+
+        self.assertEqual([entry.prompt for entry in metadata["validation_prompts"]], [args.validation_prompt])
+        self.assertEqual(metadata["validation_shortnames"], ["validation"])
+
     @patch("simpletuner.helpers.training.validation.StateTracker")
     @patch("simpletuner.helpers.training.validation.validation_audio.save_audio")
     @patch("simpletuner.helpers.training.validation.prepare_validation_prompt_list")


### PR DESCRIPTION
Summary:
- preserve audio captions, lyrics, and token paths through metadata backends and prompt sampling limits
- support text-cache-free collation and validation prompts for models that do not use cached text embeddings
- tighten audio validation/model handling for ACE-Step, HeartMuLa, OmniGen, and WanS2V

Tests:
- `.venv/bin/python -m unittest tests.helpers.metadata.test_audio_backends tests.test_collate tests.test_omnigen_model tests.test_validation_audio_mock -v`
- `.venv/bin/python -m unittest tests.test_ace_step_model tests.test_acestep_lora_targets tests.test_ace_step_attention tests.test_audio_collate tests.test_pipelines.test_wan_s2v_pipeline -v`
- `.venv/bin/pre-commit run --files <changed files>`