### PR TITLE
Add Wan latent I2V conditioning

### DIFF
--- a/simpletuner/helpers/models/wan/model.py
+++ b/simpletuner/helpers/models/wan/model.py
@@ -174,11 +174,14 @@ def add_first_frame_latent_conditioning(
     """
     device = latent_model_input.device
     dtype = latent_model_input.dtype
-    temporal_downsample = getattr(vae, "temperal_downsample", None)
+    vae_config = getattr(vae, "config", None)
+    temporal_downsample = getattr(vae_config, "temperal_downsample", None)
+    if temporal_downsample is None:
+        temporal_downsample = getattr(vae, "temperal_downsample", None)
     vae_scale_factor_temporal = 2 ** sum(temporal_downsample) if temporal_downsample is not None else 4
 
     batch, _, num_latent_frames, latent_height, latent_width = latent_model_input.shape
-    num_frames = (num_latent_frames - 1) * 4 + 1
+    num_frames = (num_latent_frames - 1) * vae_scale_factor_temporal + 1
 
     clean_latents = clean_latents.to(device=device, dtype=dtype)
     if clean_latents.shape[0] != batch:
@@ -193,7 +196,7 @@ def add_first_frame_latent_conditioning(
         device=device,
         dtype=dtype,
     )
-    mask_lat_size[:, :, list(range(1, num_frames))] = 0
+    mask_lat_size[:, :, 1:] = 0
     first_frame_mask = mask_lat_size[:, :, 0:1]
     first_frame_mask = torch.repeat_interleave(first_frame_mask, dim=2, repeats=vae_scale_factor_temporal)
     mask_lat_size = torch.concat([first_frame_mask, mask_lat_size[:, :, 1:, :]], dim=2)

--- a/simpletuner/helpers/models/wan/model.py
+++ b/simpletuner/helpers/models/wan/model.py
@@ -163,6 +163,50 @@ def add_first_frame_conditioning(
 
 
 @torch.no_grad()
+def add_first_frame_latent_conditioning(
+    latent_model_input: torch.Tensor,
+    clean_latents: torch.Tensor,
+    vae: AutoencoderKLWan,
+):
+    """
+    Adds Wan 2.1 I2V conditioning from already-cached clean latents when the
+    batch does not carry explicit first-frame pixels.
+    """
+    device = latent_model_input.device
+    dtype = latent_model_input.dtype
+    temporal_downsample = getattr(vae, "temperal_downsample", None)
+    vae_scale_factor_temporal = 2 ** sum(temporal_downsample) if temporal_downsample is not None else 4
+
+    batch, _, num_latent_frames, latent_height, latent_width = latent_model_input.shape
+    num_frames = (num_latent_frames - 1) * 4 + 1
+
+    clean_latents = clean_latents.to(device=device, dtype=dtype)
+    if clean_latents.shape[0] != batch:
+        clean_latents = clean_latents.expand(batch, -1, -1, -1, -1)
+
+    mask_lat_size = torch.ones(
+        batch,
+        1,
+        num_frames,
+        latent_height,
+        latent_width,
+        device=device,
+        dtype=dtype,
+    )
+    mask_lat_size[:, :, list(range(1, num_frames))] = 0
+    first_frame_mask = mask_lat_size[:, :, 0:1]
+    first_frame_mask = torch.repeat_interleave(first_frame_mask, dim=2, repeats=vae_scale_factor_temporal)
+    mask_lat_size = torch.concat([first_frame_mask, mask_lat_size[:, :, 1:, :]], dim=2)
+    mask_lat_size = mask_lat_size.view(batch, -1, vae_scale_factor_temporal, latent_height, latent_width)
+    mask_lat_size = mask_lat_size.transpose(1, 2)
+
+    latent_condition = torch.zeros_like(clean_latents)
+    latent_condition[:, :, :1] = clean_latents[:, :, :1]
+    first_frame_condition = torch.concat([mask_lat_size, latent_condition], dim=1)
+    return torch.cat([latent_model_input, first_frame_condition], dim=1)
+
+
+@torch.no_grad()
 def add_first_frame_conditioning_v22(
     latent_model_input: torch.Tensor,
     first_frame: torch.Tensor,
@@ -758,7 +802,14 @@ class Wan(VideoModelFoundation):
             return
         first_frame, last_frame = self._extract_conditioning_frames(prepared_batch)
         if first_frame is None:
-            if is_i2v_batch and not getattr(self, "_wan_warned_missing_i2v_conditioning", False) and should_log():
+            clean_latents = prepared_batch.get("latents")
+            if torch.is_tensor(clean_latents):
+                transformer_kwargs["hidden_states"] = add_first_frame_latent_conditioning(
+                    transformer_kwargs["hidden_states"],
+                    clean_latents,
+                    self.get_vae(),
+                )
+            elif is_i2v_batch and not getattr(self, "_wan_warned_missing_i2v_conditioning", False) and should_log():
                 logger.warning(
                     "Wan I2V conditioning data was requested but no conditioning frames were provided. "
                     "Ensure your dataset supplies conditioning images when training I2V flavours."

--- a/tests/test_wan_model.py
+++ b/tests/test_wan_model.py
@@ -2,8 +2,10 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import torch
+
 from simpletuner.helpers.models.common import PipelineTypes, VideoModelFoundation
-from simpletuner.helpers.models.wan.model import Wan
+from simpletuner.helpers.models.wan.model import Wan, add_first_frame_latent_conditioning
 
 
 class WanModelTests(unittest.TestCase):
@@ -190,6 +192,20 @@ class WanModelTests(unittest.TestCase):
 
         super_unload.assert_called_once_with(model)
         self.assertEqual(model._wan_cached_stage_modules, {})
+
+    def test_latent_i2v_conditioning_builds_36_channel_input(self):
+        latent_model_input = torch.zeros(1, 16, 3, 4, 5)
+        clean_latents = torch.arange(1 * 16 * 3 * 4 * 5, dtype=torch.float32).view(1, 16, 3, 4, 5)
+        vae = SimpleNamespace(temperal_downsample=[1, 1])
+
+        conditioned = add_first_frame_latent_conditioning(latent_model_input, clean_latents, vae)
+
+        self.assertEqual(tuple(conditioned.shape), (1, 36, 3, 4, 5))
+        self.assertTrue(torch.equal(conditioned[:, :16], latent_model_input))
+        self.assertTrue(torch.all(conditioned[:, 16:20, 0] == 1))
+        self.assertTrue(torch.all(conditioned[:, 16:20, 1:] == 0))
+        self.assertTrue(torch.equal(conditioned[:, 20:, :1], clean_latents[:, :, :1]))
+        self.assertTrue(torch.all(conditioned[:, 20:, 1:] == 0))
 
 
 if __name__ == "__main__":

--- a/tests/test_wan_model.py
+++ b/tests/test_wan_model.py
@@ -196,7 +196,7 @@ class WanModelTests(unittest.TestCase):
     def test_latent_i2v_conditioning_builds_36_channel_input(self):
         latent_model_input = torch.zeros(1, 16, 3, 4, 5)
         clean_latents = torch.arange(1 * 16 * 3 * 4 * 5, dtype=torch.float32).view(1, 16, 3, 4, 5)
-        vae = SimpleNamespace(temperal_downsample=[1, 1])
+        vae = SimpleNamespace(config=SimpleNamespace(temperal_downsample=[1, 1]))
 
         conditioned = add_first_frame_latent_conditioning(latent_model_input, clean_latents, vae)
 
@@ -206,6 +206,38 @@ class WanModelTests(unittest.TestCase):
         self.assertTrue(torch.all(conditioned[:, 16:20, 1:] == 0))
         self.assertTrue(torch.equal(conditioned[:, 20:, :1], clean_latents[:, :, :1]))
         self.assertTrue(torch.all(conditioned[:, 20:, 1:] == 0))
+
+    def test_latent_i2v_conditioning_uses_config_temporal_downsample(self):
+        latent_model_input = torch.zeros(1, 16, 3, 4, 5)
+        clean_latents = torch.zeros(1, 16, 3, 4, 5)
+        vae = SimpleNamespace(config=SimpleNamespace(temperal_downsample=[0, 1]))
+
+        conditioned = add_first_frame_latent_conditioning(latent_model_input, clean_latents, vae)
+
+        self.assertEqual(tuple(conditioned.shape), (1, 34, 3, 4, 5))
+        self.assertTrue(torch.all(conditioned[:, 16:18, 0] == 1))
+        self.assertTrue(torch.all(conditioned[:, 16:18, 1:] == 0))
+
+    def test_i2v_conditioning_uses_cached_latents_without_warning(self):
+        model = object.__new__(Wan)
+        model._is_i2v_like_flavour = MagicMock(return_value=False)
+        model._extract_conditioning_frames = MagicMock(return_value=(None, None))
+        model.get_vae = MagicMock(return_value=SimpleNamespace(config=SimpleNamespace(temperal_downsample=[1, 1])))
+
+        hidden_states = torch.zeros(1, 16, 3, 4, 5)
+        clean_latents = torch.arange(1 * 16 * 3 * 4 * 5, dtype=torch.float32).view(1, 16, 3, 4, 5)
+        transformer_kwargs = {"hidden_states": hidden_states.clone()}
+        prepared_batch = {"is_i2v_data": True, "latents": clean_latents}
+
+        with patch("simpletuner.helpers.models.wan.model.logger.warning") as warning:
+            Wan._apply_i2v_conditioning_to_kwargs(model, prepared_batch, transformer_kwargs)
+
+        conditioned = transformer_kwargs["hidden_states"]
+        self.assertEqual(tuple(conditioned.shape), (1, 36, 3, 4, 5))
+        self.assertTrue(torch.equal(conditioned[:, :16], hidden_states))
+        self.assertTrue(torch.equal(conditioned[:, 20:, :1], clean_latents[:, :, :1]))
+        self.assertTrue(torch.all(conditioned[:, 20:, 1:] == 0))
+        warning.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
- add first-frame conditioning from cached clean latents when Wan I2V batches lack explicit conditioning pixels
- use the latent fallback before warning about missing I2V conditioning data
- cover the 36-channel conditioned latent layout in Wan unit tests

Tests:
- `.venv/bin/python -m unittest tests.test_wan_model -v`
- `.venv/bin/pre-commit run --files simpletuner/helpers/models/wan/model.py tests/test_wan_model.py`