### PR TITLE
Add Flux segmented checkpointing support

### DIFF
--- a/simpletuner/helpers/models/flux/transformer.py
+++ b/simpletuner/helpers/models/flux/transformer.py
@@ -48,6 +48,7 @@ from simpletuner.helpers.training.attention_backend import maybe_metal_flash_rop
 from simpletuner.helpers.training.checkpointing import checkpoint as simpletuner_checkpoint
 from simpletuner.helpers.training.gradient_checkpointing_interval import checkpoint_sequential_state
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
+from simpletuner.helpers.training.offloaded_gradient_checkpointer import activation_offload_context
 from simpletuner.helpers.training.qk_clip_logging import publish_attention_max_logits
 from simpletuner.helpers.training.tread import TREADRouter
 from simpletuner.helpers.utils.patching import CallableDict, MutableModuleList, PatchableModule
@@ -477,6 +478,7 @@ class FluxSingleTransformerBlock(PatchableModule):
         attention_mask: Optional[torch.Tensor] = None,
         checkpoint_ffn: bool = False,
         checkpoint_fn: Any | None = None,
+        offload_attention: bool = False,
     ):
         residual = hidden_states
         norm_hidden_states, gate = _flux_apply_ada_layer_norm_zero_single(self.norm, hidden_states, temb)
@@ -487,11 +489,12 @@ class FluxSingleTransformerBlock(PatchableModule):
                 attention_mask,
             )
 
-        attn_output = self.attn(
-            hidden_states=norm_hidden_states,
-            image_rotary_emb=image_rotary_emb,
-            attention_mask=attention_mask,
-        )
+        with activation_offload_context(offload_attention, label=f"{self.__class__.__qualname__}:attention"):
+            attn_output = self.attn(
+                hidden_states=norm_hidden_states,
+                image_rotary_emb=image_rotary_emb,
+                attention_mask=attention_mask,
+            )
 
         if checkpoint_ffn:
             if checkpoint_fn is None:
@@ -611,6 +614,7 @@ class FluxTransformerBlock(PatchableModule):
         attention_mask: Optional[torch.Tensor] = None,
         checkpoint_ffn: bool = False,
         checkpoint_fn: Any | None = None,
+        offload_attention: bool = False,
     ):
         if context_temb is None:
             context_temb = temb
@@ -629,12 +633,13 @@ class FluxTransformerBlock(PatchableModule):
             )
 
         # Attention.
-        attention_outputs = self.attn(
-            hidden_states=norm_hidden_states,
-            encoder_hidden_states=norm_encoder_hidden_states,
-            image_rotary_emb=image_rotary_emb,
-            attention_mask=attention_mask,
-        )
+        with activation_offload_context(offload_attention, label=f"{self.__class__.__qualname__}:attention"):
+            attention_outputs = self.attn(
+                hidden_states=norm_hidden_states,
+                encoder_hidden_states=norm_encoder_hidden_states,
+                image_rotary_emb=image_rotary_emb,
+                attention_mask=attention_mask,
+            )
         ip_attn_output = None
         if len(attention_outputs) == 2:
             attn_output, context_attn_output = attention_outputs
@@ -702,6 +707,7 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
 
     _supports_gradient_checkpointing = True
     _supports_ffn_gradient_checkpointing = True
