### PR TITLE
Fix checkpoint rotation after successful saves

### DIFF
--- a/simpletuner/helpers/publishing/huggingface.py
+++ b/simpletuner/helpers/publishing/huggingface.py
@@ -296,9 +296,14 @@ class HubManager:
         return highest_checkpoint
 
     def upload_latest_checkpoint(
-        self, validation_images: dict, webhook_handler=None, global_step: int = None, epoch: int = None
+        self,
+        validation_images: dict,
+        webhook_handler=None,
+        global_step: int = None,
+        epoch: int = None,
+        checkpoint_path: str = None,
     ):
-        checkpoint_path = self.find_latest_checkpoint()
+        checkpoint_path = Path(checkpoint_path) if checkpoint_path else self.find_latest_checkpoint()
         if checkpoint_path:
             logging.info(f"Checkpoint path: {checkpoint_path}")
             try:

--- a/simpletuner/helpers/training/save_hooks.py
+++ b/simpletuner/helpers/training/save_hooks.py
@@ -1071,13 +1071,19 @@ class SaveHookManager:
     def save_model_hook(self, models, weights, output_dir):
         # Write "training_state.json" to the output directory containing the training state
         StateTracker.save_training_state(os.path.join(output_dir, self.training_state_path))
-        StateTracker.save_ramtorch_prefetch_orders(output_dir)
 
         distributed_type = DistributedType.NO
         is_main_process = True
+        is_local_main_process = True
         if self.accelerator is not None:
             distributed_type = getattr(self.accelerator, "distributed_type", DistributedType.NO)
             is_main_process = getattr(self.accelerator, "is_main_process", True)
+            is_local_main_process = getattr(self.accelerator, "is_local_main_process", True)
+
+        # One writer per node keeps node-local checkpoint state present without
+        # allowing every rank to race on the same prefetch-order file.
+        if is_local_main_process:
+            StateTracker.save_ramtorch_prefetch_orders(output_dir)
 
         with self._offload_models_during_save(is_main_process):
             self._save_ema_state(output_dir, is_main_process=is_main_process)

--- a/simpletuner/helpers/training/state_tracker.py
+++ b/simpletuner/helpers/training/state_tracker.py
@@ -405,7 +405,7 @@ class StateTracker:
             return
         data = cls._normalise_ramtorch_prefetch_orders(cls.ramtorch_prefetch_orders)
         path.parent.mkdir(parents=True, exist_ok=True)
-        temp_path = path.with_suffix(f"{path.suffix}.tmp")
+        temp_path = path.with_suffix(f"{path.suffix}.tmp.{os.getpid()}")
         with temp_path.open("w") as handle:
             fcntl.flock(handle, fcntl.LOCK_EX)
             try:

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -5241,15 +5241,21 @@ class Trainer:
             **progress_kwargs,
         )
         self._emit_event(event)
-        if self.accelerator.is_main_process and self.config.checkpoints_total_limit is not None:
-            self.checkpoint_state_cleanup(
-                self.config.output_dir,
-                self.config.checkpoints_total_limit,
-            )
+        checkpoint_limit = self.config.checkpoints_total_limit
+        if self.accelerator.is_main_process:
+            self.checkpoint_state_cleanup_temp(self.config.output_dir)
 
         save_path = None
         if self.accelerator.is_main_process or self.config.use_deepspeed_optimizer or self.config.fsdp_enable:
             save_path = self.checkpoint_state_save(self.config.output_dir)
+        if self.accelerator.is_main_process and checkpoint_limit is not None and checkpoint_limit > 0:
+            if len(self.checkpoint_state_filter(self.config.output_dir)) > checkpoint_limit:
+                self._drain_hub_upload_futures(wait=True)
+            self.checkpoint_state_cleanup(
+                self.config.output_dir,
+                checkpoint_limit,
+                protected_checkpoint=save_path,
+            )
 
         hub_upload_planned = upload_to_hub and self.hub_manager is not None
         if hub_upload_planned:
@@ -5264,6 +5270,7 @@ class Trainer:
                         webhook_handler=self.webhook_handler,
                         global_step=captured_step,
                         epoch=captured_epoch,
+                        checkpoint_path=save_path,
                     )
                     return remote_path, local_path, repo_url
 
@@ -5275,6 +5282,23 @@ class Trainer:
         else:
             if save_path:
                 self._run_post_upload_script(local_path=save_path, remote_path=None)
