### PR TITLE
Add MageFlow segmented checkpointing support

### DIFF
--- a/simpletuner/helpers/models/mageflow/transformer.py
+++ b/simpletuner/helpers/models/mageflow/transformer.py
@@ -52,6 +52,7 @@ def _resolve_repo_dir(repo_id_or_path: str, *, revision: Optional[str] = None, l
 class MageFlowTransformer2DModel(MageFlow, ModelMixin, ConfigMixin, PeftAdapterMixin):
     _supports_gradient_checkpointing = True
     _supports_ffn_gradient_checkpointing = True
+    _supports_attention_activation_offload = True
     _no_split_modules = ["MageFlowTransformerBlock"]
     _skip_layerwise_casting_patterns = ["pos_embed", "norm"]
 
@@ -130,6 +131,8 @@ class MageFlowTransformer2DModel(MageFlow, ModelMixin, ConfigMixin, PeftAdapterM
         self.gradient_checkpointing_backend = get_checkpoint_backend()
         self.gradient_checkpointing_scope = get_checkpoint_backend_scope()
         self.gradient_checkpointing_interval = None
+        self.gradient_checkpointing_segment_stride = None
+        self.gradient_checkpointing_offload_attention = False
         self._gradient_checkpointing_func = get_checkpoint_function()
         self._musubi_block_swap = MusubiBlockSwapManager.build(
             depth=depth,
@@ -178,8 +181,14 @@ class MageFlowTransformer2DModel(MageFlow, ModelMixin, ConfigMixin, PeftAdapterM
         self.gradient_checkpointing_scope = get_checkpoint_backend_scope(backend)
         self._gradient_checkpointing_func = get_checkpoint_function()
 
+    def set_gradient_checkpointing_offload_attention(self, enabled: bool):
+        self.gradient_checkpointing_offload_attention = bool(enabled)
+
     def set_gradient_checkpointing_interval(self, interval: int):
         self.gradient_checkpointing_interval = interval
+
+    def set_gradient_checkpointing_segment_stride(self, segment_stride: int | None):
+        self.gradient_checkpointing_segment_stride = segment_stride
 
     def enable_gradient_checkpointing(self, gradient_checkpointing_func=None):
         self.checkpoint = True
@@ -271,12 +280,9 @@ class MageFlowTransformer2DModel(MageFlow, ModelMixin, ConfigMixin, PeftAdapterM
                 and not skip_layers_set
                 and hidden_states_buffer is None
             ):
-                if index_block % self.gradient_checkpointing_interval != 0:
+                if index_block != 0:
                     continue
-                segment_blocks = list(
-                    self.transformer_blocks[index_block : index_block + self.gradient_checkpointing_interval]
-                )
-                for segment_block in segment_blocks:
+                for segment_block in self.transformer_blocks:
                     _ensure_module_device(getattr(segment_block, "img_mod", None), img.device)
                     _ensure_module_device(getattr(segment_block, "txt_mod", None), img.device)
 
@@ -289,15 +295,17 @@ class MageFlowTransformer2DModel(MageFlow, ModelMixin, ConfigMixin, PeftAdapterM
                         temb=temb,
                         image_rotary_emb=ms_pe,
                         joint_attention_kwargs=attention_kwargs,
+                        offload_attention=self.gradient_checkpointing_offload_attention,
                     )
 
                 txt, img = checkpoint_sequential_state(
-                    segment_blocks,
-                    len(segment_blocks),
+                    self.transformer_blocks,
+                    self.gradient_checkpointing_interval,
                     (txt, img),
                     run_segment_block,
                     self._gradient_checkpointing_func,
                     {"use_reentrant": False},
+                    segment_stride=self.gradient_checkpointing_segment_stride,
                 )
                 continue
 
@@ -318,10 +326,32 @@ class MageFlowTransformer2DModel(MageFlow, ModelMixin, ConfigMixin, PeftAdapterM
                     joint_attention_kwargs=attention_kwargs,
                     checkpoint_ffn=True,
                     checkpoint_fn=self._gradient_checkpointing_func,
+                    offload_attention=self.gradient_checkpointing_offload_attention,
                 )
             elif self.training and self.checkpoint:
+
+                def run_checkpointed_block(
+                    checkpoint_img,
+                    checkpoint_txt,
+                    checkpoint_temb,
+                    checkpoint_pe,
+                    checkpoint_txt_cu_seqlens,
+                    checkpoint_img_cu_seqlens,
+                    checkpoint_block=block,
+                ):
+                    return checkpoint_block(
+                        hidden_states=checkpoint_img,
+                        encoder_hidden_states=checkpoint_txt,
+                        txt_cu_lens=checkpoint_txt_cu_seqlens,
+                        img_cu_lens=checkpoint_img_cu_seqlens,
+                        temb=checkpoint_temb,
+                        image_rotary_emb=checkpoint_pe,
+                        joint_attention_kwargs=attention_kwargs,
+                        offload_attention=self.gradient_checkpointing_offload_attention,
+                    )
+
                 txt, img = self._gradient_checkpointing_func(
-                    block,
+                    run_checkpointed_block,
                     img,
                     txt,
                     temb,
@@ -339,6 +369,7 @@ class MageFlowTransformer2DModel(MageFlow, ModelMixin, ConfigMixin, PeftAdapterM
                     temb=temb,
                     image_rotary_emb=ms_pe,
                     joint_attention_kwargs=attention_kwargs,
+                    offload_attention=self.gradient_checkpointing_offload_attention,
                 )
             if musubi_offload_active and musubi_manager.is_managed_block(index_block):
                 musubi_manager.stream_out(block)

--- a/simpletuner/helpers/models/mageflow/vendor/models/modules/mage_layers.py
+++ b/simpletuner/helpers/models/mageflow/vendor/models/modules/mage_layers.py
@@ -10,6 +10,8 @@ from diffusers.models.normalization import RMSNorm
 from torch import Tensor
 from torch._dynamo import allow_in_graph as maybe_allow_in_graph
 
+from simpletuner.helpers.training.offloaded_gradient_checkpointer import activation_offload_context
+
 from ._attn_backend import flash_attn_varlen_func
 
 
@@ -619,6 +621,7 @@ class MageFlowTransformerBlock(nn.Module):
         joint_attention_kwargs: dict[str, Any] | None = None,
         checkpoint_ffn: bool = False,
         checkpoint_fn: Any | None = None,
+        offload_attention: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # Get modulation parameters for both streams
         # if isinstance(temb, tuple):
@@ -658,17 +661,18 @@ class MageFlowTransformerBlock(nn.Module):
         joint_attention_kwargs = joint_attention_kwargs or {}
         # logger.info(f"img_modulated: {img_modulated}")
         # logger.info(f"txt_modulated: {txt_modulated}")
-        attn_output = self.attn(
-            hidden_states=img_modulated,  # Image stream (will be processed as "sample")
-            encoder_hidden_states=txt_modulated,  # Text stream (will be processed as "context")
-            # encoder_hidden_states_mask=encoder_hidden_states_mask,
-            image_rotary_emb=image_rotary_emb,
-            txt_cu_lens=txt_cu_lens,
-            img_cu_lens=img_cu_lens,
-            # freqs_cos=freqs_cos,
-            # freqs_sin=freqs_sin,
-            **joint_attention_kwargs,
-        )
+        with activation_offload_context(offload_attention, label=f"{self.__class__.__qualname__}:attention"):
+            attn_output = self.attn(
+                hidden_states=img_modulated,  # Image stream (will be processed as "sample")
+                encoder_hidden_states=txt_modulated,  # Text stream (will be processed as "context")
+                # encoder_hidden_states_mask=encoder_hidden_states_mask,
+                image_rotary_emb=image_rotary_emb,
+                txt_cu_lens=txt_cu_lens,
+                img_cu_lens=img_cu_lens,
+                # freqs_cos=freqs_cos,
+                # freqs_sin=freqs_sin,
+                **joint_attention_kwargs,
+            )
         # logger.info(f"attn_output: {attn_output}")
 
         # MageDoubleStreamAttnProcessor returns (img_output, txt_output) when encoder_hidden_states is provided

--- a/simpletuner/helpers/training/default_settings/safety_check.py
+++ b/simpletuner/helpers/training/default_settings/safety_check.py
@@ -186,6 +186,7 @@ def safety_check(args, accelerator):
         "ltxvideo",
         "ltxvideo2",
         "lumina2",
+        "mageflow",
     ]
     attention_activation_offload_supported_models = [
         "chroma",
@@ -200,6 +201,7 @@ def safety_check(args, accelerator):
         "longcat_image",
         "longcat_video",
         "ltxvideo2",
+        "mageflow",
     ]
     if getattr(args, "gradient_checkpointing_offload_attention", False):
         if args.model_family.lower() not in attention_activation_offload_supported_models:

--- a/tests/test_segmented_checkpointing_model_support.py
+++ b/tests/test_segmented_checkpointing_model_support.py
@@ -479,3 +479,19 @@ class Lumina2SegmentedCheckpointingSupportTests(unittest.TestCase):
             ffn=False,
             attention_offload=False,
         )
+
+
+class MageFlowSegmentedCheckpointingSupportTests(unittest.TestCase):
+    def test_checkpointing_controls(self):
+        from simpletuner.helpers.models.mageflow.transformer import MageFlowTransformer2DModel
+
+        assert_checkpointing_controls(
+            self,
+            MageFlowTransformer2DModel,
+            backend=True,
+            interval=True,
+            stride=True,
+            checkpoint_attention_offload=True,
+            ffn=True,
+            attention_offload=True,
+        )


### PR DESCRIPTION
## Summary

Splits the MageFlow segmented checkpointing support model integration out of #2925.

- applies the model-family checkpointing hooks and support flags
- adds this family to the relevant safety-check allow-lists
- keeps the shared runtime/docs in the base PR so this diff stays model-specific

## Stack

Base branch: `agent/segmented-checkpointing-lumina2`

## Validation

- `.venv/bin/python -m unittest tests.test_segmented_checkpointing_model_support -v`
- commit hooks: Black, isort, flake8, whitespace checks