### PR TITLE
Update LTXVideo2 example preset

### DIFF
--- a/simpletuner/examples/ltxvideo2-2.3-dev-720p-single-gpu.peft-lora+sdnq-hadamard/config.json
+++ b/simpletuner/examples/ltxvideo2-2.3-dev-720p-single-gpu.peft-lora+sdnq-hadamard/config.json
@@ -34,7 +34,7 @@
   "resume_from_checkpoint": "latest",
   "sdnq_compile_mode": "compile",
   "sdnq_group_size": -1,
-  "sdnq_hadamard_group_size": 128,
+  "sdnq_hadamard_group_size": 256,
   "sdnq_use_hadamard": true,
   "sdnq_use_quantized_matmul": true,
   "seed": 42,


### PR DESCRIPTION
## Summary

Splits the LTXVideo2 example preset update out of #2923.

Files:
- simpletuner/examples/ltxvideo2-2.3-dev-720p-single-gpu.peft-lora+sdnq-hadamard/config.json

## Validation

- Parsed the changed JSON preset with `.venv/bin/python -m json.tool`
- Scanned the changed file set for local paths and generated/LLM markers
- Commit hooks: whitespace, EOF, large-file, case-conflict, merge-conflict, mixed-line-ending checks