### PR TITLE
Add AuraFlow segmented checkpointing support

### DIFF
--- a/simpletuner/helpers/models/auraflow/controlnet.py
+++ b/simpletuner/helpers/models/auraflow/controlnet.py
@@ -378,7 +378,7 @@ class AuraFlowControlNetModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOri
 
                     return custom_forward
 
-                if self.gradient_checkpointing_backend == "unsloth":
+                if self.gradient_checkpointing_backend.startswith("unsloth"):
                     from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 
                     checkpoint_fn = offloaded_checkpoint
@@ -416,7 +416,7 @@ class AuraFlowControlNetModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOri
 
                         return custom_forward
 
-                    if self.gradient_checkpointing_backend == "unsloth":
+                    if self.gradient_checkpointing_backend.startswith("unsloth"):
                         from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 
                         checkpoint_fn = offloaded_checkpoint

--- a/simpletuner/helpers/models/auraflow/controlnet.py
+++ b/simpletuner/helpers/models/auraflow/controlnet.py
@@ -372,12 +372,6 @@ class AuraFlowControlNetModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOri
         for block in self.joint_transformer_blocks:
             if self.training and self.gradient_checkpointing:
 
-                def create_custom_forward(module):
-                    def custom_forward(*inputs):
-                        return module(*inputs)
-
-                    return custom_forward
-
                 if self.gradient_checkpointing_backend.startswith("unsloth"):
                     from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 
@@ -386,8 +380,17 @@ class AuraFlowControlNetModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOri
                     checkpoint_fn = torch.utils.checkpoint.checkpoint
 
                 ckpt_kwargs: Dict[str, Any] = {"use_reentrant": False} if is_torch_version(">=", "1.11.0") else {}
