### PR TITLE
Add ACE-Step segmented checkpointing support

### DIFF
--- a/simpletuner/helpers/models/ace_step/transformer.py
+++ b/simpletuner/helpers/models/ace_step/transformer.py
@@ -37,6 +37,7 @@ from simpletuner.helpers.models.flowmap import (
     set_flowmap_gate,
     validate_flowmap_deltatime_type,
 )
+from simpletuner.helpers.training.gradient_checkpointing_interval import should_checkpoint_block
 
 from .attention import LinearTransformerBlock, t2i_modulate
 from .lyrics_utils.lyric_encoder import ConformerEncoder as LyricEncoder
@@ -364,12 +365,20 @@ class ACEStepTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromO
 
         self.final_layer = T2IFinalLayer(self.inner_dim, patch_size=patch_size, out_channels=out_channels)
         self.gradient_checkpointing = False
+        self.gradient_checkpointing_interval = None
+        self.gradient_checkpointing_segment_stride = None
         self.gradient_checkpointing_backend = "torch"
         self._mps_fp32 = False
         self._logged_dtype_mismatch = False
 
     def set_gradient_checkpointing_backend(self, backend: str):
         self.gradient_checkpointing_backend = backend
+
+    def set_gradient_checkpointing_interval(self, interval: int):
+        self.gradient_checkpointing_interval = interval
+
+    def set_gradient_checkpointing_segment_stride(self, segment_stride: int | None):
+        self.gradient_checkpointing_segment_stride = segment_stride
 
     def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
         self.flowmap_deltatime_type = validate_flowmap_deltatime_type(deltatime_type, model_name="ACEStep")
@@ -619,9 +628,14 @@ class ACEStepTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromO
         capture_idx = 0
         for index_block, block in enumerate(self.transformer_blocks):
 
-            if self.training and self.gradient_checkpointing:
+            if self.training and should_checkpoint_block(
+                index_block,
+                self.gradient_checkpointing,
+                self.gradient_checkpointing_interval,
+                self.gradient_checkpointing_segment_stride,
+            ):
 
-                if self.gradient_checkpointing_backend == "unsloth":
+                if self.gradient_checkpointing_backend.startswith("unsloth"):
                     from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 
                     checkpoint_fn = offloaded_checkpoint

--- a/simpletuner/helpers/training/default_settings/safety_check.py
+++ b/simpletuner/helpers/training/default_settings/safety_check.py
@@ -142,6 +142,7 @@ def safety_check(args, accelerator):
 
     gradient_checkpointing_interval_supported_models = [
         "flux",
+        "ace_step",
         "sana",
         "sd3",
         "chroma",
@@ -151,7 +152,9 @@ def safety_check(args, accelerator):
         "cosmos3",
         "mageflow",
     ]
-    gradient_checkpointing_segment_stride_supported_models = []
+    gradient_checkpointing_segment_stride_supported_models = [
+        "ace_step",
+    ]
     attention_activation_offload_supported_models = []
     if getattr(args, "gradient_checkpointing_offload_attention", False):
         if args.model_family.lower() not in attention_activation_offload_supported_models:

--- a/tests/test_segmented_checkpointing_model_support.py
+++ b/tests/test_segmented_checkpointing_model_support.py
@@ -1,0 +1,41 @@
+"""Model-level segmented checkpointing capability coverage."""
+
+import unittest
+
+
+def assert_checkpointing_controls(
+    test_case,
+    model_cls,
+    *,
+    backend=False,
+    interval=False,
+    stride=False,
+    offload=False,
+    ffn=False,
+    attention_offload=False,
+):
+    if backend:
+        test_case.assertTrue(hasattr(model_cls, "set_gradient_checkpointing_backend"))
+    if interval:
+        test_case.assertTrue(hasattr(model_cls, "set_gradient_checkpointing_interval"))
+    if stride:
+        test_case.assertTrue(hasattr(model_cls, "set_gradient_checkpointing_segment_stride"))
+    if offload:
+        test_case.assertTrue(hasattr(model_cls, "set_gradient_checkpointing_offload_attention"))
+    if ffn:
+        test_case.assertTrue(getattr(model_cls, "_supports_ffn_gradient_checkpointing", False))
+    if attention_offload:
+        test_case.assertTrue(getattr(model_cls, "_supports_attention_activation_offload", False))
+
+
+class AceStepSegmentedCheckpointingSupportTests(unittest.TestCase):
+    def test_checkpointing_controls(self):
+        from simpletuner.helpers.models.ace_step.transformer import ACEStepTransformer2DModel
+
+        assert_checkpointing_controls(
+            self,
+            ACEStepTransformer2DModel,
+            backend=True,
+            interval=True,
+            stride=True,
+        )

--- a/tests/test_segmented_checkpointing_model_support.py
+++ b/tests/test_segmented_checkpointing_model_support.py
@@ -10,7 +10,7 @@ def assert_checkpointing_controls(
     backend=False,
     interval=False,
     stride=False,
-    offload=False,
+    checkpoint_attention_offload=False,
     ffn=False,
     attention_offload=False,
 ):
@@ -20,7 +20,7 @@ def assert_checkpointing_controls(
         test_case.assertTrue(hasattr(model_cls, "set_gradient_checkpointing_interval"))
     if stride:
         test_case.assertTrue(hasattr(model_cls, "set_gradient_checkpointing_segment_stride"))
-    if offload:
+    if checkpoint_attention_offload:
         test_case.assertTrue(hasattr(model_cls, "set_gradient_checkpointing_offload_attention"))
     if ffn:
         test_case.assertTrue(getattr(model_cls, "_supports_ffn_gradient_checkpointing", False))


### PR DESCRIPTION
## Summary

Splits the ACE-Step segmented-checkpointing integration out of #2925.

- adds ACE-Step interval and segment-stride controls
- adds ACE-Step to the relevant safety-check allow-lists
- keeps shared runtime/docs in the base PR so this diff stays model-specific

## Stack

Base branch: `agent/segmented-checkpointing-base`

## Validation

- `.venv/bin/python -m unittest tests.test_segmented_checkpointing_model_support -v`
- commit hooks: Black, isort, flake8, whitespace checks