### PR TITLE
Update Cosmos example preset

### DIFF
--- a/simpletuner/examples/cosmos2image.lycoris-lokr/config.json
+++ b/simpletuner/examples/cosmos2image.lycoris-lokr/config.json
@@ -15,7 +15,7 @@
     "lr_scheduler": "constant",
     "lycoris_config": "config/examples/cosmos2image.lycoris-lokr/lycoris_config.json",
     "max_train_steps": 100,
-    "model_family": "cosmos2image",
+    "model_family": "cosmos",
     "model_type": "lora",
     "num_train_epochs": 0,
     "optimizer": "adamw_bf16",


### PR DESCRIPTION
## Summary

Splits the Cosmos example preset update out of #2923.

Files:
- simpletuner/examples/cosmos2image.lycoris-lokr/config.json

## Validation

- Parsed the changed JSON preset with `.venv/bin/python -m json.tool`
- Scanned the changed file set for local paths and generated/LLM markers
- Commit hooks: whitespace, EOF, large-file, case-conflict, merge-conflict, mixed-line-ending checks