### PR TITLE
Add SD3 segmented checkpointing support

### DIFF
--- a/simpletuner/helpers/models/sd3/expanded.py
+++ b/simpletuner/helpers/models/sd3/expanded.py
@@ -404,9 +404,18 @@ class SD3TransformerQKNorm2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fro
         if self.original_attn_processors is not None:
             self.set_attn_processor(self.original_attn_processors)
 
-    def _set_gradient_checkpointing(self, module, value=False):
+    def _set_gradient_checkpointing(self, module=None, value=False, enable=None, gradient_checkpointing_func=None):
+        if enable is not None:
+            value = enable
+        if gradient_checkpointing_func is not None:
+            self._gradient_checkpointing_func = gradient_checkpointing_func
+        if module is None:
+            module = self
+            self.gradient_checkpointing = value
         if hasattr(module, "gradient_checkpointing"):
             module.gradient_checkpointing = value
+        for child in module.children():
+            self._set_gradient_checkpointing(child, value=value)
 
     def forward(
         self,
@@ -474,7 +483,7 @@ class SD3TransformerQKNorm2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fro
 
                     return custom_forward
 
-                if self.gradient_checkpointing_backend == "unsloth":
+                if self.gradient_checkpointing_backend.startswith("unsloth"):
                     from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 
                     checkpoint_fn = offloaded_checkpoint

--- a/simpletuner/helpers/models/sd3/transformer.py
+++ b/simpletuner/helpers/models/sd3/transformer.py
@@ -38,7 +38,10 @@ from simpletuner.helpers.models.flowmap import (
     validate_flowmap_deltatime_type,
 )
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager
+from simpletuner.helpers.training.checkpointing import checkpoint as simpletuner_checkpoint
+from simpletuner.helpers.training.gradient_checkpointing_interval import checkpoint_sequential_state, should_checkpoint_block
 from simpletuner.helpers.training.grounding.gligen_layers import apply_grounding_fuser
+from simpletuner.helpers.training.offloaded_gradient_checkpointer import activation_offload_context
 from simpletuner.helpers.training.packed_attention_processors import PackedJointAttnProcessor2_0
 from simpletuner.helpers.training.tread import TREADRouter
 from simpletuner.helpers.utils.patching import CallableDict, MutableModuleList, PatchableModule
@@ -146,16 +149,9 @@ def _sd3_apply_joint_transformer_block(
     temb_hidden: torch.Tensor,
     temb_context: torch.Tensor,
     joint_attention_kwargs: Optional[Dict[str, Any]] = None,
+    offload_attention: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     joint_attention_kwargs = joint_attention_kwargs or {}
-    if temb_hidden.ndim == 2 and temb_context.ndim == 2:
-        return block(
-            hidden_states=hidden_states,
-            encoder_hidden_states=encoder_hidden_states,
-            temb=temb_hidden,
-            joint_attention_kwargs=joint_attention_kwargs,
-        )
-
     if block.use_dual_attention:
         (
             norm_hidden_states,
@@ -182,11 +178,12 @@ def _sd3_apply_joint_transformer_block(
             c_gate_mlp,
         ) = _sd3_apply_ada_layer_norm_zero(block.norm1_context, encoder_hidden_states, temb_context)
 
-    attn_output, context_attn_output = block.attn(
-        hidden_states=norm_hidden_states,
-        encoder_hidden_states=norm_encoder_hidden_states,
-        **joint_attention_kwargs,
-    )
+    with activation_offload_context(offload_attention, label=f"{block.__class__.__qualname__}:attention"):
+        attn_output, context_attn_output = block.attn(
+            hidden_states=norm_hidden_states,
+            encoder_hidden_states=norm_encoder_hidden_states,
+            **joint_attention_kwargs,
+        )
 
     if gate_msa.ndim == 2:
         gate_msa = gate_msa.unsqueeze(1)
@@ -194,7 +191,8 @@ def _sd3_apply_joint_transformer_block(
     hidden_states = hidden_states + attn_output
 
     if block.use_dual_attention:
-        attn_output2 = block.attn2(hidden_states=norm_hidden_states2, **joint_attention_kwargs)
+        with activation_offload_context(offload_attention, label=f"{block.__class__.__qualname__}:dual_attention"):
+            attn_output2 = block.attn2(hidden_states=norm_hidden_states2, **joint_attention_kwargs)
         if gate_msa2.ndim == 2:
             gate_msa2 = gate_msa2.unsqueeze(1)
         attn_output2 = gate_msa2 * attn_output2
@@ -269,6 +267,7 @@ class SD3Transformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapte
         "PatchEmbed",
     ]
     _supports_gradient_checkpointing = True
+    _supports_attention_activation_offload = True
     _fsdp_exclude_auto_wrap_modules = ["PatchEmbed"]
     _cp_plan = {
         "": {
@@ -375,7 +374,9 @@ class SD3Transformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapte
 
         self.gradient_checkpointing = False
         self.gradient_checkpointing_interval = None
+        self.gradient_checkpointing_segment_stride = None
         self.gradient_checkpointing_backend = "torch"
+        self.gradient_checkpointing_offload_attention = False
 
         self._musubi_block_swap = MusubiBlockSwapManager.build(
             depth=num_layers,
@@ -387,8 +388,14 @@ class SD3Transformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapte
     def set_gradient_checkpointing_interval(self, interval: int):
         self.gradient_checkpointing_interval = interval
 
+    def set_gradient_checkpointing_segment_stride(self, segment_stride: int | None):
+        self.gradient_checkpointing_segment_stride = segment_stride
+
     def set_gradient_checkpointing_backend(self, backend: str):
         self.gradient_checkpointing_backend = backend
+
+    def set_gradient_checkpointing_offload_attention(self, enabled: bool):
+        self.gradient_checkpointing_offload_attention = bool(enabled)
 
     def set_router(self, router: TREADRouter, routes: List[Dict[str, Any]]):
         self._tread_router = router
@@ -719,116 +726,152 @@ class SD3Transformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapte
         if hasattr(self, "position_net") and grounding_kwargs is not None:
             grounding_objs = self.position_net(**grounding_kwargs)
 
-        capture_idx = 0
-        for index_block, block in enumerate(self.transformer_blocks):
-            if musubi_offload_active and musubi_manager.is_managed_block(index_block):
-                musubi_manager.stream_in(block, hidden_states.device)
-            # TREAD: START a route?
-            if use_routing and route_ptr < len(routes) and global_idx == routes[route_ptr]["start_layer_idx"]:
-                mask_ratio = routes[route_ptr]["selection_ratio"]
-                tread_mask_info = router.get_mask(
-                    hidden_states,
-                    mask_ratio=mask_ratio,
-                    force_keep=force_keep_mask,
-                )
-                saved_tokens = hidden_states.clone()
-                hidden_states = router.start_route(hidden_states, tread_mask_info)
-                routing_now = True
+        segment_size = self.gradient_checkpointing_interval
+        use_segmented_checkpointing = (
+            self.training
+            and self.gradient_checkpointing
+            and segment_size is not None
+            and segment_size > 1
+            and not self.gradient_checkpointing_backend.endswith("-ffn")
+            and not use_routing
+            and not musubi_offload_active
+            and skip_layers is None
+            and block_controlnet_hidden_states is None
+            and grounding_objs is None
+            and hidden_states_buffer is None
+        )
+        segmented_checkpoint_fn = None
+        segmented_checkpoint_kwargs: Dict[str, Any] = {}
+        if use_segmented_checkpointing:
+            if self.gradient_checkpointing_backend.startswith("unsloth"):
+                from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 
-            # Skip specified layers
-            if skip_layers is not None and index_block in skip_layers:
-                if block_controlnet_hidden_states is not None and block.context_pre_only is False:
-                    interval_control = len(self.transformer_blocks) // len(block_controlnet_hidden_states)
-                    hidden_states = hidden_states + block_controlnet_hidden_states[index_block // interval_control]
-                continue
+                segmented_checkpoint_fn = offloaded_checkpoint
+            else:
+                segmented_checkpoint_fn = simpletuner_checkpoint
+            segmented_checkpoint_kwargs = {"use_reentrant": False} if is_torch_version(">=", "1.11.0") else {}
 
-            if (
-                self.training
-                and self.gradient_checkpointing
-                and (self.gradient_checkpointing_interval is None or index_block % self.gradient_checkpointing_interval == 0)
+            def run_segment_block(
+                _relative_index,
+                segment_block,
+                segment_encoder_hidden_states,
+                segment_hidden_states,
             ):
+                return _sd3_apply_joint_transformer_block(
+                    segment_block,
+                    segment_hidden_states,
+                    segment_encoder_hidden_states,
+                    temb_hidden,
+                    temb_context,
+                    joint_attention_kwargs=joint_attention_kwargs,
+                    offload_attention=self.gradient_checkpointing_offload_attention,
+                )
 
-                def create_custom_forward(module, return_dict=None):
-                    def custom_forward(*inputs):
-                        if return_dict is not None:
-                            return module(*inputs, return_dict=return_dict)
-                        else:
-                            return module(*inputs)
-
-                    return custom_forward
-
-                if self.gradient_checkpointing_backend == "unsloth":
-                    from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
-
-                    checkpoint_fn = offloaded_checkpoint
-                else:
-                    checkpoint_fn = torch.utils.checkpoint.checkpoint
-
-                ckpt_kwargs: Dict[str, Any] = {"use_reentrant": False} if is_torch_version(">=", "1.11.0") else {}
-                if temb_hidden.ndim == 2:
-                    encoder_hidden_states, hidden_states = checkpoint_fn(
-                        create_custom_forward(block),
+            encoder_hidden_states, hidden_states = checkpoint_sequential_state(
+                self.transformer_blocks,
+                segment_size,
+                (encoder_hidden_states, hidden_states),
+                run_segment_block,
+                segmented_checkpoint_fn,
+                segmented_checkpoint_kwargs,
+                segment_stride=self.gradient_checkpointing_segment_stride,
+            )
+        else:
+            capture_idx = 0
+            for index_block, block in enumerate(self.transformer_blocks):
+                if musubi_offload_active and musubi_manager.is_managed_block(index_block):
+                    musubi_manager.stream_in(block, hidden_states.device)
+                # TREAD: START a route?
+                if use_routing and route_ptr < len(routes) and global_idx == routes[route_ptr]["start_layer_idx"]:
+                    mask_ratio = routes[route_ptr]["selection_ratio"]
+                    tread_mask_info = router.get_mask(
                         hidden_states,
-                        encoder_hidden_states,
-                        temb_hidden,
-                        **ckpt_kwargs,
+                        mask_ratio=mask_ratio,
+                        force_keep=force_keep_mask,
                     )
-                else:
+                    saved_tokens = hidden_states.clone()
+                    hidden_states = router.start_route(hidden_states, tread_mask_info)
+                    routing_now = True
 
-                    def create_tokenwise_forward(module, attention_kwargs):
-                        def custom_forward(*inputs):
-                            return _sd3_apply_joint_transformer_block(
-                                module,
-                                inputs[0],
-                                inputs[1],
-                                inputs[2],
-                                inputs[3],
-                                joint_attention_kwargs=attention_kwargs,
-                            )
+                # Skip specified layers
+                if skip_layers is not None and index_block in skip_layers:
+                    if block_controlnet_hidden_states is not None and block.context_pre_only is False:
+                        interval_control = len(self.transformer_blocks) // len(block_controlnet_hidden_states)
+                        hidden_states = hidden_states + block_controlnet_hidden_states[index_block // interval_control]
+                    continue
 
-                        return custom_forward
+                if (
+                    self.training
+                    and self.gradient_checkpointing
+                    and should_checkpoint_block(
+                        index_block,
+                        True,
+                        self.gradient_checkpointing_interval,
+                        self.gradient_checkpointing_segment_stride,
+                    )
+                ):
 
+                    def custom_forward(*inputs, checkpoint_block=block, attention_kwargs=joint_attention_kwargs):
+                        return _sd3_apply_joint_transformer_block(
+                            checkpoint_block,
+                            inputs[0],
+                            inputs[1],
+                            inputs[2],
+                            inputs[3],
+                            joint_attention_kwargs=attention_kwargs,
+                            offload_attention=self.gradient_checkpointing_offload_attention,
+                        )
+
+                    if self.gradient_checkpointing_backend.startswith("unsloth"):
+                        from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
+
+                        checkpoint_fn = offloaded_checkpoint
+                    else:
+                        checkpoint_fn = simpletuner_checkpoint
+
+                    ckpt_kwargs: Dict[str, Any] = {"use_reentrant": False} if is_torch_version(">=", "1.11.0") else {}
                     encoder_hidden_states, hidden_states = checkpoint_fn(
-                        create_tokenwise_forward(block, joint_attention_kwargs),
+                        custom_forward,
                         hidden_states,
                         encoder_hidden_states,
                         temb_hidden,
                         temb_context,
                         **ckpt_kwargs,
                     )
-            else:
-                encoder_hidden_states, hidden_states = _sd3_apply_joint_transformer_block(
-                    block,
-                    hidden_states,
-                    encoder_hidden_states,
-                    temb_hidden,
-                    temb_context,
-                    joint_attention_kwargs=joint_attention_kwargs,
-                )
+                else:
+                    encoder_hidden_states, hidden_states = _sd3_apply_joint_transformer_block(
+                        block,
+                        hidden_states,
+                        encoder_hidden_states,
+                        temb_hidden,
+                        temb_context,
+                        joint_attention_kwargs=joint_attention_kwargs,
+                        offload_attention=self.gradient_checkpointing_offload_attention,
+                    )
 
-            if grounding_objs is not None and hasattr(block, "fuser"):
-                hidden_states = apply_grounding_fuser(block.fuser, hidden_states, grounding_objs)
+                if grounding_objs is not None and hasattr(block, "fuser"):
+                    hidden_states = apply_grounding_fuser(block.fuser, hidden_states, grounding_objs)
 
-            # controlnet residual
-            if block_controlnet_hidden_states is not None and block.context_pre_only is False:
-                interval_control = len(self.transformer_blocks) // len(block_controlnet_hidden_states)
-                hidden_states = hidden_states + block_controlnet_hidden_states[index_block // interval_control]
+                # controlnet residual
+                if block_controlnet_hidden_states is not None and block.context_pre_only is False:
+                    interval_control = len(self.transformer_blocks) // len(block_controlnet_hidden_states)
+                    hidden_states = hidden_states + block_controlnet_hidden_states[index_block // interval_control]
 
-            # TREAD: END the current route?
-            if routing_now and global_idx == routes[route_ptr]["end_layer_idx"]:
-                hidden_states = router.end_route(
-                    hidden_states,
-                    tread_mask_info,
-                    original_x=saved_tokens,
-                )
-                routing_now = False
-                route_ptr += 1
+                # TREAD: END the current route?
+                if routing_now and global_idx == routes[route_ptr]["end_layer_idx"]:
+                    hidden_states = router.end_route(
+                        hidden_states,
+                        tread_mask_info,
+                        original_x=saved_tokens,
+                    )
+                    routing_now = False
+                    route_ptr += 1
 
-            if musubi_offload_active and musubi_manager.is_managed_block(index_block):
-                musubi_manager.stream_out(block)
-            _store_hidden_state(hidden_states_buffer, f"layer_{capture_idx}", hidden_states)
-            capture_idx += 1
-            global_idx += 1
+                if musubi_offload_active and musubi_manager.is_managed_block(index_block):
+                    musubi_manager.stream_out(block)
+                _store_hidden_state(hidden_states_buffer, f"layer_{capture_idx}", hidden_states)
+                capture_idx += 1
+                global_idx += 1
 
         hidden_states = _sd3_apply_ada_layer_norm_continuous(self.norm_out, hidden_states, temb_hidden)
         hidden_states = self.proj_out(hidden_states)

--- a/simpletuner/helpers/training/default_settings/safety_check.py
+++ b/simpletuner/helpers/training/default_settings/safety_check.py
@@ -194,6 +194,7 @@ def safety_check(args, accelerator):
         "qwen_image",
         "sana",
         "sanavideo",
+        "sd3",
     ]
     attention_activation_offload_supported_models = [
         "chroma",
@@ -209,6 +210,7 @@ def safety_check(args, accelerator):
         "longcat_video",
         "ltxvideo2",
         "mageflow",
+        "sd3",
     ]
     if getattr(args, "gradient_checkpointing_offload_attention", False):
         if args.model_family.lower() not in attention_activation_offload_supported_models:

--- a/tests/test_segmented_checkpointing_model_support.py
+++ b/tests/test_segmented_checkpointing_model_support.py
@@ -559,3 +559,19 @@ class SanaVideoSegmentedCheckpointingSupportTests(unittest.TestCase):
             ffn=False,
             attention_offload=False,
         )
+
+
+class SD3SegmentedCheckpointingSupportTests(unittest.TestCase):
+    def test_checkpointing_controls(self):
+        from simpletuner.helpers.models.sd3.transformer import SD3Transformer2DModel
+
+        assert_checkpointing_controls(
+            self,
+            SD3Transformer2DModel,
+            backend=True,
+            interval=True,
+            stride=True,
+            checkpoint_attention_offload=True,
+            ffn=False,
+            attention_offload=True,
+        )

--- a/tests/test_transformers/test_sd3_transformer.py
+++ b/tests/test_transformers/test_sd3_transformer.py
@@ -15,6 +15,7 @@ This test suite covers:
 import os
 import sys
 import unittest
+from contextlib import nullcontext
 from typing import Any, Dict, List, Tuple
 from unittest.mock import MagicMock, Mock, patch
 
@@ -233,6 +234,93 @@ class TestSD3Transformer2DModel(TransformerBaseTest, AttentionProcessorTestMixin
             mock_model.set_gradient_checkpointing_interval(interval)
             mock_model.set_gradient_checkpointing_interval.assert_called_once_with(interval)
 
+    def test_segmented_checkpointing_uses_sequential_state_helper(self):
+        from simpletuner.helpers.models.sd3.transformer import SD3Transformer2DModel
+
+        model = SD3Transformer2DModel(
+            sample_size=8,
+            patch_size=2,
+            in_channels=4,
+            num_layers=4,
+            attention_head_dim=8,
+            num_attention_heads=2,
+            joint_attention_dim=32,
+            caption_projection_dim=16,
+            pooled_projection_dim=16,
+            out_channels=4,
+            pos_embed_max_size=8,
+        )
+        model.train()
+        model.gradient_checkpointing = True
+        model.gradient_checkpointing_interval = 2
+        model.gradient_checkpointing_segment_stride = 4
+
+        def fake_checkpoint_sequential_state(
+            blocks,
+            segment_size,
+            state,
+            run_block,
+            checkpoint_fn,
+            checkpoint_kwargs=None,
+            segment_stride=None,
+        ):
+            return state
+
+        with patch(
+            "simpletuner.helpers.models.sd3.transformer.checkpoint_sequential_state",
+            side_effect=fake_checkpoint_sequential_state,
+        ) as checkpoint_sequential:
+            output = model(
+                hidden_states=torch.randn(1, 4, 8, 8, requires_grad=True),
+                encoder_hidden_states=torch.randn(1, 3, 32),
+                pooled_projections=torch.randn(1, 16),
+                timestep=torch.tensor([100]),
+                return_dict=False,
+            )[0]
+
+        self.assertEqual(output.shape, (1, 4, 8, 8))
+        checkpoint_sequential.assert_called_once()
+        args, kwargs = checkpoint_sequential.call_args
+        self.assertIs(args[0], model.transformer_blocks)
+        self.assertEqual(args[1], 2)
+        self.assertEqual(kwargs, {"segment_stride": 4})
+
+    def test_attention_offload_context_is_used(self):
+        from simpletuner.helpers.models.sd3.transformer import SD3Transformer2DModel
+
+        model = SD3Transformer2DModel(
+            sample_size=8,
+            patch_size=2,
+            in_channels=4,
+            num_layers=1,
+            attention_head_dim=8,
+            num_attention_heads=2,
+            joint_attention_dim=32,
+            caption_projection_dim=16,
+            pooled_projection_dim=16,
+            out_channels=4,
+            pos_embed_max_size=8,
+        )
+        model.train()
+        model.set_gradient_checkpointing_offload_attention(True)
+
+        with patch(
+            "simpletuner.helpers.models.sd3.transformer.activation_offload_context",
+            side_effect=lambda *args, **kwargs: nullcontext(),
+        ) as offload_context:
+            output = model(
+                hidden_states=torch.randn(1, 4, 8, 8, requires_grad=True),
+                encoder_hidden_states=torch.randn(1, 3, 32),
+                pooled_projections=torch.randn(1, 16),
+                timestep=torch.tensor([100]),
+                return_dict=False,
+            )[0]
+
+        self.assertEqual(output.shape, (1, 4, 8, 8))
+        self.assertTrue(model.gradient_checkpointing_offload_attention)
+        offload_context.assert_called()
+        self.assertTrue(any(call.args and call.args[0] is True for call in offload_context.call_args_list))
+
     def test_tread_router_integration(self):
         """Test TREAD router setting and integration."""
         with patch("simpletuner.helpers.models.sd3.transformer.SD3Transformer2DModel") as MockSD3:
@@ -355,6 +443,8 @@ class TestSD3Transformer2DModel(TransformerBaseTest, AttentionProcessorTestMixin
             required_methods = [
                 "forward",
                 "set_gradient_checkpointing_interval",
+                "set_gradient_checkpointing_segment_stride",
+                "set_gradient_checkpointing_offload_attention",
                 "set_router",
                 "enable_forward_chunking",
                 "disable_forward_chunking",


### PR DESCRIPTION
## Summary

Splits the SD3 segmented checkpointing support model integration out of #2925.

- applies the model-family checkpointing hooks and support flags
- adds this family to the relevant safety-check allow-lists
- keeps the shared runtime/docs in the base PR so this diff stays model-specific

## Stack

Base branch: `agent/segmented-checkpointing-sanavideo`

## Validation

- `.venv/bin/python -m unittest tests.test_segmented_checkpointing_model_support -v`
- `.venv/bin/python -m unittest tests.test_transformers.test_sd3_transformer -v`
- commit hooks: Black, isort, flake8, whitespace checks