### PR TITLE
Add SanaVideo segmented checkpointing support

### DIFF
--- a/simpletuner/helpers/models/sanavideo/transformer.py
+++ b/simpletuner/helpers/models/sanavideo/transformer.py
@@ -39,6 +39,8 @@ from simpletuner.helpers.models.flowmap import (
     validate_flowmap_deltatime_type,
 )
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
+from simpletuner.helpers.training.checkpointing import checkpoint as simpletuner_checkpoint
+from simpletuner.helpers.training.gradient_checkpointing_interval import checkpoint_sequential_state, should_checkpoint_block
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
 from simpletuner.helpers.training.qk_clip_logging import publish_attention_max_logits
 
@@ -769,6 +771,9 @@ class SanaVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fro
         self.proj_out = nn.Linear(inner_dim, math.prod(patch_size) * out_channels)
 
         self.gradient_checkpointing = False
+        self.gradient_checkpointing_interval = None
+        self.gradient_checkpointing_segment_stride = None
+        self.gradient_checkpointing_backend = "torch"
 
         self._musubi_block_swap = MusubiBlockSwapManager.build(
             depth=num_layers,
@@ -776,6 +781,15 @@ class SanaVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fro
             swap_device=musubi_block_swap_device,
             logger=logger,
         )
+
+    def set_gradient_checkpointing_interval(self, interval: int):
+        self.gradient_checkpointing_interval = interval
+
+    def set_gradient_checkpointing_segment_stride(self, segment_stride: int | None):
+        self.gradient_checkpointing_segment_stride = segment_stride
+
+    def set_gradient_checkpointing_backend(self, backend: str):
+        self.gradient_checkpointing_backend = backend
 
     def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
         if hasattr(self.time_embed, "enable_flowmap_time_conditioning"):
@@ -988,13 +1002,29 @@ class SanaVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fro
             musubi_offload_active = musubi_manager.activate(combined_blocks, hidden_states.device, grad_enabled)
 
         capture_idx = 0
