### PR TITLE
Add Cosmos 3 segmented checkpointing support

### DIFF
--- a/simpletuner/helpers/models/cosmos3/transformer.py
+++ b/simpletuner/helpers/models/cosmos3/transformer.py
@@ -27,6 +27,7 @@ from diffusers.models.normalization import RMSNorm
 from diffusers.utils import BaseOutput, logging
 
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
+from simpletuner.helpers.training.gradient_checkpointing_interval import should_checkpoint_block
 
 logger = logging.get_logger(__name__)
 
@@ -666,6 +667,7 @@ class Cosmos3OmniTransformer(ModelMixin, ConfigMixin, PeftAdapterMixin, Attentio
 
         self.gradient_checkpointing = False
         self.gradient_checkpointing_interval = None
+        self.gradient_checkpointing_segment_stride = None
         self._musubi_block_swap = MusubiBlockSwapManager.build(
             depth=num_hidden_layers,
             blocks_to_swap=musubi_blocks_to_swap,
@@ -689,10 +691,18 @@ class Cosmos3OmniTransformer(ModelMixin, ConfigMixin, PeftAdapterMixin, Attentio
     def set_gradient_checkpointing_interval(self, interval: int):
         self.gradient_checkpointing_interval = interval
 
+    def set_gradient_checkpointing_segment_stride(self, segment_stride: int | None):
+        self.gradient_checkpointing_segment_stride = segment_stride
+
     def _should_gradient_checkpoint_layer(self, layer_idx: int) -> bool:
         if not torch.is_grad_enabled() or not self.gradient_checkpointing:
             return False
-        return self.gradient_checkpointing_interval is None or layer_idx % self.gradient_checkpointing_interval == 0
+        return should_checkpoint_block(
+            layer_idx,
+            True,
+            self.gradient_checkpointing_interval,
+            self.gradient_checkpointing_segment_stride,
+        )
 
     @staticmethod
     def _stream_in_for_checkpoint_recompute(musubi_manager, layer_idx: int, layer: nn.Module, device: torch.device) -> None:
@@ -772,12 +782,9 @@ class Cosmos3OmniTransformer(ModelMixin, ConfigMixin, PeftAdapterMixin, Attentio
             h_patches = h_padded // p
             w_patches = w_padded // p
             t_n = len(noisy_frame_indexes)
-            output_tensor = torch.zeros(
-                (latent_channel, t_c, h_orig, w_orig),
-                device=packed_mse_preds.device,
-                dtype=packed_mse_preds.dtype,
-            )
             num_patches = t_n * h_patches * w_patches
+            output_dtype = packed_mse_preds.dtype
+            latent = None
             if num_patches > 0:
                 end_idx = start_idx + num_patches
                 latent_patches = packed_mse_preds[start_idx:end_idx]
@@ -785,6 +792,14 @@ class Cosmos3OmniTransformer(ModelMixin, ConfigMixin, PeftAdapterMixin, Attentio
                 latent = torch.einsum("thwpqc->cthpwq", latent_patches)
                 latent = latent.reshape(latent_channel, t_n, h_patches * p, w_patches * p)
                 latent = latent[:, :, :h_orig, :w_orig]
+                output_dtype = latent.dtype
+
+            output_tensor = torch.zeros(
+                (latent_channel, t_c, h_orig, w_orig),
+                device=packed_mse_preds.device,
+                dtype=output_dtype,
+            )
+            if latent is not None:
                 output_tensor[:, noisy_frame_indexes] = latent
                 start_idx = end_idx
             unpatchified_latents.append(output_tensor.unsqueeze(0))

--- a/simpletuner/helpers/training/default_settings/safety_check.py
+++ b/simpletuner/helpers/training/default_settings/safety_check.py
@@ -160,6 +160,7 @@ def safety_check(args, accelerator):
         "boogu_image",
         "chroma",
         "cosmos",
+        "cosmos3",
     ]
     attention_activation_offload_supported_models = [
         "chroma",

--- a/tests/test_cosmos3_model.py
+++ b/tests/test_cosmos3_model.py
@@ -4,6 +4,7 @@ import unittest
 from importlib import resources
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 
 import torch
 from safetensors import safe_open
@@ -251,6 +252,55 @@ class Cosmos3ModelTests(unittest.TestCase):
         self.assertFalse(transformer.layers[0].mlp.down_proj.weight.requires_grad)
         self.assertTrue(transformer.layers[0].self_attn.add_q_proj.weight.requires_grad)
         self.assertTrue(transformer.layers[0].mlp_moe_gen.down_proj.weight.requires_grad)
+
+    def test_unpatchify_preserves_prediction_dtype(self):
+        transformer = Cosmos3OmniTransformer(
+            hidden_size=8,
+            intermediate_size=16,
+            head_dim=4,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            num_hidden_layers=1,
+            latent_channel=2,
+            patch_latent_dim=8,
+            vocab_size=32,
+        )
+        packed = torch.randn(4, 8, dtype=torch.bfloat16)
+
+        unpacked = transformer._unpatchify_and_unpack_latents(
+            packed_mse_preds=packed,
+            token_shapes_vision=[(1, 2, 2)],
+            noisy_frame_indexes_vision=[torch.tensor([0], dtype=torch.long)],
+            original_latent_shapes=[(1, 4, 4)],
+        )
+
+        self.assertEqual(unpacked[0].dtype, torch.bfloat16)
+        self.assertEqual(unpacked[0].shape, (1, 2, 1, 4, 4))
+
+    def test_unpatchify_uses_materialized_latent_dtype(self):
+        transformer = Cosmos3OmniTransformer(
+            hidden_size=8,
+            intermediate_size=16,
+            head_dim=4,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            num_hidden_layers=1,
+            latent_channel=2,
+            patch_latent_dim=8,
+            vocab_size=32,
+        )
+        packed = torch.randn(4, 8, dtype=torch.float32)
+
+        with mock.patch("torch.einsum", return_value=torch.zeros(2, 1, 2, 2, 2, 2, dtype=torch.bfloat16)):
+            unpacked = transformer._unpatchify_and_unpack_latents(
+                packed_mse_preds=packed,
+                token_shapes_vision=[(1, 2, 2)],
+                noisy_frame_indexes_vision=[torch.tensor([0], dtype=torch.long)],
+                original_latent_shapes=[(1, 4, 4)],
+            )
+
+        self.assertEqual(unpacked[0].dtype, torch.bfloat16)
+        self.assertEqual(unpacked[0].shape, (1, 2, 1, 4, 4))
 
     def test_cosmos3_text_cache_metadata_and_collation(self):
         model = TestableCosmos3Image()

--- a/tests/test_segmented_checkpointing_model_support.py
+++ b/tests/test_segmented_checkpointing_model_support.py
@@ -128,3 +128,19 @@ class CosmosSegmentedCheckpointingSupportTests(unittest.TestCase):
             ffn=False,
             attention_offload=False,
         )
+
+
+class Cosmos3SegmentedCheckpointingSupportTests(unittest.TestCase):
+    def test_checkpointing_controls(self):
+        from simpletuner.helpers.models.cosmos3.transformer import Cosmos3OmniTransformer
+
+        assert_checkpointing_controls(
+            self,
+            Cosmos3OmniTransformer,
+            backend=False,
+            interval=True,
+            stride=True,
+            checkpoint_attention_offload=False,
+            ffn=False,
+            attention_offload=False,
+        )


### PR DESCRIPTION
## Summary

Splits the Cosmos 3 segmented checkpointing support model integration out of #2925.

- applies the model-family checkpointing hooks and support flags
- adds this family to the relevant safety-check allow-lists
- keeps the shared runtime/docs in the base PR so this diff stays model-specific

## Stack

Base branch: `agent/segmented-checkpointing-cosmos`

## Validation

- `.venv/bin/python -m unittest tests.test_segmented_checkpointing_model_support -v`
- `.venv/bin/python -m unittest tests.test_cosmos3_model -v`
- commit hooks: Black, isort, flake8, whitespace checks