### PR TITLE
Add PixArt segmented checkpointing support

### DIFF
--- a/simpletuner/helpers/models/pixart/transformer.py
+++ b/simpletuner/helpers/models/pixart/transformer.py
@@ -36,6 +36,8 @@ from simpletuner.helpers.models.flowmap import (
     validate_flowmap_deltatime_type,
 )
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
+from simpletuner.helpers.training.checkpointing import checkpoint as simpletuner_checkpoint
+from simpletuner.helpers.training.gradient_checkpointing_interval import checkpoint_sequential_state, should_checkpoint_block
 from simpletuner.helpers.training.packed_attention_processors import PackedFusedAttnProcessor2_0
 from simpletuner.helpers.training.tread import TREADRouter
 from simpletuner.helpers.utils.patching import CallableDict, MutableModuleList, PatchableModule
@@ -350,6 +352,8 @@ class PixArtTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAda
             self.caption_projection = PixArtAlphaTextProjection(
                 in_features=self.config.caption_channels, hidden_size=self.inner_dim
             )
+        self.gradient_checkpointing_interval = None
+        self.gradient_checkpointing_segment_stride = None
 
         self._musubi_block_swap = MusubiBlockSwapManager.build(
             depth=num_layers,
@@ -360,6 +364,12 @@ class PixArtTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAda
 
     def set_gradient_checkpointing_backend(self, backend: str):
         self.gradient_checkpointing_backend = backend
+
+    def set_gradient_checkpointing_interval(self, interval: int):
+        self.gradient_checkpointing_interval = interval
+
+    def set_gradient_checkpointing_segment_stride(self, segment_stride: int | None):
+        self.gradient_checkpointing_segment_stride = segment_stride
 
     @property
     # Copied from diffusers.models.unets.unet_2d_condition.UNet2DConditionModel.attn_processors
@@ -614,8 +624,54 @@ class PixArtTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAda
         if musubi_manager is not None:
             musubi_offload_active = musubi_manager.activate(combined_blocks, hidden_states.device, grad_enabled)
 
+        use_segmented_checkpointing = (
+            grad_enabled
+            and self.gradient_checkpointing
+            and self.gradient_checkpointing_interval is not None
+            and self.gradient_checkpointing_interval > 1
+            and not self.gradient_checkpointing_backend.endswith("-ffn")
+            and not use_routing
+            and not musubi_offload_active
+            and controlnet_block_samples is None
+            and hidden_states_buffer is None
+        )
+        segmented_checkpoint_fn = None
+        if use_segmented_checkpointing:
+            if self.gradient_checkpointing_backend.startswith("unsloth"):
+                from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
+
+                segmented_checkpoint_fn = offloaded_checkpoint
+            else:
+                segmented_checkpoint_fn = simpletuner_checkpoint
+
         capture_idx = 0
         for index_block, block in enumerate(self.transformer_blocks):
+            if use_segmented_checkpointing:
+                if index_block != 0:
+                    continue
+
+                def run_segmented_block(_idx, segment_block, segment_hidden_states):
+                    return segment_block(
+                        segment_hidden_states,
+                        attention_mask=attention_mask,
+                        encoder_hidden_states=encoder_hidden_states,
+                        encoder_attention_mask=encoder_attention_mask,
+                        timestep=timestep,
+                        cross_attention_kwargs=cross_attention_kwargs,
+                        class_labels=None,
+                    )
+
+                (hidden_states,) = checkpoint_sequential_state(
+                    self.transformer_blocks,
+                    self.gradient_checkpointing_interval,
+                    (hidden_states,),
+                    run_segmented_block,
+                    segmented_checkpoint_fn,
+                    {"use_reentrant": False},
+                    segment_stride=self.gradient_checkpointing_segment_stride,
+                )
+                continue
+
             if musubi_offload_active and musubi_manager.is_managed_block(index_block):
                 musubi_manager.stream_in(block, hidden_states.device)
             # TREAD: START a route?
@@ -630,8 +686,13 @@ class PixArtTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAda
                 hidden_states = router.start_route(hidden_states, tread_mask_info)
                 routing_now = True
 
-            if torch.is_grad_enabled() and self.gradient_checkpointing:
-                if self.gradient_checkpointing_backend == "unsloth":
+            if torch.is_grad_enabled() and should_checkpoint_block(
+                index_block,
+                self.gradient_checkpointing,
+                self.gradient_checkpointing_interval,
+                self.gradient_checkpointing_segment_stride,
+            ):
+                if self.gradient_checkpointing_backend.startswith("unsloth"):
                     from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 
                     checkpoint_fn = offloaded_checkpoint

--- a/simpletuner/helpers/training/default_settings/safety_check.py
+++ b/simpletuner/helpers/training/default_settings/safety_check.py
@@ -164,6 +164,7 @@ def safety_check(args, accelerator):
         "ltxvideo",
         "ltxvideo2",
         "lumina2",
+        "pixart",
     ]
     gradient_checkpointing_segment_stride_supported_models = [
         "ace_step",
@@ -187,6 +188,7 @@ def safety_check(args, accelerator):
         "ltxvideo2",
         "lumina2",
         "mageflow",
+        "pixart",
     ]
     attention_activation_offload_supported_models = [
         "chroma",

--- a/tests/test_segmented_checkpointing_model_support.py
+++ b/tests/test_segmented_checkpointing_model_support.py
@@ -495,3 +495,19 @@ class MageFlowSegmentedCheckpointingSupportTests(unittest.TestCase):
             ffn=True,
             attention_offload=True,
         )