+        return save_path
+
+    def _save_rolling_checkpoint(self):
+        checkpoint_limit = self.config.checkpoints_rolling_total_limit
+        if self.accelerator.is_main_process:
+            self.checkpoint_state_cleanup_temp(self.config.output_dir)
+
+        save_path = None
+        if self.accelerator.is_main_process or self.config.use_deepspeed_optimizer or self.config.fsdp_enable:
+            save_path = self.checkpoint_state_save(self.config.output_dir, "rolling")
+        if self.accelerator.is_main_process and checkpoint_limit is not None and checkpoint_limit > 0:
+            self.checkpoint_state_cleanup(
+                self.config.output_dir,
+                checkpoint_limit,
+                "rolling",
+                protected_checkpoint=save_path,
+            )
         return save_path
 
     def _send_webhook_msg(
@@ -5861,7 +5885,7 @@ class Trainer:
                 if len(cs) < 2:
                     continue
                 elif len(cs) > 2:
-                    sfx = cs[2]
+                    sfx = cs[-1]
 
                 if base != "checkpoint":
                     continue
@@ -5874,26 +5898,36 @@ class Trainer:
 
             return checkpoints_keep
 
-    def checkpoint_state_cleanup(self, output_dir, limit, suffix=None):
+    def checkpoint_state_cleanup_temp(self, output_dir):
         if self.checkpoint_manager:
-            self.checkpoint_manager.cleanup_checkpoints(limit, suffix)
+            self.checkpoint_manager._remove_temp_checkpoints()
         else:
-            # Fallback to original implementation
-            # remove any left over temp checkpoints (partially written, etc)
             checkpoints = self.checkpoint_state_filter(output_dir, "tmp")
             for removing_checkpoint in checkpoints:
                 self.checkpoint_state_remove(output_dir, removing_checkpoint)
+
+    def checkpoint_state_cleanup(self, output_dir, limit, suffix=None, protected_checkpoint=None):
+        if self.checkpoint_manager:
+            self.checkpoint_manager.cleanup_checkpoints(
+                limit,
+                suffix,
+                protected_checkpoint=protected_checkpoint,
+            )
+        else:
+            # remove any left over temp checkpoints (partially written, etc)
+            self.checkpoint_state_cleanup_temp(output_dir)
 
             # now remove normal checkpoints past the limit
             checkpoints = self.checkpoint_state_filter(output_dir, suffix)
             checkpoints = sorted(checkpoints, key=lambda x: int(x.split("-")[1]))
 
-            # before we save the new checkpoint, we need to have at _most_ `limit - 1` checkpoints
-            if len(checkpoints) < limit:
+            if len(checkpoints) <= limit:
                 return
 
-            num_to_remove = len(checkpoints) - limit + 1
-            removing_checkpoints = checkpoints[0:num_to_remove]
+            num_to_remove = len(checkpoints) - limit
+            protected_name = os.path.basename(os.path.normpath(protected_checkpoint)) if protected_checkpoint else None
+            removal_candidates = [checkpoint for checkpoint in checkpoints if checkpoint != protected_name]
+            removing_checkpoints = removal_candidates[0:num_to_remove]
             logger.debug(f"{len(checkpoints)} checkpoints already exist, removing {len(removing_checkpoints)} checkpoints")
             logger.debug(f"removing checkpoints: {', '.join(removing_checkpoints)}")
 
@@ -5971,6 +6005,13 @@ class Trainer:
         all_processes_saving = bool(
             getattr(self.config, "use_deepspeed_optimizer", False) or getattr(self.config, "fsdp_enable", False)
         )
+        if (
+            self.accelerator is not None
+            and distributed_type != DistributedType.NO
+            and all_processes_saving
+            and self.config.checkpointing_use_tempdir
+        ):
+            self.accelerator.wait_for_everyone()
         if fsdp_v2_run:
             logger.info("FSDP v2 detected; saving with sharded state dict (_use_dtensor disabled for NCCL compatibility).")
         if is_main_process:
@@ -6812,16 +6853,7 @@ class Trainer:
                             **progress_kwargs,
                         )
                         self._emit_event(event)
