### PR TITLE
Update Kandinsky5 Video example preset

### DIFF
--- a/simpletuner/examples/kandinsky5-video-2b-t2v.peft-lora/config.json
+++ b/simpletuner/examples/kandinsky5-video-2b-t2v.peft-lora/config.json
@@ -17,7 +17,7 @@
     "max_train_steps": 200,
     "minimum_image_size": 0,
     "mixed_precision": "bf16",
-    "model_family": "kandinsky5-video",
+    "model_family": "kandinsky5_video",
     "model_type": "lora",
     "num_train_epochs": 0,
     "optimizer": "adamw_bf16",


### PR DESCRIPTION
## Summary

Splits the Kandinsky5 Video example preset update out of #2923.

Files:
- simpletuner/examples/kandinsky5-video-2b-t2v.peft-lora/config.json

## Validation

- Parsed the changed JSON preset with `.venv/bin/python -m json.tool`
- Scanned the changed file set for local paths and generated/LLM markers
- Commit hooks: whitespace, EOF, large-file, case-conflict, merge-conflict, mixed-line-ending checks