+
+
+class PixArtSegmentedCheckpointingSupportTests(unittest.TestCase):
+    def test_checkpointing_controls(self):
+        from simpletuner.helpers.models.pixart.transformer import PixArtTransformer2DModel
+
+        assert_checkpointing_controls(
+            self,
+            PixArtTransformer2DModel,
+            backend=True,
+            interval=True,
+            stride=True,
+            checkpoint_attention_offload=False,
+            ffn=False,
+            attention_offload=False,
+        )

--- a/tests/test_transformers/test_pixart_transformer.py
+++ b/tests/test_transformers/test_pixart_transformer.py
@@ -901,6 +901,57 @@ class TestPixArtTransformer2DModel(TransformerBaseTest, AttentionProcessorTestMi
                 return_dict=False,
             )
 
+    def test_segmented_checkpointing_uses_sequential_state_helper(self):
+        from simpletuner.helpers.models.pixart.transformer import PixArtTransformer2DModel
+
+        model = PixArtTransformer2DModel(
+            num_attention_heads=2,
+            attention_head_dim=8,
+            in_channels=4,
+            out_channels=8,
+            num_layers=4,
+            cross_attention_dim=16,
+            caption_channels=16,
+            sample_size=8,
+            patch_size=2,
+            num_embeds_ada_norm=1000,
+            use_additional_conditions=False,
+        )
+        model.train()
+        model.gradient_checkpointing = True
+        model.gradient_checkpointing_interval = 2
+        model.gradient_checkpointing_segment_stride = 4
+
+        def fake_checkpoint_sequential_state(
+            blocks,
+            segment_size,
+            state,
+            run_block,
+            checkpoint_fn,
+            checkpoint_kwargs=None,
+            segment_stride=None,
+        ):
+            return state
+
+        with patch(
+            "simpletuner.helpers.models.pixart.transformer.checkpoint_sequential_state",
+            side_effect=fake_checkpoint_sequential_state,
+        ) as checkpoint_sequential:
+            output = model(
+                hidden_states=torch.randn(1, 4, 8, 8, requires_grad=True),
+                encoder_hidden_states=torch.randn(1, 3, 16),
+                timestep=torch.tensor([100]),
+                encoder_attention_mask=torch.ones(1, 3),
+                return_dict=False,
+            )[0]
+
+        self.assertEqual(output.shape, (1, 8, 8, 8))
+        checkpoint_sequential.assert_called_once()
+        args, kwargs = checkpoint_sequential.call_args
+        self.assertIs(args[0], model.transformer_blocks)
+        self.assertEqual(args[1], 2)
+        self.assertEqual(kwargs, {"segment_stride": 4})
+
 
 class TestPixArtTransformerIntegration(TransformerBaseTest):
     """Integration tests for PixArtTransformer2DModel with real components."""


### PR DESCRIPTION
## Summary

Splits the PixArt segmented checkpointing support model integration out of #2925.

- applies the model-family checkpointing hooks and support flags
- adds this family to the relevant safety-check allow-lists
- keeps the shared runtime/docs in the base PR so this diff stays model-specific

## Stack

Base branch: `agent/segmented-checkpointing-mageflow`

## Validation

- `.venv/bin/python -m unittest tests.test_segmented_checkpointing_model_support -v`
- `.venv/bin/python -m unittest tests.test_transformers.test_pixart_transformer -v`
- commit hooks: Black, isort, flake8, whitespace checks