### PR TITLE
Add Cosmos segmented checkpointing support

### DIFF
--- a/simpletuner/helpers/models/cosmos/transformer.py
+++ b/simpletuner/helpers/models/cosmos/transformer.py
@@ -41,6 +41,7 @@ from simpletuner.helpers.models.flowmap import (
     validate_flowmap_deltatime_type,
 )
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
+from simpletuner.helpers.training.gradient_checkpointing_interval import should_checkpoint_block
 from simpletuner.helpers.training.qk_clip_logging import publish_attention_max_logits
 from simpletuner.helpers.training.tread import TREADRouter
 from simpletuner.helpers.utils.patching import MutableModuleList, PatchableModule
@@ -677,6 +678,8 @@ class CosmosTransformer3DModel(PatchableModule, ModelMixin, ConfigMixin, FromOri
         )
 
         self.gradient_checkpointing = False
+        self.gradient_checkpointing_interval = None
+        self.gradient_checkpointing_segment_stride = None
         self._musubi_block_swap = MusubiBlockSwapManager.build(
             depth=num_layers,
             blocks_to_swap=musubi_blocks_to_swap,
@@ -696,6 +699,12 @@ class CosmosTransformer3DModel(PatchableModule, ModelMixin, ConfigMixin, FromOri
         """Set TREAD router and routes for token reduction during training."""
         self._tread_router = router
         self._tread_routes = routes
+
+    def set_gradient_checkpointing_interval(self, interval: int):
+        self.gradient_checkpointing_interval = interval
+
+    def set_gradient_checkpointing_segment_stride(self, segment_stride: int | None):
+        self.gradient_checkpointing_segment_stride = segment_stride
 
     def forward(
         self,
@@ -889,7 +898,12 @@ class CosmosTransformer3DModel(PatchableModule, ModelMixin, ConfigMixin, FromOri
                         break
             if musubi_offload_active and musubi_manager.is_managed_block(bid):
                 musubi_manager.stream_in(block, hidden_states.device)
-            if torch.is_grad_enabled() and self.gradient_checkpointing:
+            if torch.is_grad_enabled() and should_checkpoint_block(
+                bid,
+                self.gradient_checkpointing,
+                self.gradient_checkpointing_interval,
+                self.gradient_checkpointing_segment_stride,
+            ):
                 hidden_states = self._gradient_checkpointing_func(
                     block,
                     hidden_states,

--- a/simpletuner/helpers/models/cosmos/transformer.py
+++ b/simpletuner/helpers/models/cosmos/transformer.py
@@ -805,7 +805,6 @@ class CosmosTransformer3DModel(PatchableModule, ModelMixin, ConfigMixin, FromOri
 
         # 3. Patchify input
         p_t, p_h, p_w = self.config.patch_size
-        expected_num_frames = num_frames // p_t
         expected_height = height // p_h
         expected_width = width // p_w
         hidden_states = self.patch_embed(hidden_states)
@@ -898,11 +897,15 @@ class CosmosTransformer3DModel(PatchableModule, ModelMixin, ConfigMixin, FromOri
                         break
             if musubi_offload_active and musubi_manager.is_managed_block(bid):
                 musubi_manager.stream_in(block, hidden_states.device)
-            if torch.is_grad_enabled() and should_checkpoint_block(
-                bid,
-                self.gradient_checkpointing,
-                self.gradient_checkpointing_interval,
-                self.gradient_checkpointing_segment_stride,
+            if (
+                grad_enabled
+                and self.gradient_checkpointing
+                and should_checkpoint_block(
+                    bid,
+                    self.gradient_checkpointing,
+                    self.gradient_checkpointing_interval,
+                    self.gradient_checkpointing_segment_stride,
+                )
             ):
                 hidden_states = self._gradient_checkpointing_func(
                     block,

--- a/simpletuner/helpers/training/default_settings/safety_check.py
+++ b/simpletuner/helpers/training/default_settings/safety_check.py
@@ -152,12 +152,14 @@ def safety_check(args, accelerator):
         "cosmos3",
         "mageflow",
         "boogu_image",
+        "cosmos",
     ]
     gradient_checkpointing_segment_stride_supported_models = [
         "ace_step",
         "auraflow",
         "boogu_image",
         "chroma",
+        "cosmos",
     ]
     attention_activation_offload_supported_models = [
         "chroma",

--- a/tests/test_segmented_checkpointing_model_support.py
+++ b/tests/test_segmented_checkpointing_model_support.py
@@ -124,7 +124,7 @@ class CosmosSegmentedCheckpointingSupportTests(unittest.TestCase):
             backend=False,
             interval=True,
             stride=True,
-            offload=False,
+            checkpoint_attention_offload=False,
             ffn=False,
             attention_offload=False,
         )

--- a/tests/test_segmented_checkpointing_model_support.py
+++ b/tests/test_segmented_checkpointing_model_support.py
@@ -112,3 +112,19 @@ class ChromaSegmentedCheckpointingSupportTests(unittest.TestCase):
         self.assertEqual(checkpoint_kwargs, {"use_reentrant": False})
         self.assertEqual(encoder_hidden_states.shape, (2, 3, 16))
         self.assertEqual(hidden_states.shape, (2, 4, 16))
+
+
+class CosmosSegmentedCheckpointingSupportTests(unittest.TestCase):
+    def test_checkpointing_controls(self):
+        from simpletuner.helpers.models.cosmos.transformer import CosmosTransformer3DModel
+
+        assert_checkpointing_controls(
+            self,
+            CosmosTransformer3DModel,
+            backend=False,
+            interval=True,
+            stride=True,
+            offload=False,
+            ffn=False,
+            attention_offload=False,
+        )


### PR DESCRIPTION
## Summary

Splits the Cosmos segmented checkpointing support model integration out of #2925.

- applies the model-family checkpointing hooks and support flags
- adds this family to the relevant safety-check allow-lists
- keeps the shared runtime/docs in the base PR so this diff stays model-specific

## Stack

Base branch: `agent/segmented-checkpointing-chroma`

## Validation

- `.venv/bin/python -m unittest tests.test_segmented_checkpointing_model_support -v`
- commit hooks: Black, isort, flake8, whitespace checks