-                        if self.accelerator.is_main_process and self.config.checkpoints_rolling_total_limit is not None:
-                            # _before_ saving state, check if this save would set us over the `checkpoints_rolling_total_limit`
-                            self.checkpoint_state_cleanup(
-                                self.config.output_dir,
-                                self.config.checkpoints_rolling_total_limit,
-                                "rolling",
-                            )
-
-                        if self.accelerator.is_main_process or self.config.use_deepspeed_optimizer:
-                            self.checkpoint_state_save(self.config.output_dir, "rolling")
+                        self._save_rolling_checkpoint()
 
                     if (
                         self.config.accelerator_cache_clear_interval is not None

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -5900,7 +5900,7 @@ class Trainer:
 
     def checkpoint_state_cleanup_temp(self, output_dir):
         if self.checkpoint_manager:
-            self.checkpoint_manager._remove_temp_checkpoints()
+            self.checkpoint_manager.cleanup_temp_checkpoints()
         else:
             checkpoints = self.checkpoint_state_filter(output_dir, "tmp")
             for removing_checkpoint in checkpoints:

--- a/simpletuner/helpers/utils/checkpoint_manager.py
+++ b/simpletuner/helpers/utils/checkpoint_manager.py
@@ -187,12 +187,18 @@ class CheckpointManager:
             return None
         return data
 
-    def cleanup_checkpoints(self, limit: int, suffix: Optional[str] = None):
-        """Clean up old checkpoints, keeping only the most recent ones.
+    def cleanup_checkpoints(
+        self,
+        limit: int,
+        suffix: Optional[str] = None,
+        protected_checkpoint: Optional[str] = None,
+    ):
+        """Clean up old checkpoints, preserving a specified checkpoint when provided.
 
         Args:
             limit: Maximum number of checkpoints to keep
             suffix: Optional suffix to filter checkpoints
+            protected_checkpoint: Optional checkpoint path or name to preserve
         """
         # Remove temp checkpoints first
         self._remove_temp_checkpoints()
@@ -204,7 +210,9 @@ class CheckpointManager:
         # Remove old checkpoints if we exceed the limit
         if len(checkpoints) > limit:
             num_to_remove = len(checkpoints) - limit
-            removing_checkpoints = checkpoints[:num_to_remove]
+            protected_name = os.path.basename(os.path.normpath(protected_checkpoint)) if protected_checkpoint else None
+            removal_candidates = [checkpoint for checkpoint in checkpoints if checkpoint != protected_name]
+            removing_checkpoints = removal_candidates[:num_to_remove]
 
             logger.debug(f"{len(checkpoints)} checkpoints exist, removing {len(removing_checkpoints)} checkpoints")
             logger.debug(f"Removing checkpoints: {', '.join(removing_checkpoints)}")
@@ -246,7 +254,7 @@ class CheckpointManager:
             if len(parts) < 2:
                 continue
             elif len(parts) > 2:
-                checkpoint_suffix = parts[2]
+                checkpoint_suffix = parts[-1]
 
             if base != "checkpoint":
                 continue

--- a/simpletuner/helpers/utils/checkpoint_manager.py
+++ b/simpletuner/helpers/utils/checkpoint_manager.py
@@ -220,6 +220,10 @@ class CheckpointManager:
             for checkpoint in removing_checkpoints:
                 self.remove_checkpoint(checkpoint)
 
+    def cleanup_temp_checkpoints(self):
+        """Remove temporary checkpoints without rotating completed checkpoints."""
+        self._remove_temp_checkpoints()
+
     def remove_checkpoint(self, checkpoint_name: str):
         """Remove a specific checkpoint.
 

--- a/tests/test_save_hooks.py
+++ b/tests/test_save_hooks.py
@@ -1,0 +1,101 @@
+import json
+import multiprocessing
+import tempfile
+import unittest
+from contextlib import nullcontext
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from accelerate.utils import DistributedType
+
+from simpletuner.helpers.training.save_hooks import SaveHookManager
+from simpletuner.helpers.training.state_tracker import StateTracker
+
+
+def _concurrent_prefetch_order_writer(directory, barrier, iterations, errors):
+    from simpletuner.helpers.training.state_tracker import StateTracker as Tracker
+
+    for _ in range(iterations):
+        barrier.wait()
+        try:
+            Tracker.save_ramtorch_prefetch_orders(directory)
+        except FileNotFoundError:
+            with errors.get_lock():
+                errors.value += 1
+
+
+class SaveHookManagerTests(unittest.TestCase):
+    def _run_save_model_hook(self, is_main_process=True, is_local_main_process=True):
+        output_dir = "/tmp/checkpoint"
+        with (
+            patch("simpletuner.helpers.training.save_hooks.StateTracker.save_training_state") as save_state,
+            patch("simpletuner.helpers.training.save_hooks.StateTracker.save_ramtorch_prefetch_orders") as save_orders,
+        ):
+            manager = object.__new__(SaveHookManager)
+            manager.accelerator = SimpleNamespace(
+                distributed_type=DistributedType.NO,
+                is_main_process=is_main_process,
+                is_local_main_process=is_local_main_process,
+            )
+            manager.args = SimpleNamespace(model_type="full")
+            manager.training_state_path = "training_state.json"
+            manager._offload_models_during_save = Mock(return_value=nullcontext())
+            manager._save_ema_state = Mock()
+            manager._is_fsdp2 = Mock(return_value=False)
+            manager._save_full_model = Mock()
+
+            manager.save_model_hook([], [], output_dir)
+
+        return save_state, save_orders
+
+    def test_ramtorch_prefetch_orders_are_saved_only_on_local_main_process(self):
+        for is_local_main_process in (True, False):
+            with self.subTest(is_local_main_process=is_local_main_process):
+                _, save_orders = self._run_save_model_hook(is_local_main_process=is_local_main_process)
+                self.assertEqual(save_orders.call_count, int(is_local_main_process))
+
+    def test_ramtorch_prefetch_orders_ignore_global_main_flag(self):
+        _, save_orders = self._run_save_model_hook(is_main_process=False, is_local_main_process=True)
+        save_orders.assert_called_once_with("/tmp/checkpoint")
+
+    def test_training_state_is_saved_on_every_rank(self):
+        for is_local_main_process in (True, False):
+            with self.subTest(is_local_main_process=is_local_main_process):
+                save_state, _ = self._run_save_model_hook(is_local_main_process=is_local_main_process)
+                save_state.assert_called_once_with("/tmp/checkpoint/training_state.json")
+
+
+class RamTorchPrefetchOrderWriterTests(unittest.TestCase):
+    def test_writer_leaves_only_the_final_file_behind(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            StateTracker.reset_ramtorch_prefetch_orders()
+            StateTracker.save_ramtorch_prefetch_orders(tmpdir)
+
+            entries = sorted(path.name for path in Path(tmpdir).iterdir())
+            self.assertEqual(entries, ["ramtorch_prefetch_orders.json"])
+            with Path(tmpdir, "ramtorch_prefetch_orders.json").open() as handle:
+                self.assertEqual(json.load(handle), {"version": 1, "components": {}})
+
+    def test_concurrent_writers_do_not_race(self):
+        ctx = multiprocessing.get_context("spawn")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            barrier = ctx.Barrier(2, timeout=60)
+            errors = ctx.Value("i", 0)
+            workers = [
+                ctx.Process(target=_concurrent_prefetch_order_writer, args=(tmpdir, barrier, 30, errors)) for _ in range(2)
+            ]
+            for worker in workers:
+                worker.start()
+            for worker in workers:
+                worker.join(120)
+
+            self.assertEqual(errors.value, 0)
+            entries = sorted(path.name for path in Path(tmpdir).iterdir())
+            self.assertEqual(entries, ["ramtorch_prefetch_orders.json"])
+            with Path(tmpdir, "ramtorch_prefetch_orders.json").open() as handle:
+                json.load(handle)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import torch
 
+from simpletuner.helpers.publishing.huggingface import HubManager
 from simpletuner.helpers.publishing.providers.s3 import S3PublishingProvider
 from simpletuner.helpers.training.state_tracker import StateTracker
 from simpletuner.helpers.utils.checkpoint_manager import CheckpointManager
@@ -2164,6 +2165,338 @@ class TestTrainer(unittest.TestCase):
             self.assertFalse(Path(tmpdir, "checkpoint-200").exists())
             trainer.accelerator.load_state.assert_called_once_with(os.path.join(tmpdir, "checkpoint-100"))
 
+    def _build_standard_checkpoint_test_trainer(self, output_dir, limit, use_checkpoint_manager):
+        trainer = object.__new__(Trainer)
+        trainer.job_id = None
+        trainer.hub_manager = None
+        trainer.webhook_handler = None
+        trainer.validation = None
+        trainer._prepare_training_progress_payload = Mock(return_value=({}, {}))
+        trainer._emit_event = Mock()
+        trainer._run_post_upload_script = Mock()
+        trainer._drain_hub_upload_futures = Mock()
+        trainer.checkpoint_manager = CheckpointManager(output_dir) if use_checkpoint_manager else None
+        trainer.state = {"global_step": 110, "current_epoch": 1}
+        trainer.config = SimpleNamespace(
+            output_dir=output_dir,
+            use_deepspeed_optimizer=False,
+            fsdp_enable=False,
+            checkpoints_total_limit=limit,
+            num_train_epochs=1,
+        )
+        trainer.accelerator = SimpleNamespace(is_main_process=True)
+        return trainer
+
+    def test_checkpoint_state_cleanup_temp_removes_standard_and_rolling_temp(self):
+        for use_checkpoint_manager in (True, False):
+            with self.subTest(use_checkpoint_manager=use_checkpoint_manager):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    for checkpoint in (
+                        "checkpoint-10",
+                        "checkpoint-20-rolling",
+                        "checkpoint-30-tmp",
+                        "checkpoint-40-rolling-tmp",
+                    ):
+                        Path(tmpdir, checkpoint).mkdir()
+
+                    trainer = object.__new__(Trainer)
+                    trainer.checkpoint_manager = CheckpointManager(tmpdir) if use_checkpoint_manager else None
+                    trainer.checkpoint_state_cleanup_temp(tmpdir)
+
+                    remaining = sorted(path.name for path in Path(tmpdir).glob("checkpoint-*"))
+                    self.assertEqual(remaining, ["checkpoint-10", "checkpoint-20-rolling"])
+
+    def test_standard_checkpoint_unlimited_cleans_temp_without_rotation(self):
+        for use_checkpoint_manager in (True, False):
+            with self.subTest(use_checkpoint_manager=use_checkpoint_manager):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    existing_checkpoint = Path(tmpdir, "checkpoint-100")
+                    incoming_checkpoint = Path(tmpdir, "checkpoint-110")
+                    temp_checkpoint = Path(tmpdir, "checkpoint-90-tmp")
+                    existing_checkpoint.mkdir()
+                    temp_checkpoint.mkdir()
+
+                    trainer = self._build_standard_checkpoint_test_trainer(
+                        tmpdir,
+                        limit=0,
+                        use_checkpoint_manager=use_checkpoint_manager,
+                    )
+                    trainer.checkpoint_state_cleanup = Mock(wraps=trainer.checkpoint_state_cleanup)
+
+                    def save_checkpoint(output_dir):
+                        self.assertEqual(tmpdir, output_dir)
+                        self.assertFalse(temp_checkpoint.exists())
+                        incoming_checkpoint.mkdir()
+                        return str(incoming_checkpoint)
+
+                    trainer.checkpoint_state_save = Mock(side_effect=save_checkpoint)
+                    save_path = trainer._run_standard_checkpoint(
+                        webhook_message=None,
+                        parent_loss=None,
+                        epoch=0,
+                        upload_to_hub=False,
+                    )
+
+                    self.assertEqual(str(incoming_checkpoint), save_path)
+                    remaining = sorted(path.name for path in Path(tmpdir).glob("checkpoint-*"))
+                    self.assertEqual(remaining, ["checkpoint-100", "checkpoint-110"])
+                    trainer.checkpoint_state_cleanup.assert_not_called()
+                    trainer._drain_hub_upload_futures.assert_not_called()
+
+    def test_standard_checkpoint_waits_only_when_removal_is_needed(self):
+        for use_checkpoint_manager in (True, False):
+            with self.subTest(use_checkpoint_manager=use_checkpoint_manager):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    existing_checkpoint = Path(tmpdir, "checkpoint-100")
+                    incoming_checkpoint = Path(tmpdir, "checkpoint-110")
+                    next_checkpoint = Path(tmpdir, "checkpoint-120")
+                    existing_checkpoint.mkdir()
+
+                    trainer = self._build_standard_checkpoint_test_trainer(
+                        tmpdir,
+                        limit=2,
+                        use_checkpoint_manager=use_checkpoint_manager,
+                    )
+
+                    def save_checkpoint(output_dir):
+                        self.assertEqual(tmpdir, output_dir)
+                        incoming_checkpoint.mkdir()
+                        return str(incoming_checkpoint)
+
+                    trainer.checkpoint_state_save = Mock(side_effect=save_checkpoint)
+                    save_path = trainer._run_standard_checkpoint(
+                        webhook_message=None,
+                        parent_loss=None,
+                        epoch=0,
+                        upload_to_hub=False,
+                    )
+
+                    self.assertEqual(str(incoming_checkpoint), save_path)
+                    remaining = sorted(path.name for path in Path(tmpdir).glob("checkpoint-*"))
+                    self.assertEqual(remaining, ["checkpoint-100", "checkpoint-110"])
+                    trainer._drain_hub_upload_futures.assert_not_called()
+
+                    def save_next_checkpoint(output_dir):
+                        self.assertEqual(tmpdir, output_dir)
+                        next_checkpoint.mkdir()
+                        return str(next_checkpoint)
+
+                    trainer.state["global_step"] = 120
+                    trainer.checkpoint_state_save = Mock(side_effect=save_next_checkpoint)
+                    save_path = trainer._run_standard_checkpoint(
+                        webhook_message=None,
+                        parent_loss=None,
+                        epoch=0,
+                        upload_to_hub=False,
+                    )
+
+                    self.assertEqual(str(next_checkpoint), save_path)
+                    remaining = sorted(path.name for path in Path(tmpdir).glob("checkpoint-*"))
+                    self.assertEqual(remaining, ["checkpoint-110", "checkpoint-120"])
+                    trainer._drain_hub_upload_futures.assert_called_once_with(wait=True)
+
+    def test_standard_checkpoint_rotation_preserves_recovery_and_new_save(self):
+        for use_checkpoint_manager in (True, False):
+            with self.subTest(use_checkpoint_manager=use_checkpoint_manager):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    resume_checkpoint = Path(tmpdir) / "checkpoint-100"
+                    existing_checkpoint = Path(tmpdir) / "checkpoint-200"
+                    incoming_checkpoint = Path(tmpdir) / "checkpoint-110"
+                    temp_checkpoint = Path(tmpdir) / "checkpoint-90-tmp"
+                    resume_checkpoint.mkdir()
+                    existing_checkpoint.mkdir()
+                    temp_checkpoint.mkdir()
+
+                    trainer = object.__new__(Trainer)
+                    trainer.job_id = None
+                    trainer.hub_manager = Mock()
+                    trainer.hub_manager.upload_latest_checkpoint.return_value = (
+                        "remote/checkpoint-110",
+                        str(incoming_checkpoint),
+                        "repo-url",
+                    )
+                    trainer.webhook_handler = None
+                    trainer.validation = None
+                    trainer._prepare_training_progress_payload = Mock(return_value=({}, {}))
+                    trainer._emit_event = Mock()
+                    trainer._run_post_upload_script = Mock()
+                    trainer._schedule_hub_upload = Mock(side_effect=lambda _description, upload: upload())
+
+                    def drain_uploads_before_removal(*, wait):
+                        self.assertTrue(wait)
+                        self.assertTrue(resume_checkpoint.exists())
+                        self.assertTrue(existing_checkpoint.exists())
+                        self.assertTrue(incoming_checkpoint.exists())
+
+                    trainer._drain_hub_upload_futures = Mock(side_effect=drain_uploads_before_removal)
+                    trainer.checkpoint_manager = CheckpointManager(tmpdir) if use_checkpoint_manager else None
+                    trainer.state = {"global_step": 110, "current_epoch": 1}
+                    trainer.config = SimpleNamespace(
+                        output_dir=tmpdir,
+                        use_deepspeed_optimizer=False,
+                        fsdp_enable=False,
+                        checkpoints_total_limit=1,
+                        num_train_epochs=1,
+                        resume_from_checkpoint="checkpoint-100",
+                    )
+                    trainer.accelerator = SimpleNamespace(is_main_process=True)
+
+                    def fail_save(output_dir):
+                        self.assertEqual(tmpdir, output_dir)
+                        self.assertFalse(temp_checkpoint.exists())
+                        raise RuntimeError("save failed")
+
+                    trainer.checkpoint_state_save = Mock(side_effect=fail_save)
+
+                    with self.assertRaisesRegex(RuntimeError, "save failed"):
+                        trainer._run_standard_checkpoint(
+                            webhook_message=None,
+                            parent_loss=None,
+                            epoch=0,
+                            upload_to_hub=False,
+                        )
+                    self.assertTrue(resume_checkpoint.exists())
+                    self.assertTrue(existing_checkpoint.exists())
+
+                    def save_checkpoint(output_dir):
+                        self.assertEqual(tmpdir, output_dir)
+                        self.assertTrue(resume_checkpoint.exists())
+                        self.assertTrue(existing_checkpoint.exists())
+                        incoming_checkpoint.mkdir()
+                        return str(incoming_checkpoint)
+
+                    trainer.checkpoint_state_save = Mock(side_effect=save_checkpoint)
+                    save_path = trainer._run_standard_checkpoint(
+                        webhook_message=None,
+                        parent_loss=None,
+                        epoch=0,
+                        upload_to_hub=True,
+                    )
+
+                    self.assertEqual(str(incoming_checkpoint), save_path)
+                    self.assertTrue(Path(save_path).exists())
+                    remaining = sorted(path.name for path in Path(tmpdir).glob("checkpoint-*"))
+                    self.assertEqual(remaining, ["checkpoint-110"])
+                    trainer.hub_manager.upload_latest_checkpoint.assert_called_once_with(
+                        validation_images=None,
+                        webhook_handler=None,
+                        global_step=110,
+                        epoch=1,
+                        checkpoint_path=str(incoming_checkpoint),
+                    )
+                    trainer._drain_hub_upload_futures.assert_called_once_with(wait=True)
+
+    def test_hub_upload_uses_explicit_checkpoint_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "checkpoint-200").mkdir()
+            incoming_checkpoint = Path(tmpdir, "checkpoint-110")
+            incoming_checkpoint.mkdir()
+
+            hub_manager = object.__new__(HubManager)
+            hub_manager.config = SimpleNamespace(output_dir=tmpdir)
+            hub_manager.find_latest_checkpoint = Mock(return_value=Path(tmpdir, "checkpoint-200"))
+            hub_manager.upload_model = Mock(return_value="repo-url")
+            hub_manager._repo_url = Mock(return_value="remote/checkpoint-110")
+
+            result = hub_manager.upload_latest_checkpoint(
+                validation_images=None,
+                webhook_handler=None,
+                global_step=110,
+                epoch=1,
+                checkpoint_path=str(incoming_checkpoint),
+            )
+
+            self.assertEqual(("remote/checkpoint-110", str(incoming_checkpoint), "repo-url"), result)
+            hub_manager.find_latest_checkpoint.assert_not_called()
+            hub_manager.upload_model.assert_called_once_with(
+                validation_images=None,
+                override_path=incoming_checkpoint,
+                webhook_handler=None,
+                global_step=110,
+                epoch=1,
+            )
+            hub_manager._repo_url.assert_called_once_with("checkpoint-110")
+
+    def test_rolling_checkpoint_rotation_preserves_recovery_and_new_save(self):
+        for use_checkpoint_manager in (True, False):
+            with self.subTest(use_checkpoint_manager=use_checkpoint_manager):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    resume_checkpoint = Path(tmpdir, "checkpoint-100-rolling")
+                    existing_checkpoint = Path(tmpdir, "checkpoint-200-rolling")
+                    incoming_checkpoint = Path(tmpdir, "checkpoint-110-rolling")
+                    temp_checkpoint = Path(tmpdir, "checkpoint-90-rolling-tmp")
+                    resume_checkpoint.mkdir()
+                    existing_checkpoint.mkdir()
+                    temp_checkpoint.mkdir()
+
+                    trainer = object.__new__(Trainer)
+                    trainer.checkpoint_manager = CheckpointManager(tmpdir) if use_checkpoint_manager else None
+                    trainer.config = SimpleNamespace(
+                        output_dir=tmpdir,
+                        use_deepspeed_optimizer=False,
+                        fsdp_enable=False,
+                        checkpoints_rolling_total_limit=1,
+                    )
+                    trainer.accelerator = SimpleNamespace(is_main_process=True)
+
+                    def fail_save(output_dir, suffix):
+                        self.assertEqual(tmpdir, output_dir)
+                        self.assertEqual("rolling", suffix)
+                        self.assertFalse(temp_checkpoint.exists())
+                        raise RuntimeError("save failed")
+
+                    trainer.checkpoint_state_save = Mock(side_effect=fail_save)
+                    with self.assertRaisesRegex(RuntimeError, "save failed"):
+                        trainer._save_rolling_checkpoint()
+                    self.assertTrue(resume_checkpoint.exists())
+                    self.assertTrue(existing_checkpoint.exists())
+
+                    def save_checkpoint(output_dir, suffix):
+                        self.assertEqual(tmpdir, output_dir)
+                        self.assertEqual("rolling", suffix)
+                        self.assertTrue(resume_checkpoint.exists())
+                        self.assertTrue(existing_checkpoint.exists())
+                        incoming_checkpoint.mkdir()
+                        return str(incoming_checkpoint)
+
+                    trainer.checkpoint_state_save = Mock(side_effect=save_checkpoint)
+                    save_path = trainer._save_rolling_checkpoint()
+
+                    self.assertEqual(str(incoming_checkpoint), save_path)
+                    self.assertTrue(Path(save_path).exists())
+                    remaining = sorted(path.name for path in Path(tmpdir).glob("checkpoint-*"))
+                    self.assertEqual(remaining, ["checkpoint-110-rolling"])
+
+    def test_rolling_checkpoint_non_main_save_ownership(self):
+        for use_deepspeed, fsdp_enable, should_save in (
+            (False, False, False),
+            (True, False, True),
+            (False, True, True),
+        ):
+            with self.subTest(use_deepspeed=use_deepspeed, fsdp_enable=fsdp_enable):
+                trainer = object.__new__(Trainer)
+                trainer.config = SimpleNamespace(
+                    output_dir="/tmp/output",
+                    use_deepspeed_optimizer=use_deepspeed,
+                    fsdp_enable=fsdp_enable,
+                    checkpoints_rolling_total_limit=1,
+                )
+                trainer.accelerator = SimpleNamespace(is_main_process=False)
+                trainer.checkpoint_state_cleanup_temp = Mock()
+                trainer.checkpoint_state_cleanup = Mock()
+                trainer.checkpoint_state_save = Mock(return_value="/tmp/output/checkpoint-110-rolling")
+
+                save_path = trainer._save_rolling_checkpoint()
+
+                if should_save:
+                    self.assertEqual("/tmp/output/checkpoint-110-rolling", save_path)
+                    trainer.checkpoint_state_save.assert_called_once_with("/tmp/output", "rolling")
+                else:
+                    self.assertIsNone(save_path)
+                    trainer.checkpoint_state_save.assert_not_called()
+                trainer.checkpoint_state_cleanup_temp.assert_not_called()
+                trainer.checkpoint_state_cleanup.assert_not_called()
+
     @patch("simpletuner.helpers.training.trainer.AttentionBackendController.on_save_checkpoint")
     def test_checkpoint_state_save_writes_completion_guard(self, mock_attention_backend):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -2215,6 +2548,68 @@ class TestTrainer(unittest.TestCase):
             self.assertIn("pytorch_lora_weights.safetensors", manifest["files"])
             self.assertNotIn(".guard", manifest["files"])
             trainer.accelerator.wait_for_everyone.assert_not_called()
+
+    @patch("simpletuner.helpers.training.trainer.AttentionBackendController.on_save_checkpoint")
+    def test_checkpoint_state_save_synchronizes_only_all_rank_temp_writes(self, mock_attention_backend):
+        distributed_configs = (
+            (DistributedType.DEEPSPEED, True, False, (True, False), ["wait", "save", "wait", "wait", "wait"]),
+            (DistributedType.FSDP, False, True, (True, False), ["wait", "save", "wait", "wait", "wait"]),
+            (DistributedType.MULTI_GPU, False, False, (True,), ["save"]),
+        )
+        for distributed_type, use_deepspeed, fsdp_enable, process_roles, expected_events in distributed_configs:
+            for is_main_process in process_roles:
+                with self.subTest(distributed_type=distributed_type, is_main_process=is_main_process):
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        trainer = object.__new__(Trainer)
+                        trainer.config = SimpleNamespace(
+                            output_dir=tmpdir,
+                            checkpointing_use_tempdir=True,
+                            disk_low_threshold=None,
+                            use_deepspeed_optimizer=use_deepspeed,
+                            fsdp_enable=fsdp_enable,
+                        )
+                        trainer.state = {"global_step": 100}
+                        trainer.job_id = "test-job"
+                        trainer.model = SimpleNamespace()
+                        trainer.model_hooks = SimpleNamespace(
+                            training_state_path="training_state.json",
+                            get_modelspec_architecture=Mock(return_value="test/lora"),
+                        )
+                        trainer.checkpoint_manager = CheckpointManager(tmpdir)
+                        trainer.mark_optimizer_eval = Mock()
+                        trainer.mark_optimizer_train = Mock()
+                        trainer._emit_event = Mock()
+                        trainer._run_post_checkpoint_script = Mock()
+
+                        events = []
+
+                        def wait_for_everyone():
+                            events.append("wait")
+
+                        def save_state(path):
+                            self.assertEqual(expected_events[: expected_events.index("save")], events)
+                            events.append("save")
+                            Path(path).mkdir(parents=True, exist_ok=True)
+                            Path(path, "pytorch_lora_weights.safetensors").write_bytes(b"weights")
+
+                        trainer.accelerator = SimpleNamespace(
+                            _models=[],
+                            is_main_process=is_main_process,
+                            distributed_type=distributed_type,
+                            save_state=Mock(side_effect=save_state),
+                            wait_for_everyone=Mock(side_effect=wait_for_everyone),
+                        )
+
+                        with patch(
+                            "simpletuner.helpers.training.state_tracker.StateTracker.get_data_backends",
+                            return_value={},
+                        ):
+                            save_path = trainer.checkpoint_state_save(tmpdir)
+
+                        self.assertEqual(str(Path(tmpdir, "checkpoint-100")), save_path)
+                        self.assertEqual(expected_events, events)
+                        expected_written_path = Path(save_path) if is_main_process else Path(f"{save_path}-tmp")
+                        self.assertTrue(expected_written_path.exists())
 
     @patch("simpletuner.helpers.training.trainer.logger")
     def test_init_resume_checkpoint_prodigy_without_split_groups(self, mock_logger):
@@ -2407,6 +2802,7 @@ class TestTrainer(unittest.TestCase):
             trainer._emit_event = Mock()
             trainer._run_post_upload_script = Mock()
             trainer.checkpoint_state_cleanup = Mock()
+            trainer.checkpoint_manager = None
             trainer.state = {"global_step": 10, "global_resume_step": 0, "current_epoch": 2}
             trainer.config = SimpleNamespace(
                 output_dir=str(tmpdir),


### PR DESCRIPTION
## Summary

Checkpoint retention runs **before** `checkpoint_state_save()`. Rotating first, then writing, is
the wrong order for every consequence below; this PR writes first and rotates after the save
succeeds, and protects the checkpoint that was just written.

Measured on `main` (`2d6df1245`) by driving the real `Trainer._run_standard_checkpoint` against a
minimal stub:

- **Steady-state disk usage is `limit + 1`.** `CheckpointManager.cleanup_checkpoints`
  (`checkpoint_manager.py:205-207`) trims down to exactly `limit`, and the save at
  `trainer.py:5250-5252` then adds one more. With `checkpoints_total_limit=3` over six cycles the
  on-disk count goes `[1, 2, 3, 4, 4, 4]`. After the change it is `[1, 2, 3, 3, 3, 3]`.
- **A stale higher-numbered checkpoint permanently occupies a retention slot.** Resuming from a
  lower step and continuing leaves the directory settled at
  `['checkpoint-400', 'checkpoint-5000']` forever, because numeric rotation keeps the largest step
  rather than the one just written. If a later save then fails, the only complete checkpoint left
  is the stale step-5000 one and recovery silently jumps 4900 steps. After the change the same
  sequence settles at `['checkpoint-400']`, and the failed-save case leaves
  `['checkpoint-200', 'checkpoint-300-tmp']`.
- **`checkpoints_total_limit=0` deletes every checkpoint.** The guard at `trainer.py:5244` is
  `checkpoints_total_limit is not None`, so `0` passes through to a cleanup that reads it as
  keep-zero. Measured: three existing checkpoints plus one save leaves `['checkpoint-400']`. The
  field registry documents the opposite —
  `field_registry/sections/training.py:198-212` carries
  `ValidationRule(MIN, 0, 'Must be non-negative (0 = unlimited)')` and the tooltip
  *"Set to 0 for unlimited"*. After the change all four are retained.
- **The background Hub upload re-resolves `latest` instead of using the checkpoint it was
  scheduled for.** `huggingface.py:301` calls `find_latest_checkpoint()` inside a
  single-worker background future (`trainer.py:2112`, `:5262`); measured resolving to
  `checkpoint-200` for an upload scheduled with `global_step=100`.
- **Rolling `-tmp` directories are mis-parsed, and it destroys data.** Suffix is read as
  `parts[2]` (`checkpoint_manager.py:249`) / `cs[2]` (`trainer.py:5865`), so
  `checkpoint-200-rolling-tmp` is classified as suffix `rolling`. Measured:
  `cleanup_checkpoints(1, "rolling")` deleted the real `checkpoint-200-rolling` and kept the
  orphaned `checkpoint-200-rolling-tmp`.

One thing this PR also fixes, which is **not** reachable in a shipped configuration: the fallback
rotation path in `trainer.py` (`checkpoint_state_cleanup`'s non-manager branch,
`trainer.py:5878-5902`) returns early when `len(checkpoints) < limit` and otherwise removes
`len - limit + 1`, so at `limit=1` it deletes the only checkpoint before the save and a failed
save leaves nothing. That branch is dead today — `trainer.py:2206-2208` constructs a
`CheckpointManager` whenever `config.output_dir` is truthy and the field default is
`simpletuner-results` — so this is a latent correctness fix, not an observable bug. It is listed
here so the `- limit + 1` → `- limit` change is not mistaken for an off-by-one repair: that `+1`
was the correct compensation for pre-save ordering, and it changes only because the ordering is
being inverted.

## Changes

- Clean stale temporary checkpoints before saving, but rotate completed standard and rolling
  checkpoints only **after** the new save succeeds.
- Protect the newly written `save_path` during rotation so it survives even when its step number
  is lower than another checkpoint on disk.
- `CheckpointManager.cleanup_checkpoints()` and the fallback path take an optional
  `protected_checkpoint` and use post-save retention counts.
- Keep temporary-checkpoint cleanup active when `checkpoints_total_limit=0` while leaving
  completed-checkpoint retention unlimited, matching the documented meaning of `0`.
- Pass the exact saved checkpoint path to the Hub uploader instead of re-resolving `latest` in the
  background task.
- Recognise both standard and rolling `*-tmp` directories during cleanup (`parts[-1]` / `cs[-1]`).
- Extract `_save_rolling_checkpoint()` so the rolling path follows the same order as the standard
  path.

### Two changes that are not consequences of the above

Both are deliberate and both change runtime behaviour, so they are called out separately rather
than buried in the list.

**A synchronous drain of pending Hub uploads before rotation.** Rotation may delete a directory
that a background upload is still reading, so the new code blocks on
`_drain_hub_upload_futures(wait=True)` when the post-save count exceeds the limit. At steady state
that count is always `limit + 1`, so **this fires on every checkpoint cycle**.

`main` already has a blocking drain, but only in teardown: `_finish_hub_uploads()`
(`trainer.py:2194-2198`) is called from the `finally` of the run wrapper (`:1908`) and once more
after the final model upload (`:7131`). Inside the training loop the only drain is
`trainer.py:2189` with `wait=False`, immediately before a new upload is scheduled. **This PR
introduces the first blocking drain on the per-checkpoint path**, and the uploader is a
single-worker `ThreadPoolExecutor` (`trainer.py:2108-2113`), so a slow push serialises into the
step loop.

The cost is confined to runs with `push_to_hub` enabled: with background push off,
`_hub_upload_futures` is empty and `_drain_hub_upload_futures` returns at its first line
(`trainer.py:2149-2150`). Reviewers who consider a per-checkpoint stall unacceptable should say so
— the alternative is to accept that rotation can delete a directory mid-upload.

**A pre-save barrier for all-rank temporary-directory writes.** When DeepSpeed or FSDP has every
rank saving and `checkpointing_use_tempdir` is set, the ranks must agree on the temp directory
before any of them writes into it, so `checkpoint_state_save` now calls
`accelerator.wait_for_everyone()` in exactly that case. It is a no-op for single-process runs and
for main-process-only saving.

## Ordering constraint: please merge #2988 first

**Do not merge this before #2988 (`Fix RamTorch prefetch-order save race`).**
`_save_rolling_checkpoint` widens the rolling-save gate to
`is_main_process or use_deepspeed_optimizer or fsdp_enable`; `main` (`trainer.py:6816-6825`) has no
`fsdp_enable` there. With this PR alone, every FSDP rank newly enters `accelerator.save_state` on
the rolling path — and therefore reaches `save_hooks.py:1095`, where all ranks still race on one
shared `ramtorch_prefetch_orders.json.tmp`. Rolling checkpoints normally fire on a much tighter
interval than standard ones, so the exposure is not marginal. Merging #2988 first, or both
together, removes the interaction; the combined tree was verified green.

The two PRs touch disjoint files, so this is purely a sequencing constraint — there is no conflict
and no rebase needed either way.

## Notes

- `checkpoints_total_limit=0` remains unlimited for completed checkpoints while temp cleanup keeps
  running.
- Checkpoint format and resume-selection behaviour are unchanged.
- Distributed behaviour is covered with CPU mocks. No live multi-rank or GPU run was performed for
  this branch.

## Verification

CPU-only container, current `main` (`2d6df1245`), 8 new test methods / 18 subtest cases in
`tests/test_trainer.py`.

```
tests.test_trainer          RED  Ran 82   FAILED (failures=10, errors=8)
                            GREEN Ran 82   OK

18 related modules          RED  Ran 236  FAILED (failures=10, errors=8)
                            GREEN Ran 236  OK

full suite, 317 modules     RED  Ran 4222 FAILED (failures=19, errors=23, skipped=143)
                            GREEN Ran 4222 FAILED (failures=9,  errors=15, skipped=143)
                            GREEN-only failures: NONE
```

RED is `main` plus this branch's test changes with the three production files restored from `main`.
All 8 new methods are RED there — none is green-on-arrival. The 18-failure delta between RED and
GREEN on the full suite is exactly the new tests; the 24 that remain on both are pre-existing on
`main`.

Each separable sub-fix was additionally mutation-tested by reverting it alone inside the green
tree, to confirm nothing is unpinned:

```
parts[-1] -> parts[2]                      FAILED (failures=4)
drop protected_checkpoint filtering        FAILED (failures=4)
drop the new wait_for_everyone() barrier   FAILED (failures=4)
restore the `< limit` / `- limit + 1` path  FAILED (failures=1)
```