### PR TITLE
Improve MageFlow loading defaults

### DIFF
--- a/simpletuner/helpers/models/mageflow/model.py
+++ b/simpletuner/helpers/models/mageflow/model.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional
 
 import torch
+from diffusers import FlowMatchEulerDiscreteScheduler
 from einops import rearrange
 from transformers import AutoProcessor, AutoTokenizer, Qwen3VLForConditionalGeneration
 
@@ -22,6 +23,7 @@ from simpletuner.helpers.models.mageflow.transformer import MageFlowTransformer2
 from simpletuner.helpers.models.mageflow.vendor.pipeline import _lens_to_cu
 from simpletuner.helpers.models.registry import ModelRegistry
 from simpletuner.helpers.musubi_block_swap import apply_musubi_pretrained_defaults
+from simpletuner.helpers.training.flow_match import fix_flow_match_euler_schedule_bounds
 
 logger = logging.getLogger(__name__)
 
@@ -49,12 +51,12 @@ class MageFlow(ImageModelFoundation):
 
     DEFAULT_MODEL_FLAVOUR = "base"
     HUGGINGFACE_PATHS = {
-        "base": "microsoft/Mage-Flow-Base",
-        "default": "microsoft/Mage-Flow",
-        "turbo": "microsoft/Mage-Flow-Turbo",
-        "edit-base": "microsoft/Mage-Flow-Edit-Base",
-        "edit": "microsoft/Mage-Flow-Edit",
-        "edit-turbo": "microsoft/Mage-Flow-Edit-Turbo",
+        "base": "natalie5/Mage-Flow-Base",
+        "default": "natalie5/Mage-Flow",
+        "turbo": "natalie5/Mage-Flow-Turbo",
+        "edit-base": "natalie5/Mage-Flow-Edit-Base",
+        "edit": "natalie5/Mage-Flow-Edit",
+        "edit-turbo": "natalie5/Mage-Flow-Edit-Turbo",
     }
     MODEL_LICENSE = "mit"
 
@@ -187,6 +189,52 @@ class MageFlow(ImageModelFoundation):
 
     def _is_edit_flavour(self) -> bool:
         return self._model_flavour() in {"edit-base", "edit", "edit-turbo"}
+
+    def _resolve_checkpointing_transformer(self):
+        seen = set()
+
+        def visit(module):
+            if module is None or id(module) in seen:
+                return None
+            seen.add(id(module))
+            try:
+                module = self.unwrap_model(model=module)
+            except Exception:
+                pass
+            if isinstance(module, MageFlowTransformer2DModel):
+                return module
+            for attr_name in ("base_model", "model", "module", "_orig_mod"):
+                child = getattr(module, attr_name, None)
+                if child is not module:
+                    resolved = visit(child)
+                    if resolved is not None:
+                        return resolved
+            return None
+
+        return visit(getattr(self, "model", None))
+
+    def enable_gradient_checkpointing(self):
+        transformer = self._resolve_checkpointing_transformer()
+        if transformer is not None:
+            transformer.enable_gradient_checkpointing()
+
+    def disable_gradient_checkpointing(self):
+        transformer = self._resolve_checkpointing_transformer()
+        if transformer is not None:
+            transformer.disable_gradient_checkpointing()
+
+    def setup_training_noise_schedule(self):
+        try:
+            super().setup_training_noise_schedule()
+        except OSError:
+            logger.info("Mage-Flow checkpoint has no scheduler config; using the default training flow scheduler.")
+            self.noise_schedule = FlowMatchEulerDiscreteScheduler(
+                num_train_timesteps=1000,
+                shift=self.config.flow_schedule_shift if self.config.flow_schedule_shift is not None else 6.0,
+                use_dynamic_shifting=False,
+            )
+            fix_flow_match_euler_schedule_bounds(self.noise_schedule)
+        return self.config, self.noise_schedule
 
     @staticmethod
     def _normalise_attention_mechanism(attention_mechanism: str | None) -> str:

--- a/simpletuner/helpers/models/mageflow/pipeline.py
+++ b/simpletuner/helpers/models/mageflow/pipeline.py
@@ -24,6 +24,14 @@ def _resolve_repo_dir(repo_id_or_path: str, *, revision: Optional[str] = None, l
     return snapshot_download(repo_id=repo_id_or_path, revision=revision, local_files_only=local_files_only)
 
 
+def _load_scheduler(repo_dir: str):
+    scheduler_dir = os.path.join(repo_dir, "scheduler")
+    scheduler_config = os.path.join(scheduler_dir, "scheduler_config.json")
+    if os.path.isdir(scheduler_dir) and os.path.exists(scheduler_config):
+        return FlowMatchEulerDiscreteScheduler.from_pretrained(scheduler_dir)
+    return FlowMatchEulerDiscreteScheduler(num_train_timesteps=1000, shift=6.0, use_dynamic_shifting=False)
+
+
 def _call_vae_decode(vae, latents: torch.Tensor) -> torch.Tensor:
     if hasattr(vae, "decode_to_tensor"):
         return vae.decode_to_tensor(latents)
@@ -236,7 +244,7 @@ class MageFlowPipeline(DiffusionPipeline, MageFlowLoraLoaderMixin):
             revision=revision,
             local_files_only=local_files_only,
         )