+    _supports_attention_activation_offload = True
     # Hint FSDP auto wrap policy to shard per transformer block.
     _no_split_modules = ["FluxTransformerBlock", "FluxSingleTransformerBlock"]
     _cp_plan = {
@@ -808,7 +814,9 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
         self.gradient_checkpointing = False
         # optional interval for gradient checkpointing
         self.gradient_checkpointing_interval = None
+        self.gradient_checkpointing_segment_stride = None
         self.gradient_checkpointing_backend = "torch"
+        self.gradient_checkpointing_offload_attention = False
         total_layers = num_layers + num_single_layers
         self._musubi_block_swap = MusubiBlockSwapManager.build(
             depth=total_layers,
@@ -820,8 +828,14 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
     def set_gradient_checkpointing_interval(self, value: int):
         self.gradient_checkpointing_interval = value
 
+    def set_gradient_checkpointing_segment_stride(self, segment_stride: int | None):
+        self.gradient_checkpointing_segment_stride = segment_stride
+
     def set_gradient_checkpointing_backend(self, backend: str):
         self.gradient_checkpointing_backend = backend
+
+    def set_gradient_checkpointing_offload_attention(self, enabled: bool):
+        self.gradient_checkpointing_offload_attention = bool(enabled)
 
     def set_router(self, router: TREADRouter, routes: List[Dict[str, Any]]):
         self._tread_router = router
@@ -1154,33 +1168,45 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
 
         capture_idx = 0
         for index_block, block in enumerate(self.transformer_blocks):
+            run_gap_eagerly = False
             if use_segmented_checkpointing and controlnet_block_samples is None:
-                if index_block % segment_size != 0:
+                segment_stride = self.gradient_checkpointing_segment_stride or segment_size
+                segment_offset = index_block % segment_stride
+                if segment_offset < segment_size and segment_offset != 0:
                     continue
-                segment_blocks = list(self.transformer_blocks[index_block : index_block + segment_size])
+                if segment_offset >= segment_size:
+                    run_gap_eagerly = True
+                else:
+                    segment_blocks = list(self.transformer_blocks[index_block : index_block + segment_size])
 
-                def run_double_block(_relative_index, segment_block, segment_hidden_states, segment_encoder_hidden_states):
-                    next_encoder_hidden_states, next_hidden_states = segment_block(
-                        hidden_states=segment_hidden_states,
-                        encoder_hidden_states=segment_encoder_hidden_states,
-                        temb=temb_img,
-                        context_temb=temb_txt,
-                        image_rotary_emb=image_rotary_emb,
-                        attention_mask=attention_mask,
+                    def run_double_block(
+                        _relative_index,
+                        segment_block,
+                        segment_hidden_states,
+                        segment_encoder_hidden_states,
+                    ):
+                        next_encoder_hidden_states, next_hidden_states = segment_block(
+                            hidden_states=segment_hidden_states,
+                            encoder_hidden_states=segment_encoder_hidden_states,
+                            temb=temb_img,
+                            context_temb=temb_txt,
+                            image_rotary_emb=image_rotary_emb,
+                            attention_mask=attention_mask,
+                            offload_attention=self.gradient_checkpointing_offload_attention,
+                        )
+                        return next_hidden_states, next_encoder_hidden_states
+
+                    hidden_states, encoder_hidden_states = checkpoint_sequential_state(
+                        segment_blocks,
+                        len(segment_blocks),
+                        (hidden_states, encoder_hidden_states),
+                        run_double_block,
+                        segmented_checkpoint_fn,
+                        segmented_checkpoint_kwargs,
                     )
-                    return next_hidden_states, next_encoder_hidden_states
-
-                hidden_states, encoder_hidden_states = checkpoint_sequential_state(
-                    segment_blocks,
-                    len(segment_blocks),
-                    (hidden_states, encoder_hidden_states),
-                    run_double_block,
-                    segmented_checkpoint_fn,
-                    segmented_checkpoint_kwargs,
-                )
-                global_idx += len(segment_blocks)
-                capture_idx += len(segment_blocks)
-                continue
+                    global_idx += len(segment_blocks)
+                    capture_idx += len(segment_blocks)
+                    continue
 
             if musubi_offload_active and musubi_manager.is_managed_block(global_idx):
                 musubi_manager.stream_in(block, hidden_states.device)
@@ -1214,6 +1240,7 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
             if (
                 self.training
                 and self.gradient_checkpointing
+                and not run_gap_eagerly
                 and (self.gradient_checkpointing_interval is None or index_block % self.gradient_checkpointing_interval == 0)
             ):
                 checkpoint_ffn = self.gradient_checkpointing_backend.endswith("-ffn")
@@ -1223,7 +1250,7 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
                         if return_dict is not None:
                             return module(*inputs, return_dict=return_dict)
                         else:
-                            return module(*inputs)
+                            return module(*inputs, offload_attention=self.gradient_checkpointing_offload_attention)
 
                     return custom_forward
 
@@ -1246,6 +1273,7 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
                         attention_mask=attention_mask,
                         checkpoint_ffn=True,
                         checkpoint_fn=checkpoint_fn,
+                        offload_attention=self.gradient_checkpointing_offload_attention,
                     )
                 else:
                     if is_torch_version(">=", "1.11.0"):
@@ -1269,6 +1297,7 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
                     context_temb=temb_txt,
                     image_rotary_emb=current_rope,
                     attention_mask=attention_mask,
+                    offload_attention=self.gradient_checkpointing_offload_attention,
                 )
 
             if grounding_objs is not None and hasattr(block, "fuser"):
@@ -1307,30 +1336,37 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
         txt_len = encoder_hidden_states.shape[1]
 
         for index_block, block in enumerate(self.single_transformer_blocks):
+            run_gap_eagerly = False
             if use_segmented_checkpointing and controlnet_single_block_samples is None:
-                if index_block % segment_size != 0:
+                segment_stride = self.gradient_checkpointing_segment_stride or segment_size
+                segment_offset = index_block % segment_stride
+                if segment_offset < segment_size and segment_offset != 0:
                     continue
-                segment_blocks = list(self.single_transformer_blocks[index_block : index_block + segment_size])
+                if segment_offset >= segment_size:
+                    run_gap_eagerly = True
+                else:
+                    segment_blocks = list(self.single_transformer_blocks[index_block : index_block + segment_size])
 
-                def run_single_block(_relative_index, segment_block, segment_hidden_states):
-                    return segment_block(
-                        hidden_states=segment_hidden_states,
-                        temb=temb_single,
-                        image_rotary_emb=image_rotary_emb,
-                        attention_mask=attention_mask,
+                    def run_single_block(_relative_index, segment_block, segment_hidden_states):
+                        return segment_block(
+                            hidden_states=segment_hidden_states,
+                            temb=temb_single,
+                            image_rotary_emb=image_rotary_emb,
+                            attention_mask=attention_mask,
+                            offload_attention=self.gradient_checkpointing_offload_attention,
+                        )
+
+                    (hidden_states,) = checkpoint_sequential_state(
+                        segment_blocks,
+                        len(segment_blocks),
+                        (hidden_states,),
+                        run_single_block,
+                        segmented_checkpoint_fn,
+                        segmented_checkpoint_kwargs,
                     )
-
-                (hidden_states,) = checkpoint_sequential_state(
-                    segment_blocks,
-                    len(segment_blocks),
-                    (hidden_states,),
-                    run_single_block,
-                    segmented_checkpoint_fn,
-                    segmented_checkpoint_kwargs,
-                )
-                global_idx += len(segment_blocks)
-                capture_idx += len(segment_blocks)
-                continue
+                    global_idx += len(segment_blocks)
+                    capture_idx += len(segment_blocks)
+                    continue
 
             if musubi_offload_active and musubi_manager.is_managed_block(global_idx):
                 musubi_manager.stream_in(block, hidden_states.device)
@@ -1372,6 +1408,7 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
             if (
                 self.training
                 and self.gradient_checkpointing
+                and not run_gap_eagerly
                 and (self.gradient_checkpointing_interval is None or index_block % self.gradient_checkpointing_interval == 0)
             ):
                 checkpoint_ffn = self.gradient_checkpointing_backend.endswith("-ffn")
@@ -1381,7 +1418,7 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
                         if return_dict is not None:
                             return module(*inputs, return_dict=return_dict)
                         else:
-                            return module(*inputs)
+                            return module(*inputs, offload_attention=self.gradient_checkpointing_offload_attention)
 
                     return custom_forward
 
@@ -1402,6 +1439,7 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
                         attention_mask=attention_mask,
                         checkpoint_ffn=True,
                         checkpoint_fn=checkpoint_fn,
+                        offload_attention=self.gradient_checkpointing_offload_attention,
                     )
                 else:
                     if is_torch_version(">=", "1.11.0"):
@@ -1421,6 +1459,7 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
                     temb=temb_single,
                     image_rotary_emb=current_rope,
                     attention_mask=attention_mask,
+                    offload_attention=self.gradient_checkpointing_offload_attention,
                 )
 
             if grounding_objs is not None and hasattr(block, "fuser"):

