### PR TITLE
Update ACE-Step example preset

### DIFF
--- a/simpletuner/examples/acestep-audio.json
+++ b/simpletuner/examples/acestep-audio.json
@@ -6,6 +6,11 @@
     "dataset_name": "Yi3852/ACEStep-Songs",
     "metadata_backend": "huggingface",
     "caption_strategy": "huggingface",
+    "audio": {
+      "bucket_strategy": "duration",
+      "duration_interval": 3.0,
+      "max_duration_seconds": 30
+    },
     "cache_dir_vae": "cache/vae/{model_family}/acestep-demo-data"
   },
   {


### PR DESCRIPTION
## Summary

Splits the ACE-Step audio example preset update out of #2923.

Files:
- simpletuner/examples/acestep-audio.json

## Validation

- Parsed the changed JSON preset with `.venv/bin/python -m json.tool`
- Scanned the changed file set for local paths and generated/LLM markers
- Commit hooks: whitespace, EOF, large-file, case-conflict, merge-conflict, mixed-line-ending checks