-        scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(os.path.join(repo_dir, "scheduler"))
+        scheduler = _load_scheduler(repo_dir)
         return cls(
             transformer=transformer,
             vae=vae,

--- a/simpletuner/helpers/models/mageflow/vendor/pipeline.py
+++ b/simpletuner/helpers/models/mageflow/vendor/pipeline.py
@@ -910,5 +910,14 @@ def load_from_repo(repo_dir: str, device: str = "cuda") -> MageFlowModel:
         model.vae.to(torch.bfloat16)
     model.eval()
     # Diffusers FlowMatchEulerDiscreteScheduler (scheduler/scheduler_config.json).
-    model.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(_safe_subpath(repo_dir, "scheduler"))
+    scheduler_dir = _safe_subpath(repo_dir, "scheduler")
+    scheduler_config = os.path.join(scheduler_dir, "scheduler_config.json")
+    if os.path.isdir(scheduler_dir) and os.path.exists(scheduler_config):
+        model.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(scheduler_dir)
+    else:
+        model.scheduler = build_scheduler(
+            1,
+            device=device,
+            shift=(cfg.static_shift if cfg.static_shift is not None else 6.0),
+        )
     return model

--- a/tests/test_mageflow_model.py
+++ b/tests/test_mageflow_model.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -8,8 +9,8 @@ from unittest.mock import patch
 import torch
 
 from simpletuner.helpers.acceleration import AccelerationBackend
-from simpletuner.helpers.models.common import PipelineTypes
-from simpletuner.helpers.models.mageflow.pipeline import MageFlowPipeline, _mageflow_velocity
+from simpletuner.helpers.models.common import ImageModelFoundation, PipelineTypes
+from simpletuner.helpers.models.mageflow.pipeline import MageFlowPipeline, _load_scheduler, _mageflow_velocity
 from simpletuner.helpers.models.mageflow.pipeline_edit import MageFlowEditPipeline
 from simpletuner.helpers.models.mageflow.transformer import MageFlowTransformer2DModel
 from simpletuner.helpers.models.mageflow.vendor.models.modules import _attn_backend as mageflow_attn_backend
@@ -56,6 +57,7 @@ class MageFlowModelTests(unittest.TestCase):
         self.assertIn("edit-turbo", model_cls.get_flavour_choices())
         self.assertFalse(model_cls.DDP_FIND_UNUSED_PARAMETERS)
         self.assertIn("MageFlowTransformerBlock", model_cls.MODEL_CLASS._no_split_modules)
+        self.assertEqual(model_cls.HUGGINGFACE_PATHS["base"], "natalie5/Mage-Flow-Base")
 
     def test_context_parallel_is_rejected(self):
         model_cls = _mageflow_class()
@@ -382,6 +384,40 @@ class MageFlowModelTests(unittest.TestCase):
         self.assertEqual(output.shape, (1, 4, 4))
         self.assertEqual(len(checkpoint_calls), 1)
         self.assertEqual(checkpoint_calls[0], {"use_reentrant": False})
+
+    def test_model_level_gradient_checkpointing_reaches_wrapped_transformer(self):
+        model_cls = _mageflow_class()
+        foundation = object.__new__(model_cls)
+        transformer = _tiny_transformer()
+        foundation.model = SimpleNamespace(base_model=SimpleNamespace(model=transformer))
+        foundation.unwrap_model = lambda model=None, keep_fp32_wrapper=True: model
+
+        foundation.enable_gradient_checkpointing()
+        self.assertTrue(transformer.checkpoint)
+        self.assertTrue(transformer.config.checkpoint)
+
+        foundation.disable_gradient_checkpointing()
+        self.assertFalse(transformer.checkpoint)
+        self.assertFalse(transformer.config.checkpoint)
+
+    def test_missing_pipeline_scheduler_config_uses_default_flow_scheduler(self):
+        with tempfile.TemporaryDirectory() as repo_dir:
+            scheduler = _load_scheduler(repo_dir)
+
+        self.assertEqual(scheduler.config.num_train_timesteps, 1000)
+        self.assertEqual(scheduler.config.shift, 6.0)
+
+    def test_training_noise_schedule_uses_default_when_checkpoint_has_no_scheduler_config(self):
+        model_cls = _mageflow_class()
+        foundation = object.__new__(model_cls)
+        foundation.config = SimpleNamespace(flow_schedule_shift=7.0)
+
+        with patch.object(ImageModelFoundation, "setup_training_noise_schedule", side_effect=OSError("missing")):
+            config, scheduler = foundation.setup_training_noise_schedule()
+
+        self.assertIs(config, foundation.config)
+        self.assertEqual(scheduler.config.num_train_timesteps, 1000)
+        self.assertEqual(scheduler.config.shift, 7.0)
 
     def test_transformer_supports_twinflow_time_sign(self):
         model = _tiny_transformer(enable_time_sign_embed=True)


### PR DESCRIPTION
Summary:
- point MageFlow flavours at the current hub repositories
- fall back to a default FlowMatch scheduler when a checkpoint lacks scheduler config
- route model-level gradient checkpointing through wrapped MageFlow transformers

Tests:
- `.venv/bin/python -m unittest tests.test_mageflow_model -v`
- `.venv/bin/pre-commit run --files simpletuner/helpers/models/mageflow/model.py simpletuner/helpers/models/mageflow/pipeline.py simpletuner/helpers/models/mageflow/vendor/pipeline.py tests/test_mageflow_model.py`