### PR TITLE
Add Boogu Image segmented checkpointing support

### DIFF
--- a/simpletuner/helpers/models/boogu_image/transformer.py
+++ b/simpletuner/helpers/models/boogu_image/transformer.py
@@ -28,6 +28,8 @@ from diffusers.models.modeling_utils import ModelMixin
 from diffusers.utils import USE_PEFT_BACKEND, logging, scale_lora_layers, unscale_lora_layers
 from einops import rearrange
 
+from simpletuner.helpers.training.gradient_checkpointing_interval import should_checkpoint_block
+
 from .attention_processor import BooguImageAttnProcessor, BooguImageDoubleStreamSelfAttnProcessor
 from .block_lumina2 import (
     Lumina2CombinedTimestepCaptionEmbedding,
@@ -150,6 +152,8 @@ class PromptEmbedding(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalMod
         )
 
         self.gradient_checkpointing = False
+        self.gradient_checkpointing_interval = None
+        self.gradient_checkpointing_segment_stride = None
 
         self.initialize_weights()
 
@@ -842,6 +846,8 @@ class BooguImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fr
         self.image_index_embedding = nn.Parameter(torch.randn(5, hidden_size))  # support max 5 ref images
 
         self.gradient_checkpointing = False
+        self.gradient_checkpointing_interval = None
+        self.gradient_checkpointing_segment_stride = None
 
         self.initialize_weights()
 
@@ -857,6 +863,12 @@ class BooguImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fr
         self.rescale_func = np.poly1d(coefficients)
 
         self.layers = list(self.double_stream_layers) + list(self.single_stream_layers)
+
+    def set_gradient_checkpointing_interval(self, interval: int):
+        self.gradient_checkpointing_interval = interval
+
+    def set_gradient_checkpointing_segment_stride(self, segment_stride: int | None):
+        self.gradient_checkpointing_segment_stride = segment_stride
 
     def initialize_weights(self) -> None:
         """
@@ -895,8 +907,8 @@ class BooguImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fr
             [img_len + sum(ref_img_len) for img_len, ref_img_len in zip(l_effective_img_len, l_effective_ref_img_len)]
         )
 
-        hidden_states = self.x_embedder(hidden_states)
-        ref_image_hidden_states = self.ref_image_patch_embedder(ref_image_hidden_states)
+        hidden_states = self.x_embedder(hidden_states).clone()
+        ref_image_hidden_states = self.ref_image_patch_embedder(ref_image_hidden_states).clone()
 
         for i in range(batch_size):
             shift = 0
@@ -1272,7 +1284,12 @@ class BooguImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fr
                     else:
                         layer.enable_taylorseer = False
 
-                    if torch.is_grad_enabled() and self.gradient_checkpointing:
+                    if torch.is_grad_enabled() and should_checkpoint_block(
+                        layer_idx,
+                        self.gradient_checkpointing,
+                        self.gradient_checkpointing_interval,
+                        self.gradient_checkpointing_segment_stride,
+                    ):
                         img_hidden_states, instruct_hidden_states = self._gradient_checkpointing_func(
                             layer,
                             img_hidden_states,
@@ -1355,7 +1372,12 @@ class BooguImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fr
                     layer.enable_taylorseer = True
                     self.current["layer"] = self.num_double_stream_layers + layer_idx
 
-                if torch.is_grad_enabled() and self.gradient_checkpointing:
+                if torch.is_grad_enabled() and should_checkpoint_block(
+                    self.num_double_stream_layers + layer_idx,
+                    self.gradient_checkpointing,
+                    self.gradient_checkpointing_interval,
+                    self.gradient_checkpointing_segment_stride,
+                ):
                     hidden_states = self._gradient_checkpointing_func(
                         layer, hidden_states, joint_attention_mask, rotary_emb, temb
                     )

--- a/simpletuner/helpers/models/boogu_image/transformer.py
+++ b/simpletuner/helpers/models/boogu_image/transformer.py
@@ -152,8 +152,6 @@ class PromptEmbedding(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalMod
         )
 
         self.gradient_checkpointing = False
-        self.gradient_checkpointing_interval = None
-        self.gradient_checkpointing_segment_stride = None
 
         self.initialize_weights()
 
@@ -907,8 +905,12 @@ class BooguImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fr
             [img_len + sum(ref_img_len) for img_len, ref_img_len in zip(l_effective_img_len, l_effective_ref_img_len)]
         )
 
-        hidden_states = self.x_embedder(hidden_states).clone()
-        ref_image_hidden_states = self.ref_image_patch_embedder(ref_image_hidden_states).clone()
+        hidden_states = self.x_embedder(hidden_states)
+        ref_image_hidden_states = self.ref_image_patch_embedder(ref_image_hidden_states)
+        if hidden_states.requires_grad:
+            hidden_states = hidden_states.clone()
+        if ref_image_hidden_states.requires_grad:
+            ref_image_hidden_states = ref_image_hidden_states.clone()
 
         for i in range(batch_size):
             shift = 0

--- a/simpletuner/helpers/training/default_settings/safety_check.py
+++ b/simpletuner/helpers/training/default_settings/safety_check.py
@@ -151,10 +151,12 @@ def safety_check(args, accelerator):
         "ernie",
         "cosmos3",
         "mageflow",
+        "boogu_image",
     ]
     gradient_checkpointing_segment_stride_supported_models = [
         "ace_step",
         "auraflow",
+        "boogu_image",
     ]
     attention_activation_offload_supported_models = []
     if getattr(args, "gradient_checkpointing_offload_attention", False):

--- a/tests/test_boogu_image_model.py
+++ b/tests/test_boogu_image_model.py
@@ -10,6 +10,7 @@ from simpletuner.helpers.models.boogu_image.lora_pipeline import BooguImageLoraL
 from simpletuner.helpers.models.boogu_image.model import BooguImage
 from simpletuner.helpers.models.boogu_image.pipeline import BooguImagePipeline, retrieve_timesteps
 from simpletuner.helpers.models.boogu_image.rope import BooguImageDoubleStreamRotaryPosEmbed
+from simpletuner.helpers.models.boogu_image.transformer import BooguImageTransformer2DModel
 from simpletuner.helpers.models.common import PipelineTypes
 from simpletuner.helpers.models.flux.model import Flux
 from simpletuner.helpers.training.attention_backend import _DIFFUSERS_BACKEND_ALIASES
@@ -186,6 +187,63 @@ class BooguImageModelTests(unittest.TestCase):
     def test_torchao_filter_skips_boogu_reference_image_modules(self):
         self.assertFalse(_torchao_filter_fn(torch.nn.Linear(16, 16), "ref_image_refiner.0.attn.to_q"))
         self.assertTrue(_torchao_filter_fn(torch.nn.Linear(16, 16), "context_refiner.0.attn.to_q"))
+
+    def test_patch_embed_refine_clones_custom_autograd_outputs_before_layout_writes(self):
+        class PassThroughFunction(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, tensor):
+                return tensor
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                return grad_output
+
+        class PassThroughModule(torch.nn.Module):
+            def forward(self, tensor):
+                return PassThroughFunction.apply(tensor)
+
+        transformer = BooguImageTransformer2DModel(
+            patch_size=2,
+            in_channels=1,
+            hidden_size=4,
+            num_layers=0,
+            num_double_stream_layers=0,
+            num_refiner_layers=0,
+            num_attention_heads=1,
+            num_kv_heads=1,
+            axes_dim_rope=(1, 1, 2),
+            axes_lens=(4, 4, 4),
+            instruction_feature_configs={
+                "instruction_feat_dim": 4,
+                "reduce_type": "mean",
+                "num_instruction_feat_layers": 1,
+            },
+        )
+        transformer.x_embedder = PassThroughModule()
+        transformer.ref_image_patch_embedder = PassThroughModule()
+
+        hidden_states = torch.randn(1, 4, 4, requires_grad=True)
+        ref_image_hidden_states = torch.randn(1, 2, 4, requires_grad=True)
+        padded_img_mask = torch.ones(1, 4, dtype=torch.bool)
+        padded_ref_img_mask = torch.ones(1, 2, dtype=torch.bool)
+        noise_rotary_emb = torch.zeros(1, 4, 4)
+        ref_img_rotary_emb = torch.zeros(1, 2, 4)
+        temb = torch.zeros(1, 4)
+
+        output = transformer.img_patch_embed_and_refine(
+            hidden_states,
+            ref_image_hidden_states,
+            padded_img_mask,
+            padded_ref_img_mask,
+            noise_rotary_emb,
+            ref_img_rotary_emb,
+            [[2]],
+            [4],
+            temb,
+        )
+
+        self.assertEqual(tuple(output.shape), (1, 6, 4))
+        output.sum().backward()
 
     def test_boogu_rotary_complex_inputs_use_real_valued_math(self):
         x = torch.randn(2, 5, 3, 8, dtype=torch.bfloat16)

--- a/tests/test_segmented_checkpointing_model_support.py
+++ b/tests/test_segmented_checkpointing_model_support.py
@@ -67,7 +67,7 @@ class BooguImageSegmentedCheckpointingSupportTests(unittest.TestCase):
             backend=False,
             interval=True,
             stride=True,
-            offload=False,
+            checkpoint_attention_offload=False,
             ffn=False,
             attention_offload=False,
         )

--- a/tests/test_segmented_checkpointing_model_support.py
+++ b/tests/test_segmented_checkpointing_model_support.py
@@ -55,3 +55,19 @@ class AuraFlowSegmentedCheckpointingSupportTests(unittest.TestCase):
             ffn=False,
             attention_offload=False,
         )
+
+
+class BooguImageSegmentedCheckpointingSupportTests(unittest.TestCase):
+    def test_checkpointing_controls(self):
+        from simpletuner.helpers.models.boogu_image.transformer import BooguImageTransformer2DModel
+
+        assert_checkpointing_controls(
+            self,
+            BooguImageTransformer2DModel,
+            backend=False,
+            interval=True,
+            stride=True,
+            offload=False,
+            ffn=False,
+            attention_offload=False,
+        )


### PR DESCRIPTION
## Summary

Splits the Boogu Image segmented checkpointing support model integration out of #2925.

- applies the model-family checkpointing hooks and support flags
- adds this family to the relevant safety-check allow-lists
- keeps the shared runtime/docs in the base PR so this diff stays model-specific

## Stack

Base branch: `agent/segmented-checkpointing-auraflow`

## Validation

- `.venv/bin/python -m unittest tests.test_segmented_checkpointing_model_support -v`
- `.venv/bin/python -m unittest tests.test_boogu_image_model -v`
- commit hooks: Black, isort, flake8, whitespace checks