-        if torch.is_grad_enabled() and self.gradient_checkpointing:
-            for index_block, block in enumerate(self.transformer_blocks):
-                if musubi_offload_active and musubi_manager.is_managed_block(index_block):
-                    musubi_manager.stream_in(block, hidden_states.device)
-                hidden_states = self._gradient_checkpointing_func(
-                    block,
-                    hidden_states,
+        use_segmented_checkpointing = (
+            grad_enabled
+            and self.gradient_checkpointing
+            and self.gradient_checkpointing_interval is not None
+            and self.gradient_checkpointing_interval > 1
+            and not self.gradient_checkpointing_backend.endswith("-ffn")
+            and not musubi_offload_active
+            and grounding_objs is None
+            and controlnet_block_samples is None
+            and not output_hidden_states
+            and hidden_states_buffer is None
+        )
+        if use_segmented_checkpointing:
+            if self.gradient_checkpointing_backend.startswith("unsloth"):
+                from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
+
+                segmented_checkpoint_fn = offloaded_checkpoint
+            else:
+                segmented_checkpoint_fn = simpletuner_checkpoint
+
+            def run_segmented_block(_idx, segment_block, segment_hidden_states):
+                return segment_block(
+                    segment_hidden_states,
                     attention_mask,
                     encoder_hidden_states,
                     encoder_attention_mask,
@@ -1004,6 +1034,50 @@ class SanaVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fro
                     post_patch_width,
                     rotary_emb,
                 )
+
+            (hidden_states,) = checkpoint_sequential_state(
+                self.transformer_blocks,
+                self.gradient_checkpointing_interval,
+                (hidden_states,),
+                run_segmented_block,
+                segmented_checkpoint_fn,
+                {"use_reentrant": False},
+                segment_stride=self.gradient_checkpointing_segment_stride,
+            )
+        elif torch.is_grad_enabled() and self.gradient_checkpointing:
+            for index_block, block in enumerate(self.transformer_blocks):
+                if musubi_offload_active and musubi_manager.is_managed_block(index_block):
+                    musubi_manager.stream_in(block, hidden_states.device)
+                if should_checkpoint_block(
+                    index_block,
+                    True,
+                    self.gradient_checkpointing_interval,
+                    self.gradient_checkpointing_segment_stride,
+                ):
+                    hidden_states = self._gradient_checkpointing_func(
+                        block,
+                        hidden_states,
+                        attention_mask,
+                        encoder_hidden_states,
+                        encoder_attention_mask,
+                        timestep,
+                        post_patch_num_frames,
+                        post_patch_height,
+                        post_patch_width,
+                        rotary_emb,
+                    )
+                else:
+                    hidden_states = block(
+                        hidden_states,
+                        attention_mask,
+                        encoder_hidden_states,
+                        encoder_attention_mask,
+                        timestep,
+                        post_patch_num_frames,
+                        post_patch_height,
+                        post_patch_width,
+                        rotary_emb,
+                    )
                 if grounding_objs is not None and hasattr(block, "fuser"):
                     hidden_states = apply_grounding_fuser(
                         block.fuser,

--- a/simpletuner/helpers/models/sanavideo/transformer.py
+++ b/simpletuner/helpers/models/sanavideo/transformer.py
@@ -1050,11 +1050,18 @@ class SanaVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fro
                     musubi_manager.stream_in(block, hidden_states.device)
                 if should_checkpoint_block(
                     index_block,
-                    True,
+                    self.gradient_checkpointing,
                     self.gradient_checkpointing_interval,
                     self.gradient_checkpointing_segment_stride,
                 ):
-                    hidden_states = self._gradient_checkpointing_func(
+                    if self.gradient_checkpointing_backend.startswith("unsloth"):
+                        from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
+
+                        checkpoint_fn = offloaded_checkpoint
+                    else:
+                        checkpoint_fn = self._gradient_checkpointing_func
+
+                    hidden_states = checkpoint_fn(
                         block,
                         hidden_states,
                         attention_mask,

--- a/simpletuner/helpers/training/default_settings/safety_check.py
+++ b/simpletuner/helpers/training/default_settings/safety_check.py
@@ -166,6 +166,7 @@ def safety_check(args, accelerator):
         "lumina2",
         "pixart",
         "qwen_image",
+        "sanavideo",
     ]
     gradient_checkpointing_segment_stride_supported_models = [
         "ace_step",
@@ -192,6 +193,7 @@ def safety_check(args, accelerator):
         "pixart",
         "qwen_image",
         "sana",
+        "sanavideo",
     ]
     attention_activation_offload_supported_models = [
         "chroma",

--- a/tests/test_segmented_checkpointing_model_support.py
+++ b/tests/test_segmented_checkpointing_model_support.py
@@ -543,3 +543,19 @@ class SanaSegmentedCheckpointingSupportTests(unittest.TestCase):
             ffn=False,
             attention_offload=False,
         )
+
+
+class SanaVideoSegmentedCheckpointingSupportTests(unittest.TestCase):
+    def test_checkpointing_controls(self):
+        from simpletuner.helpers.models.sanavideo.transformer import SanaVideoTransformer3DModel
+
+        assert_checkpointing_controls(
+            self,
+            SanaVideoTransformer3DModel,
+            backend=True,
+            interval=True,
+            stride=True,
+            offload=False,
+            ffn=False,
+            attention_offload=False,
+        )

--- a/tests/test_segmented_checkpointing_model_support.py
+++ b/tests/test_segmented_checkpointing_model_support.py
@@ -555,7 +555,7 @@ class SanaVideoSegmentedCheckpointingSupportTests(unittest.TestCase):
             backend=True,
             interval=True,
             stride=True,
-            offload=False,
+            checkpoint_attention_offload=False,
             ffn=False,
             attention_offload=False,
         )

--- a/tests/test_transformers/test_sanavideo_transformer.py
+++ b/tests/test_transformers/test_sanavideo_transformer.py
@@ -210,6 +210,29 @@ class TestSanaVideoTransformer3DModel(unittest.TestCase):
         self.assertEqual(args[1], 2)
         self.assertEqual(kwargs, {"segment_stride": 4})
 
+    def test_unsloth_backend_uses_offloaded_checkpoint_for_per_block_path(self):
+        self.model.train()
+        self.model.gradient_checkpointing = True
+        self.model.gradient_checkpointing_backend = "unsloth"
+        self.model.gradient_checkpointing_interval = None
+
+        def fake_offloaded_checkpoint(function, *args, **kwargs):
+            return function(*args, **kwargs)
+
+        with patch(
+            "simpletuner.helpers.training.offloaded_gradient_checkpointer.offloaded_checkpoint",
+            side_effect=fake_offloaded_checkpoint,
+        ) as offloaded_checkpoint:
+            output = self.model(
+                hidden_states=torch.randn(1, 4, 2, 2, 2, requires_grad=True),
+                encoder_hidden_states=torch.randn(1, 5, 16),
+                timestep=torch.randint(0, 1000, (1, 8)),
+            )
+
+        output_tensor = output.sample if hasattr(output, "sample") else output
+        self.assertEqual(output_tensor.shape, (1, 4, 2, 2, 2))
+        offloaded_checkpoint.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_transformers/test_sanavideo_transformer.py
+++ b/tests/test_transformers/test_sanavideo_transformer.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 import torch
 
@@ -157,6 +158,57 @@ class TestSanaVideoTransformer3DModel(unittest.TestCase):
                 guidance=guidance,
                 timestep_sign=timestep_sign,
             )
+
+    def test_segmented_checkpointing_uses_sequential_state_helper(self):
+        model = SanaVideoTransformer3DModel(
+            in_channels=4,
+            out_channels=4,
+            num_attention_heads=2,
+            attention_head_dim=8,
+            num_layers=4,
+            num_cross_attention_heads=2,
+            cross_attention_head_dim=8,
+            cross_attention_dim=16,
+            caption_channels=16,
+            mlp_ratio=2.0,
+            sample_size=2,
+            patch_size=(1, 1, 1),
+            qk_norm="rms_norm_across_heads",
+            rope_max_seq_len=32,
+        )
+        model.train()
+        model.gradient_checkpointing = True
+        model.gradient_checkpointing_interval = 2
+        model.gradient_checkpointing_segment_stride = 4
+
+        def fake_checkpoint_sequential_state(
+            blocks,
+            segment_size,
+            state,
+            run_block,
+            checkpoint_fn,
+            checkpoint_kwargs=None,
+            segment_stride=None,
+        ):
+            return state
+
+        with patch(
+            "simpletuner.helpers.models.sanavideo.transformer.checkpoint_sequential_state",
+            side_effect=fake_checkpoint_sequential_state,
+        ) as checkpoint_sequential:
+            output = model(
+                hidden_states=torch.randn(1, 4, 2, 2, 2, requires_grad=True),
+                encoder_hidden_states=torch.randn(1, 5, 16),
+                timestep=torch.randint(0, 1000, (1, 8)),
+            )
+
+        output_tensor = output.sample if hasattr(output, "sample") else output
+        self.assertEqual(output_tensor.shape, (1, 4, 2, 2, 2))
+        checkpoint_sequential.assert_called_once()
+        args, kwargs = checkpoint_sequential.call_args
+        self.assertIs(args[0], model.transformer_blocks)
+        self.assertEqual(args[1], 2)
+        self.assertEqual(kwargs, {"segment_stride": 4})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Splits the SanaVideo segmented checkpointing support model integration out of #2925.

- applies the model-family checkpointing hooks and support flags
- adds this family to the relevant safety-check allow-lists
- keeps the shared runtime/docs in the base PR so this diff stays model-specific

## Stack

Base branch: `agent/segmented-checkpointing-sana`

## Validation

- `.venv/bin/python -m unittest tests.test_segmented_checkpointing_model_support -v`
- `.venv/bin/python -m unittest tests.test_transformers.test_sanavideo_transformer -v`
- commit hooks: Black, isort, flake8, whitespace checks