### PR TITLE
fix(data): only restore a checkpointed shard when every rank has one

### DIFF
--- a/simpletuner/helpers/multiaspect/sampler.py
+++ b/simpletuner/helpers/multiaspect/sampler.py
@@ -9,7 +9,7 @@ from PIL import Image
 
 from simpletuner.helpers.data_backend.base import BaseDataBackend
 from simpletuner.helpers.image_manipulation.training_sample import TrainingSample
-from simpletuner.helpers.metadata.backends.base import MetadataBackend
+from simpletuner.helpers.metadata.backends.base import MetadataBackend, get_cp_aware_dp_info
 from simpletuner.helpers.multiaspect.image import MultiaspectImage
 from simpletuner.helpers.multiaspect.state import BucketStateManager
 from simpletuner.helpers.prompts import PromptHandler
@@ -121,6 +121,7 @@ class MultiAspectSampler(torch.utils.data.Sampler):
         This method should be called when the accelerator save hook is called,
          so that the state is correctly restored with a given checkpoint.
         """
+        effective_dp_size, dp_rank, _cp_size = get_cp_aware_dp_info(self.accelerator)
         state = {
             "aspect_ratio_bucket_indices": self.metadata_backend.aspect_ratio_bucket_indices,
             "buckets": self.buckets,
@@ -129,8 +130,45 @@ class MultiAspectSampler(torch.utils.data.Sampler):
             "current_bucket": self.current_bucket,
             "seen_images": self.metadata_backend.seen_images,
             "current_epoch": self.current_epoch,
+            "dp_size": effective_dp_size,
+            "dp_rank": dp_rank,
         }
         self.state_manager.save_state(state, state_path)
+
+    def _saved_schedule_is_restorable(self, previous_state: dict, state_path: str) -> bool:
+        """A saved schedule is one rank's shard of the dataset.
+
+        Restoring it is only correct when the data-parallel layout is unchanged and every rank
+        has a shard to restore. Restoring on some ranks while the others re-split leaves the
+        ranks disagreeing about who owns which samples.
+        """
+        effective_dp_size, dp_rank, _cp_size = get_cp_aware_dp_info(self.accelerator)
+        if previous_state.get("dp_size") != effective_dp_size or previous_state.get("dp_rank") != dp_rank:
+            self.logger.warning(
+                f"Checkpoint schedule was written for dp_size={previous_state.get('dp_size')} "
+                f"dp_rank={previous_state.get('dp_rank')}, but this run is dp_size={effective_dp_size} "
+                f"dp_rank={dp_rank}. Keeping the freshly split schedule."
+            )
+            return False
+
+        checkpoint_dir = os.path.dirname(state_path)
+        own_filename = os.path.basename(state_path)
+        stem, extension = os.path.splitext(own_filename)
+        stem = stem.split("-rank", 1)[0]
+        for rank in range(self.accelerator.num_processes):
+            # Rank 0 writes the unsuffixed name, so it has to be built separately rather than
+            # scanned as a -rank{N} sibling. This rank's own state is evidently present.
+            filename = f"{stem}{extension}" if rank == 0 else f"{stem}-rank{rank}{extension}"
+            if filename == own_filename:
+                continue
+            sibling = self.state_manager.mangle_state_path(os.path.join(checkpoint_dir, filename))
+            if not os.path.exists(sibling):
+                self.logger.warning(
+                    f"Checkpoint holds no sampler state for rank {rank}, so the rank-local schedules "
+                    "cannot be restored consistently. Keeping the freshly split schedule."
+                )
+                return False
+        return True
 
     def load_states(self, state_path: str):
         try:
@@ -141,7 +179,7 @@ class MultiAspectSampler(torch.utils.data.Sampler):
         # Checkpoints contain the rank-local schedule. Restore it before seen
         # state so legacy boolean flags can be expanded to all occurrences.
         saved_schedule = previous_state.get("aspect_ratio_bucket_indices")
-        if isinstance(saved_schedule, dict):
+        if isinstance(saved_schedule, dict) and self._saved_schedule_is_restorable(previous_state, state_path):
             self.metadata_backend.aspect_ratio_bucket_indices = saved_schedule
             self._val_master_list = sorted(sum(saved_schedule.values(), []))
         self.buckets = previous_state.get("buckets", self.load_buckets())

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,7 +1,9 @@
 import logging
 import os
+import tempfile
 import unittest
 from math import ceil
+from types import SimpleNamespace
 
 # Import test configuration to suppress logging/warnings
 try:
@@ -20,16 +22,19 @@ from unittest.mock import MagicMock, Mock, patch
 from accelerate import PartialState
 from PIL import Image
 
+from simpletuner.helpers.data_backend.dataset_types import DatasetType
+from simpletuner.helpers.metadata.backends.base import MetadataBackend
 from simpletuner.helpers.metadata.backends.discovery import DiscoveryMetadataBackend
 from simpletuner.helpers.multiaspect.sampler import MultiAspectSampler
 from simpletuner.helpers.multiaspect.state import BucketStateManager
+from simpletuner.helpers.training.state_tracker import StateTracker
 from tests.helpers.data import MockDataBackend
 
 
 class TestMultiAspectSampler(unittest.TestCase):
     def setUp(self):
         self.process_state = PartialState()
-        self.accelerator = MagicMock()
+        self.accelerator = MagicMock(num_processes=1, process_index=0)
         self.accelerator.log = MagicMock()
         self.metadata_backend = Mock(spec=DiscoveryMetadataBackend)
         self.metadata_backend.id = "foo"
@@ -105,6 +110,8 @@ class TestMultiAspectSampler(unittest.TestCase):
             "current_bucket": 0,
             "exhausted_buckets": ["old"],
             "seen_images": {"same.jpg": True, "other.jpg": False, "legacy.jpg": True},
+            "dp_size": 1,
+            "dp_rank": 0,
         }
 
         self.metadata_backend.aspect_ratio_bucket_indices = {"1.0": ["stale.jpg"]}
@@ -121,6 +128,21 @@ class TestMultiAspectSampler(unittest.TestCase):
         self.assertEqual(self.metadata_backend.seen_images["same.jpg"], 2)
         self.assertEqual(self.metadata_backend.seen_images["other.jpg"], 0)
         self.assertTrue(self.metadata_backend.seen_images["legacy.jpg"])
+
+    def test_load_states_keeps_the_fresh_split_when_the_checkpoint_records_no_layout(self):
+        # Checkpoints written before the layout was recorded cannot be attributed to a rank, so
+        # the schedule is left alone. Seen state still loads.
+        self.sampler.state_manager.load_state.return_value = {
+            "aspect_ratio_bucket_indices": {"1.0": ["same.jpg", "same.jpg", "other.jpg"]},
+            "seen_images": {"same.jpg": True},
+        }
+
+        self.metadata_backend.aspect_ratio_bucket_indices = {"1.0": ["fresh.jpg"]}
+        self.metadata_backend.seen_images = {}
+        self.sampler.load_states(self.state_path)
+
+        self.assertEqual(self.metadata_backend.aspect_ratio_bucket_indices, {"1.0": ["fresh.jpg"]})
+        self.assertTrue(self.metadata_backend.seen_images["same.jpg"])
 
     def test_change_bucket(self):
         self.sampler.buckets = ["1.5"]
@@ -233,6 +255,126 @@ class TestMultiAspectSampler(unittest.TestCase):
         self.assertIn("/fake/dir/image1.jpg", result_paths)
         self.assertIn("/fake/dir/image2.jpg", result_paths)
         self.assertIn("/fake/dir/image4.jpg", result_paths)
+
+
+class TestSamplerResumeSchedule(unittest.TestCase):
+    """A checkpointed schedule is one rank's shard; restoring it must keep the ranks partitioned."""
+
+    @staticmethod
+    def _split(world_size, rank, shuffle_seed, images):
+        backend = MagicMock(spec=MetadataBackend)
+        backend.id = "resume"
+        backend.batch_size = 1
+        backend.repeats = 0
+        backend.bucket_report = None
+        backend.dataset_type = DatasetType.IMAGE
+        backend.aspect_ratio_bucket_indices = {"1.0": list(images)}
+        backend.read_only = False
+        backend.seen_images = {}
+        backend.accelerator = SimpleNamespace(
+            num_processes=world_size,
+            process_index=rank,
+            is_main_process=rank == 0,
+        )
+        with (
+            patch.object(
+                StateTracker,
+                "get_args",
+                return_value=SimpleNamespace(allow_dataset_oversubscription=False, seed=shuffle_seed),
+            ),
+            patch.object(StateTracker, "get_data_backend_config", return_value={}),
+            patch(
+                "simpletuner.helpers.metadata.backends.base.broadcast_object_from_main",
+                side_effect=lambda value: shuffle_seed,
+            ),
+        ):
+            MetadataBackend.split_buckets_between_processes(
+                backend,
+                gradient_accumulation_steps=1,
+                apply_padding=False,
+            )
+        return backend
+
+    @staticmethod
+    def _sampler(backend):
+        sampler = object.__new__(MultiAspectSampler)
+        sampler.id = backend.id
+        sampler.metadata_backend = backend
+        sampler.accelerator = backend.accelerator
+        sampler.batch_size = 1
+        sampler.buckets = list(backend.aspect_ratio_bucket_indices)
+        sampler.exhausted_buckets = []
+        sampler.current_bucket = None
+        sampler.current_epoch = 1
+        sampler.sample_type_strs = "images"
+        sampler.logger = MagicMock()
+        sampler._val_master_list = []
+        sampler.state_manager = BucketStateManager(backend.id)
+        return sampler
+
+    @staticmethod
+    def _state_path(directory, rank):
+        filename = "training_state.json" if rank == 0 else f"training_state-rank{rank}.json"
+        return os.path.join(directory, filename)
+
+    def _resume_shards(self, *, images, save_world_size, saving_ranks, resume_world_size):
+        with tempfile.TemporaryDirectory() as checkpoint_dir:
+            for rank in range(save_world_size):
+                backend = self._split(save_world_size, rank, shuffle_seed=1, images=images)
+                if rank in saving_ranks:
+                    self._sampler(backend).save_state(self._state_path(checkpoint_dir, rank))
+
+            shards = []
+            for rank in range(resume_world_size):
+                # A relaunch without --seed draws a new shuffle seed, so the fresh split differs
+                # from the one the checkpoint was written against.
+                backend = self._split(resume_world_size, rank, shuffle_seed=2, images=images)
+                self._sampler(backend).load_states(self._state_path(checkpoint_dir, rank))
+                shards.append(list(backend.aspect_ratio_bucket_indices["1.0"]))
+            return shards
+
+    def _assert_partitions(self, shards, images):
+        scheduled = [path for shard in shards for path in shard]
+        self.assertEqual(
+            sorted(scheduled),
+            sorted(images),
+            msg=f"ranks no longer partition the dataset: {shards}",
+        )
+
+    def test_resume_after_a_rank_zero_only_save_keeps_the_ranks_partitioned(self):
+        images = [f"image-{index:02d}.jpg" for index in range(12)]
+        shards = self._resume_shards(images=images, save_world_size=4, saving_ranks={0}, resume_world_size=4)
+        self._assert_partitions(shards, images)
+
+    def test_resume_when_every_rank_saved_keeps_the_ranks_partitioned(self):
+        # Control: a complete checkpoint is restorable and stays a partition.
+        images = [f"image-{index:02d}.jpg" for index in range(12)]
+        shards = self._resume_shards(images=images, save_world_size=4, saving_ranks=set(range(4)), resume_world_size=4)
+        self._assert_partitions(shards, images)
+
+    def test_resume_when_no_rank_saved_keeps_the_ranks_partitioned(self):
+        # Control: with nothing to restore the fresh split is already a partition. Together with
+        # the previous control this isolates the mixed state as the cause.
+        images = [f"image-{index:02d}.jpg" for index in range(12)]
+        shards = self._resume_shards(images=images, save_world_size=4, saving_ranks=set(), resume_world_size=4)
+        self._assert_partitions(shards, images)
+
+    def test_resume_when_rank_zero_alone_did_not_save_keeps_the_ranks_partitioned(self):
+        # The completeness check has to cover rank 0 as well: its state file is the one that is
+        # named differently, so scanning only the -rank{N} siblings would miss it.
+        images = [f"image-{index:02d}.jpg" for index in range(12)]
+        shards = self._resume_shards(images=images, save_world_size=4, saving_ranks={1, 2, 3}, resume_world_size=4)
+        self._assert_partitions(shards, images)
+
+    def test_resume_onto_a_smaller_world_size_keeps_the_ranks_partitioned(self):
+        images = [f"image-{index:02d}.jpg" for index in range(16)]
+        shards = self._resume_shards(images=images, save_world_size=8, saving_ranks={0}, resume_world_size=4)
+        self._assert_partitions(shards, images)
+
+    def test_resume_onto_a_larger_world_size_keeps_the_ranks_partitioned(self):
+        images = [f"image-{index:02d}.jpg" for index in range(16)]
+        shards = self._resume_shards(images=images, save_world_size=4, saving_ranks=set(range(4)), resume_world_size=8)
+        self._assert_partitions(shards, images)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

