### PR TITLE
Map HunyuanVideo flavours to Diffusers repos

### DIFF
--- a/simpletuner/helpers/models/hunyuanvideo/model.py
+++ b/simpletuner/helpers/models/hunyuanvideo/model.py
@@ -75,6 +75,7 @@ class HunyuanVideo(VideoModelFoundation):
         "i2v-480p-distilled": "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_i2v_distilled",
         "i2v-720p-distilled": "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-720p_i2v_distilled",
     }
+    UPSTREAM_MODEL_REPO = "tencent/HunyuanVideo-1.5"
     MODEL_LICENSE = "agpl-3.0"
 
     # Component repositories - direct loading without subfolders
@@ -255,6 +256,16 @@ class HunyuanVideo(VideoModelFoundation):
             return str(flavour).strip().lower().startswith("i2v")
         except Exception:
             return False
+
+    def check_user_config(self):
+        super().check_user_config()
+        flavour = getattr(self.config, "model_flavour", None) or self.DEFAULT_MODEL_FLAVOUR
+        if flavour not in self.HUGGINGFACE_PATHS:
+            raise ValueError(f"Unsupported HunyuanVideo flavour '{flavour}'. Expected one of {list(self.HUGGINGFACE_PATHS)}")
+
+        model_path = getattr(self.config, "pretrained_model_name_or_path", None)
+        if model_path in (None, "", "None", self.UPSTREAM_MODEL_REPO):
+            self.config.pretrained_model_name_or_path = self.HUGGINGFACE_PATHS[flavour]
 
     def requires_conditioning_dataset(self) -> bool:
         return self._is_i2v_like_flavour() or super().requires_conditioning_dataset()

--- a/tests/test_hunyuanvideo_model.py
+++ b/tests/test_hunyuanvideo_model.py
@@ -80,6 +80,31 @@ class HunyuanVideoModelTests(unittest.TestCase):
         model = HunyuanVideo.__new__(HunyuanVideo)
         self.assertTrue(model.supports_crepa_self_flow())
 
+    def test_check_user_config_maps_upstream_repo_to_diffusers_flavour_repo(self):
+        model = HunyuanVideo.__new__(HunyuanVideo)
+        model.config = SimpleNamespace(
+            model_flavour="t2v-480p",
+            pretrained_model_name_or_path=HunyuanVideo.UPSTREAM_MODEL_REPO,
+        )
+
+        model.check_user_config()
+
+        self.assertEqual(
+            model.config.pretrained_model_name_or_path,
+            HunyuanVideo.HUGGINGFACE_PATHS["t2v-480p"],
+        )
+
+    def test_check_user_config_preserves_explicit_custom_model_path(self):
+        model = HunyuanVideo.__new__(HunyuanVideo)
+        model.config = SimpleNamespace(
+            model_flavour="t2v-480p",
+            pretrained_model_name_or_path="local-or-hub/custom-hunyuan-diffusers",
+        )
+
+        model.check_user_config()
+
+        self.assertEqual(model.config.pretrained_model_name_or_path, "local-or-hub/custom-hunyuan-diffusers")
+
     def test_prepare_crepa_self_flow_batch_builds_tokenwise_student_and_teacher_views(self):
         model = HunyuanVideo.__new__(HunyuanVideo)
         model.accelerator = SimpleNamespace(device=torch.device("cpu"))


### PR DESCRIPTION
Summary:
- add the upstream HunyuanVideo 1.5 repo alias
- map empty/default/upstream model paths to the selected Diffusers flavour repo
- preserve explicit custom local or hub model paths

Tests:
- `.venv/bin/python -m unittest tests.test_hunyuanvideo_model -v`
- `.venv/bin/pre-commit run --files simpletuner/helpers/models/hunyuanvideo/model.py tests/test_hunyuanvideo_model.py`