### PR TITLE
Validate HiDream mixed precision settings

### DIFF
--- a/simpletuner/helpers/models/hidream/model.py
+++ b/simpletuner/helpers/models/hidream/model.py
@@ -762,6 +762,25 @@ class HiDream(ImageModelFoundation):
             )
         return targets
 
+    @staticmethod
+    def _precision_backend(precision: Optional[str]) -> Optional[str]:
+        if not isinstance(precision, str) or precision in ("", "no_change"):
+            return None
+        precision = precision.lower()
+        if "quanto" in precision:
+            return "quanto"
+        if "torchao" in precision:
+            return "torchao"
+        if "sdnq" in precision:
+            return "sdnq"
+        if "bnb" in precision:
+            return "bnb"
+        if precision == "fp8-native":
+            return "fp8-native"
+        if precision == "fp8-transformerengine":
+            return "fp8-transformerengine"
+        return None
+
     def check_user_config(self):
         """
         Checks self.config values against important issues. Optionally implemented in child class.
@@ -770,6 +789,23 @@ class HiDream(ImageModelFoundation):
             raise ValueError(
                 f"{self.NAME} does not support fp8-quanto. Please use fp8-torchao or int8 precision level instead."
             )
+        base_backend = self._precision_backend(self.config.base_model_precision)
+        text_encoder_4_precision = getattr(self.config, "text_encoder_4_precision", None)
+        text_encoder_4_backend = self._precision_backend(text_encoder_4_precision)
+        if base_backend and text_encoder_4_backend and base_backend != text_encoder_4_backend:
+            if text_encoder_4_precision == "int4-quanto":
+                logger.warning(
+                    "HiDream's bundled Llama text encoder int4-quanto setting is only compatible with Quanto "
+                    "base quantisation; setting text_encoder_4_precision=no_change for %s.",
+                    self.config.base_model_precision,
+                )
+                self.config.text_encoder_4_precision = "no_change"
+            else:
+                raise ValueError(
+                    f"{self.NAME} cannot mix base model precision {self.config.base_model_precision!r} with "
+                    f"text_encoder_4_precision={text_encoder_4_precision!r}. Use one quant backend or set "
+                    "text_encoder_4_precision=no_change."
+                )
         t5_max_length = 128
         if self.config.tokenizer_max_length is None or self.config.tokenizer_max_length == 0:
             logger.warning(f"Setting T5 XXL tokeniser max length to {t5_max_length} for {self.NAME}.")

--- a/tests/test_hidream_model.py
+++ b/tests/test_hidream_model.py
@@ -67,6 +67,57 @@ class HiDreamModelTests(unittest.TestCase):
         transformer_kwargs = self.model.model.call_args.kwargs
         self.assertTrue(torch.equal(transformer_kwargs["timesteps"], prepared_batch["timesteps"]))
 
+    def test_check_user_config_keeps_bundled_quanto_text_encoder_with_quanto_base(self):
+        self.model.config = SimpleNamespace(
+            base_model_precision="int8-quanto",
+            text_encoder_4_precision="int4-quanto",
+            tokenizer_max_length=0,
+            i_know_what_i_am_doing=False,
+            aspect_bucket_alignment=32,
+        )
+
+        self.model.check_user_config()
+
+        self.assertEqual(self.model.config.text_encoder_4_precision, "int4-quanto")
+
+    def test_check_user_config_disables_bundled_quanto_text_encoder_for_torchao_base(self):
+        self.model.config = SimpleNamespace(
+            base_model_precision="fp8-torchao",
+            text_encoder_4_precision="int4-quanto",
+            tokenizer_max_length=0,
+            i_know_what_i_am_doing=False,
+            aspect_bucket_alignment=32,
+        )
+
+        self.model.check_user_config()
+
+        self.assertEqual(self.model.config.text_encoder_4_precision, "no_change")
+
+    def test_check_user_config_disables_bundled_quanto_text_encoder_for_sdnq_base(self):
+        self.model.config = SimpleNamespace(
+            base_model_precision="int8-sdnq",
+            text_encoder_4_precision="int4-quanto",
+            tokenizer_max_length=0,
+            i_know_what_i_am_doing=False,
+            aspect_bucket_alignment=32,
+        )
+
+        self.model.check_user_config()
+
+        self.assertEqual(self.model.config.text_encoder_4_precision, "no_change")
+
+    def test_check_user_config_rejects_non_default_mixed_text_encoder_backend(self):
+        self.model.config = SimpleNamespace(
+            base_model_precision="fp8-torchao",
+            text_encoder_4_precision="int8-quanto",
+            tokenizer_max_length=0,
+            i_know_what_i_am_doing=False,
+            aspect_bucket_alignment=32,
+        )
+
+        with self.assertRaisesRegex(ValueError, "cannot mix base model precision"):
+            self.model.check_user_config()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
- detect the quantization backend selected by HiDream precision settings
- keep the bundled Quanto Llama text encoder only with Quanto base precision
- reject unsupported mixed text encoder/base quantization backends

Tests:
- `.venv/bin/python -m unittest tests.test_hidream_model -v`
- `.venv/bin/pre-commit run --files simpletuner/helpers/models/hidream/model.py tests/test_hidream_model.py`