### PR TITLE
Write LoRA checkpoints in PEFT naming instead of converting them to legacy diffusers names

### DIFF
--- a/simpletuner/helpers/training/lora_format.py
+++ b/simpletuner/helpers/training/lora_format.py
@@ -233,24 +233,16 @@ def convert_diffusers_to_comfyui(
 
         if ".lora.down." in new_key:
             new_key = new_key.replace(".lora.down.", ".lora_A.")
+        elif ".lora.up." in new_key:
+            new_key = new_key.replace(".lora.up.", ".lora_B.")
+
+        if ".lora_A." in new_key:
             module_key = new_key[: new_key.rfind(".lora_A.")]
             alpha_value = _resolve_alpha_for_module(
                 module_key.removeprefix(f"{diffusion_prefix}."), weight, adapter_metadata
             )
             if alpha_value is not None and module_key not in alpha_entries:
                 alpha_entries[module_key] = torch.tensor(alpha_value, dtype=torch.float32)
-        elif new_key.endswith(".lora.down.weight"):
-            new_key = new_key.replace(".lora.down.weight", ".lora_A.weight")
-            module_key = new_key[: new_key.rfind(".lora_A.weight")]
-            alpha_value = _resolve_alpha_for_module(
-                module_key.removeprefix(f"{diffusion_prefix}."), weight, adapter_metadata
-            )
-            if alpha_value is not None and module_key not in alpha_entries:
-                alpha_entries[module_key] = torch.tensor(alpha_value, dtype=torch.float32)
-        elif ".lora.up." in new_key:
-            new_key = new_key.replace(".lora.up.", ".lora_B.")
-        elif new_key.endswith(".lora.up.weight"):
-            new_key = new_key.replace(".lora.up.weight", ".lora_B.weight")
 
         converted[new_key] = weight
 

--- a/simpletuner/helpers/training/save_hooks.py
+++ b/simpletuner/helpers/training/save_hooks.py
@@ -742,10 +742,7 @@ class SaveHookManager:
             self.ema_model.copy_to(trainable_parameters)
             ema_trained_component = unwrap_model(self.accelerator, self.model.get_trained_component())
             lora_save_parameters = {
-                f"{self.model.MODEL_SUBFOLDER}_lora_layers": convert_state_dict_to_diffusers(
-                    get_peft_model_state_dict(ema_trained_component),
-                    original_type=StateDictType.PEFT,
-                ),
+                f"{self.model.MODEL_SUBFOLDER}_lora_layers": get_peft_model_state_dict(ema_trained_component),
             }
             ema_modules_to_save = {self.model.MODEL_SUBFOLDER: ema_trained_component}
             ema_metadata = _collate_lora_metadata(ema_modules_to_save)
@@ -792,9 +789,8 @@ class SaveHookManager:
                 modules_to_save["controlnet"] = unwrapped_model
             elif isinstance(unwrapped_model, tuple(trained_component_classes)):
                 # unet_lora_layers or transformer_lora_layers
-                lora_save_parameters[f"{self.model.MODEL_SUBFOLDER}_lora_layers"] = convert_state_dict_to_diffusers(
-                    get_peft_model_state_dict(unwrapped_model),
-                    original_type=StateDictType.PEFT,
+                lora_save_parameters[f"{self.model.MODEL_SUBFOLDER}_lora_layers"] = get_peft_model_state_dict(
+                    unwrapped_model
                 )
                 modules_to_save[self.model.MODEL_SUBFOLDER] = unwrapped_model
             elif text_encoder_0_cls is not None and isinstance(unwrapped_model, text_encoder_0_cls):

--- a/tests/test_lora_format.py
+++ b/tests/test_lora_format.py
@@ -1,0 +1,93 @@
+import unittest
+
+import torch
+
+from simpletuner.helpers.training.lora_format import (
+    PEFTLoRAFormat,
+    convert_diffusers_to_comfyui,
+    convert_diffusers_to_comfyui_sd_lora,
+    detect_state_dict_format,
+)
+
+
+DOWN = torch.full((4, 8), 1.0)
+UP = torch.full((8, 4), 2.0)
+
+
+def _diffusers_named(module_key):
+    return {
+        f"{module_key}.lora.down.weight": DOWN,
+        f"{module_key}.lora.up.weight": UP,
+    }
+
+
+def _peft_named(module_key):
+    return {
+        f"{module_key}.lora_A.weight": DOWN,
+        f"{module_key}.lora_B.weight": UP,
+    }
+
+
+SPELLINGS = (("diffusers", _diffusers_named), ("peft", _peft_named))
+
+
+class ConvertDiffusersToComfyUITests(unittest.TestCase):
+    MODULE = "transformer.blocks.0.attn.to_q"
+    CONVERTED = "diffusion_model.blocks.0.attn.to_q"
+    ALPHA_KEY = "diffusion_model.blocks.0.attn.to_q.alpha"
+    METADATA = {"lora_alpha": 16}
+
+    def _convert(self, state_dict):
+        return convert_diffusers_to_comfyui(state_dict, adapter_metadata=self.METADATA)
+
+    def test_both_spellings_convert_to_the_same_keys(self):
+        converted = {name: set(self._convert(build(self.MODULE))) for name, build in SPELLINGS}
+        self.assertEqual(converted["diffusers"], converted["peft"])
+
+    def test_alpha_is_emitted_for_both_spellings(self):
+        for name, build in SPELLINGS:
+            with self.subTest(spelling=name):
+                converted = self._convert(build(self.MODULE))
+                self.assertIn(self.ALPHA_KEY, converted)
+                self.assertEqual(float(converted[self.ALPHA_KEY]), float(self.METADATA["lora_alpha"]))
+
+    def test_down_and_up_weights_keep_their_roles(self):
+        for name, build in SPELLINGS:
+            with self.subTest(spelling=name):
+                converted = self._convert(build(self.MODULE))
+                self.assertTrue(torch.equal(converted[f"{self.CONVERTED}.lora_A.weight"], DOWN))
+                self.assertTrue(torch.equal(converted[f"{self.CONVERTED}.lora_B.weight"], UP))
+
+
+class ConvertDiffusersToComfyUISDLoraTests(unittest.TestCase):
+    MODULE = "unet.down_blocks.1.attentions.0.transformer_blocks.0.attn1.to_k"
+    ALPHA_KEY = "lora_unet_down_blocks_1_attentions_0_transformer_blocks_0_attn1_to_k.alpha"
+    METADATA = {"lora_alpha": 8}
+
+    def _convert(self, state_dict):
+        return convert_diffusers_to_comfyui_sd_lora(state_dict, adapter_metadata=self.METADATA)
+
+    def test_both_spellings_convert_to_the_same_keys(self):
+        converted = {name: set(self._convert(build(self.MODULE))) for name, build in SPELLINGS}
+        self.assertEqual(converted["diffusers"], converted["peft"])
+
+    def test_alpha_is_emitted_for_both_spellings(self):
+        for name, build in SPELLINGS:
+            with self.subTest(spelling=name):
+                converted = self._convert(build(self.MODULE))
+                self.assertIn(self.ALPHA_KEY, converted)
+                self.assertEqual(float(converted[self.ALPHA_KEY]), float(self.METADATA["lora_alpha"]))
+
+
+class DetectStateDictFormatTests(unittest.TestCase):
+    MODULE = "transformer.blocks.0.attn.to_q"
+
+    def test_peft_named_dict_is_reported_as_comfyui(self):
+        self.assertEqual(detect_state_dict_format(_peft_named(self.MODULE)), PEFTLoRAFormat.COMFYUI)
+
+    def test_diffusers_named_dict_is_reported_as_diffusers(self):
+        self.assertEqual(detect_state_dict_format(_diffusers_named(self.MODULE)), PEFTLoRAFormat.DIFFUSERS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lora_metadata.py
+++ b/tests/test_lora_metadata.py
@@ -41,7 +41,8 @@ class _DummyBaseModule:
 
 
 class _DummyTrainedComponent(_DummyBaseModule):
-    pass
+    def parameters(self):
+        return []
 
 
 class _DummyControlNet(_DummyTrainedComponent):
@@ -131,6 +132,14 @@ class _DummySavePipeline:
         save_function(packed, filename)
 
 
+class _DummyDiffusersSavePipeline(_DummySavePipeline):
+    @classmethod
+    def save_lora_weights(cls, save_directory, transformer_lora_layers=None, save_function=None, **kwargs):
+        filename = os.path.join(save_directory, kwargs.get("weight_name") or "pytorch_lora_weights.safetensors")
+        packed = {f"transformer.{key}": value for key, value in (transformer_lora_layers or {}).items()}
+        (save_function or save_file)(packed, filename)
+
+
 class _DummySDXLSavePipeline:
     @classmethod
     def save_lora_weights(
@@ -163,6 +172,20 @@ class _DummySaveModel:
 
 class _DummySDXLSaveModel(_DummySaveModel):
     PIPELINE_CLASSES = {PipelineTypes.TEXT2IMG: _DummySDXLSavePipeline, PipelineTypes.CONTROLNET: _DummySDXLSavePipeline}
+
+
+class _DummyArtifactModel(_DummyModel):
+    """Routes _save_lora through the real ModelFoundation.save_lora_weights so a file is written."""
+
+    PIPELINE_CLASSES = {
+        PipelineTypes.TEXT2IMG: _DummyDiffusersSavePipeline,
+        PipelineTypes.CONTROLNET: _DummyDiffusersSavePipeline,
+    }
+
+    def __init__(self, trained_component, text_encoder=None):
+        super().__init__(trained_component=trained_component, text_encoder=text_encoder)
+        self.config = SimpleNamespace(model_family="sdxl", lora_format="diffusers", controlnet=False)
+        self.save_lora_weights = lambda *args, **kwargs: ModelFoundation.save_lora_weights(self, *args, **kwargs)
 
 
 _ema_stub = SimpleNamespace(
@@ -434,6 +457,111 @@ class SaveHookMetadataTests(unittest.TestCase):
         self.assertEqual(kwargs["controlnet_lora_adapter_metadata"], {"name": "controlnet"})
         self.assertNotIn("transformer_lora_adapter_metadata", kwargs)
         self.assertIn("text_encoder_lora_adapter_metadata", kwargs)
+
+    def test_save_hook_writes_denoiser_lora_in_peft_naming(self):
+        manager, model, trained_component = self._make_manager()
+
+        lora_state = {
+            "transformer_blocks.0.attn.to_q.lora_A.weight": torch.zeros(4, 8),
+            "transformer_blocks.0.attn.to_q.lora_B.weight": torch.zeros(8, 4),
+            "transformer_blocks.0.ff.up.lora_A.weight": torch.zeros(4, 8),
+            "transformer_blocks.0.ff.up.lora_B.weight": torch.zeros(8, 4),
+        }
+        with patch("simpletuner.helpers.training.save_hooks.get_peft_model_state_dict", return_value=lora_state):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                manager._save_lora(models=[trained_component], weights=[object()], output_dir=tmpdir)
+
+        written = model.save_lora_weights.call_args.kwargs["transformer_lora_layers"]
+        self.assertEqual(set(written), set(lora_state))
+        for key in written:
+            self.assertTrue(key.endswith((".lora_A.weight", ".lora_B.weight")), key)
+            self.assertNotIn(".lora.down", key)
+            self.assertNotIn(".lora.up", key)
+
+    def test_save_hook_never_writes_a_mixed_naming_scheme(self):
+        lora_state = {
+            "transformer_blocks.0.attn.to_q.lora_A.weight": torch.zeros(4, 8),
+            "transformer_blocks.0.attn.to_q.lora_B.weight": torch.zeros(8, 4),
+            "transformer_blocks.0.ff.up.lora_A.weight": torch.zeros(4, 8),
+            "transformer_blocks.0.ff.up.lora_B.weight": torch.zeros(8, 4),
+        }
+
+        for use_ema in (False, True):
+            with self.subTest(use_ema=use_ema):
+                manager, model, trained_component = self._make_manager(args_overrides={"use_ema": use_ema})
+                with patch(
+                    "simpletuner.helpers.training.save_hooks.get_peft_model_state_dict", return_value=lora_state
+                ):
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        manager._save_lora(models=[trained_component], weights=[object()], output_dir=tmpdir)
+
+                calls = model.save_lora_weights.call_args_list
+                self.assertEqual(len(calls), 2 if use_ema else 1)
+                for call in calls:
+                    written = call.kwargs["transformer_lora_layers"]
+                    schemes = {"peft" if (".lora_A." in key or ".lora_B." in key) else "diffusers" for key in written}
+                    self.assertEqual(schemes, {"peft"}, written)
+
+    def test_saved_denoiser_file_uses_peft_naming(self):
+        args = SimpleNamespace(
+            use_ema=False,
+            model_type="lora",
+            lora_type="standard",
+            controlnet=False,
+            validation_using_datasets=False,
+            model_family="sdxl",
+            model_flavour="base-1.0",
+            tracker_run_name="run-name",
+            resolution=1024,
+        )
+        trained_component = _DummyTrainedComponent("transformer")
+        manager = SaveHookManager(
+            args=args,
+            model=_DummyArtifactModel(trained_component=trained_component),
+            ema_model=_ema_stub,
+            accelerator=_DummyAccelerator(),
+            use_deepspeed_optimizer=False,
+        )
+
+        lora_state = {
+            "transformer_blocks.0.attn.to_q.lora_A.weight": torch.zeros(4, 8),
+            "transformer_blocks.0.attn.to_q.lora_B.weight": torch.zeros(8, 4),
+            "transformer_blocks.0.ff.up.lora_A.weight": torch.zeros(4, 8),
+            "transformer_blocks.0.ff.up.lora_B.weight": torch.zeros(8, 4),
+        }
+        with patch("simpletuner.helpers.training.save_hooks.get_peft_model_state_dict", return_value=lora_state):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                manager._save_lora(models=[trained_component], weights=[object()], output_dir=tmpdir)
+                lora_path = os.path.join(tmpdir, "pytorch_lora_weights.safetensors")
+                with safe_open(lora_path, framework="pt", device="cpu") as handle:
+                    written = list(handle.keys())
+
+        self.assertEqual(len(written), len(lora_state))
+        for key in written:
+            self.assertTrue(key.endswith((".lora_A.weight", ".lora_B.weight")), key)
+
+    def test_legacy_mixed_checkpoint_normalises_for_resume(self):
+        from diffusers.utils import convert_unet_state_dict_to_peft
+
+        mixed = {
+            "transformer_blocks.0.attn.to_gate.lora_A.weight": torch.zeros(4, 8),
+            "transformer_blocks.0.attn.to_gate.lora_B.weight": torch.zeros(8, 4),
+            "transformer_blocks.0.attn.to_q.lora.down.weight": torch.zeros(4, 8),
+            "transformer_blocks.0.attn.to_q.lora.up.weight": torch.zeros(8, 4),
+        }
+
+        # safetensors sorts keys, and diffusers' loader gates conversion on the first one alone.
+        self.assertIn("lora_A", sorted(mixed)[0])
+
+        converted = convert_unet_state_dict_to_peft(mixed)
+
+        self.assertEqual(len(converted), len(mixed))
+        for key in converted:
+            self.assertTrue(key.endswith((".lora_A.weight", ".lora_B.weight")), key)
+        self.assertEqual(
+            {key.rsplit(".lora_", 1)[0] for key in converted},
+            {"transformer_blocks.0.attn.to_gate", "transformer_blocks.0.attn.to_q"},
+        )
 
     def test_models_spec_metadata_written_to_lora_file(self):
         manager, _, _ = self._make_manager(


### PR DESCRIPTION
## Summary

`SaveHookManager._save_lora` passes the denoiser adapter through diffusers'
`convert_state_dict_to_diffusers()`. That helper's `PEFT_TO_DIFFUSERS` table is per-leaf and
covers only `to_q` / `to_k` / `to_v` / `to_out.0`. Any other LoRA target — `ff.*`, `to_gate`,
`mlp.*` — matches no rule and passes through with its PEFT name intact, so an intermediate
checkpoint is written with **two naming schemes in one file**.

On load, diffusers decides whether to convert back by inspecting **one key**
(`loaders/peft.py:216-219`). safetensors sorts keys, so on a mixed file the first key is often a
PEFT-named non-attention leaf; the gate concludes "already PEFT", skips the conversion, and every
diffusers-named entry becomes unmatchable and is dropped.

Measured on a wide-target Krea2 run: 256 modules in the file, **128 active after load**. The same
run's final export at the run root is clean, because `trainer.py:6970` already writes
`get_peft_model_state_dict()` verbatim. The controlnet branch at `save_hooks.py:790`, five lines
above the defect and in the same function, does the same. **The asymmetry between those two save
paths is the bug**; this change makes the denoiser branch match what the repository already does
in both neighbouring places.

Scope on disk, from a header-only census of a 16-run tree (256 adapter files): 120 checkpoints are
mixed and every one of them defeats the gate, totalling 30,720 silently dropped tensors. The 120
narrow-run checkpoints are uniformly diffusers-named and load fine — which is why an
attention-only LoRA never exposed this.

Affected consumers are the ones that read the file: third-party `load_lora_weights`,
`--validation_adapter_path`, `--init_lora`, and the EMA adapter export. SimpleTuner's own resume
is unaffected today, because `common.py:1867` calls `convert_unet_state_dict_to_peft`
**unconditionally** with no first-key gate. The loss only shows up once the published checkpoint
is loaded by diffusers or other downstream tooling — which is the artifact users actually share.

### Reproducing it — pick the config carefully

Because one key decides for the whole file, whether a given run is affected is an alphabetical
accident, and **some configurations escape**. On Flux the default `flux_lora_target=all` is
attention-only, so its first sorted key is `single_transformer_blocks.0.attn.to_k.lora.down.weight`,
the gate fires, and the file round-trips losslessly (measured 15/15 modules). The presets that
break are the ones carrying a bare top-level `proj_out` — `all+ffs`, `all+ffs+embedder` and
`ai-toolkit` (`flux/model.py:1155-1156`, `:1193-1194`, `:1216-1217`) — where
`proj_out.lora_A.weight` sorts ahead of every `single_transformer_blocks.*` key, the gate is
skipped, and the whole attention half is dropped: measured 21 → 13 and 24 → 16 modules, 16 tensors
lost in each case. Anyone reproducing this with the default preset will see nothing wrong.

## Changes

- `save_hooks.py:795` (denoiser) and `save_hooks.py:745` (EMA denoiser): write
  `get_peft_model_state_dict(...)` verbatim instead of converting to legacy diffusers naming.
- `lora_format.py:234-253` (`convert_diffusers_to_comfyui`): normalise both spellings first, then
  derive `.alpha` from the normalised key. **This companion change is required, not optional** —
  the function emitted `.alpha` only inside its `.lora.down.` branch, so PEFT-named input produced
  weights with no alpha at all. Without it, `--lora_format=comfyui` would silently lose every
  alpha the moment checkpoints become PEFT-named. The shape used here is the one already in tree
  at `simpletuner/helpers/models/flux2/pipeline.py:176-186`.
- Regression tests: 11 new methods across `tests/test_lora_metadata.py` and a new
  `tests/test_lora_format.py` (no test module existed for `lora_format.py`).

The `lora_format.py` restructure also **subsumes two unreachable branches**. The old chain was:

```python
if ".lora.down." in new_key:            ...
elif new_key.endswith(".lora.down.weight"):   ...   # unreachable
elif ".lora.up." in new_key:            ...
elif new_key.endswith(".lora.up.weight"):     ...   # unreachable
```

Any key ending `.lora.down.weight` necessarily contains `.lora.down.`, so the first branch always
wins and the second can never be entered; the same argument applies to the `.lora.up.` pair. Both
dead branches were strictly narrower duplicates of the branch above them, so folding them in loses
no coverage. This is a consequence of the fix, not a drive-by cleanup — it is called out here so
the deletion is not mistaken for one.

Deliberately **not** changed: the two text-encoder save sites (`save_hooks.py:801`, `:807`), the
final-export text encoders, the `save_hooks.py:15-16` imports (still live via those sites), the
resume-side unconditional convert at `common.py:1867`, the vendored first-key gates, and the
LyCORIS writer. Text-encoder LoRAs target `q_proj/k_proj/v_proj/out_proj`, which
`PEFT_TO_DIFFUSERS` covers in full, so those stay single-scheme either way; and the gate operates
on a dict already filtered to one component by prefix (`loaders/peft.py:200-201`, with
`prefix="transformer"` by default at `:81`), so text-encoder keys can never reach the denoiser's
first key.

## Notes

Two things surfaced while validating this that reviewers should know about. Neither changes the
diff, but both would be misleading by omission.

**1. `q_proj`-named denoisers are already losing keys on resume today.** The
backwards-compatibility argument — old files still resume because `convert_unet_state_dict_to_peft`
has the leaf-agnostic `.lora.down → .lora_A` catch-all — is exact for `to_q/to_k/to_v/to_out.0`
denoisers. It does **not** hold for denoisers whose modules are named
`q_proj/k_proj/v_proj/out_proj` (`heartmula`, `ace_step` v1.5). For those, `PEFT_TO_DIFFUSERS`
rewrites the keys to `.lora_linear_layer.{down,up}`, and `UNET_TO_DIFFUSERS` has no inverse rule,
so they are unmatchable on resume and reported only as `unexpected_keys`. Measured with real
`peft` injection: **16/28 keys restored** from a file written by the current code, versus 28/28
from a file written after this change. This change fixes it going forward; already-written files
additionally need `.lora_linear_layer.down → .lora_A` / `.lora_linear_layer.up → .lora_B` to be
recovered. This is pre-existing and is not addressed here.

**2. Resume takes a different (previously dormant) branch for five model families.** No read-path
line is edited, but `detect_state_dict_format()` (`lora_format.py:42`) labels any dict with
`lora_A`/`lora_B` and no `.lora.down` as ComfyUI. Today the mixed file's diffusers half masks
that; afterwards an intermediate checkpoint classifies as `COMFYUI`, so for the five families with
`AUTO_LORA_FORMAT_DETECTION = True` (flux, flux2, ernie, lumina2, boogu_image) resume now runs
`convert_comfyui_to_diffusers` at `common.py:1853` before the unconditional convert.

Measured on a peft-injected Flux-shaped module, the round trip is the **identity**: 36/36 keys
restored with 0 unexpected, and 54/54 with `use_dora=True` — `convert_comfyui_to_diffusers`
rewrites `lora_A → lora.down` and `common.py:1867` rewrites it straight back. The run-root export
already classifies the same way today, so this routing is not new to the codebase, only newly
reached by intermediate checkpoints. Tightening the `comfy_prefix_hits >= 0` condition at
`lora_format.py:42` (it is vacuously true) is a separate change and is not required here.

Also unchanged by design: `save_hooks.py:795` keys off `MODEL_SUBFOLDER` while `trainer.py:6970`
uses `MODEL_TYPE.value`, and `_apply_modelspec_metadata_to_lora` runs only for intermediate
checkpoints. Both are pre-existing and orthogonal.

## Known limitation

**The end-to-end success criterion has not been verified at runtime.** No training run was
performed for this change: every measurement above is either a header-level read of real
artifacts, or a state-dict-level simulation using real `peft.inject_adapter_in_model` +
`set_peft_model_state_dict` against real checkpoint tensors — never a full training step or a
numerical inference run. Specifically **not** verified: that a checkpoint written by a patched
training run is 100% `lora_A`/`lora_B` on disk and loads 256/256 through a real pipeline. Unit
tests cover the save path down to the written `.safetensors`, but a real run has not been done.
Reviewers who can spare a GPU should exercise that path before merging.

Reproductions were executed on diffusers 0.39.0. The behaviour of `loaders/peft.py` and both
conversion tables was confirmed byte-identical in v0.36.0 by source comparison, but not executed
there; 0.37 and 0.38 were not checked.

## Verification

CPU-only container, upstream `main` @ `2d6df1245`, diffusers 0.39.0 / peft 0.20.0 / torch 2.13.0.

```
12 existing LoRA-related test modules   181 -> 185 passing
+ new tests/test_lora_format.py                  192 passing
```

Eleven new test methods; **five confirmed RED on unpatched `main`** (six failures counting
subTests):

- the denoiser save writes PEFT names
- the written `.safetensors` itself carries only `.lora_A` / `.lora_B`
- no mixed-scheme dict is produced by the denoiser branch
- ...nor by the EMA branch, which had **zero** test coverage before this change
- `convert_diffusers_to_comfyui` emits `.alpha` for PEFT-named input, and converts both spellings
  to the same key set

The artifact-level test drives `_save_lora` through the real `ModelFoundation.save_lora_weights`
and reads the file back, rather than asserting at a mock boundary. That is deliberate:
`save_lora_weights` is the layer that already owns the ComfyUI conversion, so it is where a future
"consolidate the conversions" refactor would most plausibly reintroduce this defect, and a
mock-boundary assertion cannot see that.

The remaining tests are characterization pins that pass either way — including one asserting that
a legacy mixed dict still normalises through `convert_unet_state_dict_to_peft`, which exists to
keep the backwards-compatibility guarantee from regressing.