### PR TITLE
Add LongCat segmented checkpointing support

### DIFF
--- a/simpletuner/helpers/models/longcat_image/transformer.py
+++ b/simpletuner/helpers/models/longcat_image/transformer.py
@@ -27,6 +27,8 @@ from simpletuner.helpers.models.flowmap import (
     validate_flowmap_deltatime_type,
 )
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
+from simpletuner.helpers.training.gradient_checkpointing_interval import should_checkpoint_block
+from simpletuner.helpers.training.offloaded_gradient_checkpointer import activation_offload_context
 
 logger = get_logger(__name__, log_level="INFO")
 
@@ -185,6 +187,7 @@ def _run_longcat_transformer_block(
     temb: torch.Tensor,
     context_temb: torch.Tensor,
     image_rotary_emb,
+    offload_attention: bool = False,
 ):
     norm_hidden_states, gate_msa, shift_mlp, scale_mlp, gate_mlp = _longcat_apply_ada_layer_norm_zero(
         block.norm1, hidden_states, temb
@@ -193,11 +196,12 @@ def _run_longcat_transformer_block(
         block.norm1_context, encoder_hidden_states, context_temb
     )
 
-    attention_outputs = block.attn(
-        hidden_states=norm_hidden_states,
-        encoder_hidden_states=norm_encoder_hidden_states,
-        image_rotary_emb=image_rotary_emb,
-    )
+    with activation_offload_context(offload_attention, label=f"{block.__class__.__qualname__}:attention"):
+        attention_outputs = block.attn(
+            hidden_states=norm_hidden_states,
+            encoder_hidden_states=norm_encoder_hidden_states,
+            image_rotary_emb=image_rotary_emb,
+        )
     if len(attention_outputs) == 2:
         attn_output, context_attn_output = attention_outputs
     elif len(attention_outputs) == 3:
@@ -244,6 +248,7 @@ def _run_longcat_single_transformer_block(
     encoder_hidden_states: torch.Tensor,
     temb: torch.Tensor,
     image_rotary_emb,
+    offload_attention: bool = False,
 ):
     text_seq_len = encoder_hidden_states.shape[1]
     hidden_states = torch.cat([encoder_hidden_states, hidden_states], dim=1)
@@ -251,7 +256,8 @@ def _run_longcat_single_transformer_block(
     residual = hidden_states
     norm_hidden_states, gate = _longcat_apply_ada_layer_norm_zero_single(block.norm, hidden_states, temb)
     mlp_hidden_states = block.act_mlp(block.proj_mlp(norm_hidden_states))
-    attn_output = block.attn(hidden_states=norm_hidden_states, image_rotary_emb=image_rotary_emb)
+    with activation_offload_context(offload_attention, label=f"{block.__class__.__qualname__}:attention"):
+        attn_output = block.attn(hidden_states=norm_hidden_states, image_rotary_emb=image_rotary_emb)
 
     hidden_states = torch.cat([attn_output, mlp_hidden_states], dim=2)
     if gate.ndim == 2:
@@ -271,6 +277,7 @@ class LongCatImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
     """
 
     _supports_gradient_checkpointing = True
+    _supports_attention_activation_offload = True
     _cp_plan = {
         "": {
             "hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
@@ -341,6 +348,9 @@ class LongCatImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         self.proj_out = nn.Linear(self.inner_dim, patch_size * patch_size * self.out_channels, bias=True)
 
         self.gradient_checkpointing = False
+        self.gradient_checkpointing_interval = None
+        self.gradient_checkpointing_segment_stride = None
+        self.gradient_checkpointing_offload_attention = False
         self.initialize_weights()
 
         self.use_checkpoint = [True] * num_layers
@@ -353,6 +363,15 @@ class LongCatImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
             swap_device=musubi_block_swap_device,
             logger=logger,
         )
+
+    def set_gradient_checkpointing_interval(self, interval: int):
+        self.gradient_checkpointing_interval = interval
+
+    def set_gradient_checkpointing_segment_stride(self, segment_stride: int | None):
+        self.gradient_checkpointing_segment_stride = segment_stride
+
+    def set_gradient_checkpointing_offload_attention(self, enabled: bool):
+        self.gradient_checkpointing_offload_attention = bool(enabled)
 
     def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
         self.time_embed.enable_flowmap_time_conditioning(gate_value=gate_value, deltatime_type=deltatime_type)
@@ -456,7 +475,16 @@ class LongCatImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         for index_block, block in enumerate(self.transformer_blocks):
             if musubi_offload_active and musubi_manager.is_managed_block(capture_idx):
                 musubi_manager.stream_in(block, hidden_states.device)
-            if torch.is_grad_enabled() and self.gradient_checkpointing and self.use_checkpoint[index_block]:
+            if (
+                torch.is_grad_enabled()
+                and self.use_checkpoint[index_block]
+                and should_checkpoint_block(
+                    capture_idx,
+                    self.gradient_checkpointing,
+                    self.gradient_checkpointing_interval,
+                    self.gradient_checkpointing_segment_stride,
+                )
+            ):
                 encoder_hidden_states, hidden_states = self._gradient_checkpointing_func(
                     _run_longcat_transformer_block,
                     block,
@@ -465,6 +493,7 @@ class LongCatImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
                     temb_img,
                     temb_txt,
                     image_rotary_emb,
+                    self.gradient_checkpointing_offload_attention,
                 )
             else:
                 encoder_hidden_states, hidden_states = _run_longcat_transformer_block(
@@ -474,6 +503,7 @@ class LongCatImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
                     temb_img,
                     temb_txt,
                     image_rotary_emb,
+                    offload_attention=self.gradient_checkpointing_offload_attention,
                 )
             if musubi_offload_active and musubi_manager.is_managed_block(capture_idx):
                 musubi_manager.stream_out(block)
@@ -483,7 +513,16 @@ class LongCatImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         for index_block, block in enumerate(self.single_transformer_blocks):
             if musubi_offload_active and musubi_manager.is_managed_block(capture_idx):
                 musubi_manager.stream_in(block, hidden_states.device)
-            if torch.is_grad_enabled() and self.gradient_checkpointing and self.use_single_checkpoint[index_block]:
+            if (
+                torch.is_grad_enabled()
+                and self.use_single_checkpoint[index_block]
+                and should_checkpoint_block(
+                    capture_idx,
+                    self.gradient_checkpointing,
+                    self.gradient_checkpointing_interval,
+                    self.gradient_checkpointing_segment_stride,
+                )
+            ):
                 encoder_hidden_states, hidden_states = self._gradient_checkpointing_func(
                     _run_longcat_single_transformer_block,
                     block,
@@ -491,6 +530,7 @@ class LongCatImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
                     encoder_hidden_states,
                     temb_single,
                     image_rotary_emb,
+                    self.gradient_checkpointing_offload_attention,
                 )
             else:
                 encoder_hidden_states, hidden_states = _run_longcat_single_transformer_block(
@@ -499,6 +539,7 @@ class LongCatImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
                     encoder_hidden_states,
                     temb_single,
                     image_rotary_emb,
+                    offload_attention=self.gradient_checkpointing_offload_attention,
                 )
             if musubi_offload_active and musubi_manager.is_managed_block(capture_idx):
                 musubi_manager.stream_out(block)

--- a/simpletuner/helpers/models/longcat_video/transformer.py
+++ b/simpletuner/helpers/models/longcat_video/transformer.py
@@ -23,6 +23,8 @@ from simpletuner.helpers.models.flowmap import (
     validate_flowmap_deltatime_type,
 )
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
+from simpletuner.helpers.training.gradient_checkpointing_interval import should_checkpoint_block
+from simpletuner.helpers.training.offloaded_gradient_checkpointer import activation_offload_context
 
 logger = logging.getLogger(__name__)
 _BSA_DISABLED_WARNED = False
@@ -961,7 +963,17 @@ class LongCatSingleStreamBlock(nn.Module):
         self.ffn = FeedForwardSwiGLU(dim=hidden_size, hidden_dim=int(hidden_size * mlp_ratio))
 
     def forward(
-        self, x, y, t, y_seqlen, latent_shape, num_cond_latents=None, return_kv=False, kv_cache=None, skip_crs_attn=False
+        self,
+        x,
+        y,
+        t,
+        y_seqlen,
+        latent_shape,
+        num_cond_latents=None,
+        return_kv=False,
+        kv_cache=None,
+        skip_crs_attn=False,
+        offload_attention=False,
     ):
         x_dtype = x.dtype
 
@@ -987,13 +999,14 @@ class LongCatSingleStreamBlock(nn.Module):
 
         x_m = modulate_fp32(self.mod_norm_attn, x.view(B, T, -1, C), shift_msa, scale_msa).view(B, N, C)
 
-        if kv_cache is not None:
-            attn_outputs = self.attn.forward_with_kv_cache(
-                x_m, shape=latent_shape, num_cond_latents=num_cond_latents, kv_cache=kv_cache
-            )
-            kv_cache = kv_cache
-        else:
-            attn_outputs = self.attn(x_m, shape=latent_shape, num_cond_latents=num_cond_latents, return_kv=return_kv)
+        with activation_offload_context(offload_attention, label=f"{self.__class__.__qualname__}:self_attention"):
+            if kv_cache is not None:
+                attn_outputs = self.attn.forward_with_kv_cache(
+                    x_m, shape=latent_shape, num_cond_latents=num_cond_latents, kv_cache=kv_cache
+                )
+                kv_cache = kv_cache
+            else:
+                attn_outputs = self.attn(x_m, shape=latent_shape, num_cond_latents=num_cond_latents, return_kv=return_kv)
         if return_kv:
             x_s, kv_cache = attn_outputs
         else:
@@ -1006,9 +1019,10 @@ class LongCatSingleStreamBlock(nn.Module):
         if not skip_crs_attn:
             if kv_cache is not None:
                 num_cond_latents = None
-            x = x + self.cross_attn(
-                self.pre_crs_attn_norm(x), y, y_seqlen, num_cond_latents=num_cond_latents, shape=latent_shape
-            )
+            with activation_offload_context(offload_attention, label=f"{self.__class__.__qualname__}:cross_attention"):
+                x = x + self.cross_attn(
+                    self.pre_crs_attn_norm(x), y, y_seqlen, num_cond_latents=num_cond_latents, shape=latent_shape
+                )
 
         x = modulate_fp32(self.mod_norm_ffn, x.view(B, T, -1, C), shift_mlp, scale_mlp).view(B, N, C)
 
@@ -1027,6 +1041,7 @@ class LongCatVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
     """
 
     _supports_gradient_checkpointing = True
+    _supports_attention_activation_offload = True
     _cp_plan = {
         "": {
             "hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
@@ -1107,6 +1122,9 @@ class LongCatVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
 
         self.gradient_checkpointing = False
         self.gradient_checkpointing_backend = "torch"
+        self.gradient_checkpointing_interval = None
+        self.gradient_checkpointing_segment_stride = None
+        self.gradient_checkpointing_offload_attention = False
         self.text_tokens_zero_pad = text_tokens_zero_pad
         self._musubi_block_swap = MusubiBlockSwapManager.build(
             depth=depth,
@@ -1117,6 +1135,15 @@ class LongCatVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
 
     def set_gradient_checkpointing_backend(self, backend: str):
         self.gradient_checkpointing_backend = backend
+
+    def set_gradient_checkpointing_interval(self, interval: int):
+        self.gradient_checkpointing_interval = interval
+
+    def set_gradient_checkpointing_segment_stride(self, segment_stride: int | None):
+        self.gradient_checkpointing_segment_stride = segment_stride
+
+    def set_gradient_checkpointing_offload_attention(self, enabled: bool):
+        self.gradient_checkpointing_offload_attention = bool(enabled)
 
     def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
         self.t_embedder.enable_flowmap_time_conditioning(gate_value=gate_value, deltatime_type=deltatime_type)
@@ -1273,8 +1300,13 @@ class LongCatVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
             if musubi_offload_active and musubi_manager.is_managed_block(i):
                 musubi_manager.stream_in(block, hidden_states.device)
 
-            if grad_enabled and self.gradient_checkpointing:
-                if self.gradient_checkpointing_backend == "unsloth":
+            if grad_enabled and should_checkpoint_block(
+                capture_idx,
+                self.gradient_checkpointing,
+                self.gradient_checkpointing_interval,
+                self.gradient_checkpointing_segment_stride,
+            ):
+                if self.gradient_checkpointing_backend.startswith("unsloth"):
                     from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 
                     checkpoint_fn = offloaded_checkpoint
@@ -1292,6 +1324,7 @@ class LongCatVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
                     return_kv,
                     kv_cache_dict.get(i, None),
                     skip_crs_attn,
+                    self.gradient_checkpointing_offload_attention,
                     use_reentrant=False,
                 )
             else:
@@ -1305,6 +1338,7 @@ class LongCatVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
                     return_kv,
                     kv_cache_dict.get(i, None),
                     skip_crs_attn,
+                    self.gradient_checkpointing_offload_attention,
                 )
 
             if return_kv:

--- a/simpletuner/helpers/training/default_settings/safety_check.py
+++ b/simpletuner/helpers/training/default_settings/safety_check.py
@@ -159,6 +159,8 @@ def safety_check(args, accelerator):
         "kandinsky5_image",
         "kandinsky5_video",
         "krea2",
+        "longcat_image",
+        "longcat_video",
     ]
     gradient_checkpointing_segment_stride_supported_models = [
         "ace_step",
@@ -176,6 +178,8 @@ def safety_check(args, accelerator):
         "kandinsky5_image",
         "kandinsky5_video",
         "krea2",
+        "longcat_image",
+        "longcat_video",
     ]
     attention_activation_offload_supported_models = [
         "chroma",
@@ -187,6 +191,8 @@ def safety_check(args, accelerator):
         "kandinsky5_image",
         "kandinsky5_video",
         "krea2",
+        "longcat_image",
+        "longcat_video",
     ]
     if getattr(args, "gradient_checkpointing_offload_attention", False):
         if args.model_family.lower() not in attention_activation_offload_supported_models:

--- a/tests/test_segmented_checkpointing_model_support.py
+++ b/tests/test_segmented_checkpointing_model_support.py
@@ -399,3 +399,35 @@ class Krea2SegmentedCheckpointingSupportTests(unittest.TestCase):
             ffn=True,
             attention_offload=True,
         )
+
+
+class LongCatImageSegmentedCheckpointingSupportTests(unittest.TestCase):
+    def test_checkpointing_controls(self):
+        from simpletuner.helpers.models.longcat_image.transformer import LongCatImageTransformer2DModel
+
+        assert_checkpointing_controls(
+            self,
+            LongCatImageTransformer2DModel,
+            backend=False,
+            interval=True,
+            stride=True,
+            checkpoint_attention_offload=True,
+            ffn=False,
+            attention_offload=True,
+        )
+
+
+class LongCatVideoSegmentedCheckpointingSupportTests(unittest.TestCase):
+    def test_checkpointing_controls(self):
+        from simpletuner.helpers.models.longcat_video.transformer import LongCatVideoTransformer3DModel
+
+        assert_checkpointing_controls(
+            self,
+            LongCatVideoTransformer3DModel,
+            backend=True,
+            interval=True,
+            stride=True,
+            checkpoint_attention_offload=True,
+            ffn=False,
+            attention_offload=True,
+        )


### PR DESCRIPTION
## Summary

Splits the LongCat segmented checkpointing support model integration out of #2925.

- applies the model-family checkpointing hooks and support flags
- adds this family to the relevant safety-check allow-lists
- keeps the shared runtime/docs in the base PR so this diff stays model-specific

## Stack

Base branch: `agent/segmented-checkpointing-krea2`

## Validation

- `.venv/bin/python -m unittest tests.test_segmented_checkpointing_model_support -v`
- commit hooks: Black, isort, flake8, whitespace checks