### PR TITLE
Add ERNIE segmented checkpointing support

### DIFF
--- a/simpletuner/helpers/models/ernie/transformer.py
+++ b/simpletuner/helpers/models/ernie/transformer.py
@@ -15,6 +15,7 @@ from simpletuner.helpers.training.context_parallel_tensors import (
     shard_cp_tensor,
     unshard_cp_tensor,
 )
+from simpletuner.helpers.training.gradient_checkpointing_interval import should_checkpoint_block
 from simpletuner.helpers.training.tread import TREADRouter
 
 logger = logging.getLogger(__name__)
@@ -65,6 +66,9 @@ class ErnieImageTransformer2DModel(
 
     def set_gradient_checkpointing_interval(self, interval: int):
         self.gradient_checkpointing_interval = interval
+
+    def set_gradient_checkpointing_segment_stride(self, segment_stride: int | None):
+        self.gradient_checkpointing_segment_stride = segment_stride
 
     def set_gradient_checkpointing_backend(self, backend: str):
         self.gradient_checkpointing_backend = backend
@@ -217,9 +221,14 @@ class ErnieImageTransformer2DModel(
             if (
                 torch.is_grad_enabled()
                 and self.gradient_checkpointing
-                and (self.gradient_checkpointing_interval is None or layer_idx % self.gradient_checkpointing_interval == 0)
+                and should_checkpoint_block(
+                    layer_idx,
+                    True,
+                    self.gradient_checkpointing_interval,
+                    getattr(self, "gradient_checkpointing_segment_stride", None),
+                )
             ):
-                if self.gradient_checkpointing_backend == "unsloth":
+                if self.gradient_checkpointing_backend.startswith("unsloth"):
                     from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 
                     sequence_first_hidden_states = offloaded_checkpoint(

--- a/simpletuner/helpers/models/ernie/transformer_diffusers.py
+++ b/simpletuner/helpers/models/ernie/transformer_diffusers.py
@@ -502,7 +502,7 @@ class ErnieImageTransformer2DModel(ModelMixin, ConfigMixin):
                 and self.gradient_checkpointing
                 and (self.gradient_checkpointing_interval is None or layer_idx % self.gradient_checkpointing_interval == 0)
             ):
-                if self.gradient_checkpointing_backend == "unsloth":
+                if self.gradient_checkpointing_backend.startswith("unsloth"):
                     from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 
                     x = offloaded_checkpoint(layer, x, rotary_pos_emb, temb, attention_mask, use_reentrant=False)

--- a/simpletuner/helpers/training/default_settings/safety_check.py
+++ b/simpletuner/helpers/training/default_settings/safety_check.py
@@ -161,6 +161,7 @@ def safety_check(args, accelerator):
         "chroma",
         "cosmos",
         "cosmos3",
+        "ernie",
     ]
     attention_activation_offload_supported_models = [
         "chroma",

--- a/tests/test_segmented_checkpointing_model_support.py
+++ b/tests/test_segmented_checkpointing_model_support.py
@@ -144,3 +144,19 @@ class Cosmos3SegmentedCheckpointingSupportTests(unittest.TestCase):
             ffn=False,
             attention_offload=False,
         )
+
+
+class ErnieSegmentedCheckpointingSupportTests(unittest.TestCase):
+    def test_checkpointing_controls(self):
+        from simpletuner.helpers.models.ernie.transformer import ErnieImageTransformer2DModel
+
+        assert_checkpointing_controls(
+            self,
+            ErnieImageTransformer2DModel,
+            backend=True,
+            interval=True,
+            stride=True,
+            checkpoint_attention_offload=False,
+            ffn=False,
+            attention_offload=False,
+        )


### PR DESCRIPTION
## Summary

Splits the ERNIE segmented checkpointing support model integration out of #2925.

- applies the model-family checkpointing hooks and support flags
- adds this family to the relevant safety-check allow-lists
- keeps the shared runtime/docs in the base PR so this diff stays model-specific

## Stack

Base branch: `agent/segmented-checkpointing-cosmos3`

## Validation

- `.venv/bin/python -m unittest tests.test_segmented_checkpointing_model_support -v`
- commit hooks: Black, isort, flake8, whitespace checks