--- a/simpletuner/helpers/models/flux/transformer.py
+++ b/simpletuner/helpers/models/flux/transformer.py
@@ -1245,12 +1245,9 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
             ):
                 checkpoint_ffn = self.gradient_checkpointing_backend.endswith("-ffn")
 
-                def create_custom_forward(module, return_dict=None):
+                def create_custom_forward(module):
                     def custom_forward(*inputs):
-                        if return_dict is not None:
-                            return module(*inputs, return_dict=return_dict)
-                        else:
-                            return module(*inputs, offload_attention=self.gradient_checkpointing_offload_attention)
+                        return module(*inputs, offload_attention=self.gradient_checkpointing_offload_attention)
 
                     return custom_forward
 
@@ -1413,12 +1410,9 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
             ):
                 checkpoint_ffn = self.gradient_checkpointing_backend.endswith("-ffn")
 
-                def create_custom_forward(module, return_dict=None):
+                def create_custom_forward(module):
                     def custom_forward(*inputs):
-                        if return_dict is not None:
-                            return module(*inputs, return_dict=return_dict)
-                        else:
-                            return module(*inputs, offload_attention=self.gradient_checkpointing_offload_attention)
+                        return module(*inputs, offload_attention=self.gradient_checkpointing_offload_attention)
 
                     return custom_forward
 