Resume restored a checkpointed schedule that only rank 0 had written, leaving the ranks no longer partitioning the dataset.

### Problem

`load_states` restored `aspect_ratio_bucket_indices` from the checkpoint unconditionally (`sampler.py:143-146`), but that dict is one rank's shard.

Under plain DDP only rank 0 reaches `checkpoint_state_save` — `trainer.py:5251` and `trainer.py:6824` gate the whole function on `is_main_process or use_deepspeed_optimizer or fsdp_enable`, and the sampler save is inside it at `trainer.py:6019`. The `training_state-rank{N}.json` names that `save_hooks.py:309-313` anticipates are never created, and `state.py:66-67` returns `{}` for the missing file with only a DEBUG log.

So on resume rank 0 replayed its old shard while every other rank re-split against a new per-launch shuffle seed (`--seed` defaults to `None`, `base.py:868-874`). Measured with 12 images over 4 ranks: 2 images scheduled twice, 2 not scheduled at all. Controls isolate the cause — when all four ranks saved, and when none did, the ranks still partitioned cleanly.

Nothing recorded the data-parallel layout either, so resuming onto a different world size restored shards belonging to a topology that no longer exists.

### Resolution

`save_state` records the effective DP size and rank from `get_cp_aware_dp_info` (not `accelerator.num_processes`, which would false-mismatch every context-parallel run). `load_states` restores the schedule only when that layout still matches **and** the checkpoint holds a sampler state file for every rank of the current world size.

Checkpoints written without the layout are left alone. That is what `load_states` did before the schedule restore was introduced, so existing checkpoints keep their previous resume behaviour rather than changing under users.

`current_epoch` and `seen_images` restore as before; their rank-0-only asymmetry predates the schedule restore and is out of scope here.

### Note on the modified test

`test_load_states_restores_schedule_before_normalizing_legacy_seen_flags` asserted the unconditional restore, which is the behaviour this PR changes. Its checkpoint now carries the layout so it still exercises the restore path, and `test_load_states_keeps_the_fresh_split_when_the_checkpoint_records_no_layout` covers the other side of the contract. No other assertion in that test moved.

`setUp` now gives the mock accelerator real `num_processes` / `process_index` values; the default `MagicMock` attributes are not integers and no topology can be read from them.

### Tests

`tests/test_sampler.py::TestSamplerResumeSchedule` drives real `save_state` / `load_states` / `BucketStateManager` against a temporary checkpoint directory and the real splitter. It covers the rank-0-only save, a save that skipped only rank 0, shrinking 8 → 4 and growing 4 → 8, plus the two controls above. Every case asserts the same fix-agnostic property: the ranks between them schedule each sample exactly once.

