### PR TITLE
fix(data): keep post-split shard length when filtering a sample

### DIFF
--- a/simpletuner/helpers/caching/vae.py
+++ b/simpletuner/helpers/caching/vae.py
@@ -400,9 +400,17 @@ class VAECache(WebhookMixin):
         delete_from_backend: bool = False,
         details: dict = None,
     ) -> None:
+        buckets = getattr(self.metadata_backend, "aspect_ratio_bucket_indices", None)
+        shard_lengths = (
+            {shard: len(images) for shard, images in buckets.items()}
+            if isinstance(buckets, dict) and getattr(self.metadata_backend, "read_only", False)
+            else None
+        )
         removed = self._remove_image_from_metadata_backend(self.metadata_backend, filepath, bucket)
         if removed:
             self._record_filter_stat(reason, bucket, filepath)
+            if shard_lengths is not None:
+                self._restore_split_shard_lengths(shard_lengths)
         self._queue_metadata_filter_action(
             filepath=filepath,
             bucket=bucket,
@@ -410,6 +418,20 @@ class VAECache(WebhookMixin):
             delete_from_backend=delete_from_backend,
             details=details,
         )
+
+    def _restore_split_shard_lengths(self, shard_lengths: dict) -> None:
+        """Refill a post-split shard the filter just shortened.
+
+        Every data-parallel rank has to schedule the same number of samples, so removing an
+        entry from one rank's shard desynchronises them. The removed slots are refilled by
+        repeating the final surviving sample, which is how the splitter pads. A bucket the
+        filter emptied has nothing to repeat and stays empty until the next split.
+        """
+        for bucket, length in shard_lengths.items():
+            images = self.metadata_backend.aspect_ratio_bucket_indices.get(bucket)
+            if not images or len(images) >= length:
+                continue
+            images.extend([images[-1]] * (length - len(images)))
 
     def _handle_nsfw_rejected_sample(self, filepath: str, bucket: str, classification: dict) -> None:
         rejected_entry = {

--- a/tests/test_vae.py
+++ b/tests/test_vae.py
@@ -297,5 +297,108 @@ class TestVaeCacheAudio(unittest.TestCase):
         self.assertEqual(output["latent_lengths"].shape[0], 1)
 
 
+class TestMetadataFilterOnSplitShard(unittest.TestCase):
+    """A filtered sample must leave this rank's shard the same length as its DP peers'."""
+
+    IMAGES = [f"image-{index}.jpg" for index in range(5)]
+
+    @classmethod
+    def _padded_shard_backend(cls, dp_rank, *, world_size=2, images=None):
+        from simpletuner.helpers.metadata.backends.base import MetadataBackend
+        from simpletuner.helpers.training.state_tracker import StateTracker
+
+        backend = MagicMock(spec=MetadataBackend)
+        backend.id = "filtered-shard"
+        backend.batch_size = 1
+        backend.repeats = 0
+        backend.bucket_report = None
+        backend.dataset_type = DatasetType.IMAGE
+        backend.aspect_ratio_bucket_indices = {"1.0": list(images or cls.IMAGES)}
+        backend.read_only = False
+        backend.filtering_statistics = None
+        backend.accelerator = SimpleNamespace(
+            num_processes=world_size,
+            process_index=dp_rank,
+            is_main_process=dp_rank == 0,
+        )
+        with (
+            patch.dict("os.environ", {"SIMPLETUNER_SHUFFLE_BUCKETS": "0"}),
+            patch.object(
+                StateTracker,
+                "get_args",
+                return_value=SimpleNamespace(allow_dataset_oversubscription=True),
+            ),
+            patch.object(StateTracker, "get_data_backend_config", return_value={}),
+        ):
+            MetadataBackend.split_buckets_between_processes(
+                backend,
+                gradient_accumulation_steps=1,
+                apply_padding=True,
+            )
+        return backend
+
+    @staticmethod
+    def _cache(metadata_backend):
+        from simpletuner.helpers.caching.vae import VAECache
+
+        cache = object.__new__(VAECache)
+        cache.id = "filtered-shard"
+        cache.metadata_backend = metadata_backend
+        return cache
+
+    def test_padded_shard_keeps_its_length_when_a_duplicate_is_filtered(self):
+        backend = self._padded_shard_backend(1)
+        # Five images over two DP shards: this rank holds three slots, the last of which is a
+        # padding copy of the final global item.
+        self.assertEqual(backend.aspect_ratio_bucket_indices["1.0"], ["image-3.jpg", "image-4.jpg", "image-4.jpg"])
+        self.assertTrue(backend.read_only)
+
+        self._cache(backend)._handle_metadata_filtered_sample(filepath="image-4.jpg", bucket="1.0", reason="problematic")
+
+        shard = backend.aspect_ratio_bucket_indices["1.0"]
+        self.assertNotIn("image-4.jpg", shard)
+        self.assertEqual(len(shard), 3)
+        self.assertEqual(shard, ["image-3.jpg"] * 3)
+
+    def test_padded_shard_keeps_its_length_when_a_unique_sample_is_filtered(self):
+        backend = self._padded_shard_backend(1)
+        self._cache(backend)._handle_metadata_filtered_sample(filepath="image-3.jpg", bucket="1.0", reason="nsfw")
+
+        shard = backend.aspect_ratio_bucket_indices["1.0"]
+        self.assertNotIn("image-3.jpg", shard)
+        self.assertEqual(shard, ["image-4.jpg"] * 3)
+
+    def test_a_shard_made_entirely_of_one_filtered_sample_cannot_be_refilled(self):
+        # Known limitation: with nothing left in the bucket there is no sample to repeat. The
+        # shortened cache is picked up by the next split.
+        backend = self._padded_shard_backend(4, world_size=5, images=[f"image-{index}.jpg" for index in range(9)])
+        self.assertEqual(backend.aspect_ratio_bucket_indices["1.0"], ["image-8.jpg", "image-8.jpg"])
+
+        self._cache(backend)._handle_metadata_filtered_sample(filepath="image-8.jpg", bucket="1.0", reason="problematic")
+
+        self.assertEqual(backend.aspect_ratio_bucket_indices["1.0"], [])
+
+    def test_unsplit_backend_is_not_repadded(self):
+        # Control: before the split the backend holds the dataset, not a shard, so a filtered
+        # sample simply disappears.
+        backend = self._padded_shard_backend(1)
+        backend.aspect_ratio_bucket_indices = {"1.0": list(self.IMAGES)}
+        backend.read_only = False
+
+        self._cache(backend)._handle_metadata_filtered_sample(filepath="image-4.jpg", bucket="1.0", reason="problematic")
+
+        self.assertEqual(backend.aspect_ratio_bucket_indices["1.0"], self.IMAGES[:4])
+
+    def test_filter_action_is_still_queued_for_the_unsplit_cache(self):
+        backend = self._padded_shard_backend(1)
+        cache = self._cache(backend)
+        cache._handle_metadata_filtered_sample(filepath="image-4.jpg", bucket="1.0", reason="problematic")
+
+        self.assertEqual(
+            [(action["filepath"], action["reason"]) for action in cache._deferred_metadata_filter_actions],
+            [("image-4.jpg", "problematic")],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary

Filtering one sample could shorten or empty a rank's shard while its data-parallel peers kept theirs.

### Problem

`_handle_metadata_filtered_sample` removes every occurrence of the filtered path from the live bucket list (`vae.py:347-349`). After a padded split that list is this rank's shard, and its padding tail repeats one item, so a single filter event can take out several scheduled slots at once. The deferred path already protects the shard with a save/restore wrapper (`vae.py:469`, `vae.py:503-504`), but that deepcopy is taken after this immediate mutation, so it cannot undo it.

Measured on a shard of `['image-3.jpg', 'image-4.jpg', 'image-4.jpg']`: filtering `image-4.jpg` left one entry where the peer rank still had three.

Of the three call sites, `vae.py:739` and `vae.py:1806` re-raise immediately, so the path that continues with a damaged shard is the NSFW scan at `vae.py:563`.

### Resolution

The removal is unchanged — a problematic or NSFW sample must not be trained on. The vacated slots are refilled by repeating the final surviving sample in that bucket, which is the rule `split_buckets_between_processes` already uses when it pads (`base.py:912-913`). Only backends flagged `read_only` are refilled, so an unsplit backend still just loses the sample. The queued action that rewrites the unsplit cache is untouched.

### Known limitation

A shard that consists **only** of copies of the filtered sample has nothing left to repeat, and stays empty until the next split re-derives it from the shortened cache. Repairing that here is not possible: a split backend cannot see the samples that went to other ranks. The existing comment at `vae.py:1804` describes the same expectation ("They will be captured on restart").

This PR does not claim that the following split necessarily restores a balanced shard — that depends on the split itself, which is out of scope here.

### Tests

`tests/test_vae.py::TestMetadataFilterOnSplitShard` builds shards with the real splitter and calls the real `_handle_metadata_filtered_sample`. It covers filtering a padding duplicate and a unique sample, pins the empty-shard limitation above, checks an unsplit backend is not refilled, and checks the deferred action is still queued.

