### PR TITLE
Update LongCat Image example preset

### DIFF
--- a/simpletuner/examples/longcat-image.peft-lora/config.json
+++ b/simpletuner/examples/longcat-image.peft-lora/config.json
@@ -1,5 +1,6 @@
 {
     "base_model_precision": "int8-quanto",
+    "attention_mechanism": "native-flash",
     "checkpoint_step_interval": 10,
     "data_backend_config": "config/examples/multidatabackend-small-dreambooth-512px.json",
     "disable_bucket_pruning": true,


### PR DESCRIPTION
## Summary

Splits the LongCat Image example preset update out of #2923.

Files:
- simpletuner/examples/longcat-image.peft-lora/config.json

## Validation

- Parsed the changed JSON preset with `.venv/bin/python -m json.tool`
- Scanned the changed file set for local paths and generated/LLM markers
- Commit hooks: whitespace, EOF, large-file, case-conflict, merge-conflict, mixed-line-ending checks