--- a/simpletuner/helpers/training/default_settings/safety_check.py
+++ b/simpletuner/helpers/training/default_settings/safety_check.py
@@ -162,9 +162,11 @@ def safety_check(args, accelerator):
         "cosmos",
         "cosmos3",
         "ernie",
+        "flux",
     ]
     attention_activation_offload_supported_models = [
         "chroma",
+        "flux",
     ]
     if getattr(args, "gradient_checkpointing_offload_attention", False):
         if args.model_family.lower() not in attention_activation_offload_supported_models:

--- a/tests/test_segmented_checkpointing_model_support.py
+++ b/tests/test_segmented_checkpointing_model_support.py
@@ -172,10 +172,92 @@ class FluxSegmentedCheckpointingSupportTests(unittest.TestCase):
             backend=True,
             interval=True,
             stride=True,
-            offload=True,
+            checkpoint_attention_offload=True,
             ffn=True,
             attention_offload=True,
         )
+
+    def test_checkpointing_forwards_attention_offload_to_block_wrappers(self):
+        from unittest.mock import patch
+
+        import torch
+        import torch.nn as nn
+
+        from simpletuner.helpers.models.flux.transformer import FluxTransformer2DModel
+
+        class RecordingDoubleBlock(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.received_offload_attention = None
+
+            def forward(
+                self,
+                hidden_states,
+                encoder_hidden_states,
+                temb,
+                context_temb=None,
+                image_rotary_emb=None,
+                attention_mask=None,
+                checkpoint_ffn=False,
+                checkpoint_fn=None,
+                offload_attention=False,
+            ):
+                self.received_offload_attention = offload_attention
+                return encoder_hidden_states + hidden_states.mean() * 0, hidden_states + temb.mean() * 0
+
+        class RecordingSingleBlock(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.received_offload_attention = None
+
+            def forward(
+                self,
+                hidden_states,
+                temb,
+                image_rotary_emb=None,
+                attention_mask=None,
+                checkpoint_ffn=False,
+                checkpoint_fn=None,
+                offload_attention=False,
+            ):
+                self.received_offload_attention = offload_attention
+                return hidden_states + temb.mean() * 0
+
+        model = FluxTransformer2DModel(
+            patch_size=1,
+            in_channels=4,
+            num_layers=1,
+            num_single_layers=1,
+            attention_head_dim=6,
+            num_attention_heads=2,
+            joint_attention_dim=12,
+            pooled_projection_dim=12,
+            axes_dims_rope=(2, 2, 2),
+        )
+        double_block = RecordingDoubleBlock()
+        single_block = RecordingSingleBlock()
+        model.transformer_blocks[0] = double_block
+        model.single_transformer_blocks[0] = single_block
+        model.train()
+        model.gradient_checkpointing = True
+        model.set_gradient_checkpointing_offload_attention(True)
+
+        def fake_checkpoint(function, *args, **kwargs):
+            return function(*args)
+
+        with patch("simpletuner.helpers.models.flux.transformer.simpletuner_checkpoint", side_effect=fake_checkpoint):
+            model(
+                hidden_states=torch.randn(1, 2, 4, requires_grad=True),
+                encoder_hidden_states=torch.randn(1, 3, 12),
+                pooled_projections=torch.randn(1, 12),
+                timestep=torch.tensor([1.0]),
+                img_ids=torch.zeros(2, 3),
+                txt_ids=torch.zeros(3, 3),
+                return_dict=True,
+            )
+
+        self.assertTrue(double_block.received_offload_attention)
+        self.assertTrue(single_block.received_offload_attention)
 
 
 class FluxBlockCheckpointingScopeTests(unittest.TestCase):

--- a/tests/test_segmented_checkpointing_model_support.py
+++ b/tests/test_segmented_checkpointing_model_support.py
@@ -160,3 +160,53 @@ class ErnieSegmentedCheckpointingSupportTests(unittest.TestCase):
             ffn=False,
             attention_offload=False,
         )
+
+
+class FluxSegmentedCheckpointingSupportTests(unittest.TestCase):
+    def test_checkpointing_controls(self):
+        from simpletuner.helpers.models.flux.transformer import FluxTransformer2DModel
+
+        assert_checkpointing_controls(
+            self,
+            FluxTransformer2DModel,
+            backend=True,
+            interval=True,
+            stride=True,
+            offload=True,
+            ffn=True,
+            attention_offload=True,
+        )
+
+
+class FluxBlockCheckpointingScopeTests(unittest.TestCase):
+    def test_blocks_accept_ffn_checkpoint_and_attention_offload_scope(self):
+        import torch
+
+        from simpletuner.helpers.models.flux.transformer import FluxSingleTransformerBlock, FluxTransformerBlock
+
+        double_block = FluxTransformerBlock(dim=16, num_attention_heads=2, attention_head_dim=8).train()
+        hidden = torch.randn(2, 4, 16, requires_grad=True)
+        encoder_hidden = torch.randn(2, 3, 16, requires_grad=True)
+        temb = torch.randn(2, 16)
+
+        expected_encoder, expected_hidden = double_block(hidden, encoder_hidden, temb)
+        actual_encoder, actual_hidden = double_block(
+            hidden,
+            encoder_hidden,
+            temb,
+            checkpoint_ffn=True,
+            checkpoint_fn=torch.utils.checkpoint.checkpoint,
+            offload_attention=True,
+        )
+        self.assertTrue(torch.allclose(expected_encoder, actual_encoder, atol=1e-6))
+        self.assertTrue(torch.allclose(expected_hidden, actual_hidden, atol=1e-6))
+
+        single_block = FluxSingleTransformerBlock(dim=16, num_attention_heads=2, attention_head_dim=8).train()
+        hidden = torch.randn(2, 7, 16, requires_grad=True)
+        temb = torch.randn(2, 16)
+
+        expected_hidden = single_block(hidden, temb)
+        actual_hidden = single_block(
+            hidden, temb, checkpoint_ffn=True, checkpoint_fn=torch.utils.checkpoint.checkpoint, offload_attention=True
+        )
+        self.assertTrue(torch.allclose(expected_hidden, actual_hidden, atol=1e-6))


### PR DESCRIPTION
## Summary

Splits the Flux segmented-checkpointing integration out of #2925.

- adds Flux stride handling, attention activation offload, and FFN/offload block plumbing
- adds Flux to the stride and attention-offload safety-check allow-lists
- keeps shared runtime/docs in the base PR so this diff stays model-specific

## Stack

Base branch: `agent/segmented-checkpointing-ernie`

## Validation

- `.venv/bin/python -m unittest tests.test_segmented_checkpointing_model_support -v`
- commit hooks: Black, isort, flake8, whitespace checks