+
+                def custom_forward(hidden_states, encoder_hidden_states, temb, checkpoint_block=block):
+                    return checkpoint_block(
+                        hidden_states=hidden_states,
+                        encoder_hidden_states=encoder_hidden_states,
+                        temb=temb,
+                        attention_kwargs=attention_kwargs,
+                    )
+
                 encoder_hidden_states, hidden_states = checkpoint_fn(
-                    create_custom_forward(block),
+                    custom_forward,
                     hidden_states,
                     encoder_hidden_states,
                     temb,
@@ -410,12 +413,6 @@ class AuraFlowControlNetModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOri
             for block in self.single_transformer_blocks:
                 if self.training and self.gradient_checkpointing:
 
-                    def create_custom_forward(module):
-                        def custom_forward(*inputs):
-                            return module(*inputs)
-
-                        return custom_forward
-
                     if self.gradient_checkpointing_backend.startswith("unsloth"):
                         from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 
@@ -424,8 +421,16 @@ class AuraFlowControlNetModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOri
                         checkpoint_fn = torch.utils.checkpoint.checkpoint
 
                     ckpt_kwargs: Dict[str, Any] = {"use_reentrant": False} if is_torch_version(">=", "1.11.0") else {}
+
+                    def custom_forward(hidden_states, temb, checkpoint_block=block):
+                        return checkpoint_block(
+                            hidden_states=hidden_states,
+                            temb=temb,
+                            attention_kwargs=attention_kwargs,
+                        )
+
                     combined_hidden_states = checkpoint_fn(
-                        create_custom_forward(block),
+                        custom_forward,
                         combined_hidden_states,
                         temb,
                         **ckpt_kwargs,

--- a/simpletuner/helpers/models/auraflow/transformer.py
+++ b/simpletuner/helpers/models/auraflow/transformer.py
@@ -23,6 +23,7 @@ from simpletuner.helpers.models.flowmap import (
     validate_flowmap_deltatime_type,
 )
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
+from simpletuner.helpers.training.gradient_checkpointing_interval import should_checkpoint_block
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
 from simpletuner.helpers.training.packed_attention_processors import PackedAuraFlowAttnProcessor2_0
 from simpletuner.helpers.training.tread import TREADRouter
@@ -493,6 +494,7 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
 
         self.gradient_checkpointing = False
         self.gradient_checkpointing_interval = None
+        self.gradient_checkpointing_segment_stride = None
         self.gradient_checkpointing_backend = "torch"
 
         total_layers = num_mmdit_layers + num_single_dit_layers
@@ -511,6 +513,9 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
             interval (`int`): The interval for gradient checkpointing.
         """
         self.gradient_checkpointing_interval = interval
+
+    def set_gradient_checkpointing_segment_stride(self, segment_stride: int | None):
+        self.gradient_checkpointing_segment_stride = segment_stride
 
     def set_gradient_checkpointing_backend(self, backend: str):
         self.gradient_checkpointing_backend = backend
@@ -824,17 +829,16 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
 
             if (
                 self.training
-                and self.gradient_checkpointing
-                and (self.gradient_checkpointing_interval is None or index_block % self.gradient_checkpointing_interval == 0)
+                and torch.is_grad_enabled()
+                and should_checkpoint_block(
+                    index_block,
+                    self.gradient_checkpointing,
+                    self.gradient_checkpointing_interval,
+                    self.gradient_checkpointing_segment_stride,
+                )
             ):
 
-                def create_custom_forward(module):
-                    def custom_forward(*inputs):
-                        return module(*inputs)
-
-                    return custom_forward
-
-                if self.gradient_checkpointing_backend == "unsloth":
+                if self.gradient_checkpointing_backend.startswith("unsloth"):
                     from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 
                     checkpoint_fn = offloaded_checkpoint
@@ -842,8 +846,18 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
                     checkpoint_fn = torch.utils.checkpoint.checkpoint
 
                 ckpt_kwargs: Dict[str, Any] = {"use_reentrant": False} if is_torch_version(">=", "1.11.0") else {}
+
+                def custom_forward(hidden_states, encoder_hidden_states, temb, context_temb, checkpoint_block=block):
+                    return checkpoint_block(
+                        hidden_states=hidden_states,
+                        encoder_hidden_states=encoder_hidden_states,
+                        temb=temb,
+                        context_temb=context_temb,
+                        attention_kwargs=attention_kwargs,
+                    )
+
                 encoder_hidden_states, hidden_states = checkpoint_fn(
-                    create_custom_forward(block),
+                    custom_forward,
                     hidden_states,
                     encoder_hidden_states,
                     temb,
@@ -947,20 +961,16 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
 
                 if (
                     self.training
-                    and self.gradient_checkpointing
-                    and (
-                        self.gradient_checkpointing_interval is None
-                        or index_block % self.gradient_checkpointing_interval == 0
+                    and torch.is_grad_enabled()
+                    and should_checkpoint_block(
+                        index_block,
+                        self.gradient_checkpointing,
+                        self.gradient_checkpointing_interval,
+                        self.gradient_checkpointing_segment_stride,
                     )
                 ):
 
-                    def create_custom_forward(module):
-                        def custom_forward(*inputs):
-                            return module(*inputs)
-
-                        return custom_forward
-
-                    if self.gradient_checkpointing_backend == "unsloth":
+                    if self.gradient_checkpointing_backend.startswith("unsloth"):
                         from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 
                         checkpoint_fn = offloaded_checkpoint
@@ -968,8 +978,16 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
                         checkpoint_fn = torch.utils.checkpoint.checkpoint
 
                     ckpt_kwargs: Dict[str, Any] = {"use_reentrant": False} if is_torch_version(">=", "1.11.0") else {}
+
+                    def custom_forward(hidden_states, temb, checkpoint_block=block):
+                        return checkpoint_block(
+                            hidden_states=hidden_states,
+                            temb=temb,
+                            attention_kwargs=attention_kwargs,
+                        )
+
                     combined_hidden_states = checkpoint_fn(
-                        create_custom_forward(block),
+                        custom_forward,
                         combined_hidden_states,
                         single_temb,
                         **ckpt_kwargs,

--- a/simpletuner/helpers/training/default_settings/safety_check.py
+++ b/simpletuner/helpers/training/default_settings/safety_check.py
@@ -154,6 +154,7 @@ def safety_check(args, accelerator):
     ]
     gradient_checkpointing_segment_stride_supported_models = [
         "ace_step",
+        "auraflow",
     ]
     attention_activation_offload_supported_models = []
     if getattr(args, "gradient_checkpointing_offload_attention", False):

--- a/tests/test_segmented_checkpointing_model_support.py
+++ b/tests/test_segmented_checkpointing_model_support.py
@@ -39,3 +39,19 @@ class AceStepSegmentedCheckpointingSupportTests(unittest.TestCase):
             interval=True,
             stride=True,
         )
+
+
+class AuraFlowSegmentedCheckpointingSupportTests(unittest.TestCase):
+    def test_checkpointing_controls(self):
+        from simpletuner.helpers.models.auraflow.transformer import AuraFlowTransformer2DModel
+
+        assert_checkpointing_controls(
+            self,
+            AuraFlowTransformer2DModel,
+            backend=True,
+            interval=True,
+            stride=True,
+            offload=False,
+            ffn=False,
+            attention_offload=False,
+        )

--- a/tests/test_segmented_checkpointing_model_support.py
+++ b/tests/test_segmented_checkpointing_model_support.py
@@ -51,7 +51,7 @@ class AuraFlowSegmentedCheckpointingSupportTests(unittest.TestCase):
             backend=True,
             interval=True,
             stride=True,
-            offload=False,
+            checkpoint_attention_offload=False,
             ffn=False,
             attention_offload=False,
         )

--- a/tests/test_transformers/test_auraflow_transformer.py
+++ b/tests/test_transformers/test_auraflow_transformer.py
@@ -33,6 +33,8 @@ from transformer_test_helpers import (
     TypoTestUtils,
 )
 
+from simpletuner.helpers.models.auraflow.controlnet import AuraFlowControlNetModel
+
 # Import the target classes
 from simpletuner.helpers.models.auraflow.transformer import (
     AuraFlowFeedForward,
@@ -941,6 +943,59 @@ class TestAuraFlowTransformer2DModel(TransformerBaseTest):
 
         output.float().mean().backward()
         self.assertIsNotNone(hidden_states.grad)
+
+    def test_controlnet_checkpointing_forwards_attention_kwargs(self):
+        class RecordingJointBlock(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.received_attention_kwargs = None
+
+            def forward(self, hidden_states, encoder_hidden_states, temb, attention_kwargs=None):
+                self.received_attention_kwargs = attention_kwargs
+                return encoder_hidden_states + hidden_states.mean() * 0, hidden_states + temb.mean() * 0
+
+        class RecordingSingleBlock(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.received_attention_kwargs = None
+
+            def forward(self, hidden_states, temb, attention_kwargs=None):
+                self.received_attention_kwargs = attention_kwargs
+                return hidden_states + temb.mean() * 0
+
+        model = AuraFlowControlNetModel(
+            sample_size=8,
+            patch_size=2,
+            in_channels=4,
+            out_channels=4,
+            num_mmdit_layers=1,
+            num_single_dit_layers=1,
+            attention_head_dim=8,
+            num_attention_heads=2,
+            joint_attention_dim=16,
+            caption_projection_dim=16,
+            pos_embed_max_size=16,
+        )
+        joint_block = RecordingJointBlock()
+        single_block = RecordingSingleBlock()
+        model.joint_transformer_blocks[0] = joint_block
+        model.single_transformer_blocks[0] = single_block
+        model.train()
+        model.gradient_checkpointing = True
+
+        hidden_states = torch.randn(1, 4, 8, 8, requires_grad=True)
+        attention_kwargs = {"processor_marker": "preserved"}
+        model(
+            hidden_states=hidden_states,
+            controlnet_cond=torch.zeros_like(hidden_states),
+            encoder_hidden_states=torch.randn(1, 3, 16),
+            timestep=torch.tensor([1.0]),
+            attention_kwargs=attention_kwargs,
+            return_dict=False,
+        )
+
+        self.assertEqual(joint_block.received_attention_kwargs, attention_kwargs)
+        self.assertEqual(single_block.received_attention_kwargs, attention_kwargs)
 
     def test_transformer_tread_router_methods(self):
         """Test TREAD router configuration methods."""

--- a/tests/test_transformers/test_auraflow_transformer.py
+++ b/tests/test_transformers/test_auraflow_transformer.py
@@ -912,6 +912,36 @@ class TestAuraFlowTransformer2DModel(TransformerBaseTest):
             model.set_gradient_checkpointing_interval(interval)
             self.assertEqual(model.gradient_checkpointing_interval, interval)
 
+    def test_gradient_checkpointing_handles_joint_and_single_blocks_backward(self):
+        model = AuraFlowTransformer2DModel(
+            sample_size=8,
+            patch_size=2,
+            in_channels=4,
+            out_channels=4,
+            num_mmdit_layers=1,
+            num_single_dit_layers=1,
+            attention_head_dim=8,
+            num_attention_heads=2,
+            joint_attention_dim=16,
+            caption_projection_dim=16,
+            pos_embed_max_size=16,
+        )
+        model.train()
+        model.gradient_checkpointing = True
+        model.set_gradient_checkpointing_interval(None)
+
+        hidden_states = torch.randn(1, 4, 8, 8, requires_grad=True)
+        encoder_hidden_states = torch.randn(1, 3, 16)
+        output = model(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            timestep=torch.tensor([1.0]),
+            return_dict=False,
+        )[0]
+
+        output.float().mean().backward()
+        self.assertIsNotNone(hidden_states.grad)
+
     def test_transformer_tread_router_methods(self):
         """Test TREAD router configuration methods."""
         with patch("diffusers.models.embeddings.Timesteps"), patch("diffusers.models.embeddings.TimestepEmbedding"):


### PR DESCRIPTION
## Summary

Splits the AuraFlow segmented-checkpointing integration out of #2925.

- adds AuraFlow segment-stride checkpoint selection
- updates AuraFlow ControlNet for unsloth backend matching
- adds AuraFlow to the stride safety-check allow-list

## Stack

Base branch: `agent/segmented-checkpointing-ace-step`

## Validation

- `.venv/bin/python -m unittest tests.test_segmented_checkpointing_model_support tests.test_transformers.test_auraflow_transformer -v`
- commit hooks: Black, isort, flake8, whitespace checks