### PR TITLE
add licensing info to feature matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,29 +81,73 @@ For deployment details, see the [Enterprise Guide](/documentation/experimental/s
 
 ### Model Architecture Support
 
-| Model | Parameters | PEFT LoRA | Lycoris | Full-Rank | ControlNet | Ref Inputs | Quantization | Flow Matching | Text Encoders |
-|-------|------------|-----------|---------|-----------|------------|------------|--------------|---------------|---------------|
-| **Stable Diffusion XL** | 3.5B | ✓ | ✓ | ✓ | ✓ | ✗ | int8/nf4 | ✗ | CLIP-L/G |
-| **Stable Diffusion 3** | 2B-8B | ✓ | ✓ | ✓* | ✓ | ✗ | int8/fp8/nf4 | ✓ | CLIP-L/G + T5-XXL |
-| **Flux.1** | 12B | ✓ | ✓ | ✓* | ✓ | ✓ (Kontext) | int8/fp8/nf4 | ✓ | CLIP-L + T5-XXL |
-| **Flux.2** | 32B | ✓ | ✓ | ✓* | ✗ | ✓ opt | int8/fp8/nf4 | ✓ | Mistral-3 Small |
-| **Ideogram 4** | 9B | ✓ | ✓ | ✓* | ✗ | ✗ | fp8/nf4 | ✓ | Qwen3-VL |
-| **ACE-Step** | 3.5B | ✓ | ✓ | ✓* | ✗ | ✗ | int8 | ✓ | UMT5 |
-| **HeartMuLa** | 3B | ✓ | ✓ | ✓* | ✗ | ✗ | int8 | ✗ | None |
-| **Chroma 1** | 8.9B | ✓ | ✓ | ✓* | ✗ | ✗ | int8/fp8/nf4 | ✓ | T5-XXL |
-| **Auraflow** | 6.8B | ✓ | ✓ | ✓* | ✓ | ✗ | int8/fp8/nf4 | ✓ | UMT5-XXL |
-| **PixArt Sigma** | 0.6B-0.9B | ✗ | ✓ | ✓ | ✓ | ✗ | int8 | ✗ | T5-XXL |
-| **Sana** | 0.6B-4.8B | ✗ | ✓ | ✓ | ✗ | ✗ | int8 | ✓ | Gemma2-2B |
-| **Lumina2** | 2B | ✓ | ✓ | ✓ | ✗ | ✗ | int8 | ✓ | Gemma2 |
-| **Kwai Kolors** | 5B | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ChatGLM-6B |
-| **LTX Video** | 5B | ✓ | ✓ | ✓ | ✗ | ✓ I2V | int8/fp8 | ✓ | T5-XXL |
-| **LTX Video 2** | 19B | ✓ | ✓ | ✓* | ✗ | ✓ opt | int8/fp8 | ✓ | Gemma3 |
-| **Wan Video** | 1.3B-14B | ✓ | ✓ | ✓* | ✗ | ✗ | int8 | ✓ | UMT5 |
-| **HiDream** | 17B (8.5B MoE) | ✓ | ✓ | ✓* | ✓ | ✗ | int8/fp8/nf4 | ✓ | CLIP-L + T5-XXL + Llama |
-| **Cosmos2** | 2B-14B | ✗ | ✓ | ✓ | ✗ | ✗ | int8 | ✓ | T5-XXL |
-| **OmniGen** | 3.8B | ✓ | ✓ | ✓ | ✗ | ✗ | int8/fp8 | ✓ | T5-XXL |
-| **Qwen Image** | 20B | ✓ | ✓ | ✓* | ✗ | ✓ req (Edit) | int8/nf4 (req.) | ✓ | T5-XXL |
-| **SD 1.x/2.x (Legacy)** | 0.9B | ✓ | ✓ | ✓ | ✓ | ✗ | int8/nf4 | ✗ | CLIP-L |
+| Model | Parameters | PEFT LoRA | Lycoris | Full-Rank | ControlNet | Ref Inputs | Quantization | Flow Matching | Text Encoders | License | Allows commercial use |
+| ------- | ------------ | ----------- | --------- | ----------- | ------------ | ------------ | -------------- | --------------- | --------------- | ------- | :---: |
+| **Stable Diffusion XL** | 3.5B | ✓ | ✓ | ✓ | ✓ | ✗ | int8/nf4 | ✗ | CLIP-L/G | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | Conditions apply<sup>1</sup> |
+| **Stable Diffusion 3** | 2B-8B | ✓ | ✓ | ✓* | ✓ | ✗ | int8/fp8/nf4 | ✓ | CLIP-L/G + T5-XXL | [Stability AI Community](https://stability.ai/license) | Conditions apply<sup>2</sup> |
+| **Flux.1** | 12B | ✓ | ✓ | ✓* | ✓ | ✓ (Kontext) | int8/fp8/nf4 | ✓ | CLIP-L + T5-XXL | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Conditions apply<sup>3</sup> |
+| **Flux.2** | 32B | ✓ | ✓ | ✓* | ✗ | ✓ opt | int8/fp8/nf4 | ✓ | Mistral-3 Small | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Conditions apply<sup>4</sup> |
+| **Ideogram 4** | 9B | ✓ | ✓ | ✓* | ✗ | ✗ | fp8/nf4 | ✓ | Qwen3-VL | [Ideogram 4 Non-Commercial](https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md) | No<sup>5</sup> |
+| **Z-Image** | 6B | ✓ | ✓ | ✓* | ✗ | ✗ | int8 | ✓ | Qwen3 4B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes |
+| **Z-Image Omni** | 6B | ✓ | ✓ | ✓* | ✗ | ✓ edit | int8/fp8/nf4 | ✓ | Qwen3 4B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes |
+| **Krea2** | - | ✓ | ✓ | ✓* | ✗ | ✓ opt | int8 | ✓ | Qwen3-VL | [Krea 2 Community](https://www.krea.ai/krea-2-licensing) | Conditions apply<sup>6</sup> |
+| **Anima** | 2B | ✓ | ✓ | ✓* | ✗ | ✗ | not recommended | ✓ | Qwen3 0.6B | [CircleStone Labs Non-Commercial](https://huggingface.co/circlestone-labs/Anima/blob/main/LICENSE.md) | No<sup>5</sup> |
+| **Mage-Flow** | 4B | ✓ | ✓ | ✓* | ✗ | ✓ edit | int8/fp8 | ✓ | Qwen3-VL | [MIT](https://opensource.org/license/mit) | Yes |
+| **Boogu-Image** | - | ✓ | ✓ | ✓* | ✗ | ✓ edit | fp8 | ✓ | Qwen3-VL | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes |
+| **zlab i1** | 3B | ✓ | ✓ | ✓ | ✗ | ✗ | int8 | ✓ | T5Gemma 2B | [Unspecified](https://huggingface.co/bghira/zlab-i1-diffusers) | Conditions apply<sup>12</sup> |
+| **ERNIE-Image** | - | ✓ | ✓ | ✓* | ✗ | ✗ | int8 | ✓ | ERNIE | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes |
+| **ACE-Step** | 3.5B | ✓ | ✓ | ✓* | ✗ | ✗ | int8 | ✓ | UMT5 | [Apache-2.0](https://huggingface.co/ACE-Step/ACE-Step-v1-3.5B) / [MIT](https://huggingface.co/ACE-Step/Ace-Step1.5) | Yes |
+| **HeartMuLa** | 3B | ✓ | ✓ | ✓* | ✗ | ✗ | int8 | ✗ | None | [Apache-2.0](https://huggingface.co/HeartMuLa/HeartMuLa-oss-3B) | Yes |
+| **Chroma 1** | 8.9B | ✓ | ✓ | ✓* | ✗ | ✗ | int8/fp8/nf4 | ✓ | T5-XXL | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes |
+| **Auraflow** | 6.8B | ✓ | ✓ | ✓* | ✓ | ✗ | int8/fp8/nf4 | ✓ | UMT5-XXL | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) / [Pony License](https://huggingface.co/purplesmartai/pony-v7-base/blob/main/LICENSE) | Conditions apply<sup>8</sup> |
+| **PixArt Sigma** | 0.6B-0.9B | ✗ | ✓ | ✓ | ✓ | ✗ | int8 | ✗ | T5-XXL | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | Conditions apply<sup>1</sup> |
+| **Sana** | 0.6B-4.8B | ✗ | ✓ | ✓ | ✗ | ✗ | int8 | ✓ | Gemma2-2B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes |
+| **Lumina2** | 2B | ✓ | ✓ | ✓ | ✗ | ✗ | int8 | ✓ | Gemma2 | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes |
+| **Kwai Kolors** | 5B | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ChatGLM-6B | [Kwai Kolors License](https://huggingface.co/terminusresearch/kwai-kolors-1.0/blob/main/MODEL_LICENSE) | Conditions apply<sup>7</sup> |
+| **LTX Video** | 5B | ✓ | ✓ | ✓ | ✗ | ✓ I2V | int8/fp8 | ✓ | T5-XXL | [LTX Video OpenRAIL-M](https://huggingface.co/Lightricks/LTX-Video-0.9.5/blob/main/ltx-video-2b-v0.9.5.license.txt) | Conditions apply<sup>10</sup> |
+| **LTX Video 2** | 19B | ✓ | ✓ | ✓* | ✗ | ✓ opt | int8/fp8 | ✓ | Gemma3 | [LTX-2 Community](https://ltx.io/model/license) | Conditions apply<sup>10</sup> |
+| **Wan Video** | 1.3B-14B | ✓ | ✓ | ✓* | ✗ | ✗ | int8 | ✓ | UMT5 | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes |
+| **Wan S2V** | 14B | ✓ | ✓ | ✓* | ✗ | audio req | int8 | ✓ | UMT5 | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes |
+| **HiDream** | 17B (8.5B MoE) | ✓ | ✓ | ✓* | ✓ | ✗ | int8/fp8/nf4 | ✓ | CLIP-L + T5-XXL + Llama | [MIT](https://opensource.org/license/mit) | Yes |
+| **Cosmos2** | 2B-14B | ✗ | ✓ | ✓ | ✗ | ✗ | int8 | ✓ | T5-XXL | [NVIDIA Open Model License](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) | Yes<sup>9</sup> |
+| **Cosmos3** | 4B-65B | ✓ | ✓ | ✓* | ✗ | ✓ I2V/audio | no_change first | ✓ | built-in | [OpenMDW 1.1](https://github.com/OpenMDW/openmdw/blob/main/1.1/LICENSE.OpenMDW-1.1) | Yes |
+| **Hunyuan Video 1.5** | 8.3B | ✓ | ✓ | ✓* | ✗ | ✓ I2V | int8 | ✓ | Hunyuan LLM + CLIP | [Tencent Hunyuan Community](https://huggingface.co/tencent/HunyuanVideo-1.5/blob/main/LICENSE) | Conditions apply<sup>11</sup> |
+| **SanaVideo** | 2B | ✓ | ✓ | ✓* | ✗ | ✗ | int8/fp8 | ✓ | Gemma2 | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes |
+| **Kandinsky 5.0 Image** | 6B | ✓ | ✓ | ✓* | ✗ | ✓ I2I | int8 | ✓ | Qwen2.5-VL | [MIT](https://opensource.org/license/mit) | Yes |
+| **Kandinsky 5.0 Video** | 2B-19B | ✓ | ✓ | ✓* | ✗ | ✓ I2V | int8 | ✓ | Qwen2.5-VL | [MIT](https://opensource.org/license/mit) | Yes |
+| **LongCat-Image** | 6B | ✓ | ✓ | ✓* | ✗ | ✓ edit | int8/fp8 | ✓ | Qwen2.5-VL | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes |
+| **LongCat-Video** | 13.6B | ✓ | ✓ | ✓* | ✗ | ✓ I2V/edit | int8/fp8 | ✓ | Qwen2.5-VL | [MIT](https://opensource.org/license/mit) | Yes |
+| **OmniGen** | 3.8B | ✓ | ✓ | ✓ | ✗ | ✗ | int8/fp8 | ✓ | T5-XXL | [MIT](https://opensource.org/license/mit) | Yes |
+| **Qwen Image** | 20B | ✓ | ✓ | ✓* | ✗ | ✓ req (Edit) | int8/nf4 (req.) | ✓ | T5-XXL | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes |
+| **DeepFloyd IF** | 0.4B-4.3B | ✓ | ✓ | ✓ | ✗ | ✓ SR | int8/fp8 | ✗ | T5-XXL | [DeepFloyd IF License](https://huggingface.co/DeepFloyd/IF-I-M-v1.0) | No<sup>5</sup> |
+| **Stable Cascade (C)** | 1B, 3.6B prior | ✓ | ✓ | ✓* | ✗ | ✗ | not supported | ✗ | CLIP-bigG | [Stable Cascade NC Community](https://huggingface.co/stabilityai/stable-cascade/blob/main/LICENSE) | No<sup>5</sup> |
+| **SD 1.x/2.x (Legacy)** | 0.9B | ✓ | ✓ | ✓ | ✓ | ✗ | int8/nf4 | ✗ | CLIP-L | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | Conditions apply<sup>1</sup> |
+
+*Commercial-use status covers model weights, derivative checkpoints, fine-tunes, and hosted model use. Generated-output rights can differ; read the linked license text before commercial deployment.*
+
+<sup>1</sup> OpenRAIL-style licenses generally permit commercial use with usage restrictions that remain attached to the model and derivatives.
+
+<sup>2</sup> Stability AI Community License is available for qualifying users below the revenue threshold; larger commercial use needs Stability enterprise terms.
+
+<sup>3</sup> Flux.1 varies by flavour: Schnell and LibreFlux are Apache-2.0, while Dev, Krea, and Kontext use BFL non-commercial terms; review FluxBooru upstream metadata before commercial use.
+
+<sup>4</sup> Flux.2 varies by flavour: Klein 4B is Apache-2.0, while Dev and Klein 9B use BFL non-commercial terms.
+
+<sup>5</sup> Public non-commercial model terms do not permit commercial use of weights, derivative checkpoints, or hosted model services without a separate license.
+
+<sup>6</sup> Krea 2 Community License permits commercial use only under its revenue and safety/filtering requirements; otherwise an enterprise license is required.
+
+<sup>7</sup> Kolors commercial model or derivative use requires applying for and receiving explicit permission from the licensor.
+
+<sup>8</sup> AuraFlow supports Apache-2.0 upstream flavours and a Pony flavour with a separate custom license; check the selected flavour.
+
+<sup>9</sup> NVIDIA Open Model License permits commercial use but includes agreement, acceptable-use, and export-control terms.
+
+<sup>10</sup> LTX Video 0.9.5 uses OpenRAIL-M; LTX Video 2 uses LTX community terms with a revenue threshold for commercial use.
+
+<sup>11</sup> Tencent Hunyuan Community License includes territorial exclusions and a commercial threshold for very large services.
+
+<sup>12</sup> This mirror publishes `license: other` without a standard license text; review upstream terms before commercial use.
 
 *✓ = Supported, ✗ = Not supported, * = Requires DeepSpeed for full-rank training, Ref Inputs marks existing reference/edit/I2V conditioning paths only*
 

--- a/documentation/QUICKSTART.es.md
+++ b/documentation/QUICKSTART.es.md
@@ -8,45 +8,74 @@ Para la matriz de funciones completa y más precisa, consulta el [README princip
 
 ## Guías de inicio rápido por modelo
 
-| Modelo | Parámetros | PEFT LoRA | Lycoris | Rango completo | Cuantización | Precisión mixta | Checkpointing de gradiente | Flow Shift | TwinFlow | Self-Flow | LayerSync | Ref Inputs | ControlNet | Sliders† | Guía |
-| --- | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | --- |
-| PixArt Sigma | 0.6B–0.9B | ✗ | ✓ | ✓ | int8 opcional | bf16 | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | [SIGMA.md](quickstart/SIGMA.md) |
-| NVLabs Sana | 1.6B–4.8B | ✗ | ✓ | ✓ | int8 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [SANA.md](quickstart/SANA.md) |
-| Kwai Kolors | 2.7B | ✓ | ✓ | ✓ | no recomendado | bf16 | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [KOLORS.md](quickstart/KOLORS.md) |
-| Stable Diffusion 3 | 2B–8B | ✓ | ✓ | ✓ | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [SD3.md](quickstart/SD3.md) |
-| Flux.1 | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [FLUX.md](quickstart/FLUX.md) |
-| Flux.2 | 32B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [FLUX2.md](quickstart/FLUX2.md) |
-| Flux Kontext | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✓ | ✓ | [FLUX_KONTEXT.md](quickstart/FLUX_KONTEXT.md) |
-| Z-Image Turbo | 6B | ✓ | ✗ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [ZIMAGE.md](quickstart/ZIMAGE.md) |
-| Krea2 | - | ✓ | ✗ | ✓* | int8 opcional | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✓ opt | ✗ | ✓ | [KREA2.md](quickstart/KREA2.es.md) |
-| Boogu-Image 0.1 | - | ✓ | ✓ | ✓* | fp8 opcional | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ edit | ✗ | ✓ | [BOOGU_IMAGE.md](quickstart/BOOGU_IMAGE.es.md) |
-| zlab i1 | 3B | ✓ | ✓ | ✓ | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [ZLAB_i1.md](quickstart/ZLAB_i1.es.md) |
-| Ideogram 4 | 9B | ✓ | ✓ | ✓* | fp8 predeterminado, nf4 opcional | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [IDEOGRAM4.md](quickstart/IDEOGRAM4.es.md) |
-| ACE-Step | 3.5B | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | [ACE_STEP.md](quickstart/ACE_STEP.md) |
-| Chroma 1 | 8.9B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [CHROMA.md](quickstart/CHROMA.md) |
-| Auraflow | 6B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [AURAFLOW.md](quickstart/AURAFLOW.md) |
-| HiDream I1 | 17B (8.5B MoE) | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [HIDREAM.md](quickstart/HIDREAM.md) |
-| OmniGen | 3.8B | ✓ | ✓ | ✓ | int8/fp8 opcional | bf16 | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | [OMNIGEN.md](quickstart/OMNIGEN.md) |
-| Stable Diffusion XL | 2.6B | ✓ | ✓ | ✓ | no recomendado | bf16 | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | [SDXL.md](quickstart/SDXL.md) |
-| Lumina2 | 2B | ✓ | ✓ | ✓ | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | [LUMINA2.md](quickstart/LUMINA2.md) |
-| Cosmos2 | 2B | ✓ | ✓ | ✓ | no recomendado | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [COSMOS2IMAGE.md](quickstart/COSMOS2IMAGE.md) |
-| Cosmos3 | 16B-65B | ✓ | ✓ | ✓* | no_change primero | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | audio opt | ✗ | ✓ | [COSMOS3.md](quickstart/COSMOS3.es.md) |
-| LTX Video | ~2.5B | ✓ | ✓ | ✓ | int8/fp8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [LTXVIDEO.md](quickstart/LTXVIDEO.md) |
-| LTX Video 2 | 19B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [LTXVIDEO2.md](quickstart/LTXVIDEO2.md) |
-| Hunyuan Video 1.5 | 8.3B | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [HUNYUANVIDEO.md](quickstart/HUNYUANVIDEO.md) |
-| Wan 2.x | 1.3B–14B | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [WAN.md](quickstart/WAN.md) |
-| Wan 2.2 S2V | 14B | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [WAN_S2V.md](quickstart/WAN_S2V.md) |
-| Qwen Image | 20B | ✓ | ✓ | ✓* | **requerido** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [QWEN_IMAGE.md](quickstart/QWEN_IMAGE.md) |
-| Qwen Image Edit | 20B | ✓ | ✓ | ✓* | **requerido** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [QWEN_EDIT.md](quickstart/QWEN_EDIT.md) |
-| Stable Cascade (C) | 1B, prior 3.6B | ✓ | ✓ | ✓* | no soportado | fp32 (requerido) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [STABLE_CASCADE_C.md](quickstart/STABLE_CASCADE_C.md) |
-| Kandinsky 5.0 Image | 6B (lite) | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ I2I | ✗ | ✓ | [KANDINSKY5_IMAGE.md](quickstart/KANDINSKY5_IMAGE.md) |
-| Kandinsky 5.0 Video | 2B (lite), 19B (pro) | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [KANDINSKY5_VIDEO.md](quickstart/KANDINSKY5_VIDEO.md) |
-| LongCat-Video | 13.6B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [LONGCAT_VIDEO.md](quickstart/LONGCAT_VIDEO.md) |
-| LongCat-Video Edit | 13.6B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [LONGCAT_VIDEO_EDIT.md](quickstart/LONGCAT_VIDEO_EDIT.md) |
-| LongCat-Image | 6B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [LONGCAT_IMAGE.md](quickstart/LONGCAT_IMAGE.md) |
-| LongCat-Image Edit | 6B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [LONGCAT_EDIT.md](quickstart/LONGCAT_EDIT.md) |
+| Modelo | Parámetros | PEFT LoRA | Lycoris | Rango completo | Cuantización | Precisión mixta | Checkpointing de gradiente | Flow Shift | TwinFlow | Self-Flow | LayerSync | Ref Inputs | ControlNet | Sliders† | Licencia | Permite uso comercial | Guía |
+| --- | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | --- | :---: | --- |
+| PixArt Sigma | 0.6B–0.9B | ✗ | ✓ | ✓ | int8 opcional | bf16 | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | Aplican condiciones<sup>1</sup> | [SIGMA.md](quickstart/SIGMA.md) |
+| NVLabs Sana | 1.6B–4.8B | ✗ | ✓ | ✓ | int8 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [SANA.md](quickstart/SANA.md) |
+| Kwai Kolors | 2.7B | ✓ | ✓ | ✓ | no recomendado | bf16 | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [Kwai Kolors License](https://huggingface.co/terminusresearch/kwai-kolors-1.0/blob/main/MODEL_LICENSE) | Aplican condiciones<sup>7</sup> | [KOLORS.md](quickstart/KOLORS.md) |
+| Stable Diffusion 3 | 2B–8B | ✓ | ✓ | ✓ | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [Stability AI Community](https://stability.ai/license) | Aplican condiciones<sup>2</sup> | [SD3.md](quickstart/SD3.md) |
+| Flux.1 | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Aplican condiciones<sup>3</sup> | [FLUX.md](quickstart/FLUX.md) |
+| Flux.2 | 32B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Aplican condiciones<sup>4</sup> | [FLUX2.md](quickstart/FLUX2.md) |
+| Flux Kontext | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✓ | ✓ | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) | No<sup>5</sup> | [FLUX_KONTEXT.md](quickstart/FLUX_KONTEXT.md) |
+| Z-Image Turbo | 6B | ✓ | ✗ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [ZIMAGE.md](quickstart/ZIMAGE.md) |
+| Krea2 | - | ✓ | ✗ | ✓* | int8 opcional | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✓ opt | ✗ | ✓ | [Krea 2 Community](https://www.krea.ai/krea-2-licensing) | Aplican condiciones<sup>6</sup> | [KREA2.md](quickstart/KREA2.es.md) |
+| Mage-Flow | 4B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ edit | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | Sí | [MAGEFLOW.md](quickstart/MAGEFLOW.es.md) |
+| Boogu-Image 0.1 | - | ✓ | ✓ | ✓* | fp8 opcional | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ edit | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [BOOGU_IMAGE.md](quickstart/BOOGU_IMAGE.es.md) |
+| zlab i1 | 3B | ✓ | ✓ | ✓ | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Unspecified](https://huggingface.co/bghira/zlab-i1-diffusers) | Aplican condiciones<sup>12</sup> | [ZLAB_i1.md](quickstart/ZLAB_i1.es.md) |
+| Ideogram 4 | 9B | ✓ | ✓ | ✓* | fp8 predeterminado, nf4 opcional | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [Ideogram 4 Non-Commercial](https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md) | No<sup>5</sup> | [IDEOGRAM4.md](quickstart/IDEOGRAM4.es.md) |
+| ERNIE-Image | - | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [ERNIE.md](quickstart/ERNIE.es.md) |
+| ACE-Step | 3.5B | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://huggingface.co/ACE-Step/ACE-Step-v1-3.5B) / [MIT](https://huggingface.co/ACE-Step/Ace-Step1.5) | Sí | [ACE_STEP.md](quickstart/ACE_STEP.md) |
+| Chroma 1 | 8.9B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [CHROMA.md](quickstart/CHROMA.md) |
+| Auraflow | 6B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) / [Pony License](https://huggingface.co/purplesmartai/pony-v7-base/blob/main/LICENSE) | Aplican condiciones<sup>8</sup> | [AURAFLOW.md](quickstart/AURAFLOW.md) |
+| HiDream I1 | 17B (8.5B MoE) | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [MIT](https://opensource.org/license/mit) | Sí | [HIDREAM.md](quickstart/HIDREAM.md) |
+| OmniGen | 3.8B | ✓ | ✓ | ✓ | int8/fp8 opcional | bf16 | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | Sí | [OMNIGEN.md](quickstart/OMNIGEN.md) |
+| Stable Diffusion XL | 2.6B | ✓ | ✓ | ✓ | no recomendado | bf16 | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | Aplican condiciones<sup>1</sup> | [SDXL.md](quickstart/SDXL.md) |
+| Lumina2 | 2B | ✓ | ✓ | ✓ | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [LUMINA2.md](quickstart/LUMINA2.md) |
+| Cosmos2 | 2B | ✓ | ✓ | ✓ | no recomendado | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [NVIDIA Open Model License](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) | Sí<sup>9</sup> | [COSMOS2IMAGE.md](quickstart/COSMOS2IMAGE.md) |
+| Cosmos3 | 16B-65B | ✓ | ✓ | ✓* | no_change primero | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | audio opt | ✗ | ✓ | [OpenMDW 1.1](https://github.com/OpenMDW/openmdw/blob/main/1.1/LICENSE.OpenMDW-1.1) | Sí | [COSMOS3.md](quickstart/COSMOS3.es.md) |
+| LTX Video | ~2.5B | ✓ | ✓ | ✓ | int8/fp8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [LTX Video OpenRAIL-M](https://huggingface.co/Lightricks/LTX-Video-0.9.5/blob/main/ltx-video-2b-v0.9.5.license.txt) | Aplican condiciones<sup>10</sup> | [LTXVIDEO.md](quickstart/LTXVIDEO.md) |
+| LTX Video 2 | 19B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [LTX-2 Community](https://ltx.io/model/license) | Aplican condiciones<sup>10</sup> | [LTXVIDEO2.md](quickstart/LTXVIDEO2.md) |
+| Hunyuan Video 1.5 | 8.3B | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [Tencent Hunyuan Community](https://huggingface.co/tencent/HunyuanVideo-1.5/blob/main/LICENSE) | Aplican condiciones<sup>11</sup> | [HUNYUANVIDEO.md](quickstart/HUNYUANVIDEO.md) |
+| SanaVideo | 2B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [SANAVIDEO.md](quickstart/SANAVIDEO.es.md) |
+| Wan 2.x | 1.3B–14B | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [WAN.md](quickstart/WAN.md) |
+| Wan 2.2 S2V | 14B | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [WAN_S2V.md](quickstart/WAN_S2V.md) |
+| Qwen Image | 20B | ✓ | ✓ | ✓* | **requerido** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [QWEN_IMAGE.md](quickstart/QWEN_IMAGE.md) |
+| Qwen Image Edit | 20B | ✓ | ✓ | ✓* | **requerido** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [QWEN_EDIT.md](quickstart/QWEN_EDIT.md) |
+| Stable Cascade (C) | 1B, prior 3.6B | ✓ | ✓ | ✓* | no soportado | fp32 (requerido) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [Stable Cascade NC Community](https://huggingface.co/stabilityai/stable-cascade/blob/main/LICENSE) | No<sup>5</sup> | [STABLE_CASCADE_C.md](quickstart/STABLE_CASCADE_C.md) |
+| Kandinsky 5.0 Image | 6B (lite) | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ I2I | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | Sí | [KANDINSKY5_IMAGE.md](quickstart/KANDINSKY5_IMAGE.md) |
+| Kandinsky 5.0 Video | 2B (lite), 19B (pro) | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | Sí | [KANDINSKY5_VIDEO.md](quickstart/KANDINSKY5_VIDEO.md) |
+| LongCat-Video | 13.6B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | Sí | [LONGCAT_VIDEO.md](quickstart/LONGCAT_VIDEO.md) |
+| LongCat-Video Edit | 13.6B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | Sí | [LONGCAT_VIDEO_EDIT.md](quickstart/LONGCAT_VIDEO_EDIT.md) |
+| LongCat-Image | 6B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [LONGCAT_IMAGE.md](quickstart/LONGCAT_IMAGE.md) |
+| LongCat-Image Edit | 6B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [LONGCAT_EDIT.md](quickstart/LONGCAT_EDIT.md) |
 
 *✓ = soportado, ✓* = requiere DeepSpeed/FSDP2 para rango completo, ✗ = no soportado, `✓+` indica que se recomienda checkpointing por presión de VRAM. Ref Inputs marca rutas existentes de condicionamiento por referencia/edición/I2V; `opt` significa opcional y `req` significa requerido por el flavour de edición/I2V. TwinFlow ✓ significa soporte nativo cuando `twinflow_enabled=true` (los modelos de difusión necesitan `diff2flow_enabled+twinflow_allow_diff2flow`). Self-Flow ✓ significa soporte nativo para `crepa_enabled=true` con `crepa_feature_source=self_flow`, `use_ema=true` y `crepa_teacher_block_index` configurado. LayerSync ✓ significa que el backbone expone estados ocultos del transformer para autoalineación; ✗ marca backbones tipo UNet sin ese buffer. †Sliders aplican a LoRA y LyCORIS (incluido LyCORIS de rango completo “full”).*
+
+**Notas de licencia:** El estado de uso comercial cubre pesos del modelo, checkpoints derivados, fine-tunes y uso del modelo alojado. Los derechos sobre salidas generadas pueden diferir; lee el texto de licencia enlazado antes de un despliegue comercial.
+
+<sup>1</sup> Las licencias estilo OpenRAIL suelen permitir uso comercial con restricciones de uso que siguen aplicando al modelo y sus derivados.
+
+<sup>2</sup> La Stability AI Community License está disponible para usuarios que califican por debajo del umbral de ingresos; el uso comercial mayor requiere términos empresariales de Stability.
+
+<sup>3</sup> Flux.1 varía por flavour: Schnell y LibreFlux son Apache-2.0, mientras que Dev, Krea y Kontext usan términos no comerciales de BFL; revisa los metadatos upstream de FluxBooru antes de uso comercial.
+
+<sup>4</sup> Flux.2 varía por flavour: Klein 4B es Apache-2.0, mientras que Dev y Klein 9B usan términos no comerciales de BFL.
+
+<sup>5</sup> Los términos públicos no comerciales no permiten uso comercial de pesos, checkpoints derivados o servicios alojados del modelo sin una licencia separada.
+
+<sup>6</sup> La Krea 2 Community License permite uso comercial solo bajo sus requisitos de ingresos y seguridad/filtrado; de lo contrario se requiere una licencia empresarial.
+
+<sup>7</sup> El uso comercial del modelo Kolors o sus derivados requiere solicitar y recibir permiso explícito del licenciante.
+
+<sup>8</sup> AuraFlow admite flavours upstream Apache-2.0 y un flavour Pony con una licencia personalizada separada; revisa el flavour seleccionado.
+
+<sup>9</sup> La NVIDIA Open Model License permite uso comercial, pero incluye términos de acuerdo, uso aceptable y control de exportación.
+
+<sup>10</sup> LTX Video 0.9.5 usa OpenRAIL-M; LTX Video 2 usa términos comunitarios de LTX con un umbral de ingresos para uso comercial.
+
+<sup>11</sup> La Tencent Hunyuan Community License incluye exclusiones territoriales y un umbral comercial para servicios muy grandes.
+
+<sup>12</sup> Este mirror publica `license: other` sin un texto de licencia estándar; revisa los términos upstream antes de uso comercial.
 
 > ℹ️ El inicio rápido de Wan incluye presets de las etapas 2.1 y 2.2 y el toggle de time-embedding. Flux Kontext cubre flujos de edición construidos sobre Flux.1.
 
@@ -76,4 +105,4 @@ Si tu dataset termina con menos muestras utilizables de lo esperado, los archivo
 - En la WebUI, navega al directorio de tu dataset y selecciónalo para ver estadísticas de filtrado
 - Revisa los logs durante el procesamiento del dataset para estadísticas como: `Sample processing statistics: {'total_processed': 100, 'skipped': {'too_small': 15, ...}}`
 
-Para solución de problemas detallada, consulta [Solución de problemas de datasets filtrados](DATALOADER.es.md#solución-de-problemas-de-datasets-filtrados) en la documentación del dataloader.
+Para solución de problemas detallada, consulta [Solución de problemas de datasets filtrados](DATALOADER.es.md) en la documentación del dataloader.

--- a/documentation/QUICKSTART.hi.md
+++ b/documentation/QUICKSTART.hi.md
@@ -8,45 +8,74 @@
 
 ## मॉडल क्विकस्टार्ट गाइड
 
-| मॉडल | पैरामीटर | PEFT LoRA | Lycoris | फुल-रैंक | क्वांटाइज़ेशन | मिक्स्ड प्रिसिजन | ग्रैड चेकपॉइंट | फ्लो शिफ्ट | TwinFlow | Self-Flow | LayerSync | Ref Inputs | ControlNet | Sliders† | गाइड |
-| --- | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | --- |
-| PixArt Sigma | 0.6B–0.9B | ✗ | ✓ | ✓ | int8 वैकल्पिक | bf16 | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | [SIGMA.md](quickstart/SIGMA.md) |
-| NVLabs Sana | 1.6B–4.8B | ✗ | ✓ | ✓ | int8 वैकल्पिक | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [SANA.md](quickstart/SANA.md) |
-| Kwai Kolors | 2.7B | ✓ | ✓ | ✓ | अनुशंसित नहीं | bf16 | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [KOLORS.md](quickstart/KOLORS.md) |
-| Stable Diffusion 3 | 2B–8B | ✓ | ✓ | ✓ | int8/fp8/nf4 वैकल्पिक | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [SD3.md](quickstart/SD3.md) |
-| Flux.1 | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 वैकल्पिक | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [FLUX.md](quickstart/FLUX.md) |
-| Flux.2 | 32B | ✓ | ✓ | ✓* | int8/fp8/nf4 वैकल्पिक | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [FLUX2.md](quickstart/FLUX2.md) |
-| Flux Kontext | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 वैकल्पिक | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✓ | ✓ | [FLUX_KONTEXT.md](quickstart/FLUX_KONTEXT.md) |
-| Z-Image Turbo | 6B | ✓ | ✗ | ✓* | int8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [ZIMAGE.md](quickstart/ZIMAGE.md) |
-| Krea2 | - | ✓ | ✗ | ✓* | int8 वैकल्पिक | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✓ opt | ✗ | ✓ | [KREA2.md](quickstart/KREA2.hi.md) |
-| Boogu-Image 0.1 | - | ✓ | ✓ | ✓* | fp8 वैकल्पिक | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ edit | ✗ | ✓ | [BOOGU_IMAGE.md](quickstart/BOOGU_IMAGE.hi.md) |
-| zlab i1 | 3B | ✓ | ✓ | ✓ | int8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [ZLAB_i1.md](quickstart/ZLAB_i1.hi.md) |
-| Ideogram 4 | 9B | ✓ | ✓ | ✓* | fp8 डिफ़ॉल्ट, nf4 वैकल्पिक | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [IDEOGRAM4.md](quickstart/IDEOGRAM4.hi.md) |
-| ACE-Step | 3.5B | ✓ | ✓ | ✓* | int8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | [ACE_STEP.md](quickstart/ACE_STEP.md) |
-| Chroma 1 | 8.9B | ✓ | ✓ | ✓* | int8/fp8/nf4 वैकल्पिक | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [CHROMA.md](quickstart/CHROMA.md) |
-| Auraflow | 6B | ✓ | ✓ | ✓* | int8/fp8/nf4 वैकल्पिक | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [AURAFLOW.md](quickstart/AURAFLOW.md) |
-| HiDream I1 | 17B (8.5B MoE) | ✓ | ✓ | ✓* | int8/fp8/nf4 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [HIDREAM.md](quickstart/HIDREAM.md) |
-| OmniGen | 3.8B | ✓ | ✓ | ✓ | int8/fp8 वैकल्पिक | bf16 | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | [OMNIGEN.md](quickstart/OMNIGEN.md) |
-| Stable Diffusion XL | 2.6B | ✓ | ✓ | ✓ | अनुशंसित नहीं | bf16 | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | [SDXL.md](quickstart/SDXL.md) |
-| Lumina2 | 2B | ✓ | ✓ | ✓ | int8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | [LUMINA2.md](quickstart/LUMINA2.md) |
-| Cosmos2 | 2B | ✓ | ✓ | ✓ | अनुशंसित नहीं | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [COSMOS2IMAGE.md](quickstart/COSMOS2IMAGE.md) |
-| Cosmos3 | 16B-65B | ✓ | ✓ | ✓* | no_change first | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | audio opt | ✗ | ✓ | [COSMOS3.md](quickstart/COSMOS3.hi.md) |
-| LTX Video | ~2.5B | ✓ | ✓ | ✓ | int8/fp8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [LTXVIDEO.md](quickstart/LTXVIDEO.md) |
-| LTX Video 2 | 19B | ✓ | ✓ | ✓* | int8/fp8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [LTXVIDEO2.md](quickstart/LTXVIDEO2.md) |
-| Hunyuan Video 1.5 | 8.3B | ✓ | ✓ | ✓* | int8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [HUNYUANVIDEO.md](quickstart/HUNYUANVIDEO.md) |
-| Wan 2.x | 1.3B–14B | ✓ | ✓ | ✓* | int8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [WAN.md](quickstart/WAN.md) |
-| Wan 2.2 S2V | 14B | ✓ | ✓ | ✓* | int8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [WAN_S2V.md](quickstart/WAN_S2V.md) |
-| Qwen Image | 20B | ✓ | ✓ | ✓* | **आवश्यक** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [QWEN_IMAGE.md](quickstart/QWEN_IMAGE.md) |
-| Qwen Image Edit | 20B | ✓ | ✓ | ✓* | **आवश्यक** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [QWEN_EDIT.md](quickstart/QWEN_EDIT.md) |
-| Stable Cascade (C) | 1B, 3.6B prior | ✓ | ✓ | ✓* | समर्थित नहीं | fp32 (आवश्यक) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [STABLE_CASCADE_C.md](quickstart/STABLE_CASCADE_C.md) |
-| Kandinsky 5.0 Image | 6B (lite) | ✓ | ✓ | ✓* | int8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ I2I | ✗ | ✓ | [KANDINSKY5_IMAGE.md](quickstart/KANDINSKY5_IMAGE.md) |
-| Kandinsky 5.0 Video | 2B (lite), 19B (pro) | ✓ | ✓ | ✓* | int8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [KANDINSKY5_VIDEO.md](quickstart/KANDINSKY5_VIDEO.md) |
-| LongCat-Video | 13.6B | ✓ | ✓ | ✓* | int8/fp8 वैकल्पिक | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [LONGCAT_VIDEO.md](quickstart/LONGCAT_VIDEO.md) |
-| LongCat-Video Edit | 13.6B | ✓ | ✓ | ✓* | int8/fp8 वैकल्पिक | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [LONGCAT_VIDEO_EDIT.md](quickstart/LONGCAT_VIDEO_EDIT.md) |
-| LongCat-Image | 6B | ✓ | ✓ | ✓* | int8/fp8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [LONGCAT_IMAGE.md](quickstart/LONGCAT_IMAGE.md) |
-| LongCat-Image Edit | 6B | ✓ | ✓ | ✓* | int8/fp8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [LONGCAT_EDIT.md](quickstart/LONGCAT_EDIT.md) |
+| मॉडल | पैरामीटर | PEFT LoRA | Lycoris | फुल-रैंक | क्वांटाइज़ेशन | मिक्स्ड प्रिसिजन | ग्रैड चेकपॉइंट | फ्लो शिफ्ट | TwinFlow | Self-Flow | LayerSync | Ref Inputs | ControlNet | Sliders† | लाइसेंस | व्यावसायिक उपयोग की अनुमति | गाइड |
+| --- | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | --- | :---: | --- |
+| PixArt Sigma | 0.6B–0.9B | ✗ | ✓ | ✓ | int8 वैकल्पिक | bf16 | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | शर्तें लागू<sup>1</sup> | [SIGMA.md](quickstart/SIGMA.md) |
+| NVLabs Sana | 1.6B–4.8B | ✗ | ✓ | ✓ | int8 वैकल्पिक | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [SANA.md](quickstart/SANA.md) |
+| Kwai Kolors | 2.7B | ✓ | ✓ | ✓ | अनुशंसित नहीं | bf16 | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [Kwai Kolors License](https://huggingface.co/terminusresearch/kwai-kolors-1.0/blob/main/MODEL_LICENSE) | शर्तें लागू<sup>7</sup> | [KOLORS.md](quickstart/KOLORS.md) |
+| Stable Diffusion 3 | 2B–8B | ✓ | ✓ | ✓ | int8/fp8/nf4 वैकल्पिक | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [Stability AI Community](https://stability.ai/license) | शर्तें लागू<sup>2</sup> | [SD3.md](quickstart/SD3.md) |
+| Flux.1 | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 वैकल्पिक | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | शर्तें लागू<sup>3</sup> | [FLUX.md](quickstart/FLUX.md) |
+| Flux.2 | 32B | ✓ | ✓ | ✓* | int8/fp8/nf4 वैकल्पिक | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | शर्तें लागू<sup>4</sup> | [FLUX2.md](quickstart/FLUX2.md) |
+| Flux Kontext | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 वैकल्पिक | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✓ | ✓ | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) | नहीं<sup>5</sup> | [FLUX_KONTEXT.md](quickstart/FLUX_KONTEXT.md) |
+| Z-Image Turbo | 6B | ✓ | ✗ | ✓* | int8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [ZIMAGE.md](quickstart/ZIMAGE.md) |
+| Krea2 | - | ✓ | ✗ | ✓* | int8 वैकल्पिक | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✓ opt | ✗ | ✓ | [Krea 2 Community](https://www.krea.ai/krea-2-licensing) | शर्तें लागू<sup>6</sup> | [KREA2.md](quickstart/KREA2.hi.md) |
+| Mage-Flow | 4B | ✓ | ✓ | ✓* | int8/fp8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ edit | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | हाँ | [MAGEFLOW.md](quickstart/MAGEFLOW.hi.md) |
+| Boogu-Image 0.1 | - | ✓ | ✓ | ✓* | fp8 वैकल्पिक | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ edit | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [BOOGU_IMAGE.md](quickstart/BOOGU_IMAGE.hi.md) |
+| zlab i1 | 3B | ✓ | ✓ | ✓ | int8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Unspecified](https://huggingface.co/bghira/zlab-i1-diffusers) | शर्तें लागू<sup>12</sup> | [ZLAB_i1.md](quickstart/ZLAB_i1.hi.md) |
+| Ideogram 4 | 9B | ✓ | ✓ | ✓* | fp8 डिफ़ॉल्ट, nf4 वैकल्पिक | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [Ideogram 4 Non-Commercial](https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md) | नहीं<sup>5</sup> | [IDEOGRAM4.md](quickstart/IDEOGRAM4.hi.md) |
+| ERNIE-Image | - | ✓ | ✓ | ✓* | int8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [ERNIE.md](quickstart/ERNIE.hi.md) |
+| ACE-Step | 3.5B | ✓ | ✓ | ✓* | int8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://huggingface.co/ACE-Step/ACE-Step-v1-3.5B) / [MIT](https://huggingface.co/ACE-Step/Ace-Step1.5) | हाँ | [ACE_STEP.md](quickstart/ACE_STEP.md) |
+| Chroma 1 | 8.9B | ✓ | ✓ | ✓* | int8/fp8/nf4 वैकल्पिक | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [CHROMA.md](quickstart/CHROMA.md) |
+| Auraflow | 6B | ✓ | ✓ | ✓* | int8/fp8/nf4 वैकल्पिक | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) / [Pony License](https://huggingface.co/purplesmartai/pony-v7-base/blob/main/LICENSE) | शर्तें लागू<sup>8</sup> | [AURAFLOW.md](quickstart/AURAFLOW.md) |
+| HiDream I1 | 17B (8.5B MoE) | ✓ | ✓ | ✓* | int8/fp8/nf4 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [MIT](https://opensource.org/license/mit) | हाँ | [HIDREAM.md](quickstart/HIDREAM.md) |
+| OmniGen | 3.8B | ✓ | ✓ | ✓ | int8/fp8 वैकल्पिक | bf16 | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | हाँ | [OMNIGEN.md](quickstart/OMNIGEN.md) |
+| Stable Diffusion XL | 2.6B | ✓ | ✓ | ✓ | अनुशंसित नहीं | bf16 | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | शर्तें लागू<sup>1</sup> | [SDXL.md](quickstart/SDXL.md) |
+| Lumina2 | 2B | ✓ | ✓ | ✓ | int8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [LUMINA2.md](quickstart/LUMINA2.md) |
+| Cosmos2 | 2B | ✓ | ✓ | ✓ | अनुशंसित नहीं | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [NVIDIA Open Model License](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) | हाँ<sup>9</sup> | [COSMOS2IMAGE.md](quickstart/COSMOS2IMAGE.md) |
+| Cosmos3 | 16B-65B | ✓ | ✓ | ✓* | no_change first | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | audio opt | ✗ | ✓ | [OpenMDW 1.1](https://github.com/OpenMDW/openmdw/blob/main/1.1/LICENSE.OpenMDW-1.1) | हाँ | [COSMOS3.md](quickstart/COSMOS3.hi.md) |
+| LTX Video | ~2.5B | ✓ | ✓ | ✓ | int8/fp8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [LTX Video OpenRAIL-M](https://huggingface.co/Lightricks/LTX-Video-0.9.5/blob/main/ltx-video-2b-v0.9.5.license.txt) | शर्तें लागू<sup>10</sup> | [LTXVIDEO.md](quickstart/LTXVIDEO.md) |
+| LTX Video 2 | 19B | ✓ | ✓ | ✓* | int8/fp8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [LTX-2 Community](https://ltx.io/model/license) | शर्तें लागू<sup>10</sup> | [LTXVIDEO2.md](quickstart/LTXVIDEO2.md) |
+| Hunyuan Video 1.5 | 8.3B | ✓ | ✓ | ✓* | int8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [Tencent Hunyuan Community](https://huggingface.co/tencent/HunyuanVideo-1.5/blob/main/LICENSE) | शर्तें लागू<sup>11</sup> | [HUNYUANVIDEO.md](quickstart/HUNYUANVIDEO.md) |
+| SanaVideo | 2B | ✓ | ✓ | ✓* | int8/fp8 वैकल्पिक | bf16 | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [SANAVIDEO.md](quickstart/SANAVIDEO.hi.md) |
+| Wan 2.x | 1.3B–14B | ✓ | ✓ | ✓* | int8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [WAN.md](quickstart/WAN.md) |
+| Wan 2.2 S2V | 14B | ✓ | ✓ | ✓* | int8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [WAN_S2V.md](quickstart/WAN_S2V.md) |
+| Qwen Image | 20B | ✓ | ✓ | ✓* | **आवश्यक** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [QWEN_IMAGE.md](quickstart/QWEN_IMAGE.md) |
+| Qwen Image Edit | 20B | ✓ | ✓ | ✓* | **आवश्यक** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [QWEN_EDIT.md](quickstart/QWEN_EDIT.md) |
+| Stable Cascade (C) | 1B, 3.6B prior | ✓ | ✓ | ✓* | समर्थित नहीं | fp32 (आवश्यक) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [Stable Cascade NC Community](https://huggingface.co/stabilityai/stable-cascade/blob/main/LICENSE) | नहीं<sup>5</sup> | [STABLE_CASCADE_C.md](quickstart/STABLE_CASCADE_C.md) |
+| Kandinsky 5.0 Image | 6B (lite) | ✓ | ✓ | ✓* | int8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ I2I | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | हाँ | [KANDINSKY5_IMAGE.md](quickstart/KANDINSKY5_IMAGE.md) |
+| Kandinsky 5.0 Video | 2B (lite), 19B (pro) | ✓ | ✓ | ✓* | int8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | हाँ | [KANDINSKY5_VIDEO.md](quickstart/KANDINSKY5_VIDEO.md) |
+| LongCat-Video | 13.6B | ✓ | ✓ | ✓* | int8/fp8 वैकल्पिक | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | हाँ | [LONGCAT_VIDEO.md](quickstart/LONGCAT_VIDEO.md) |
+| LongCat-Video Edit | 13.6B | ✓ | ✓ | ✓* | int8/fp8 वैकल्पिक | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | हाँ | [LONGCAT_VIDEO_EDIT.md](quickstart/LONGCAT_VIDEO_EDIT.md) |
+| LongCat-Image | 6B | ✓ | ✓ | ✓* | int8/fp8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [LONGCAT_IMAGE.md](quickstart/LONGCAT_IMAGE.md) |
+| LongCat-Image Edit | 6B | ✓ | ✓ | ✓* | int8/fp8 वैकल्पिक | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [LONGCAT_EDIT.md](quickstart/LONGCAT_EDIT.md) |
 
 *✓ = समर्थित, ✓* = फुल‑रैंक के लिए DeepSpeed/FSDP2 आवश्यक, ✗ = समर्थित नहीं, `✓+` VRAM दबाव के कारण checkpointing की सिफ़ारिश को दर्शाता है। Ref Inputs सिर्फ मौजूदा reference/edit/I2V conditioning paths को दिखाता है; `opt` वैकल्पिक है और `req` edit/I2V flavour के लिए आवश्यक है। TwinFlow ✓ का अर्थ है `twinflow_enabled=true` होने पर native support (diffusion मॉडल्स को `diff2flow_enabled+twinflow_allow_diff2flow` चाहिए)। Self-Flow ✓ का अर्थ है `crepa_enabled=true`, `crepa_feature_source=self_flow`, `use_ema=true`, और `crepa_teacher_block_index` सेट होने पर native support। LayerSync ✓ का अर्थ है कि backbone self‑alignment के लिए transformer hidden states उपलब्ध कराता है; ✗ UNet‑style backbones को दर्शाता है जिनमें वह buffer नहीं होता। †Sliders LoRA और LyCORIS (full‑rank LyCORIS “full” सहित) पर लागू होते हैं।*
+
+**लाइसेंस नोट्स:** व्यावसायिक उपयोग की स्थिति model weights, derivative checkpoints, fine-tunes, और hosted model use को कवर करती है। Generated outputs के अधिकार अलग हो सकते हैं; commercial deployment से पहले linked license text पढ़ें।
+
+<sup>1</sup> OpenRAIL-style licenses आम तौर पर commercial use की अनुमति देती हैं, लेकिन usage restrictions model और derivatives के साथ बनी रहती हैं।
+
+<sup>2</sup> Stability AI Community License revenue threshold से नीचे qualify करने वाले users के लिए उपलब्ध है; बड़े commercial use के लिए Stability enterprise terms चाहिए।
+
+<sup>3</sup> Flux.1 flavour के अनुसार बदलता है: Schnell और LibreFlux Apache-2.0 हैं, जबकि Dev, Krea, और Kontext BFL non-commercial terms का उपयोग करते हैं; commercial use से पहले FluxBooru upstream metadata देखें।
+
+<sup>4</sup> Flux.2 flavour के अनुसार बदलता है: Klein 4B Apache-2.0 है, जबकि Dev और Klein 9B BFL non-commercial terms का उपयोग करते हैं।
+
+<sup>5</sup> Public non-commercial model terms अलग license के बिना weights, derivative checkpoints, या hosted model services के commercial use की अनुमति नहीं देते।
+
+<sup>6</sup> Krea 2 Community License केवल revenue और safety/filtering requirements के तहत commercial use की अनुमति देती है; अन्यथा enterprise license चाहिए।
+
+<sup>7</sup> Kolors model या derivatives का commercial use करने के लिए licensor से explicit permission माँगनी और प्राप्त करनी होती है।
+
+<sup>8</sup> AuraFlow Apache-2.0 upstream flavours और अलग custom license वाले Pony flavour को support करता है; selected flavour देखें।
+
+<sup>9</sup> NVIDIA Open Model License commercial use की अनुमति देती है, लेकिन agreement, acceptable-use, और export-control terms शामिल हैं।
+
+<sup>10</sup> LTX Video 0.9.5 OpenRAIL-M का उपयोग करता है; LTX Video 2 commercial use के लिए revenue threshold वाले LTX community terms का उपयोग करता है।
+
+<sup>11</sup> Tencent Hunyuan Community License में territorial exclusions और बहुत बड़े services के लिए commercial threshold शामिल है।
+
+<sup>12</sup> यह mirror standard license text के बिना `license: other` publish करता है; commercial use से पहले upstream terms देखें।
 
 > ℹ️ Wan quickstart में 2.1 + 2.2 stage presets और time‑embedding toggle शामिल है। Flux Kontext में Flux.1 के ऊपर बने editing वर्कफ़्लो शामिल हैं।
 
@@ -76,4 +105,4 @@
 - WebUI में, अपने dataset directory पर browse करें और filtering statistics देखने के लिए इसे select करें
 - Dataset processing के दौरान logs में इस तरह के statistics check करें: `Sample processing statistics: {'total_processed': 100, 'skipped': {'too_small': 15, ...}}`
 
-विस्तृत troubleshooting के लिए, dataloader documentation में [Filtered datasets का Troubleshooting](DATALOADER.hi.md#filtered-datasets-का-troubleshooting) देखें।
+विस्तृत troubleshooting के लिए, dataloader documentation में [Filtered datasets का Troubleshooting](DATALOADER.hi.md) देखें।

--- a/documentation/QUICKSTART.ja.md
+++ b/documentation/QUICKSTART.ja.md
@@ -8,45 +8,74 @@
 
 ## モデルクイックスタートガイド
 
-| モデル | パラメータ数 | PEFT LoRA | Lycoris | Full-Rank | 量子化 | 混合精度 | Grad Checkpoint | Flow Shift | TwinFlow | Self-Flow | LayerSync | Ref Inputs | ControlNet | Sliders† | ガイド |
-| --- | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | --- |
-| PixArt Sigma | 0.6B–0.9B | ✗ | ✓ | ✓ | int8 オプション | bf16 | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | [SIGMA.md](quickstart/SIGMA.md) |
-| NVLabs Sana | 1.6B–4.8B | ✗ | ✓ | ✓ | int8 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [SANA.md](quickstart/SANA.md) |
-| Kwai Kolors | 2.7B | ✓ | ✓ | ✓ | 非推奨 | bf16 | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [KOLORS.md](quickstart/KOLORS.md) |
-| Stable Diffusion 3 | 2B–8B | ✓ | ✓ | ✓ | int8/fp8/nf4 オプション | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [SD3.md](quickstart/SD3.md) |
-| Flux.1 | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [FLUX.md](quickstart/FLUX.md) |
-| Flux.2 | 32B | ✓ | ✓ | ✓* | int8/fp8/nf4 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [FLUX2.md](quickstart/FLUX2.md) |
-| Flux Kontext | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✓ | ✓ | [FLUX_KONTEXT.md](quickstart/FLUX_KONTEXT.md) |
-| Z-Image Turbo | 6B | ✓ | ✗ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [ZIMAGE.md](quickstart/ZIMAGE.md) |
-| Krea2 | - | ✓ | ✗ | ✓* | int8 オプション | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✓ opt | ✗ | ✓ | [KREA2.md](quickstart/KREA2.ja.md) |
-| Boogu-Image 0.1 | - | ✓ | ✓ | ✓* | fp8 オプション | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ edit | ✗ | ✓ | [BOOGU_IMAGE.md](quickstart/BOOGU_IMAGE.ja.md) |
-| zlab i1 | 3B | ✓ | ✓ | ✓ | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [ZLAB_i1.md](quickstart/ZLAB_i1.ja.md) |
-| Ideogram 4 | 9B | ✓ | ✓ | ✓* | fp8 デフォルト、nf4 オプション | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [IDEOGRAM4.md](quickstart/IDEOGRAM4.ja.md) |
-| ACE-Step | 3.5B | ✓ | ✓ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | [ACE_STEP.md](quickstart/ACE_STEP.md) |
-| Chroma 1 | 8.9B | ✓ | ✓ | ✓* | int8/fp8/nf4 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [CHROMA.md](quickstart/CHROMA.md) |
-| Auraflow | 6B | ✓ | ✓ | ✓* | int8/fp8/nf4 オプション | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [AURAFLOW.md](quickstart/AURAFLOW.md) |
-| HiDream I1 | 17B (8.5B MoE) | ✓ | ✓ | ✓* | int8/fp8/nf4 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [HIDREAM.md](quickstart/HIDREAM.md) |
-| OmniGen | 3.8B | ✓ | ✓ | ✓ | int8/fp8 オプション | bf16 | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | [OMNIGEN.md](quickstart/OMNIGEN.md) |
-| Stable Diffusion XL | 2.6B | ✓ | ✓ | ✓ | 非推奨 | bf16 | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | [SDXL.md](quickstart/SDXL.md) |
-| Lumina2 | 2B | ✓ | ✓ | ✓ | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | [LUMINA2.md](quickstart/LUMINA2.md) |
-| Cosmos2 | 2B | ✓ | ✓ | ✓ | 非推奨 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [COSMOS2IMAGE.md](quickstart/COSMOS2IMAGE.md) |
-| Cosmos3 | 16B-65B | ✓ | ✓ | ✓* | no_change first | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | audio opt | ✗ | ✓ | [COSMOS3.md](quickstart/COSMOS3.ja.md) |
-| LTX Video | ~2.5B | ✓ | ✓ | ✓ | int8/fp8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [LTXVIDEO.md](quickstart/LTXVIDEO.md) |
-| LTX Video 2 | 19B | ✓ | ✓ | ✓* | int8/fp8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [LTXVIDEO2.md](quickstart/LTXVIDEO2.md) |
-| Hunyuan Video 1.5 | 8.3B | ✓ | ✓ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [HUNYUANVIDEO.md](quickstart/HUNYUANVIDEO.md) |
-| Wan 2.x | 1.3B–14B | ✓ | ✓ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [WAN.md](quickstart/WAN.md) |
-| Wan 2.2 S2V | 14B | ✓ | ✓ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [WAN_S2V.md](quickstart/WAN_S2V.md) |
-| Qwen Image | 20B | ✓ | ✓ | ✓* | **必須** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [QWEN_IMAGE.md](quickstart/QWEN_IMAGE.md) |
-| Qwen Image Edit | 20B | ✓ | ✓ | ✓* | **必須** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [QWEN_EDIT.md](quickstart/QWEN_EDIT.md) |
-| Stable Cascade (C) | 1B, 3.6B prior | ✓ | ✓ | ✓* | 非対応 | fp32 (必須) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [STABLE_CASCADE_C.md](quickstart/STABLE_CASCADE_C.md) |
-| Kandinsky 5.0 Image | 6B (lite) | ✓ | ✓ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ I2I | ✗ | ✓ | [KANDINSKY5_IMAGE.md](quickstart/KANDINSKY5_IMAGE.md) |
-| Kandinsky 5.0 Video | 2B (lite), 19B (pro) | ✓ | ✓ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [KANDINSKY5_VIDEO.md](quickstart/KANDINSKY5_VIDEO.md) |
-| LongCat-Video | 13.6B | ✓ | ✓ | ✓* | int8/fp8 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [LONGCAT_VIDEO.md](quickstart/LONGCAT_VIDEO.md) |
-| LongCat-Video Edit | 13.6B | ✓ | ✓ | ✓* | int8/fp8 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [LONGCAT_VIDEO_EDIT.md](quickstart/LONGCAT_VIDEO_EDIT.md) |
-| LongCat-Image | 6B | ✓ | ✓ | ✓* | int8/fp8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [LONGCAT_IMAGE.md](quickstart/LONGCAT_IMAGE.md) |
-| LongCat-Image Edit | 6B | ✓ | ✓ | ✓* | int8/fp8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [LONGCAT_EDIT.md](quickstart/LONGCAT_EDIT.md) |
+| モデル | パラメータ数 | PEFT LoRA | Lycoris | Full-Rank | 量子化 | 混合精度 | Grad Checkpoint | Flow Shift | TwinFlow | Self-Flow | LayerSync | Ref Inputs | ControlNet | Sliders† | ライセンス | 商用利用 | ガイド |
+| --- | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | --- | :---: | --- |
+| PixArt Sigma | 0.6B–0.9B | ✗ | ✓ | ✓ | int8 オプション | bf16 | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | 条件付き<sup>1</sup> | [SIGMA.md](quickstart/SIGMA.md) |
+| NVLabs Sana | 1.6B–4.8B | ✗ | ✓ | ✓ | int8 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [SANA.md](quickstart/SANA.md) |
+| Kwai Kolors | 2.7B | ✓ | ✓ | ✓ | 非推奨 | bf16 | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [Kwai Kolors License](https://huggingface.co/terminusresearch/kwai-kolors-1.0/blob/main/MODEL_LICENSE) | 条件付き<sup>7</sup> | [KOLORS.md](quickstart/KOLORS.md) |
+| Stable Diffusion 3 | 2B–8B | ✓ | ✓ | ✓ | int8/fp8/nf4 オプション | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [Stability AI Community](https://stability.ai/license) | 条件付き<sup>2</sup> | [SD3.md](quickstart/SD3.md) |
+| Flux.1 | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 条件付き<sup>3</sup> | [FLUX.md](quickstart/FLUX.md) |
+| Flux.2 | 32B | ✓ | ✓ | ✓* | int8/fp8/nf4 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 条件付き<sup>4</sup> | [FLUX2.md](quickstart/FLUX2.md) |
+| Flux Kontext | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✓ | ✓ | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) | いいえ<sup>5</sup> | [FLUX_KONTEXT.md](quickstart/FLUX_KONTEXT.md) |
+| Z-Image Turbo | 6B | ✓ | ✗ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [ZIMAGE.md](quickstart/ZIMAGE.md) |
+| Krea2 | - | ✓ | ✗ | ✓* | int8 オプション | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✓ opt | ✗ | ✓ | [Krea 2 Community](https://www.krea.ai/krea-2-licensing) | 条件付き<sup>6</sup> | [KREA2.md](quickstart/KREA2.ja.md) |
+| Mage-Flow | 4B | ✓ | ✓ | ✓* | int8/fp8 オプション | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ edit | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | はい | [MAGEFLOW.md](quickstart/MAGEFLOW.ja.md) |
+| Boogu-Image 0.1 | - | ✓ | ✓ | ✓* | fp8 オプション | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ edit | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [BOOGU_IMAGE.md](quickstart/BOOGU_IMAGE.ja.md) |
+| zlab i1 | 3B | ✓ | ✓ | ✓ | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Unspecified](https://huggingface.co/bghira/zlab-i1-diffusers) | 条件付き<sup>12</sup> | [ZLAB_i1.md](quickstart/ZLAB_i1.ja.md) |
+| Ideogram 4 | 9B | ✓ | ✓ | ✓* | fp8 デフォルト、nf4 オプション | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [Ideogram 4 Non-Commercial](https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md) | いいえ<sup>5</sup> | [IDEOGRAM4.md](quickstart/IDEOGRAM4.ja.md) |
+| ERNIE-Image | - | ✓ | ✓ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [ERNIE.md](quickstart/ERNIE.ja.md) |
+| ACE-Step | 3.5B | ✓ | ✓ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://huggingface.co/ACE-Step/ACE-Step-v1-3.5B) / [MIT](https://huggingface.co/ACE-Step/Ace-Step1.5) | はい | [ACE_STEP.md](quickstart/ACE_STEP.md) |
+| Chroma 1 | 8.9B | ✓ | ✓ | ✓* | int8/fp8/nf4 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [CHROMA.md](quickstart/CHROMA.md) |
+| Auraflow | 6B | ✓ | ✓ | ✓* | int8/fp8/nf4 オプション | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) / [Pony License](https://huggingface.co/purplesmartai/pony-v7-base/blob/main/LICENSE) | 条件付き<sup>8</sup> | [AURAFLOW.md](quickstart/AURAFLOW.md) |
+| HiDream I1 | 17B (8.5B MoE) | ✓ | ✓ | ✓* | int8/fp8/nf4 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [MIT](https://opensource.org/license/mit) | はい | [HIDREAM.md](quickstart/HIDREAM.md) |
+| OmniGen | 3.8B | ✓ | ✓ | ✓ | int8/fp8 オプション | bf16 | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | はい | [OMNIGEN.md](quickstart/OMNIGEN.md) |
+| Stable Diffusion XL | 2.6B | ✓ | ✓ | ✓ | 非推奨 | bf16 | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | 条件付き<sup>1</sup> | [SDXL.md](quickstart/SDXL.md) |
+| Lumina2 | 2B | ✓ | ✓ | ✓ | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [LUMINA2.md](quickstart/LUMINA2.md) |
+| Cosmos2 | 2B | ✓ | ✓ | ✓ | 非推奨 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [NVIDIA Open Model License](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) | はい<sup>9</sup> | [COSMOS2IMAGE.md](quickstart/COSMOS2IMAGE.md) |
+| Cosmos3 | 16B-65B | ✓ | ✓ | ✓* | no_change first | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | audio opt | ✗ | ✓ | [OpenMDW 1.1](https://github.com/OpenMDW/openmdw/blob/main/1.1/LICENSE.OpenMDW-1.1) | はい | [COSMOS3.md](quickstart/COSMOS3.ja.md) |
+| LTX Video | ~2.5B | ✓ | ✓ | ✓ | int8/fp8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [LTX Video OpenRAIL-M](https://huggingface.co/Lightricks/LTX-Video-0.9.5/blob/main/ltx-video-2b-v0.9.5.license.txt) | 条件付き<sup>10</sup> | [LTXVIDEO.md](quickstart/LTXVIDEO.md) |
+| LTX Video 2 | 19B | ✓ | ✓ | ✓* | int8/fp8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [LTX-2 Community](https://ltx.io/model/license) | 条件付き<sup>10</sup> | [LTXVIDEO2.md](quickstart/LTXVIDEO2.md) |
+| Hunyuan Video 1.5 | 8.3B | ✓ | ✓ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [Tencent Hunyuan Community](https://huggingface.co/tencent/HunyuanVideo-1.5/blob/main/LICENSE) | 条件付き<sup>11</sup> | [HUNYUANVIDEO.md](quickstart/HUNYUANVIDEO.md) |
+| SanaVideo | 2B | ✓ | ✓ | ✓* | int8/fp8 オプション | bf16 | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [SANAVIDEO.md](quickstart/SANAVIDEO.ja.md) |
+| Wan 2.x | 1.3B–14B | ✓ | ✓ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [WAN.md](quickstart/WAN.md) |
+| Wan 2.2 S2V | 14B | ✓ | ✓ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [WAN_S2V.md](quickstart/WAN_S2V.md) |
+| Qwen Image | 20B | ✓ | ✓ | ✓* | **必須** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [QWEN_IMAGE.md](quickstart/QWEN_IMAGE.md) |
+| Qwen Image Edit | 20B | ✓ | ✓ | ✓* | **必須** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [QWEN_EDIT.md](quickstart/QWEN_EDIT.md) |
+| Stable Cascade (C) | 1B, 3.6B prior | ✓ | ✓ | ✓* | 非対応 | fp32 (必須) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [Stable Cascade NC Community](https://huggingface.co/stabilityai/stable-cascade/blob/main/LICENSE) | いいえ<sup>5</sup> | [STABLE_CASCADE_C.md](quickstart/STABLE_CASCADE_C.md) |
+| Kandinsky 5.0 Image | 6B (lite) | ✓ | ✓ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ I2I | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | はい | [KANDINSKY5_IMAGE.md](quickstart/KANDINSKY5_IMAGE.md) |
+| Kandinsky 5.0 Video | 2B (lite), 19B (pro) | ✓ | ✓ | ✓* | int8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | はい | [KANDINSKY5_VIDEO.md](quickstart/KANDINSKY5_VIDEO.md) |
+| LongCat-Video | 13.6B | ✓ | ✓ | ✓* | int8/fp8 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | はい | [LONGCAT_VIDEO.md](quickstart/LONGCAT_VIDEO.md) |
+| LongCat-Video Edit | 13.6B | ✓ | ✓ | ✓* | int8/fp8 オプション | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | はい | [LONGCAT_VIDEO_EDIT.md](quickstart/LONGCAT_VIDEO_EDIT.md) |
+| LongCat-Image | 6B | ✓ | ✓ | ✓* | int8/fp8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [LONGCAT_IMAGE.md](quickstart/LONGCAT_IMAGE.md) |
+| LongCat-Image Edit | 6B | ✓ | ✓ | ✓* | int8/fp8 オプション | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [LONGCAT_EDIT.md](quickstart/LONGCAT_EDIT.md) |
 
 *✓ = サポート、✓* = Full-RankにはDeepSpeed/FSDP2が必要、✗ = 非サポート、`✓+`はVRAMプレッシャーによりチェックポイントが推奨されることを示します。Ref Inputs は既存の参照/編集/I2V 条件パスのみを示し、`opt` は任意、`req` は編集/I2V flavour で必須であることを示します。TwinFlow ✓は`twinflow_enabled=true`のときのネイティブサポートを意味します（拡散モデルには`diff2flow_enabled+twinflow_allow_diff2flow`が必要）。Self-Flow ✓は`crepa_enabled=true`、`crepa_feature_source=self_flow`、`use_ema=true`、および`crepa_teacher_block_index`設定時のネイティブサポートを意味します。LayerSync ✓はバックボーンがセルフアライメント用のトランスフォーマー隠れ状態を公開していることを意味し、✗はそのバッファを持たないUNetスタイルのバックボーンを示します。†SlidersはLoRAおよびLyCORIS（Full-Rank LyCORIS "full"を含む）に適用されます。*
+
+**ライセンス注記:** 商用利用の表示はモデル重み、派生チェックポイント、fine-tune、ホスト型モデル利用を対象にしています。生成出力の権利は異なる場合があります。商用展開前にリンク先のライセンス本文を確認してください。
+
+<sup>1</sup> OpenRAIL 系ライセンスは通常、商用利用を許可しますが、モデルと派生物には利用制限が残ります。
+
+<sup>2</sup> Stability AI Community License は収益しきい値未満の対象ユーザー向けです。より大きな商用利用には Stability のエンタープライズ条件が必要です。
+
+<sup>3</sup> Flux.1 は flavour により異なります。Schnell と LibreFlux は Apache-2.0、Dev、Krea、Kontext は BFL の非商用条件です。FluxBooru は商用利用前に upstream metadata を確認してください。
+
+<sup>4</sup> Flux.2 は flavour により異なります。Klein 4B は Apache-2.0、Dev と Klein 9B は BFL の非商用条件です。
+
+<sup>5</sup> 公開されている非商用モデル条件では、別ライセンスなしに重み、派生チェックポイント、ホスト型モデルサービスを商用利用できません。
+
+<sup>6</sup> Krea 2 Community License は収益および安全性/フィルタリング要件を満たす場合のみ商用利用を許可します。それ以外はエンタープライズライセンスが必要です。
+
+<sup>7</sup> Kolors のモデルまたは派生物の商用利用には、ライセンサーへの申請と明示的な許可が必要です。
+
+<sup>8</sup> AuraFlow は Apache-2.0 の upstream flavour と、別のカスタムライセンスを持つ Pony flavour をサポートします。選択した flavour を確認してください。
+
+<sup>9</sup> NVIDIA Open Model License は商用利用を許可しますが、契約、利用許諾ポリシー、輸出管理条件を含みます。
+
+<sup>10</sup> LTX Video 0.9.5 は OpenRAIL-M、LTX Video 2 は商用利用に収益しきい値がある LTX community terms を使用します。
+
+<sup>11</sup> Tencent Hunyuan Community License には地域除外と、非常に大規模なサービス向けの商用しきい値があります。
+
+<sup>12</sup> この mirror は標準ライセンス本文なしで `license: other` を公開しています。商用利用前に upstream terms を確認してください。
 
 > ℹ️ Wanクイックスタートには2.1 + 2.2ステージプリセットと時間埋め込みトグルが含まれます。Flux Kontextは、Flux.1をベースに構築された編集ワークフローをカバーします。
 
@@ -76,4 +105,4 @@
 - WebUI でデータセットディレクトリを参照し、選択するとフィルタリング統計が表示されます
 - データセット処理中のログで次のような統計を確認: `Sample processing statistics: {'total_processed': 100, 'skipped': {'too_small': 15, ...}}`
 
-詳細なトラブルシューティングについては、データローダードキュメントの[フィルタされたデータセットのトラブルシューティング](DATALOADER.ja.md#フィルタされたデータセットのトラブルシューティング)を参照してください。
+詳細なトラブルシューティングについては、データローダードキュメントの[フィルタされたデータセットのトラブルシューティング](DATALOADER.ja.md)を参照してください。

--- a/documentation/QUICKSTART.md
+++ b/documentation/QUICKSTART.md
@@ -8,45 +8,74 @@ For the complete and most accurate feature matrix, refer to the [main README](ht
 
 ## Model Quickstart Guides
 
-| Model | Params | PEFT LoRA | Full-Rank | Quantization | Mixed Precision | Grad Checkpoint | Flow Shift | TwinFlow | Self-Flow | LayerSync | Ref Inputs | ControlNet | Sliders† | Guide |
-| --- | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | --- |
-| PixArt Sigma | 0.6B–0.9B | ✗ | ✓ | int8 optional | bf16 | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | [SIGMA.md](/documentation/quickstart/SIGMA.md) |
-| NVLabs Sana | 1.6B–4.8B | ✗ | ✓ | int8 optional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [SANA.md](/documentation/quickstart/SANA.md) |
-| Kwai Kolors | 2.7B | ✓ | ✓ | not recommended | bf16 | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [KOLORS.md](/documentation/quickstart/KOLORS.md) |
-| Stable Diffusion 3 | 2B–8B | ✓ | ✓ | int8/fp8/nf4 optional | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [SD3.md](/documentation/quickstart/SD3.md) |
-| Flux.1 | 8B–12B | ✓ | ✓* | int8/fp8/nf4 optional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [FLUX.md](/documentation/quickstart/FLUX.md) |
-| Flux.2 | 32B | ✓ | ✓* | int8/fp8/nf4 optional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [FLUX2.md](/documentation/quickstart/FLUX2.md) |
-| Flux Kontext | 8B–12B | ✓ | ✓* | int8/fp8/nf4 optional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✓ | ✓ | [FLUX_KONTEXT.md](/documentation/quickstart/FLUX_KONTEXT.md) |
-| Z-Image Turbo | 6B | ✓ | ✓* | int8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [ZIMAGE.md](/documentation/quickstart/ZIMAGE.md) |
-| Krea2 | - | ✓ | ✓* | int8 optional | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✓ opt | ✗ | ✓ | [KREA2.md](/documentation/quickstart/KREA2.md) |
-| Boogu-Image 0.1 | - | ✓ | ✓* | fp8 optional | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ edit | ✗ | ✓ | [BOOGU_IMAGE.md](/documentation/quickstart/BOOGU_IMAGE.md) |
-| zlab i1 | 3B | ✓ | ✓ | int8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [ZLAB_i1.md](/documentation/quickstart/ZLAB_i1.md) |
-| Ideogram 4 | 9B | ✓ | ✓* | fp8 default, nf4 optional | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [IDEOGRAM4.md](/documentation/quickstart/IDEOGRAM4.md) |
-| ACE-Step | 3.5B | ✓ | ✓* | int8 optional | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | [ACE_STEP.md](/documentation/quickstart/ACE_STEP.md) |
-| Chroma 1 | 8.9B | ✓ | ✓* | int8/fp8/nf4 optional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [CHROMA.md](/documentation/quickstart/CHROMA.md) |
-| Auraflow | 6B | ✓ | ✓* | int8/fp8/nf4 optional | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [AURAFLOW.md](/documentation/quickstart/AURAFLOW.md) |
-| HiDream I1 | 17B (8.5B MoE) | ✓ | ✓* | int8/fp8/nf4 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [HIDREAM.md](/documentation/quickstart/HIDREAM.md) |
-| OmniGen | 3.8B | ✓ | ✓ | int8/fp8 optional | bf16 | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | [OMNIGEN.md](/documentation/quickstart/OMNIGEN.md) |
-| Stable Diffusion XL | 2.6B | ✓ | ✓ | not recommended | bf16 | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | [SDXL.md](/documentation/quickstart/SDXL.md) |
-| Lumina2 | 2B | ✓ | ✓ | int8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | [LUMINA2.md](/documentation/quickstart/LUMINA2.md) |
-| Cosmos2 | 2B | ✓ | ✓ | not recommended | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [COSMOS2IMAGE.md](/documentation/quickstart/COSMOS2IMAGE.md) |
-| Cosmos3 | 16B-65B | ✓ | ✓* | no_change first | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | audio opt | ✗ | ✓ | [COSMOS3.md](/documentation/quickstart/COSMOS3.md) |
-| LTX Video | ~2.5B | ✓ | ✓ | int8/fp8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [LTXVIDEO.md](/documentation/quickstart/LTXVIDEO.md) |
-| LTX Video 2 | 19B | ✓ | ✓* | int8/fp8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [LTXVIDEO2.md](/documentation/quickstart/LTXVIDEO2.md) |
-| Hunyuan Video 1.5 | 8.3B | ✓ | ✓* | int8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [HUNYUANVIDEO.md](/documentation/quickstart/HUNYUANVIDEO.md) |
-| Wan 2.x | 1.3B–14B | ✓ | ✓* | int8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [WAN.md](/documentation/quickstart/WAN.md) |
-| Wan 2.2 S2V | 14B | ✓ | ✓* | int8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [WAN_S2V.md](/documentation/quickstart/WAN_S2V.md) |
-| Qwen Image | 20B | ✓ | ✓* | **required** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [QWEN_IMAGE.md](/documentation/quickstart/QWEN_IMAGE.md) |
-| Qwen Image Edit | 20B | ✓ | ✓* | **required** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [QWEN_EDIT.md](/documentation/quickstart/QWEN_EDIT.md) |
-| Stable Cascade (C) | 1B, 3.6B prior | ✓ | ✓* | not supported | fp32 (required) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [STABLE_CASCADE_C.md](/documentation/quickstart/STABLE_CASCADE_C.md) |
-| Kandinsky 5.0 Image | 6B (lite) | ✓ | ✓* | int8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ I2I | ✗ | ✓ | [KANDINSKY5_IMAGE.md](/documentation/quickstart/KANDINSKY5_IMAGE.md) |
-| Kandinsky 5.0 Video | 2B (lite), 19B (pro) | ✓ | ✓* | int8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [KANDINSKY5_VIDEO.md](/documentation/quickstart/KANDINSKY5_VIDEO.md) |
-| LongCat-Video | 13.6B | ✓ | ✓* | int8/fp8 optional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [LONGCAT_VIDEO.md](/documentation/quickstart/LONGCAT_VIDEO.md) |
-| LongCat-Video Edit | 13.6B | ✓ | ✓* | int8/fp8 optional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [LONGCAT_VIDEO_EDIT.md](/documentation/quickstart/LONGCAT_VIDEO_EDIT.md) |
-| LongCat-Image | 6B | ✓ | ✓* | int8/fp8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [LONGCAT_IMAGE.md](/documentation/quickstart/LONGCAT_IMAGE.md) |
-| LongCat-Image Edit | 6B | ✓ | ✓* | int8/fp8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [LONGCAT_EDIT.md](/documentation/quickstart/LONGCAT_EDIT.md) |
+| Model | Params | PEFT LoRA | Full-Rank | Quantization | Mixed Precision | Grad Checkpoint | Flow Shift | TwinFlow | Self-Flow | LayerSync | Ref Inputs | ControlNet | Sliders† | License | Allows commercial use | Guide |
+| --- | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | --- | :---: | --- |
+| PixArt Sigma | 0.6B–0.9B | ✗ | ✓ | int8 optional | bf16 | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | Conditions apply<sup>1</sup> | [SIGMA.md](quickstart/SIGMA.md) |
+| NVLabs Sana | 1.6B–4.8B | ✗ | ✓ | int8 optional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [SANA.md](quickstart/SANA.md) |
+| Kwai Kolors | 2.7B | ✓ | ✓ | not recommended | bf16 | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [Kwai Kolors License](https://huggingface.co/terminusresearch/kwai-kolors-1.0/blob/main/MODEL_LICENSE) | Conditions apply<sup>7</sup> | [KOLORS.md](quickstart/KOLORS.md) |
+| Stable Diffusion 3 | 2B–8B | ✓ | ✓ | int8/fp8/nf4 optional | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [Stability AI Community](https://stability.ai/license) | Conditions apply<sup>2</sup> | [SD3.md](quickstart/SD3.md) |
+| Flux.1 | 8B–12B | ✓ | ✓* | int8/fp8/nf4 optional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Conditions apply<sup>3</sup> | [FLUX.md](quickstart/FLUX.md) |
+| Flux.2 | 32B | ✓ | ✓* | int8/fp8/nf4 optional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Conditions apply<sup>4</sup> | [FLUX2.md](quickstart/FLUX2.md) |
+| Flux Kontext | 8B–12B | ✓ | ✓* | int8/fp8/nf4 optional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✓ | ✓ | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) | No<sup>5</sup> | [FLUX_KONTEXT.md](quickstart/FLUX_KONTEXT.md) |
+| Z-Image Turbo | 6B | ✓ | ✓* | int8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [ZIMAGE.md](quickstart/ZIMAGE.md) |
+| Krea2 | - | ✓ | ✓* | int8 optional | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✓ opt | ✗ | ✓ | [Krea 2 Community](https://www.krea.ai/krea-2-licensing) | Conditions apply<sup>6</sup> | [KREA2.md](quickstart/KREA2.md) |
+| Mage-Flow | 4B | ✓ | ✓* | int8/fp8 optional | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ edit | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | Yes | [MAGEFLOW.md](quickstart/MAGEFLOW.md) |
+| Boogu-Image 0.1 | - | ✓ | ✓* | fp8 optional | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ edit | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [BOOGU_IMAGE.md](quickstart/BOOGU_IMAGE.md) |
+| zlab i1 | 3B | ✓ | ✓ | int8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Unspecified](https://huggingface.co/bghira/zlab-i1-diffusers) | Conditions apply<sup>12</sup> | [ZLAB_i1.md](quickstart/ZLAB_i1.md) |
+| Ideogram 4 | 9B | ✓ | ✓* | fp8 default, nf4 optional | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [Ideogram 4 Non-Commercial](https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md) | No<sup>5</sup> | [IDEOGRAM4.md](quickstart/IDEOGRAM4.md) |
+| ERNIE-Image | - | ✓ | ✓* | int8 optional | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [ERNIE.md](quickstart/ERNIE.md) |
+| ACE-Step | 3.5B | ✓ | ✓* | int8 optional | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://huggingface.co/ACE-Step/ACE-Step-v1-3.5B) / [MIT](https://huggingface.co/ACE-Step/Ace-Step1.5) | Yes | [ACE_STEP.md](quickstart/ACE_STEP.md) |
+| Chroma 1 | 8.9B | ✓ | ✓* | int8/fp8/nf4 optional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [CHROMA.md](quickstart/CHROMA.md) |
+| Auraflow | 6B | ✓ | ✓* | int8/fp8/nf4 optional | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) / [Pony License](https://huggingface.co/purplesmartai/pony-v7-base/blob/main/LICENSE) | Conditions apply<sup>8</sup> | [AURAFLOW.md](quickstart/AURAFLOW.md) |
+| HiDream I1 | 17B (8.5B MoE) | ✓ | ✓* | int8/fp8/nf4 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [MIT](https://opensource.org/license/mit) | Yes | [HIDREAM.md](quickstart/HIDREAM.md) |
+| OmniGen | 3.8B | ✓ | ✓ | int8/fp8 optional | bf16 | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | Yes | [OMNIGEN.md](quickstart/OMNIGEN.md) |
+| Stable Diffusion XL | 2.6B | ✓ | ✓ | not recommended | bf16 | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | Conditions apply<sup>1</sup> | [SDXL.md](quickstart/SDXL.md) |
+| Lumina2 | 2B | ✓ | ✓ | int8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [LUMINA2.md](quickstart/LUMINA2.md) |
+| Cosmos2 | 2B | ✓ | ✓ | not recommended | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [NVIDIA Open Model License](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) | Yes<sup>9</sup> | [COSMOS2IMAGE.md](quickstart/COSMOS2IMAGE.md) |
+| Cosmos3 | 16B-65B | ✓ | ✓* | no_change first | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | audio opt | ✗ | ✓ | [OpenMDW 1.1](https://github.com/OpenMDW/openmdw/blob/main/1.1/LICENSE.OpenMDW-1.1) | Yes | [COSMOS3.md](quickstart/COSMOS3.md) |
+| LTX Video | ~2.5B | ✓ | ✓ | int8/fp8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [LTX Video OpenRAIL-M](https://huggingface.co/Lightricks/LTX-Video-0.9.5/blob/main/ltx-video-2b-v0.9.5.license.txt) | Conditions apply<sup>10</sup> | [LTXVIDEO.md](quickstart/LTXVIDEO.md) |
+| LTX Video 2 | 19B | ✓ | ✓* | int8/fp8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [LTX-2 Community](https://ltx.io/model/license) | Conditions apply<sup>10</sup> | [LTXVIDEO2.md](quickstart/LTXVIDEO2.md) |
+| Hunyuan Video 1.5 | 8.3B | ✓ | ✓* | int8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [Tencent Hunyuan Community](https://huggingface.co/tencent/HunyuanVideo-1.5/blob/main/LICENSE) | Conditions apply<sup>11</sup> | [HUNYUANVIDEO.md](quickstart/HUNYUANVIDEO.md) |
+| SanaVideo | 2B | ✓ | ✓* | int8/fp8 optional | bf16 | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [SANAVIDEO.md](quickstart/SANAVIDEO.md) |
+| Wan 2.x | 1.3B–14B | ✓ | ✓* | int8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [WAN.md](quickstart/WAN.md) |
+| Wan 2.2 S2V | 14B | ✓ | ✓* | int8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [WAN_S2V.md](quickstart/WAN_S2V.md) |
+| Qwen Image | 20B | ✓ | ✓* | **required** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [QWEN_IMAGE.md](quickstart/QWEN_IMAGE.md) |
+| Qwen Image Edit | 20B | ✓ | ✓* | **required** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [QWEN_EDIT.md](quickstart/QWEN_EDIT.md) |
+| Stable Cascade (C) | 1B, 3.6B prior | ✓ | ✓* | not supported | fp32 (required) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [Stable Cascade NC Community](https://huggingface.co/stabilityai/stable-cascade/blob/main/LICENSE) | No<sup>5</sup> | [STABLE_CASCADE_C.md](quickstart/STABLE_CASCADE_C.md) |
+| Kandinsky 5.0 Image | 6B (lite) | ✓ | ✓* | int8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ I2I | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | Yes | [KANDINSKY5_IMAGE.md](quickstart/KANDINSKY5_IMAGE.md) |
+| Kandinsky 5.0 Video | 2B (lite), 19B (pro) | ✓ | ✓* | int8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | Yes | [KANDINSKY5_VIDEO.md](quickstart/KANDINSKY5_VIDEO.md) |
+| LongCat-Video | 13.6B | ✓ | ✓* | int8/fp8 optional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | Yes | [LONGCAT_VIDEO.md](quickstart/LONGCAT_VIDEO.md) |
+| LongCat-Video Edit | 13.6B | ✓ | ✓* | int8/fp8 optional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | Yes | [LONGCAT_VIDEO_EDIT.md](quickstart/LONGCAT_VIDEO_EDIT.md) |
+| LongCat-Image | 6B | ✓ | ✓* | int8/fp8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [LONGCAT_IMAGE.md](quickstart/LONGCAT_IMAGE.md) |
+| LongCat-Image Edit | 6B | ✓ | ✓* | int8/fp8 optional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [LONGCAT_EDIT.md](quickstart/LONGCAT_EDIT.md) |
 
 *✓ = supported, ✓* = requires DeepSpeed/FSDP2 for full-rank, ✗ = not supported, `✓+` indicates checkpointing is recommended due to VRAM pressure. Ref Inputs marks existing reference/edit/I2V conditioning paths; `opt` means optional, `req` means the edit/I2V flavour requires it. TwinFlow ✓ means native support when `twinflow_enabled=true` (diffusion models need `diff2flow_enabled+twinflow_allow_diff2flow`). Self-Flow ✓ means native support for `crepa_enabled=true` with `crepa_feature_source=self_flow`, `use_ema=true`, and `crepa_teacher_block_index` set. LayerSync ✓ means the backbone exposes transformer hidden states for self-alignment; ✗ marks UNet-style backbones without that buffer. †Sliders apply to LoRA and LyCORIS (including full-rank LyCORIS "full"). All models support LyCORIS.*
+
+**License notes:** The commercial-use status covers model weights, derivative checkpoints, fine-tunes, and hosted model use. Generated-output rights can differ; read the linked license text before commercial deployment.
+
+<sup>1</sup> OpenRAIL-style licenses generally permit commercial use with usage restrictions that remain attached to the model and derivatives.
+
+<sup>2</sup> Stability AI Community License is available for qualifying users below the revenue threshold; larger commercial use needs Stability enterprise terms.
+
+<sup>3</sup> Flux.1 varies by flavour: Schnell and LibreFlux are Apache-2.0, while Dev, Krea, and Kontext use BFL non-commercial terms; review FluxBooru upstream metadata before commercial use.
+
+<sup>4</sup> Flux.2 varies by flavour: Klein 4B is Apache-2.0, while Dev and Klein 9B use BFL non-commercial terms.
+
+<sup>5</sup> Public non-commercial model terms do not permit commercial use of weights, derivative checkpoints, or hosted model services without a separate license.
+
+<sup>6</sup> Krea 2 Community License permits commercial use only under its revenue and safety/filtering requirements; otherwise an enterprise license is required.
+
+<sup>7</sup> Kolors commercial model or derivative use requires applying for and receiving explicit permission from the licensor.
+
+<sup>8</sup> AuraFlow supports Apache-2.0 upstream flavours and a Pony flavour with a separate custom license; check the selected flavour.
+
+<sup>9</sup> NVIDIA Open Model License permits commercial use but includes agreement, acceptable-use, and export-control terms.
+
+<sup>10</sup> LTX Video 0.9.5 uses OpenRAIL-M; LTX Video 2 uses LTX community terms with a revenue threshold for commercial use.
+
+<sup>11</sup> Tencent Hunyuan Community License includes territorial exclusions and a commercial threshold for very large services.
+
+<sup>12</sup> This mirror publishes `license: other` without a standard license text; review upstream terms before commercial use.
 
 > ℹ️ Wan quickstart includes 2.1 + 2.2 stage presets and the time-embedding toggle. Flux Kontext covers editing workflows built atop Flux.1.
 

--- a/documentation/QUICKSTART.pt-BR.md
+++ b/documentation/QUICKSTART.pt-BR.md
@@ -8,45 +8,74 @@ Para a matriz completa e mais precisa de recursos, consulte o [README principal]
 
 ## Guias de início rápido por modelo
 
-| Modelo | Parâmetros | LoRA PEFT | Lycoris | Full-Rank | Quantização | Precisão mista | Checkpoint de gradiente | Flow Shift | TwinFlow | Self-Flow | LayerSync | Ref Inputs | ControlNet | Sliders† | Guia |
-| --- | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | --- |
-| PixArt Sigma | 0.6B–0.9B | ✗ | ✓ | ✓ | int8 opcional | bf16 | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | [SIGMA.md](quickstart/SIGMA.md) |
-| NVLabs Sana | 1.6B–4.8B | ✗ | ✓ | ✓ | int8 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [SANA.md](quickstart/SANA.md) |
-| Kwai Kolors | 2.7B | ✓ | ✓ | ✓ | não recomendado | bf16 | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [KOLORS.md](quickstart/KOLORS.md) |
-| Stable Diffusion 3 | 2B–8B | ✓ | ✓ | ✓ | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [SD3.md](quickstart/SD3.md) |
-| Flux.1 | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [FLUX.md](quickstart/FLUX.md) |
-| Flux.2 | 32B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [FLUX2.md](quickstart/FLUX2.md) |
-| Flux Kontext | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✓ | ✓ | [FLUX_KONTEXT.md](quickstart/FLUX_KONTEXT.md) |
-| Z-Image Turbo | 6B | ✓ | ✗ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [ZIMAGE.md](quickstart/ZIMAGE.md) |
-| Krea2 | - | ✓ | ✗ | ✓* | int8 opcional | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✓ opt | ✗ | ✓ | [KREA2.md](quickstart/KREA2.pt-BR.md) |
-| Boogu-Image 0.1 | - | ✓ | ✓ | ✓* | fp8 opcional | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ edit | ✗ | ✓ | [BOOGU_IMAGE.md](quickstart/BOOGU_IMAGE.pt-BR.md) |
-| zlab i1 | 3B | ✓ | ✓ | ✓ | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [ZLAB_i1.md](quickstart/ZLAB_i1.pt-BR.md) |
-| Ideogram 4 | 9B | ✓ | ✓ | ✓* | fp8 padrão, nf4 opcional | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [IDEOGRAM4.md](quickstart/IDEOGRAM4.pt-BR.md) |
-| ACE-Step | 3.5B | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | [ACE_STEP.md](quickstart/ACE_STEP.md) |
-| Chroma 1 | 8.9B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [CHROMA.md](quickstart/CHROMA.md) |
-| Auraflow | 6B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [AURAFLOW.md](quickstart/AURAFLOW.md) |
-| HiDream I1 | 17B (8.5B MoE) | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [HIDREAM.md](quickstart/HIDREAM.md) |
-| OmniGen | 3.8B | ✓ | ✓ | ✓ | int8/fp8 opcional | bf16 | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | [OMNIGEN.md](quickstart/OMNIGEN.md) |
-| Stable Diffusion XL | 2.6B | ✓ | ✓ | ✓ | não recomendado | bf16 | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | [SDXL.md](quickstart/SDXL.md) |
-| Lumina2 | 2B | ✓ | ✓ | ✓ | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | [LUMINA2.md](quickstart/LUMINA2.md) |
-| Cosmos2 | 2B | ✓ | ✓ | ✓ | não recomendado | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [COSMOS2IMAGE.md](quickstart/COSMOS2IMAGE.md) |
-| Cosmos3 | 16B-65B | ✓ | ✓ | ✓* | no_change primeiro | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | audio opt | ✗ | ✓ | [COSMOS3.md](quickstart/COSMOS3.pt-BR.md) |
-| LTX Video | ~2.5B | ✓ | ✓ | ✓ | int8/fp8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [LTXVIDEO.md](quickstart/LTXVIDEO.md) |
-| LTX Video 2 | 19B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [LTXVIDEO2.md](quickstart/LTXVIDEO2.md) |
-| Hunyuan Video 1.5 | 8.3B | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [HUNYUANVIDEO.md](quickstart/HUNYUANVIDEO.md) |
-| Wan 2.x | 1.3B–14B | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [WAN.md](quickstart/WAN.md) |
-| Wan 2.2 S2V | 14B | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [WAN_S2V.md](quickstart/WAN_S2V.md) |
-| Qwen Image | 20B | ✓ | ✓ | ✓* | **obrigatório** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [QWEN_IMAGE.md](quickstart/QWEN_IMAGE.md) |
-| Qwen Image Edit | 20B | ✓ | ✓ | ✓* | **obrigatório** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [QWEN_EDIT.md](quickstart/QWEN_EDIT.md) |
-| Stable Cascade (C) | 1B, 3.6B prior | ✓ | ✓ | ✓* | não suportado | fp32 (obrigatório) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [STABLE_CASCADE_C.md](quickstart/STABLE_CASCADE_C.md) |
-| Kandinsky 5.0 Image | 6B (lite) | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ I2I | ✗ | ✓ | [KANDINSKY5_IMAGE.md](quickstart/KANDINSKY5_IMAGE.md) |
-| Kandinsky 5.0 Video | 2B (lite), 19B (pro) | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [KANDINSKY5_VIDEO.md](quickstart/KANDINSKY5_VIDEO.md) |
-| LongCat-Video | 13.6B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [LONGCAT_VIDEO.md](quickstart/LONGCAT_VIDEO.md) |
-| LongCat-Video Edit | 13.6B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [LONGCAT_VIDEO_EDIT.md](quickstart/LONGCAT_VIDEO_EDIT.md) |
-| LongCat-Image | 6B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [LONGCAT_IMAGE.md](quickstart/LONGCAT_IMAGE.md) |
-| LongCat-Image Edit | 6B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [LONGCAT_EDIT.md](quickstart/LONGCAT_EDIT.md) |
+| Modelo | Parâmetros | LoRA PEFT | Lycoris | Full-Rank | Quantização | Precisão mista | Checkpoint de gradiente | Flow Shift | TwinFlow | Self-Flow | LayerSync | Ref Inputs | ControlNet | Sliders† | Licença | Permite uso comercial | Guia |
+| --- | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | --- | :---: | --- |
+| PixArt Sigma | 0.6B–0.9B | ✗ | ✓ | ✓ | int8 opcional | bf16 | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | Condições aplicáveis<sup>1</sup> | [SIGMA.md](quickstart/SIGMA.md) |
+| NVLabs Sana | 1.6B–4.8B | ✗ | ✓ | ✓ | int8 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [SANA.md](quickstart/SANA.md) |
+| Kwai Kolors | 2.7B | ✓ | ✓ | ✓ | não recomendado | bf16 | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [Kwai Kolors License](https://huggingface.co/terminusresearch/kwai-kolors-1.0/blob/main/MODEL_LICENSE) | Condições aplicáveis<sup>7</sup> | [KOLORS.md](quickstart/KOLORS.md) |
+| Stable Diffusion 3 | 2B–8B | ✓ | ✓ | ✓ | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [Stability AI Community](https://stability.ai/license) | Condições aplicáveis<sup>2</sup> | [SD3.md](quickstart/SD3.md) |
+| Flux.1 | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Condições aplicáveis<sup>3</sup> | [FLUX.md](quickstart/FLUX.md) |
+| Flux.2 | 32B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Condições aplicáveis<sup>4</sup> | [FLUX2.md](quickstart/FLUX2.md) |
+| Flux Kontext | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✓ | ✓ | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) | Não<sup>5</sup> | [FLUX_KONTEXT.md](quickstart/FLUX_KONTEXT.md) |
+| Z-Image Turbo | 6B | ✓ | ✗ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [ZIMAGE.md](quickstart/ZIMAGE.md) |
+| Krea2 | - | ✓ | ✗ | ✓* | int8 opcional | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✓ opt | ✗ | ✓ | [Krea 2 Community](https://www.krea.ai/krea-2-licensing) | Condições aplicáveis<sup>6</sup> | [KREA2.md](quickstart/KREA2.pt-BR.md) |
+| Mage-Flow | 4B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ edit | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | Sim | [MAGEFLOW.md](quickstart/MAGEFLOW.pt-BR.md) |
+| Boogu-Image 0.1 | - | ✓ | ✓ | ✓* | fp8 opcional | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ edit | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [BOOGU_IMAGE.md](quickstart/BOOGU_IMAGE.pt-BR.md) |
+| zlab i1 | 3B | ✓ | ✓ | ✓ | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Unspecified](https://huggingface.co/bghira/zlab-i1-diffusers) | Condições aplicáveis<sup>12</sup> | [ZLAB_i1.md](quickstart/ZLAB_i1.pt-BR.md) |
+| Ideogram 4 | 9B | ✓ | ✓ | ✓* | fp8 padrão, nf4 opcional | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [Ideogram 4 Non-Commercial](https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md) | Não<sup>5</sup> | [IDEOGRAM4.md](quickstart/IDEOGRAM4.pt-BR.md) |
+| ERNIE-Image | - | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [ERNIE.md](quickstart/ERNIE.pt-BR.md) |
+| ACE-Step | 3.5B | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://huggingface.co/ACE-Step/ACE-Step-v1-3.5B) / [MIT](https://huggingface.co/ACE-Step/Ace-Step1.5) | Sim | [ACE_STEP.md](quickstart/ACE_STEP.md) |
+| Chroma 1 | 8.9B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [CHROMA.md](quickstart/CHROMA.md) |
+| Auraflow | 6B | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) / [Pony License](https://huggingface.co/purplesmartai/pony-v7-base/blob/main/LICENSE) | Condições aplicáveis<sup>8</sup> | [AURAFLOW.md](quickstart/AURAFLOW.md) |
+| HiDream I1 | 17B (8.5B MoE) | ✓ | ✓ | ✓* | int8/fp8/nf4 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [MIT](https://opensource.org/license/mit) | Sim | [HIDREAM.md](quickstart/HIDREAM.md) |
+| OmniGen | 3.8B | ✓ | ✓ | ✓ | int8/fp8 opcional | bf16 | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | Sim | [OMNIGEN.md](quickstart/OMNIGEN.md) |
+| Stable Diffusion XL | 2.6B | ✓ | ✓ | ✓ | não recomendado | bf16 | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | Condições aplicáveis<sup>1</sup> | [SDXL.md](quickstart/SDXL.md) |
+| Lumina2 | 2B | ✓ | ✓ | ✓ | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [LUMINA2.md](quickstart/LUMINA2.md) |
+| Cosmos2 | 2B | ✓ | ✓ | ✓ | não recomendado | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [NVIDIA Open Model License](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) | Sim<sup>9</sup> | [COSMOS2IMAGE.md](quickstart/COSMOS2IMAGE.md) |
+| Cosmos3 | 16B-65B | ✓ | ✓ | ✓* | no_change primeiro | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | audio opt | ✗ | ✓ | [OpenMDW 1.1](https://github.com/OpenMDW/openmdw/blob/main/1.1/LICENSE.OpenMDW-1.1) | Sim | [COSMOS3.md](quickstart/COSMOS3.pt-BR.md) |
+| LTX Video | ~2.5B | ✓ | ✓ | ✓ | int8/fp8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [LTX Video OpenRAIL-M](https://huggingface.co/Lightricks/LTX-Video-0.9.5/blob/main/ltx-video-2b-v0.9.5.license.txt) | Condições aplicáveis<sup>10</sup> | [LTXVIDEO.md](quickstart/LTXVIDEO.md) |
+| LTX Video 2 | 19B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [LTX-2 Community](https://ltx.io/model/license) | Condições aplicáveis<sup>10</sup> | [LTXVIDEO2.md](quickstart/LTXVIDEO2.md) |
+| Hunyuan Video 1.5 | 8.3B | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [Tencent Hunyuan Community](https://huggingface.co/tencent/HunyuanVideo-1.5/blob/main/LICENSE) | Condições aplicáveis<sup>11</sup> | [HUNYUANVIDEO.md](quickstart/HUNYUANVIDEO.md) |
+| SanaVideo | 2B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [SANAVIDEO.md](quickstart/SANAVIDEO.pt-BR.md) |
+| Wan 2.x | 1.3B–14B | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [WAN.md](quickstart/WAN.md) |
+| Wan 2.2 S2V | 14B | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [WAN_S2V.md](quickstart/WAN_S2V.md) |
+| Qwen Image | 20B | ✓ | ✓ | ✓* | **obrigatório** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [QWEN_IMAGE.md](quickstart/QWEN_IMAGE.md) |
+| Qwen Image Edit | 20B | ✓ | ✓ | ✓* | **obrigatório** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [QWEN_EDIT.md](quickstart/QWEN_EDIT.md) |
+| Stable Cascade (C) | 1B, 3.6B prior | ✓ | ✓ | ✓* | não suportado | fp32 (obrigatório) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [Stable Cascade NC Community](https://huggingface.co/stabilityai/stable-cascade/blob/main/LICENSE) | Não<sup>5</sup> | [STABLE_CASCADE_C.md](quickstart/STABLE_CASCADE_C.md) |
+| Kandinsky 5.0 Image | 6B (lite) | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ I2I | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | Sim | [KANDINSKY5_IMAGE.md](quickstart/KANDINSKY5_IMAGE.md) |
+| Kandinsky 5.0 Video | 2B (lite), 19B (pro) | ✓ | ✓ | ✓* | int8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | Sim | [KANDINSKY5_VIDEO.md](quickstart/KANDINSKY5_VIDEO.md) |
+| LongCat-Video | 13.6B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | Sim | [LONGCAT_VIDEO.md](quickstart/LONGCAT_VIDEO.md) |
+| LongCat-Video Edit | 13.6B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | Sim | [LONGCAT_VIDEO_EDIT.md](quickstart/LONGCAT_VIDEO_EDIT.md) |
+| LongCat-Image | 6B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [LONGCAT_IMAGE.md](quickstart/LONGCAT_IMAGE.md) |
+| LongCat-Image Edit | 6B | ✓ | ✓ | ✓* | int8/fp8 opcional | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [LONGCAT_EDIT.md](quickstart/LONGCAT_EDIT.md) |
 
 *✓ = suportado, ✓* = requer DeepSpeed/FSDP2 para full-rank, ✗ = não suportado, `✓+` indica que o checkpointing é recomendado devido à pressão de VRAM. Ref Inputs marca caminhos existentes de condicionamento por referência/edição/I2V; `opt` significa opcional e `req` significa obrigatório para o flavour de edição/I2V. TwinFlow ✓ significa suporte nativo quando `twinflow_enabled=true` (modelos de difusão precisam de `diff2flow_enabled+twinflow_allow_diff2flow`). Self-Flow ✓ significa suporte nativo para `crepa_enabled=true` com `crepa_feature_source=self_flow`, `use_ema=true` e `crepa_teacher_block_index` definido. LayerSync ✓ significa que o backbone expõe estados ocultos do transformer para autoalinhamento; ✗ marca backbones estilo UNet sem esse buffer. †Sliders se aplicam a LoRA e LyCORIS (incluindo LyCORIS full-rank “full”).*
+
+**Notas de licença:** O status de uso comercial cobre pesos do modelo, checkpoints derivados, fine-tunes e uso de modelo hospedado. Os direitos sobre saídas geradas podem diferir; leia o texto da licença vinculada antes de uma implantação comercial.
+
+<sup>1</sup> Licenças estilo OpenRAIL geralmente permitem uso comercial com restrições de uso que continuam aplicáveis ao modelo e seus derivados.
+
+<sup>2</sup> A Stability AI Community License está disponível para usuários qualificados abaixo do limite de receita; uso comercial maior exige termos empresariais da Stability.
+
+<sup>3</sup> Flux.1 varia por flavour: Schnell e LibreFlux são Apache-2.0, enquanto Dev, Krea e Kontext usam termos não comerciais da BFL; revise os metadados upstream do FluxBooru antes de uso comercial.
+
+<sup>4</sup> Flux.2 varia por flavour: Klein 4B é Apache-2.0, enquanto Dev e Klein 9B usam termos não comerciais da BFL.
+
+<sup>5</sup> Termos públicos de modelo não comercial não permitem uso comercial de pesos, checkpoints derivados ou serviços hospedados do modelo sem uma licença separada.
+
+<sup>6</sup> A Krea 2 Community License permite uso comercial apenas sob seus requisitos de receita e segurança/filtragem; caso contrário, é necessária uma licença empresarial.
+
+<sup>7</sup> O uso comercial do modelo Kolors ou de seus derivados exige solicitar e receber permissão explícita do licenciante.
+
+<sup>8</sup> AuraFlow aceita flavours upstream Apache-2.0 e um flavour Pony com uma licença personalizada separada; confira o flavour selecionado.
+
+<sup>9</sup> A NVIDIA Open Model License permite uso comercial, mas inclui termos de contrato, uso aceitável e controle de exportação.
+
+<sup>10</sup> LTX Video 0.9.5 usa OpenRAIL-M; LTX Video 2 usa termos comunitários da LTX com limite de receita para uso comercial.
+
+<sup>11</sup> A Tencent Hunyuan Community License inclui exclusões territoriais e um limite comercial para serviços muito grandes.
+
+<sup>12</sup> Este mirror publica `license: other` sem texto de licença padrão; revise os termos upstream antes de uso comercial.
 
 > ℹ️ O quickstart do Wan inclui presets das etapas 2.1 + 2.2 e o toggle de time-embedding. Flux Kontext cobre fluxos de edição construídos sobre o Flux.1.
 
@@ -76,4 +105,4 @@ Se seu dataset acaba com menos amostras utilizáveis do que você esperava, arqu
 - Na WebUI, navegue até o diretório do seu dataset e selecione-o para ver estatísticas de filtragem
 - Verifique os logs durante o processamento do dataset por estatísticas como: `Sample processing statistics: {'total_processed': 100, 'skipped': {'too_small': 15, ...}}`
 
-Para solução de problemas detalhada, consulte [Solucionando problemas de datasets filtrados](DATALOADER.pt-BR.md#solucionando-problemas-de-datasets-filtrados) na documentação do dataloader.
+Para solução de problemas detalhada, consulte [Solucionando problemas de datasets filtrados](DATALOADER.pt-BR.md) na documentação do dataloader.

--- a/documentation/QUICKSTART.zh.md
+++ b/documentation/QUICKSTART.zh.md
@@ -8,45 +8,74 @@
 
 ## 模型快速开始指南
 
-| 模型 | 参数量 | PEFT LoRA | Lycoris | 全秩 | 量化 | 混合精度 | 梯度检查点 | Flow Shift | TwinFlow | Self-Flow | LayerSync | Ref Inputs | ControlNet | Sliders† | 指南 |
-| --- | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | --- |
-| PixArt Sigma | 0.6B–0.9B | ✗ | ✓ | ✓ | int8 可选 | bf16 | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | [SIGMA.md](quickstart/SIGMA.md) |
-| NVLabs Sana | 1.6B–4.8B | ✗ | ✓ | ✓ | int8 可选 | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [SANA.md](quickstart/SANA.md) |
-| Kwai Kolors | 2.7B | ✓ | ✓ | ✓ | 不推荐 | bf16 | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [KOLORS.md](quickstart/KOLORS.md) |
-| Stable Diffusion 3 | 2B–8B | ✓ | ✓ | ✓ | int8/fp8/nf4 可选 | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [SD3.md](quickstart/SD3.md) |
-| Flux.1 | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 可选 | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [FLUX.md](quickstart/FLUX.md) |
-| Flux.2 | 32B | ✓ | ✓ | ✓* | int8/fp8/nf4 可选 | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [FLUX2.md](quickstart/FLUX2.md) |
-| Flux Kontext | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 可选 | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✓ | ✓ | [FLUX_KONTEXT.md](quickstart/FLUX_KONTEXT.md) |
-| Z-Image Turbo | 6B | ✓ | ✗ | ✓* | int8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [ZIMAGE.md](quickstart/ZIMAGE.md) |
-| Krea2 | - | ✓ | ✗ | ✓* | int8 可选 | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✓ opt | ✗ | ✓ | [KREA2.md](quickstart/KREA2.zh.md) |
-| Boogu-Image 0.1 | - | ✓ | ✓ | ✓* | fp8 可选 | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ edit | ✗ | ✓ | [BOOGU_IMAGE.md](quickstart/BOOGU_IMAGE.zh.md) |
-| zlab i1 | 3B | ✓ | ✓ | ✓ | int8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [ZLAB_i1.md](quickstart/ZLAB_i1.zh.md) |
-| Ideogram 4 | 9B | ✓ | ✓ | ✓* | fp8 默认，nf4 可选 | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [IDEOGRAM4.md](quickstart/IDEOGRAM4.zh.md) |
-| ACE-Step | 3.5B | ✓ | ✓ | ✓* | int8 可选 | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | [ACE_STEP.md](quickstart/ACE_STEP.md) |
-| Chroma 1 | 8.9B | ✓ | ✓ | ✓* | int8/fp8/nf4 可选 | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [CHROMA.md](quickstart/CHROMA.md) |
-| Auraflow | 6B | ✓ | ✓ | ✓* | int8/fp8/nf4 可选 | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [AURAFLOW.md](quickstart/AURAFLOW.md) |
-| HiDream I1 | 17B (8.5B MoE) | ✓ | ✓ | ✓* | int8/fp8/nf4 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [HIDREAM.md](quickstart/HIDREAM.md) |
-| OmniGen | 3.8B | ✓ | ✓ | ✓ | int8/fp8 可选 | bf16 | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | [OMNIGEN.md](quickstart/OMNIGEN.md) |
-| Stable Diffusion XL | 2.6B | ✓ | ✓ | ✓ | 不推荐 | bf16 | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | [SDXL.md](quickstart/SDXL.md) |
-| Lumina2 | 2B | ✓ | ✓ | ✓ | int8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | [LUMINA2.md](quickstart/LUMINA2.md) |
-| Cosmos2 | 2B | ✓ | ✓ | ✓ | 不推荐 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [COSMOS2IMAGE.md](quickstart/COSMOS2IMAGE.md) |
-| Cosmos3 | 16B-65B | ✓ | ✓ | ✓* | no_change first | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | audio opt | ✗ | ✓ | [COSMOS3.md](quickstart/COSMOS3.zh.md) |
-| LTX Video | ~2.5B | ✓ | ✓ | ✓ | int8/fp8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [LTXVIDEO.md](quickstart/LTXVIDEO.md) |
-| LTX Video 2 | 19B | ✓ | ✓ | ✓* | int8/fp8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [LTXVIDEO2.md](quickstart/LTXVIDEO2.md) |
-| Hunyuan Video 1.5 | 8.3B | ✓ | ✓ | ✓* | int8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [HUNYUANVIDEO.md](quickstart/HUNYUANVIDEO.md) |
-| Wan 2.x | 1.3B–14B | ✓ | ✓ | ✓* | int8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [WAN.md](quickstart/WAN.md) |
-| Wan 2.2 S2V | 14B | ✓ | ✓ | ✓* | int8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [WAN_S2V.md](quickstart/WAN_S2V.md) |
-| Qwen Image | 20B | ✓ | ✓ | ✓* | **必需** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [QWEN_IMAGE.md](quickstart/QWEN_IMAGE.md) |
-| Qwen Image Edit | 20B | ✓ | ✓ | ✓* | **必需** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [QWEN_EDIT.md](quickstart/QWEN_EDIT.md) |
-| Stable Cascade (C) | 1B, 3.6B prior | ✓ | ✓ | ✓* | 不支持 | fp32 (必需) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [STABLE_CASCADE_C.md](quickstart/STABLE_CASCADE_C.md) |
-| Kandinsky 5.0 Image | 6B (lite) | ✓ | ✓ | ✓* | int8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ I2I | ✗ | ✓ | [KANDINSKY5_IMAGE.md](quickstart/KANDINSKY5_IMAGE.md) |
-| Kandinsky 5.0 Video | 2B (lite), 19B (pro) | ✓ | ✓ | ✓* | int8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [KANDINSKY5_VIDEO.md](quickstart/KANDINSKY5_VIDEO.md) |
-| LongCat-Video | 13.6B | ✓ | ✓ | ✓* | int8/fp8 可选 | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [LONGCAT_VIDEO.md](quickstart/LONGCAT_VIDEO.md) |
-| LongCat-Video Edit | 13.6B | ✓ | ✓ | ✓* | int8/fp8 可选 | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [LONGCAT_VIDEO_EDIT.md](quickstart/LONGCAT_VIDEO_EDIT.md) |
-| LongCat-Image | 6B | ✓ | ✓ | ✓* | int8/fp8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [LONGCAT_IMAGE.md](quickstart/LONGCAT_IMAGE.md) |
-| LongCat-Image Edit | 6B | ✓ | ✓ | ✓* | int8/fp8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [LONGCAT_EDIT.md](quickstart/LONGCAT_EDIT.md) |
+| 模型 | 参数量 | PEFT LoRA | Lycoris | 全秩 | 量化 | 混合精度 | 梯度检查点 | Flow Shift | TwinFlow | Self-Flow | LayerSync | Ref Inputs | ControlNet | Sliders† | 许可证 | 允许商用 | 指南 |
+| --- | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | --- | :---: | --- |
+| PixArt Sigma | 0.6B–0.9B | ✗ | ✓ | ✓ | int8 可选 | bf16 | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | 有条件<sup>1</sup> | [SIGMA.md](quickstart/SIGMA.md) |
+| NVLabs Sana | 1.6B–4.8B | ✗ | ✓ | ✓ | int8 可选 | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [SANA.md](quickstart/SANA.md) |
+| Kwai Kolors | 2.7B | ✓ | ✓ | ✓ | 不推荐 | bf16 | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [Kwai Kolors License](https://huggingface.co/terminusresearch/kwai-kolors-1.0/blob/main/MODEL_LICENSE) | 有条件<sup>7</sup> | [KOLORS.md](quickstart/KOLORS.md) |
+| Stable Diffusion 3 | 2B–8B | ✓ | ✓ | ✓ | int8/fp8/nf4 可选 | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [Stability AI Community](https://stability.ai/license) | 有条件<sup>2</sup> | [SD3.md](quickstart/SD3.md) |
+| Flux.1 | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 可选 | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 有条件<sup>3</sup> | [FLUX.md](quickstart/FLUX.md) |
+| Flux.2 | 32B | ✓ | ✓ | ✓* | int8/fp8/nf4 可选 | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 有条件<sup>4</sup> | [FLUX2.md](quickstart/FLUX2.md) |
+| Flux Kontext | 8B–12B | ✓ | ✓ | ✓* | int8/fp8/nf4 可选 | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✓ | ✓ | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) | 否<sup>5</sup> | [FLUX_KONTEXT.md](quickstart/FLUX_KONTEXT.md) |
+| Z-Image Turbo | 6B | ✓ | ✗ | ✓* | int8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [ZIMAGE.md](quickstart/ZIMAGE.md) |
+| Krea2 | - | ✓ | ✗ | ✓* | int8 可选 | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✓ opt | ✗ | ✓ | [Krea 2 Community](https://www.krea.ai/krea-2-licensing) | 有条件<sup>6</sup> | [KREA2.md](quickstart/KREA2.zh.md) |
+| Mage-Flow | 4B | ✓ | ✓ | ✓* | int8/fp8 可选 | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ edit | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | 是 | [MAGEFLOW.md](quickstart/MAGEFLOW.zh.md) |
+| Boogu-Image 0.1 | - | ✓ | ✓ | ✓* | fp8 可选 | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ edit | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [BOOGU_IMAGE.md](quickstart/BOOGU_IMAGE.zh.md) |
+| zlab i1 | 3B | ✓ | ✓ | ✓ | int8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Unspecified](https://huggingface.co/bghira/zlab-i1-diffusers) | 有条件<sup>12</sup> | [ZLAB_i1.md](quickstart/ZLAB_i1.zh.md) |
+| Ideogram 4 | 9B | ✓ | ✓ | ✓* | fp8 默认，nf4 可选 | bf16 | ✓+ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [Ideogram 4 Non-Commercial](https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md) | 否<sup>5</sup> | [IDEOGRAM4.md](quickstart/IDEOGRAM4.zh.md) |
+| ERNIE-Image | - | ✓ | ✓ | ✓* | int8 可选 | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [ERNIE.md](quickstart/ERNIE.zh.md) |
+| ACE-Step | 3.5B | ✓ | ✓ | ✓* | int8 可选 | bf16 | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://huggingface.co/ACE-Step/ACE-Step-v1-3.5B) / [MIT](https://huggingface.co/ACE-Step/Ace-Step1.5) | 是 | [ACE_STEP.md](quickstart/ACE_STEP.md) |
+| Chroma 1 | 8.9B | ✓ | ✓ | ✓* | int8/fp8/nf4 可选 | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [CHROMA.md](quickstart/CHROMA.md) |
+| Auraflow | 6B | ✓ | ✓ | ✓* | int8/fp8/nf4 可选 | bf16 | ✓+ | ✓ (SLG) | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) / [Pony License](https://huggingface.co/purplesmartai/pony-v7-base/blob/main/LICENSE) | 有条件<sup>8</sup> | [AURAFLOW.md](quickstart/AURAFLOW.md) |
+| HiDream I1 | 17B (8.5B MoE) | ✓ | ✓ | ✓* | int8/fp8/nf4 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | [MIT](https://opensource.org/license/mit) | 是 | [HIDREAM.md](quickstart/HIDREAM.md) |
+| OmniGen | 3.8B | ✓ | ✓ | ✓ | int8/fp8 可选 | bf16 | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | 是 | [OMNIGEN.md](quickstart/OMNIGEN.md) |
+| Stable Diffusion XL | 2.6B | ✓ | ✓ | ✓ | 不推荐 | bf16 | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | 有条件<sup>1</sup> | [SDXL.md](quickstart/SDXL.md) |
+| Lumina2 | 2B | ✓ | ✓ | ✓ | int8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [LUMINA2.md](quickstart/LUMINA2.md) |
+| Cosmos2 | 2B | ✓ | ✓ | ✓ | 不推荐 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [NVIDIA Open Model License](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) | 是<sup>9</sup> | [COSMOS2IMAGE.md](quickstart/COSMOS2IMAGE.md) |
+| Cosmos3 | 16B-65B | ✓ | ✓ | ✓* | no_change first | bf16 | ✓ | ✓ | ✗ | ✗ | ✗ | audio opt | ✗ | ✓ | [OpenMDW 1.1](https://github.com/OpenMDW/openmdw/blob/main/1.1/LICENSE.OpenMDW-1.1) | 是 | [COSMOS3.md](quickstart/COSMOS3.zh.md) |
+| LTX Video | ~2.5B | ✓ | ✓ | ✓ | int8/fp8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [LTX Video OpenRAIL-M](https://huggingface.co/Lightricks/LTX-Video-0.9.5/blob/main/ltx-video-2b-v0.9.5.license.txt) | 有条件<sup>10</sup> | [LTXVIDEO.md](quickstart/LTXVIDEO.md) |
+| LTX Video 2 | 19B | ✓ | ✓ | ✓* | int8/fp8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [LTX-2 Community](https://ltx.io/model/license) | 有条件<sup>10</sup> | [LTXVIDEO2.md](quickstart/LTXVIDEO2.md) |
+| Hunyuan Video 1.5 | 8.3B | ✓ | ✓ | ✓* | int8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [Tencent Hunyuan Community](https://huggingface.co/tencent/HunyuanVideo-1.5/blob/main/LICENSE) | 有条件<sup>11</sup> | [HUNYUANVIDEO.md](quickstart/HUNYUANVIDEO.md) |
+| SanaVideo | 2B | ✓ | ✓ | ✓* | int8/fp8 可选 | bf16 | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [SANAVIDEO.md](quickstart/SANAVIDEO.zh.md) |
+| Wan 2.x | 1.3B–14B | ✓ | ✓ | ✓* | int8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [WAN.md](quickstart/WAN.md) |
+| Wan 2.2 S2V | 14B | ✓ | ✓ | ✓* | int8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [WAN_S2V.md](quickstart/WAN_S2V.md) |
+| Qwen Image | 20B | ✓ | ✓ | ✓* | **必需** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [QWEN_IMAGE.md](quickstart/QWEN_IMAGE.md) |
+| Qwen Image Edit | 20B | ✓ | ✓ | ✓* | **必需** (int8/nf4) | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [QWEN_EDIT.md](quickstart/QWEN_EDIT.md) |
+| Stable Cascade (C) | 1B, 3.6B prior | ✓ | ✓ | ✓* | 不支持 | fp32 (必需) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | [Stable Cascade NC Community](https://huggingface.co/stabilityai/stable-cascade/blob/main/LICENSE) | 否<sup>5</sup> | [STABLE_CASCADE_C.md](quickstart/STABLE_CASCADE_C.md) |
+| Kandinsky 5.0 Image | 6B (lite) | ✓ | ✓ | ✓* | int8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ I2I | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | 是 | [KANDINSKY5_IMAGE.md](quickstart/KANDINSKY5_IMAGE.md) |
+| Kandinsky 5.0 Video | 2B (lite), 19B (pro) | ✓ | ✓ | ✓* | int8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ I2V | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | 是 | [KANDINSKY5_VIDEO.md](quickstart/KANDINSKY5_VIDEO.md) |
+| LongCat-Video | 13.6B | ✓ | ✓ | ✓* | int8/fp8 可选 | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ opt | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | 是 | [LONGCAT_VIDEO.md](quickstart/LONGCAT_VIDEO.md) |
+| LongCat-Video Edit | 13.6B | ✓ | ✓ | ✓* | int8/fp8 可选 | bf16 | ✓+ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [MIT](https://opensource.org/license/mit) | 是 | [LONGCAT_VIDEO_EDIT.md](quickstart/LONGCAT_VIDEO_EDIT.md) |
+| LongCat-Image | 6B | ✓ | ✓ | ✓* | int8/fp8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [LONGCAT_IMAGE.md](quickstart/LONGCAT_IMAGE.md) |
+| LongCat-Image Edit | 6B | ✓ | ✓ | ✓* | int8/fp8 可选 | bf16 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ req | ✗ | ✓ | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [LONGCAT_EDIT.md](quickstart/LONGCAT_EDIT.md) |
 
 *✓ = 支持，✓* = 全秩训练需要 DeepSpeed/FSDP2，✗ = 不支持，`✓+` 表示由于 VRAM 压力建议启用检查点。Ref Inputs 仅标记现有参考/编辑/I2V 条件路径；`opt` 表示可选，`req` 表示该编辑/I2V flavour 需要它。TwinFlow ✓ 表示当 `twinflow_enabled=true` 时原生支持（扩散模型需要 `diff2flow_enabled+twinflow_allow_diff2flow`）。Self-Flow ✓ 表示原生支持 `crepa_enabled=true`、`crepa_feature_source=self_flow`、`use_ema=true` 且设置 `crepa_teacher_block_index`。LayerSync ✓ 表示骨干网络暴露 transformer 隐藏状态用于自对齐；✗ 标记没有该缓冲区的 UNet 风格骨干网络。†Sliders 适用于 LoRA 和 LyCORIS（包括全秩 LyCORIS "full"）。*
+
+**许可证说明：** 商用状态覆盖模型权重、派生 checkpoint、fine-tune 和托管模型使用。生成输出的权利可能不同；商业部署前请以链接的许可证正文为准。
+
+<sup>1</sup> OpenRAIL 风格许可证通常允许商用，但使用限制仍适用于模型和派生物。
+
+<sup>2</sup> Stability AI Community License 适用于低于收入门槛且符合条件的用户；更大规模商用需要 Stability 企业条款。
+
+<sup>3</sup> Flux.1 随 flavour 不同而不同：Schnell 和 LibreFlux 为 Apache-2.0，Dev、Krea 和 Kontext 使用 BFL 非商用条款；FluxBooru 商用前请检查 upstream metadata。
+
+<sup>4</sup> Flux.2 随 flavour 不同而不同：Klein 4B 为 Apache-2.0，Dev 和 Klein 9B 使用 BFL 非商用条款。
+
+<sup>5</sup> 公开的非商用模型条款不允许在没有单独许可证的情况下商用权重、派生 checkpoint 或托管模型服务。
+
+<sup>6</sup> Krea 2 Community License 只在满足收入和安全/过滤要求时允许商用；否则需要企业许可证。
+
+<sup>7</sup> Kolors 模型或派生物的商用需要向许可方申请并获得明确许可。
+
+<sup>8</sup> AuraFlow 支持 Apache-2.0 upstream flavour，以及带有单独自定义许可证的 Pony flavour；请检查所选 flavour。
+
+<sup>9</sup> NVIDIA Open Model License 允许商用，但包含协议、可接受使用和出口管制条款。
+
+<sup>10</sup> LTX Video 0.9.5 使用 OpenRAIL-M；LTX Video 2 使用带商用收入门槛的 LTX community terms。
+
+<sup>11</sup> Tencent Hunyuan Community License 包含地域排除，以及针对超大规模服务的商用门槛。
+
+<sup>12</sup> 此 mirror 发布 `license: other`，但没有标准许可证正文；商用前请检查 upstream terms。
 
 > 注：Wan 快速开始包含 2.1 + 2.2 阶段预设和时间嵌入切换。Flux Kontext 涵盖基于 Flux.1 构建的编辑工作流程。
 
@@ -76,4 +105,4 @@
 - 在 WebUI 中，浏览到您的数据集目录并选择它以查看过滤统计
 - 在数据集处理期间检查日志中的统计信息，如：`Sample processing statistics: {'total_processed': 100, 'skipped': {'too_small': 15, ...}}`
 
-详细故障排除请参阅数据加载器文档中的[故障排除-过滤后的数据集](DATALOADER.zh.md#故障排除-过滤后的数据集)。
+详细故障排除请参阅数据加载器文档中的[故障排除-过滤后的数据集](DATALOADER.zh.md)。

--- a/documentation/quickstart/index.es.md
+++ b/documentation/quickstart/index.es.md
@@ -6,65 +6,91 @@ Guías paso a paso para entrenar cada arquitectura de modelo compatible.
 
 ### Flow Matching
 
-| Modelo | Parámetros | Guía |
-|-------|------------|-------|
-| **Flux.1** | 12B | [Guía de Flux.1](FLUX.md) |
-| **Flux.2** | 32B | [Guía de Flux.2](FLUX2.md) |
-| **Flux Kontext** | 12B | [Guía de Kontext](FLUX_KONTEXT.md) |
-| **Chroma** | 8.9B | [Guía de Chroma](CHROMA.md) |
-| **Stable Diffusion 3** | 2-8B | [Guía de SD3](SD3.md) |
-| **Auraflow** | 6.8B | [Guía de Auraflow](AURAFLOW.md) |
-| **Sana** | 0.6-4.8B | [Guía de Sana](SANA.md) |
-| **Lumina2** | 2B | [Guía de Lumina2](LUMINA2.md) |
-| **HiDream** | 17B MoE | [Guía de HiDream](HIDREAM.md) |
-| **Z-Image** | - | [Guía de Z-Image](ZIMAGE.md) |
-| **Krea2** | - | [Guía de Krea2](KREA2.es.md) |
-| **Mage-Flow** | 4B | [Guía de Mage-Flow](MAGEFLOW.es.md) |
-| **Boogu-Image** | - | [Guía de Boogu-Image](BOOGU_IMAGE.es.md) |
-| **zlab i1** | 3B | [Guía de zlab i1](ZLAB_i1.es.md) |
-| **Ideogram 4** | 9B | [Guía de Ideogram 4](IDEOGRAM4.es.md) |
-| **ERNIE-Image** | - | [Guía de ERNIE](ERNIE.md) |
+| Modelo | Parámetros | Licencia | Permite uso comercial | Guía |
+| ------- | ------------ | --- | :---: | ------- |
+| **Flux.1** | 12B | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Aplican condiciones<sup>3</sup> | [Guía de Flux.1](FLUX.md) |
+| **Flux.2** | 32B | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Aplican condiciones<sup>4</sup> | [Guía de Flux.2](FLUX2.md) |
+| **Flux Kontext** | 12B | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) | No<sup>5</sup> | [Guía de Kontext](FLUX_KONTEXT.md) |
+| **Chroma** | 8.9B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [Guía de Chroma](CHROMA.md) |
+| **Stable Diffusion 3** | 2-8B | [Stability AI Community](https://stability.ai/license) | Aplican condiciones<sup>2</sup> | [Guía de SD3](SD3.md) |
+| **Auraflow** | 6.8B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) / [Pony License](https://huggingface.co/purplesmartai/pony-v7-base/blob/main/LICENSE) | Aplican condiciones<sup>8</sup> | [Guía de Auraflow](AURAFLOW.md) |
+| **Sana** | 0.6-4.8B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [Guía de Sana](SANA.md) |
+| **Lumina2** | 2B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [Guía de Lumina2](LUMINA2.md) |
+| **HiDream** | 17B MoE | [MIT](https://opensource.org/license/mit) | Sí | [Guía de HiDream](HIDREAM.md) |
+| **Z-Image** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [Guía de Z-Image](ZIMAGE.md) |
+| **Krea2** | - | [Krea 2 Community](https://www.krea.ai/krea-2-licensing) | Aplican condiciones<sup>6</sup> | [Guía de Krea2](KREA2.es.md) |
+| **Mage-Flow** | 4B | [MIT](https://opensource.org/license/mit) | Sí | [Guía de Mage-Flow](MAGEFLOW.es.md) |
+| **Boogu-Image** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [Guía de Boogu-Image](BOOGU_IMAGE.es.md) |
+| **zlab i1** | 3B | [Unspecified](https://huggingface.co/bghira/zlab-i1-diffusers) | Aplican condiciones<sup>12</sup> | [Guía de zlab i1](ZLAB_i1.es.md) |
+| **Ideogram 4** | 9B | [Ideogram 4 Non-Commercial](https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md) | No<sup>5</sup> | [Guía de Ideogram 4](IDEOGRAM4.es.md) |
+| **ERNIE-Image** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [Guía de ERNIE](ERNIE.md) |
 
 ### DiT / Transformer
 
-| Modelo | Parámetros | Guía |
-|-------|------------|-------|
-| **PixArt Sigma** | 0.6-0.9B | [Guía de Sigma](SIGMA.md) |
-| **Cosmos2** | 2-14B | [Guía de Cosmos2](COSMOS2IMAGE.md) |
-| **Cosmos3** | 4-65B | [Guía de Cosmos3](COSMOS3.es.md) |
-| **OmniGen** | 3.8B | [Guía de OmniGen](OMNIGEN.md) |
-| **Qwen Image** | 20B | [Guía de Qwen](QWEN_IMAGE.md) |
-| **LongCat Image** | 6B | [Guía de LongCat](LONGCAT_IMAGE.md) |
-| **Kandinsky 5** | - | [Guía de Kandinsky](KANDINSKY5_IMAGE.md) |
+| Modelo | Parámetros | Licencia | Permite uso comercial | Guía |
+| ------- | ------------ | --- | :---: | ------- |
+| **PixArt Sigma** | 0.6-0.9B | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | Aplican condiciones<sup>1</sup> | [Guía de Sigma](SIGMA.md) |
+| **Cosmos2** | 2-14B | [NVIDIA Open Model License](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) | Sí<sup>9</sup> | [Guía de Cosmos2](COSMOS2IMAGE.md) |
+| **Cosmos3** | 4-65B | [OpenMDW 1.1](https://github.com/OpenMDW/openmdw/blob/main/1.1/LICENSE.OpenMDW-1.1) | Sí | [Guía de Cosmos3](COSMOS3.es.md) |
+| **OmniGen** | 3.8B | [MIT](https://opensource.org/license/mit) | Sí | [Guía de OmniGen](OMNIGEN.md) |
+| **Qwen Image** | 20B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [Guía de Qwen](QWEN_IMAGE.md) |
+| **LongCat Image** | 6B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [Guía de LongCat](LONGCAT_IMAGE.md) |
+| **Kandinsky 5** | - | [MIT](https://opensource.org/license/mit) | Sí | [Guía de Kandinsky](KANDINSKY5_IMAGE.md) |
 
 ### U-Net
 
-| Modelo | Parámetros | Guía |
-|-------|------------|-------|
-| **Stable Diffusion XL** | 3.5B | [Guía de SDXL](SDXL.md) |
-| **Kolors** | 5B | [Guía de Kolors](KOLORS.md) |
-| **Stable Cascade** | - | [Guía de Cascade](STABLE_CASCADE_C.md) |
+| Modelo | Parámetros | Licencia | Permite uso comercial | Guía |
+| ------- | ------------ | --- | :---: | ------- |
+| **Stable Diffusion XL** | 3.5B | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | Aplican condiciones<sup>1</sup> | [Guía de SDXL](SDXL.md) |
+| **Kolors** | 5B | [Kwai Kolors License](https://huggingface.co/terminusresearch/kwai-kolors-1.0/blob/main/MODEL_LICENSE) | Aplican condiciones<sup>7</sup> | [Guía de Kolors](KOLORS.md) |
+| **Stable Cascade** | - | [Stable Cascade NC Community](https://huggingface.co/stabilityai/stable-cascade/blob/main/LICENSE) | No<sup>5</sup> | [Guía de Cascade](STABLE_CASCADE_C.md) |
 
 ### Edición de imágenes
 
-| Modelo | Guía |
-|-------|-------|
-| **Qwen Edit** | [Guía de Qwen Edit](QWEN_EDIT.md) |
-| **LongCat Edit** | [Guía de LongCat Edit](LONGCAT_EDIT.md) |
+| Modelo | Licencia | Permite uso comercial | Guía |
+| ------- | --- | :---: | ------- |
+| **Qwen Edit** | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [Guía de Qwen Edit](QWEN_EDIT.md) |
+| **LongCat Edit** | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [Guía de LongCat Edit](LONGCAT_EDIT.md) |
 
 ## Modelos de video
 
-| Modelo | Parámetros | Guía |
-|-------|------------|-------|
-| **Wan Video** | 1.3-14B | [Guía de Wan](WAN.md) |
-| **LTX Video** | 5B | [Guía de LTX](LTXVIDEO.md) |
-| **LTX Video 2** | 19B | [Guía de LTX Video 2](LTXVIDEO2.md) |
-| **Cosmos3** | 4-65B | [Guía de Cosmos3](COSMOS3.es.md) |
-| **Hunyuan Video** | 8.3B | [Guía de Hunyuan](HUNYUANVIDEO.md) |
-| **Sana Video** | - | [Guía de Sana Video](SANAVIDEO.md) |
-| **Kandinsky 5 Video** | - | [Guía de Kandinsky Video](KANDINSKY5_VIDEO.md) |
-| **LongCat Video** | - | [Guía de LongCat Video](LONGCAT_VIDEO.md) |
-| **LongCat Video Edit** | - | [Guía de LongCat Video Edit](LONGCAT_VIDEO_EDIT.md) |
+| Modelo | Parámetros | Licencia | Permite uso comercial | Guía |
+| ------- | ------------ | --- | :---: | ------- |
+| **Wan Video** | 1.3-14B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [Guía de Wan](WAN.md) |
+| **LTX Video** | 5B | [LTX Video OpenRAIL-M](https://huggingface.co/Lightricks/LTX-Video-0.9.5/blob/main/ltx-video-2b-v0.9.5.license.txt) | Aplican condiciones<sup>10</sup> | [Guía de LTX](LTXVIDEO.md) |
+| **LTX Video 2** | 19B | [LTX-2 Community](https://ltx.io/model/license) | Aplican condiciones<sup>10</sup> | [Guía de LTX Video 2](LTXVIDEO2.md) |
+| **Cosmos3** | 4-65B | [OpenMDW 1.1](https://github.com/OpenMDW/openmdw/blob/main/1.1/LICENSE.OpenMDW-1.1) | Sí | [Guía de Cosmos3](COSMOS3.es.md) |
+| **Hunyuan Video** | 8.3B | [Tencent Hunyuan Community](https://huggingface.co/tencent/HunyuanVideo-1.5/blob/main/LICENSE) | Aplican condiciones<sup>11</sup> | [Guía de Hunyuan](HUNYUANVIDEO.md) |
+| **Sana Video** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sí | [Guía de Sana Video](SANAVIDEO.md) |
+| **Kandinsky 5 Video** | - | [MIT](https://opensource.org/license/mit) | Sí | [Guía de Kandinsky Video](KANDINSKY5_VIDEO.md) |
+| **LongCat Video** | - | [MIT](https://opensource.org/license/mit) | Sí | [Guía de LongCat Video](LONGCAT_VIDEO.md) |
+| **LongCat Video Edit** | - | [MIT](https://opensource.org/license/mit) | Sí | [Guía de LongCat Video Edit](LONGCAT_VIDEO_EDIT.md) |
+
+**Notas de licencia:** El estado de uso comercial cubre pesos del modelo, checkpoints derivados, fine-tunes y uso del modelo alojado. Los derechos sobre salidas generadas pueden diferir; lee el texto de licencia enlazado antes de un despliegue comercial.
+
+<sup>1</sup> Las licencias estilo OpenRAIL suelen permitir uso comercial con restricciones de uso que siguen aplicando al modelo y sus derivados.
+
+<sup>2</sup> La Stability AI Community License está disponible para usuarios que califican por debajo del umbral de ingresos; el uso comercial mayor requiere términos empresariales de Stability.
+
+<sup>3</sup> Flux.1 varía por flavour: Schnell y LibreFlux son Apache-2.0, mientras que Dev, Krea y Kontext usan términos no comerciales de BFL; revisa los metadatos upstream de FluxBooru antes de uso comercial.
+
+<sup>4</sup> Flux.2 varía por flavour: Klein 4B es Apache-2.0, mientras que Dev y Klein 9B usan términos no comerciales de BFL.
+
+<sup>5</sup> Los términos públicos no comerciales no permiten uso comercial de pesos, checkpoints derivados o servicios alojados del modelo sin una licencia separada.
+
+<sup>6</sup> La Krea 2 Community License permite uso comercial solo bajo sus requisitos de ingresos y seguridad/filtrado; de lo contrario se requiere una licencia empresarial.
+
+<sup>7</sup> El uso comercial del modelo Kolors o sus derivados requiere solicitar y recibir permiso explícito del licenciante.
+
+<sup>8</sup> AuraFlow admite flavours upstream Apache-2.0 y un flavour Pony con una licencia personalizada separada; revisa el flavour seleccionado.
+
+<sup>9</sup> La NVIDIA Open Model License permite uso comercial, pero incluye términos de acuerdo, uso aceptable y control de exportación.
+
+<sup>10</sup> LTX Video 0.9.5 usa OpenRAIL-M; LTX Video 2 usa términos comunitarios de LTX con un umbral de ingresos para uso comercial.
+
+<sup>11</sup> La Tencent Hunyuan Community License incluye exclusiones territoriales y un umbral comercial para servicios muy grandes.
+
+<sup>12</sup> Este mirror publica `license: other` sin un texto de licencia estándar; revisa los términos upstream antes de uso comercial.
 
 ## Modelos de audio
 

--- a/documentation/quickstart/index.hi.md
+++ b/documentation/quickstart/index.hi.md
@@ -6,65 +6,91 @@
 
 ### फ्लो मैचिंग
 
-| मॉडल | पैरामीटर | गाइड |
-|-------|------------|-------|
-| **Flux.1** | 12B | [Flux.1 गाइड](FLUX.md) |
-| **Flux.2** | 32B | [Flux.2 गाइड](FLUX2.md) |
-| **Flux Kontext** | 12B | [Kontext गाइड](FLUX_KONTEXT.md) |
-| **Chroma** | 8.9B | [Chroma गाइड](CHROMA.md) |
-| **Stable Diffusion 3** | 2-8B | [SD3 गाइड](SD3.md) |
-| **Auraflow** | 6.8B | [Auraflow गाइड](AURAFLOW.md) |
-| **Sana** | 0.6-4.8B | [Sana गाइड](SANA.md) |
-| **Lumina2** | 2B | [Lumina2 गाइड](LUMINA2.md) |
-| **HiDream** | 17B MoE | [HiDream गाइड](HIDREAM.md) |
-| **Z-Image** | - | [Z-Image गाइड](ZIMAGE.md) |
-| **Krea2** | - | [Krea2 गाइड](KREA2.hi.md) |
-| **Mage-Flow** | 4B | [Mage-Flow गाइड](MAGEFLOW.hi.md) |
-| **Boogu-Image** | - | [Boogu-Image गाइड](BOOGU_IMAGE.hi.md) |
-| **zlab i1** | 3B | [zlab i1 गाइड](ZLAB_i1.hi.md) |
-| **Ideogram 4** | 9B | [Ideogram 4 गाइड](IDEOGRAM4.hi.md) |
-| **ERNIE-Image** | - | [ERNIE गाइड](ERNIE.md) |
+| मॉडल | पैरामीटर | लाइसेंस | व्यावसायिक उपयोग की अनुमति | गाइड |
+| ------- | ------------ | --- | :---: | ------- |
+| **Flux.1** | 12B | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | शर्तें लागू<sup>3</sup> | [Flux.1 गाइड](FLUX.md) |
+| **Flux.2** | 32B | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | शर्तें लागू<sup>4</sup> | [Flux.2 गाइड](FLUX2.md) |
+| **Flux Kontext** | 12B | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) | नहीं<sup>5</sup> | [Kontext गाइड](FLUX_KONTEXT.md) |
+| **Chroma** | 8.9B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [Chroma गाइड](CHROMA.md) |
+| **Stable Diffusion 3** | 2-8B | [Stability AI Community](https://stability.ai/license) | शर्तें लागू<sup>2</sup> | [SD3 गाइड](SD3.md) |
+| **Auraflow** | 6.8B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) / [Pony License](https://huggingface.co/purplesmartai/pony-v7-base/blob/main/LICENSE) | शर्तें लागू<sup>8</sup> | [Auraflow गाइड](AURAFLOW.md) |
+| **Sana** | 0.6-4.8B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [Sana गाइड](SANA.md) |
+| **Lumina2** | 2B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [Lumina2 गाइड](LUMINA2.md) |
+| **HiDream** | 17B MoE | [MIT](https://opensource.org/license/mit) | हाँ | [HiDream गाइड](HIDREAM.md) |
+| **Z-Image** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [Z-Image गाइड](ZIMAGE.md) |
+| **Krea2** | - | [Krea 2 Community](https://www.krea.ai/krea-2-licensing) | शर्तें लागू<sup>6</sup> | [Krea2 गाइड](KREA2.hi.md) |
+| **Mage-Flow** | 4B | [MIT](https://opensource.org/license/mit) | हाँ | [Mage-Flow गाइड](MAGEFLOW.hi.md) |
+| **Boogu-Image** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [Boogu-Image गाइड](BOOGU_IMAGE.hi.md) |
+| **zlab i1** | 3B | [Unspecified](https://huggingface.co/bghira/zlab-i1-diffusers) | शर्तें लागू<sup>12</sup> | [zlab i1 गाइड](ZLAB_i1.hi.md) |
+| **Ideogram 4** | 9B | [Ideogram 4 Non-Commercial](https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md) | नहीं<sup>5</sup> | [Ideogram 4 गाइड](IDEOGRAM4.hi.md) |
+| **ERNIE-Image** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [ERNIE गाइड](ERNIE.md) |
 
 ### DiT / ट्रांसफ़ॉर्मर
 
-| मॉडल | पैरामीटर | गाइड |
-|-------|------------|-------|
-| **PixArt Sigma** | 0.6-0.9B | [Sigma गाइड](SIGMA.md) |
-| **Cosmos2** | 2-14B | [Cosmos2 गाइड](COSMOS2IMAGE.md) |
-| **Cosmos3** | 4-65B | [Cosmos3 गाइड](COSMOS3.hi.md) |
-| **OmniGen** | 3.8B | [OmniGen गाइड](OMNIGEN.md) |
-| **Qwen Image** | 20B | [Qwen गाइड](QWEN_IMAGE.md) |
-| **LongCat Image** | 6B | [LongCat गाइड](LONGCAT_IMAGE.md) |
-| **Kandinsky 5** | - | [Kandinsky गाइड](KANDINSKY5_IMAGE.md) |
+| मॉडल | पैरामीटर | लाइसेंस | व्यावसायिक उपयोग की अनुमति | गाइड |
+| ------- | ------------ | --- | :---: | ------- |
+| **PixArt Sigma** | 0.6-0.9B | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | शर्तें लागू<sup>1</sup> | [Sigma गाइड](SIGMA.md) |
+| **Cosmos2** | 2-14B | [NVIDIA Open Model License](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) | हाँ<sup>9</sup> | [Cosmos2 गाइड](COSMOS2IMAGE.md) |
+| **Cosmos3** | 4-65B | [OpenMDW 1.1](https://github.com/OpenMDW/openmdw/blob/main/1.1/LICENSE.OpenMDW-1.1) | हाँ | [Cosmos3 गाइड](COSMOS3.hi.md) |
+| **OmniGen** | 3.8B | [MIT](https://opensource.org/license/mit) | हाँ | [OmniGen गाइड](OMNIGEN.md) |
+| **Qwen Image** | 20B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [Qwen गाइड](QWEN_IMAGE.md) |
+| **LongCat Image** | 6B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [LongCat गाइड](LONGCAT_IMAGE.md) |
+| **Kandinsky 5** | - | [MIT](https://opensource.org/license/mit) | हाँ | [Kandinsky गाइड](KANDINSKY5_IMAGE.md) |
 
 ### U‑Net
 
-| मॉडल | पैरामीटर | गाइड |
-|-------|------------|-------|
-| **Stable Diffusion XL** | 3.5B | [SDXL गाइड](SDXL.md) |
-| **Kolors** | 5B | [Kolors गाइड](KOLORS.md) |
-| **Stable Cascade** | - | [Cascade गाइड](STABLE_CASCADE_C.md) |
+| मॉडल | पैरामीटर | लाइसेंस | व्यावसायिक उपयोग की अनुमति | गाइड |
+| ------- | ------------ | --- | :---: | ------- |
+| **Stable Diffusion XL** | 3.5B | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | शर्तें लागू<sup>1</sup> | [SDXL गाइड](SDXL.md) |
+| **Kolors** | 5B | [Kwai Kolors License](https://huggingface.co/terminusresearch/kwai-kolors-1.0/blob/main/MODEL_LICENSE) | शर्तें लागू<sup>7</sup> | [Kolors गाइड](KOLORS.md) |
+| **Stable Cascade** | - | [Stable Cascade NC Community](https://huggingface.co/stabilityai/stable-cascade/blob/main/LICENSE) | नहीं<sup>5</sup> | [Cascade गाइड](STABLE_CASCADE_C.md) |
 
 ### छवि संपादन
 
-| मॉडल | गाइड |
-|-------|-------|
-| **Qwen Edit** | [Qwen Edit गाइड](QWEN_EDIT.md) |
-| **LongCat Edit** | [LongCat Edit गाइड](LONGCAT_EDIT.md) |
+| मॉडल | लाइसेंस | व्यावसायिक उपयोग की अनुमति | गाइड |
+| ------- | --- | :---: | ------- |
+| **Qwen Edit** | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [Qwen Edit गाइड](QWEN_EDIT.md) |
+| **LongCat Edit** | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [LongCat Edit गाइड](LONGCAT_EDIT.md) |
 
 ## वीडियो मॉडल
 
-| मॉडल | पैरामीटर | गाइड |
-|-------|------------|-------|
-| **Wan Video** | 1.3-14B | [Wan गाइड](WAN.md) |
-| **LTX Video** | 5B | [LTX गाइड](LTXVIDEO.md) |
-| **LTX Video 2** | 19B | [LTX Video 2 गाइड](LTXVIDEO2.md) |
-| **Cosmos3** | 4-65B | [Cosmos3 गाइड](COSMOS3.hi.md) |
-| **Hunyuan Video** | 8.3B | [Hunyuan गाइड](HUNYUANVIDEO.md) |
-| **Sana Video** | - | [Sana Video गाइड](SANAVIDEO.md) |
-| **Kandinsky 5 Video** | - | [Kandinsky Video गाइड](KANDINSKY5_VIDEO.md) |
-| **LongCat Video** | - | [LongCat Video गाइड](LONGCAT_VIDEO.md) |
-| **LongCat Video Edit** | - | [LongCat Video Edit गाइड](LONGCAT_VIDEO_EDIT.md) |
+| मॉडल | पैरामीटर | लाइसेंस | व्यावसायिक उपयोग की अनुमति | गाइड |
+| ------- | ------------ | --- | :---: | ------- |
+| **Wan Video** | 1.3-14B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [Wan गाइड](WAN.md) |
+| **LTX Video** | 5B | [LTX Video OpenRAIL-M](https://huggingface.co/Lightricks/LTX-Video-0.9.5/blob/main/ltx-video-2b-v0.9.5.license.txt) | शर्तें लागू<sup>10</sup> | [LTX गाइड](LTXVIDEO.md) |
+| **LTX Video 2** | 19B | [LTX-2 Community](https://ltx.io/model/license) | शर्तें लागू<sup>10</sup> | [LTX Video 2 गाइड](LTXVIDEO2.md) |
+| **Cosmos3** | 4-65B | [OpenMDW 1.1](https://github.com/OpenMDW/openmdw/blob/main/1.1/LICENSE.OpenMDW-1.1) | हाँ | [Cosmos3 गाइड](COSMOS3.hi.md) |
+| **Hunyuan Video** | 8.3B | [Tencent Hunyuan Community](https://huggingface.co/tencent/HunyuanVideo-1.5/blob/main/LICENSE) | शर्तें लागू<sup>11</sup> | [Hunyuan गाइड](HUNYUANVIDEO.md) |
+| **Sana Video** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | हाँ | [Sana Video गाइड](SANAVIDEO.md) |
+| **Kandinsky 5 Video** | - | [MIT](https://opensource.org/license/mit) | हाँ | [Kandinsky Video गाइड](KANDINSKY5_VIDEO.md) |
+| **LongCat Video** | - | [MIT](https://opensource.org/license/mit) | हाँ | [LongCat Video गाइड](LONGCAT_VIDEO.md) |
+| **LongCat Video Edit** | - | [MIT](https://opensource.org/license/mit) | हाँ | [LongCat Video Edit गाइड](LONGCAT_VIDEO_EDIT.md) |
+
+**लाइसेंस नोट्स:** व्यावसायिक उपयोग की स्थिति model weights, derivative checkpoints, fine-tunes, और hosted model use को कवर करती है। Generated outputs के अधिकार अलग हो सकते हैं; commercial deployment से पहले linked license text पढ़ें।
+
+<sup>1</sup> OpenRAIL-style licenses आम तौर पर commercial use की अनुमति देती हैं, लेकिन usage restrictions model और derivatives के साथ बनी रहती हैं।
+
+<sup>2</sup> Stability AI Community License revenue threshold से नीचे qualify करने वाले users के लिए उपलब्ध है; बड़े commercial use के लिए Stability enterprise terms चाहिए।
+
+<sup>3</sup> Flux.1 flavour के अनुसार बदलता है: Schnell और LibreFlux Apache-2.0 हैं, जबकि Dev, Krea, और Kontext BFL non-commercial terms का उपयोग करते हैं; commercial use से पहले FluxBooru upstream metadata देखें।
+
+<sup>4</sup> Flux.2 flavour के अनुसार बदलता है: Klein 4B Apache-2.0 है, जबकि Dev और Klein 9B BFL non-commercial terms का उपयोग करते हैं।
+
+<sup>5</sup> Public non-commercial model terms अलग license के बिना weights, derivative checkpoints, या hosted model services के commercial use की अनुमति नहीं देते।
+
+<sup>6</sup> Krea 2 Community License केवल revenue और safety/filtering requirements के तहत commercial use की अनुमति देती है; अन्यथा enterprise license चाहिए।
+
+<sup>7</sup> Kolors model या derivatives का commercial use करने के लिए licensor से explicit permission माँगनी और प्राप्त करनी होती है।
+
+<sup>8</sup> AuraFlow Apache-2.0 upstream flavours और अलग custom license वाले Pony flavour को support करता है; selected flavour देखें।
+
+<sup>9</sup> NVIDIA Open Model License commercial use की अनुमति देती है, लेकिन agreement, acceptable-use, और export-control terms शामिल हैं।
+
+<sup>10</sup> LTX Video 0.9.5 OpenRAIL-M का उपयोग करता है; LTX Video 2 commercial use के लिए revenue threshold वाले LTX community terms का उपयोग करता है।
+
+<sup>11</sup> Tencent Hunyuan Community License में territorial exclusions और बहुत बड़े services के लिए commercial threshold शामिल है।
+
+<sup>12</sup> यह mirror standard license text के बिना `license: other` publish करता है; commercial use से पहले upstream terms देखें।
 
 ## ऑडियो मॉडल
 

--- a/documentation/quickstart/index.ja.md
+++ b/documentation/quickstart/index.ja.md
@@ -6,65 +6,91 @@
 
 ### Flow Matching
 
-| モデル | パラメータ | ガイド |
-|-------|------------|-------|
-| **Flux.1** | 12B | [Flux.1 ガイド](FLUX.md) |
-| **Flux.2** | 32B | [Flux.2 ガイド](FLUX2.md) |
-| **Flux Kontext** | 12B | [Kontext ガイド](FLUX_KONTEXT.md) |
-| **Chroma** | 8.9B | [Chroma ガイド](CHROMA.md) |
-| **Stable Diffusion 3** | 2-8B | [SD3 ガイド](SD3.md) |
-| **Auraflow** | 6.8B | [Auraflow ガイド](AURAFLOW.md) |
-| **Sana** | 0.6-4.8B | [Sana ガイド](SANA.md) |
-| **Lumina2** | 2B | [Lumina2 ガイド](LUMINA2.md) |
-| **HiDream** | 17B MoE | [HiDream ガイド](HIDREAM.md) |
-| **Z-Image** | - | [Z-Image ガイド](ZIMAGE.md) |
-| **Krea2** | - | [Krea2 ガイド](KREA2.ja.md) |
-| **Mage-Flow** | 4B | [Mage-Flow ガイド](MAGEFLOW.ja.md) |
-| **Boogu-Image** | - | [Boogu-Image ガイド](BOOGU_IMAGE.ja.md) |
-| **zlab i1** | 3B | [zlab i1 ガイド](ZLAB_i1.ja.md) |
-| **Ideogram 4** | 9B | [Ideogram 4 ガイド](IDEOGRAM4.ja.md) |
-| **ERNIE-Image** | - | [ERNIE ガイド](ERNIE.md) |
+| モデル | パラメータ | ライセンス | 商用利用 | ガイド |
+| ------- | ------------ | --- | :---: | ------- |
+| **Flux.1** | 12B | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 条件付き<sup>3</sup> | [Flux.1 ガイド](FLUX.md) |
+| **Flux.2** | 32B | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 条件付き<sup>4</sup> | [Flux.2 ガイド](FLUX2.md) |
+| **Flux Kontext** | 12B | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) | いいえ<sup>5</sup> | [Kontext ガイド](FLUX_KONTEXT.md) |
+| **Chroma** | 8.9B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [Chroma ガイド](CHROMA.md) |
+| **Stable Diffusion 3** | 2-8B | [Stability AI Community](https://stability.ai/license) | 条件付き<sup>2</sup> | [SD3 ガイド](SD3.md) |
+| **Auraflow** | 6.8B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) / [Pony License](https://huggingface.co/purplesmartai/pony-v7-base/blob/main/LICENSE) | 条件付き<sup>8</sup> | [Auraflow ガイド](AURAFLOW.md) |
+| **Sana** | 0.6-4.8B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [Sana ガイド](SANA.md) |
+| **Lumina2** | 2B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [Lumina2 ガイド](LUMINA2.md) |
+| **HiDream** | 17B MoE | [MIT](https://opensource.org/license/mit) | はい | [HiDream ガイド](HIDREAM.md) |
+| **Z-Image** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [Z-Image ガイド](ZIMAGE.md) |
+| **Krea2** | - | [Krea 2 Community](https://www.krea.ai/krea-2-licensing) | 条件付き<sup>6</sup> | [Krea2 ガイド](KREA2.ja.md) |
+| **Mage-Flow** | 4B | [MIT](https://opensource.org/license/mit) | はい | [Mage-Flow ガイド](MAGEFLOW.ja.md) |
+| **Boogu-Image** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [Boogu-Image ガイド](BOOGU_IMAGE.ja.md) |
+| **zlab i1** | 3B | [Unspecified](https://huggingface.co/bghira/zlab-i1-diffusers) | 条件付き<sup>12</sup> | [zlab i1 ガイド](ZLAB_i1.ja.md) |
+| **Ideogram 4** | 9B | [Ideogram 4 Non-Commercial](https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md) | いいえ<sup>5</sup> | [Ideogram 4 ガイド](IDEOGRAM4.ja.md) |
+| **ERNIE-Image** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [ERNIE ガイド](ERNIE.md) |
 
 ### DiT / Transformer
 
-| モデル | パラメータ | ガイド |
-|-------|------------|-------|
-| **PixArt Sigma** | 0.6-0.9B | [Sigma ガイド](SIGMA.md) |
-| **Cosmos2** | 2-14B | [Cosmos2 ガイド](COSMOS2IMAGE.md) |
-| **Cosmos3** | 4-65B | [Cosmos3 ガイド](COSMOS3.ja.md) |
-| **OmniGen** | 3.8B | [OmniGen ガイド](OMNIGEN.md) |
-| **Qwen Image** | 20B | [Qwen ガイド](QWEN_IMAGE.md) |
-| **LongCat Image** | 6B | [LongCat ガイド](LONGCAT_IMAGE.md) |
-| **Kandinsky 5** | - | [Kandinsky ガイド](KANDINSKY5_IMAGE.md) |
+| モデル | パラメータ | ライセンス | 商用利用 | ガイド |
+| ------- | ------------ | --- | :---: | ------- |
+| **PixArt Sigma** | 0.6-0.9B | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | 条件付き<sup>1</sup> | [Sigma ガイド](SIGMA.md) |
+| **Cosmos2** | 2-14B | [NVIDIA Open Model License](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) | はい<sup>9</sup> | [Cosmos2 ガイド](COSMOS2IMAGE.md) |
+| **Cosmos3** | 4-65B | [OpenMDW 1.1](https://github.com/OpenMDW/openmdw/blob/main/1.1/LICENSE.OpenMDW-1.1) | はい | [Cosmos3 ガイド](COSMOS3.ja.md) |
+| **OmniGen** | 3.8B | [MIT](https://opensource.org/license/mit) | はい | [OmniGen ガイド](OMNIGEN.md) |
+| **Qwen Image** | 20B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [Qwen ガイド](QWEN_IMAGE.md) |
+| **LongCat Image** | 6B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [LongCat ガイド](LONGCAT_IMAGE.md) |
+| **Kandinsky 5** | - | [MIT](https://opensource.org/license/mit) | はい | [Kandinsky ガイド](KANDINSKY5_IMAGE.md) |
 
 ### U-Net
 
-| モデル | パラメータ | ガイド |
-|-------|------------|-------|
-| **Stable Diffusion XL** | 3.5B | [SDXL ガイド](SDXL.md) |
-| **Kolors** | 5B | [Kolors ガイド](KOLORS.md) |
-| **Stable Cascade** | - | [Cascade ガイド](STABLE_CASCADE_C.md) |
+| モデル | パラメータ | ライセンス | 商用利用 | ガイド |
+| ------- | ------------ | --- | :---: | ------- |
+| **Stable Diffusion XL** | 3.5B | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | 条件付き<sup>1</sup> | [SDXL ガイド](SDXL.md) |
+| **Kolors** | 5B | [Kwai Kolors License](https://huggingface.co/terminusresearch/kwai-kolors-1.0/blob/main/MODEL_LICENSE) | 条件付き<sup>7</sup> | [Kolors ガイド](KOLORS.md) |
+| **Stable Cascade** | - | [Stable Cascade NC Community](https://huggingface.co/stabilityai/stable-cascade/blob/main/LICENSE) | いいえ<sup>5</sup> | [Cascade ガイド](STABLE_CASCADE_C.md) |
 
 ### 画像編集
 
-| モデル | ガイド |
-|-------|-------|
-| **Qwen Edit** | [Qwen Edit ガイド](QWEN_EDIT.md) |
-| **LongCat Edit** | [LongCat Edit ガイド](LONGCAT_EDIT.md) |
+| モデル | ライセンス | 商用利用 | ガイド |
+| ------- | --- | :---: | ------- |
+| **Qwen Edit** | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [Qwen Edit ガイド](QWEN_EDIT.md) |
+| **LongCat Edit** | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [LongCat Edit ガイド](LONGCAT_EDIT.md) |
 
 ## 動画モデル
 
-| モデル | パラメータ | ガイド |
-|-------|------------|-------|
-| **Wan Video** | 1.3-14B | [Wan ガイド](WAN.md) |
-| **LTX Video** | 5B | [LTX ガイド](LTXVIDEO.md) |
-| **LTX Video 2** | 19B | [LTX Video 2 ガイド](LTXVIDEO2.md) |
-| **Cosmos3** | 4-65B | [Cosmos3 ガイド](COSMOS3.ja.md) |
-| **Hunyuan Video** | 8.3B | [Hunyuan ガイド](HUNYUANVIDEO.md) |
-| **Sana Video** | - | [Sana Video ガイド](SANAVIDEO.md) |
-| **Kandinsky 5 Video** | - | [Kandinsky Video ガイド](KANDINSKY5_VIDEO.md) |
-| **LongCat Video** | - | [LongCat Video ガイド](LONGCAT_VIDEO.md) |
-| **LongCat Video Edit** | - | [LongCat Video Edit ガイド](LONGCAT_VIDEO_EDIT.md) |
+| モデル | パラメータ | ライセンス | 商用利用 | ガイド |
+| ------- | ------------ | --- | :---: | ------- |
+| **Wan Video** | 1.3-14B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [Wan ガイド](WAN.md) |
+| **LTX Video** | 5B | [LTX Video OpenRAIL-M](https://huggingface.co/Lightricks/LTX-Video-0.9.5/blob/main/ltx-video-2b-v0.9.5.license.txt) | 条件付き<sup>10</sup> | [LTX ガイド](LTXVIDEO.md) |
+| **LTX Video 2** | 19B | [LTX-2 Community](https://ltx.io/model/license) | 条件付き<sup>10</sup> | [LTX Video 2 ガイド](LTXVIDEO2.md) |
+| **Cosmos3** | 4-65B | [OpenMDW 1.1](https://github.com/OpenMDW/openmdw/blob/main/1.1/LICENSE.OpenMDW-1.1) | はい | [Cosmos3 ガイド](COSMOS3.ja.md) |
+| **Hunyuan Video** | 8.3B | [Tencent Hunyuan Community](https://huggingface.co/tencent/HunyuanVideo-1.5/blob/main/LICENSE) | 条件付き<sup>11</sup> | [Hunyuan ガイド](HUNYUANVIDEO.md) |
+| **Sana Video** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | はい | [Sana Video ガイド](SANAVIDEO.md) |
+| **Kandinsky 5 Video** | - | [MIT](https://opensource.org/license/mit) | はい | [Kandinsky Video ガイド](KANDINSKY5_VIDEO.md) |
+| **LongCat Video** | - | [MIT](https://opensource.org/license/mit) | はい | [LongCat Video ガイド](LONGCAT_VIDEO.md) |
+| **LongCat Video Edit** | - | [MIT](https://opensource.org/license/mit) | はい | [LongCat Video Edit ガイド](LONGCAT_VIDEO_EDIT.md) |
+
+**ライセンス注記:** 商用利用の表示はモデル重み、派生チェックポイント、fine-tune、ホスト型モデル利用を対象にしています。生成出力の権利は異なる場合があります。商用展開前にリンク先のライセンス本文を確認してください。
+
+<sup>1</sup> OpenRAIL 系ライセンスは通常、商用利用を許可しますが、モデルと派生物には利用制限が残ります。
+
+<sup>2</sup> Stability AI Community License は収益しきい値未満の対象ユーザー向けです。より大きな商用利用には Stability のエンタープライズ条件が必要です。
+
+<sup>3</sup> Flux.1 は flavour により異なります。Schnell と LibreFlux は Apache-2.0、Dev、Krea、Kontext は BFL の非商用条件です。FluxBooru は商用利用前に upstream metadata を確認してください。
+
+<sup>4</sup> Flux.2 は flavour により異なります。Klein 4B は Apache-2.0、Dev と Klein 9B は BFL の非商用条件です。
+
+<sup>5</sup> 公開されている非商用モデル条件では、別ライセンスなしに重み、派生チェックポイント、ホスト型モデルサービスを商用利用できません。
+
+<sup>6</sup> Krea 2 Community License は収益および安全性/フィルタリング要件を満たす場合のみ商用利用を許可します。それ以外はエンタープライズライセンスが必要です。
+
+<sup>7</sup> Kolors のモデルまたは派生物の商用利用には、ライセンサーへの申請と明示的な許可が必要です。
+
+<sup>8</sup> AuraFlow は Apache-2.0 の upstream flavour と、別のカスタムライセンスを持つ Pony flavour をサポートします。選択した flavour を確認してください。
+
+<sup>9</sup> NVIDIA Open Model License は商用利用を許可しますが、契約、利用許諾ポリシー、輸出管理条件を含みます。
+
+<sup>10</sup> LTX Video 0.9.5 は OpenRAIL-M、LTX Video 2 は商用利用に収益しきい値がある LTX community terms を使用します。
+
+<sup>11</sup> Tencent Hunyuan Community License には地域除外と、非常に大規模なサービス向けの商用しきい値があります。
+
+<sup>12</sup> この mirror は標準ライセンス本文なしで `license: other` を公開しています。商用利用前に upstream terms を確認してください。
 
 ## 音声モデル
 

--- a/documentation/quickstart/index.md
+++ b/documentation/quickstart/index.md
@@ -6,65 +6,91 @@ Step-by-step guides for training each supported model architecture.
 
 ### Flow Matching
 
-| Model | Parameters | Guide |
-|-------|------------|-------|
-| **Flux.1** | 12B | [Flux.1 Guide](FLUX.md) |
-| **Flux.2** | 32B | [Flux.2 Guide](FLUX2.md) |
-| **Flux Kontext** | 12B | [Kontext Guide](FLUX_KONTEXT.md) |
-| **Chroma** | 8.9B | [Chroma Guide](CHROMA.md) |
-| **Stable Diffusion 3** | 2-8B | [SD3 Guide](SD3.md) |
-| **Auraflow** | 6.8B | [Auraflow Guide](AURAFLOW.md) |
-| **Sana** | 0.6-4.8B | [Sana Guide](SANA.md) |
-| **Lumina2** | 2B | [Lumina2 Guide](LUMINA2.md) |
-| **HiDream** | 17B MoE | [HiDream Guide](HIDREAM.md) |
-| **Z-Image** | - | [Z-Image Guide](ZIMAGE.md) |
-| **Krea2** | - | [Krea2 Guide](KREA2.md) |
-| **Mage-Flow** | 4B | [Mage-Flow Guide](MAGEFLOW.md) |
-| **Boogu-Image** | - | [Boogu-Image Guide](BOOGU_IMAGE.md) |
-| **zlab i1** | 3B | [zlab i1 Guide](ZLAB_i1.md) |
-| **Ideogram 4** | 9B | [Ideogram 4 Guide](IDEOGRAM4.md) |
-| **ERNIE-Image** | - | [ERNIE Guide](ERNIE.md) |
+| Model | Parameters | License | Allows commercial use | Guide |
+| ------- | ------------ | --- | :---: | ------- |
+| **Flux.1** | 12B | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Conditions apply<sup>3</sup> | [Flux.1 Guide](FLUX.md) |
+| **Flux.2** | 32B | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Conditions apply<sup>4</sup> | [Flux.2 Guide](FLUX2.md) |
+| **Flux Kontext** | 12B | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) | No<sup>5</sup> | [Kontext Guide](FLUX_KONTEXT.md) |
+| **Chroma** | 8.9B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [Chroma Guide](CHROMA.md) |
+| **Stable Diffusion 3** | 2-8B | [Stability AI Community](https://stability.ai/license) | Conditions apply<sup>2</sup> | [SD3 Guide](SD3.md) |
+| **Auraflow** | 6.8B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) / [Pony License](https://huggingface.co/purplesmartai/pony-v7-base/blob/main/LICENSE) | Conditions apply<sup>8</sup> | [Auraflow Guide](AURAFLOW.md) |
+| **Sana** | 0.6-4.8B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [Sana Guide](SANA.md) |
+| **Lumina2** | 2B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [Lumina2 Guide](LUMINA2.md) |
+| **HiDream** | 17B MoE | [MIT](https://opensource.org/license/mit) | Yes | [HiDream Guide](HIDREAM.md) |
+| **Z-Image** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [Z-Image Guide](ZIMAGE.md) |
+| **Krea2** | - | [Krea 2 Community](https://www.krea.ai/krea-2-licensing) | Conditions apply<sup>6</sup> | [Krea2 Guide](KREA2.md) |
+| **Mage-Flow** | 4B | [MIT](https://opensource.org/license/mit) | Yes | [Mage-Flow Guide](MAGEFLOW.md) |
+| **Boogu-Image** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [Boogu-Image Guide](BOOGU_IMAGE.md) |
+| **zlab i1** | 3B | [Unspecified](https://huggingface.co/bghira/zlab-i1-diffusers) | Conditions apply<sup>12</sup> | [zlab i1 Guide](ZLAB_i1.md) |
+| **Ideogram 4** | 9B | [Ideogram 4 Non-Commercial](https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md) | No<sup>5</sup> | [Ideogram 4 Guide](IDEOGRAM4.md) |
+| **ERNIE-Image** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [ERNIE Guide](ERNIE.md) |
 
 ### DiT / Transformer
 
-| Model | Parameters | Guide |
-|-------|------------|-------|
-| **PixArt Sigma** | 0.6-0.9B | [Sigma Guide](SIGMA.md) |
-| **Cosmos2** | 2-14B | [Cosmos2 Guide](COSMOS2IMAGE.md) |
-| **Cosmos3** | 4-65B | [Cosmos3 Guide](COSMOS3.md) |
-| **OmniGen** | 3.8B | [OmniGen Guide](OMNIGEN.md) |
-| **Qwen Image** | 20B | [Qwen Guide](QWEN_IMAGE.md) |
-| **LongCat Image** | 6B | [LongCat Guide](LONGCAT_IMAGE.md) |
-| **Kandinsky 5** | - | [Kandinsky Guide](KANDINSKY5_IMAGE.md) |
+| Model | Parameters | License | Allows commercial use | Guide |
+| ------- | ------------ | --- | :---: | ------- |
+| **PixArt Sigma** | 0.6-0.9B | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | Conditions apply<sup>1</sup> | [Sigma Guide](SIGMA.md) |
+| **Cosmos2** | 2-14B | [NVIDIA Open Model License](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) | Yes<sup>9</sup> | [Cosmos2 Guide](COSMOS2IMAGE.md) |
+| **Cosmos3** | 4-65B | [OpenMDW 1.1](https://github.com/OpenMDW/openmdw/blob/main/1.1/LICENSE.OpenMDW-1.1) | Yes | [Cosmos3 Guide](COSMOS3.md) |
+| **OmniGen** | 3.8B | [MIT](https://opensource.org/license/mit) | Yes | [OmniGen Guide](OMNIGEN.md) |
+| **Qwen Image** | 20B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [Qwen Guide](QWEN_IMAGE.md) |
+| **LongCat Image** | 6B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [LongCat Guide](LONGCAT_IMAGE.md) |
+| **Kandinsky 5** | - | [MIT](https://opensource.org/license/mit) | Yes | [Kandinsky Guide](KANDINSKY5_IMAGE.md) |
 
 ### U-Net
 
-| Model | Parameters | Guide |
-|-------|------------|-------|
-| **Stable Diffusion XL** | 3.5B | [SDXL Guide](SDXL.md) |
-| **Kolors** | 5B | [Kolors Guide](KOLORS.md) |
-| **Stable Cascade** | - | [Cascade Guide](STABLE_CASCADE_C.md) |
+| Model | Parameters | License | Allows commercial use | Guide |
+| ------- | ------------ | --- | :---: | ------- |
+| **Stable Diffusion XL** | 3.5B | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | Conditions apply<sup>1</sup> | [SDXL Guide](SDXL.md) |
+| **Kolors** | 5B | [Kwai Kolors License](https://huggingface.co/terminusresearch/kwai-kolors-1.0/blob/main/MODEL_LICENSE) | Conditions apply<sup>7</sup> | [Kolors Guide](KOLORS.md) |
+| **Stable Cascade** | - | [Stable Cascade NC Community](https://huggingface.co/stabilityai/stable-cascade/blob/main/LICENSE) | No<sup>5</sup> | [Cascade Guide](STABLE_CASCADE_C.md) |
 
 ### Image Editing
 
-| Model | Guide |
-|-------|-------|
-| **Qwen Edit** | [Qwen Edit Guide](QWEN_EDIT.md) |
-| **LongCat Edit** | [LongCat Edit Guide](LONGCAT_EDIT.md) |
+| Model | License | Allows commercial use | Guide |
+| ------- | --- | :---: | ------- |
+| **Qwen Edit** | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [Qwen Edit Guide](QWEN_EDIT.md) |
+| **LongCat Edit** | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [LongCat Edit Guide](LONGCAT_EDIT.md) |
 
 ## Video Models
 
-| Model | Parameters | Guide |
-|-------|------------|-------|
-| **Wan Video** | 1.3-14B | [Wan Guide](WAN.md) |
-| **LTX Video** | 5B | [LTX Guide](LTXVIDEO.md) |
-| **LTX Video 2** | 19B | [LTX Video 2 Guide](LTXVIDEO2.md) |
-| **Cosmos3** | 4-65B | [Cosmos3 Guide](COSMOS3.md) |
-| **Hunyuan Video** | 8.3B | [Hunyuan Guide](HUNYUANVIDEO.md) |
-| **Sana Video** | - | [Sana Video Guide](SANAVIDEO.md) |
-| **Kandinsky 5 Video** | - | [Kandinsky Video Guide](KANDINSKY5_VIDEO.md) |
-| **LongCat Video** | - | [LongCat Video Guide](LONGCAT_VIDEO.md) |
-| **LongCat Video Edit** | - | [LongCat Video Edit Guide](LONGCAT_VIDEO_EDIT.md) |
+| Model | Parameters | License | Allows commercial use | Guide |
+| ------- | ------------ | --- | :---: | ------- |
+| **Wan Video** | 1.3-14B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [Wan Guide](WAN.md) |
+| **LTX Video** | 5B | [LTX Video OpenRAIL-M](https://huggingface.co/Lightricks/LTX-Video-0.9.5/blob/main/ltx-video-2b-v0.9.5.license.txt) | Conditions apply<sup>10</sup> | [LTX Guide](LTXVIDEO.md) |
+| **LTX Video 2** | 19B | [LTX-2 Community](https://ltx.io/model/license) | Conditions apply<sup>10</sup> | [LTX Video 2 Guide](LTXVIDEO2.md) |
+| **Cosmos3** | 4-65B | [OpenMDW 1.1](https://github.com/OpenMDW/openmdw/blob/main/1.1/LICENSE.OpenMDW-1.1) | Yes | [Cosmos3 Guide](COSMOS3.md) |
+| **Hunyuan Video** | 8.3B | [Tencent Hunyuan Community](https://huggingface.co/tencent/HunyuanVideo-1.5/blob/main/LICENSE) | Conditions apply<sup>11</sup> | [Hunyuan Guide](HUNYUANVIDEO.md) |
+| **Sana Video** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Yes | [Sana Video Guide](SANAVIDEO.md) |
+| **Kandinsky 5 Video** | - | [MIT](https://opensource.org/license/mit) | Yes | [Kandinsky Video Guide](KANDINSKY5_VIDEO.md) |
+| **LongCat Video** | - | [MIT](https://opensource.org/license/mit) | Yes | [LongCat Video Guide](LONGCAT_VIDEO.md) |
+| **LongCat Video Edit** | - | [MIT](https://opensource.org/license/mit) | Yes | [LongCat Video Edit Guide](LONGCAT_VIDEO_EDIT.md) |
+
+**License notes:** The commercial-use status covers model weights, derivative checkpoints, fine-tunes, and hosted model use. Generated-output rights can differ; read the linked license text before commercial deployment.
+
+<sup>1</sup> OpenRAIL-style licenses generally permit commercial use with usage restrictions that remain attached to the model and derivatives.
+
+<sup>2</sup> Stability AI Community License is available for qualifying users below the revenue threshold; larger commercial use needs Stability enterprise terms.
+
+<sup>3</sup> Flux.1 varies by flavour: Schnell and LibreFlux are Apache-2.0, while Dev, Krea, and Kontext use BFL non-commercial terms; review FluxBooru upstream metadata before commercial use.
+
+<sup>4</sup> Flux.2 varies by flavour: Klein 4B is Apache-2.0, while Dev and Klein 9B use BFL non-commercial terms.
+
+<sup>5</sup> Public non-commercial model terms do not permit commercial use of weights, derivative checkpoints, or hosted model services without a separate license.
+
+<sup>6</sup> Krea 2 Community License permits commercial use only under its revenue and safety/filtering requirements; otherwise an enterprise license is required.
+
+<sup>7</sup> Kolors commercial model or derivative use requires applying for and receiving explicit permission from the licensor.
+
+<sup>8</sup> AuraFlow supports Apache-2.0 upstream flavours and a Pony flavour with a separate custom license; check the selected flavour.
+
+<sup>9</sup> NVIDIA Open Model License permits commercial use but includes agreement, acceptable-use, and export-control terms.
+
+<sup>10</sup> LTX Video 0.9.5 uses OpenRAIL-M; LTX Video 2 uses LTX community terms with a revenue threshold for commercial use.
+
+<sup>11</sup> Tencent Hunyuan Community License includes territorial exclusions and a commercial threshold for very large services.
+
+<sup>12</sup> This mirror publishes `license: other` without a standard license text; review upstream terms before commercial use.
 
 ## Audio Models
 

--- a/documentation/quickstart/index.pt-BR.md
+++ b/documentation/quickstart/index.pt-BR.md
@@ -6,65 +6,91 @@ Guias passo a passo para treinar cada arquitetura de modelo suportada.
 
 ### Flow Matching
 
-| Modelo | Parâmetros | Guia |
-|-------|------------|------|
-| **Flux.1** | 12B | [Guia Flux.1](FLUX.md) |
-| **Flux.2** | 32B | [Guia Flux.2](FLUX2.md) |
-| **Flux Kontext** | 12B | [Guia Kontext](FLUX_KONTEXT.md) |
-| **Chroma** | 8.9B | [Guia Chroma](CHROMA.md) |
-| **Stable Diffusion 3** | 2-8B | [Guia SD3](SD3.md) |
-| **Auraflow** | 6.8B | [Guia Auraflow](AURAFLOW.md) |
-| **Sana** | 0.6-4.8B | [Guia Sana](SANA.md) |
-| **Lumina2** | 2B | [Guia Lumina2](LUMINA2.md) |
-| **HiDream** | 17B MoE | [Guia HiDream](HIDREAM.md) |
-| **Z-Image** | - | [Guia Z-Image](ZIMAGE.md) |
-| **Krea2** | - | [Guia Krea2](KREA2.pt-BR.md) |
-| **Mage-Flow** | 4B | [Guia Mage-Flow](MAGEFLOW.pt-BR.md) |
-| **Boogu-Image** | - | [Guia Boogu-Image](BOOGU_IMAGE.pt-BR.md) |
-| **zlab i1** | 3B | [Guia zlab i1](ZLAB_i1.pt-BR.md) |
-| **Ideogram 4** | 9B | [Guia Ideogram 4](IDEOGRAM4.pt-BR.md) |
-| **ERNIE-Image** | - | [Guia ERNIE](ERNIE.md) |
+| Modelo | Parâmetros | Licença | Permite uso comercial | Guia |
+| ------- | ------------ | --- | :---: | ------ |
+| **Flux.1** | 12B | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Condições aplicáveis<sup>3</sup> | [Guia Flux.1](FLUX.md) |
+| **Flux.2** | 32B | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Condições aplicáveis<sup>4</sup> | [Guia Flux.2](FLUX2.md) |
+| **Flux Kontext** | 12B | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) | Não<sup>5</sup> | [Guia Kontext](FLUX_KONTEXT.md) |
+| **Chroma** | 8.9B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [Guia Chroma](CHROMA.md) |
+| **Stable Diffusion 3** | 2-8B | [Stability AI Community](https://stability.ai/license) | Condições aplicáveis<sup>2</sup> | [Guia SD3](SD3.md) |
+| **Auraflow** | 6.8B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) / [Pony License](https://huggingface.co/purplesmartai/pony-v7-base/blob/main/LICENSE) | Condições aplicáveis<sup>8</sup> | [Guia Auraflow](AURAFLOW.md) |
+| **Sana** | 0.6-4.8B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [Guia Sana](SANA.md) |
+| **Lumina2** | 2B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [Guia Lumina2](LUMINA2.md) |
+| **HiDream** | 17B MoE | [MIT](https://opensource.org/license/mit) | Sim | [Guia HiDream](HIDREAM.md) |
+| **Z-Image** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [Guia Z-Image](ZIMAGE.md) |
+| **Krea2** | - | [Krea 2 Community](https://www.krea.ai/krea-2-licensing) | Condições aplicáveis<sup>6</sup> | [Guia Krea2](KREA2.pt-BR.md) |
+| **Mage-Flow** | 4B | [MIT](https://opensource.org/license/mit) | Sim | [Guia Mage-Flow](MAGEFLOW.pt-BR.md) |
+| **Boogu-Image** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [Guia Boogu-Image](BOOGU_IMAGE.pt-BR.md) |
+| **zlab i1** | 3B | [Unspecified](https://huggingface.co/bghira/zlab-i1-diffusers) | Condições aplicáveis<sup>12</sup> | [Guia zlab i1](ZLAB_i1.pt-BR.md) |
+| **Ideogram 4** | 9B | [Ideogram 4 Non-Commercial](https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md) | Não<sup>5</sup> | [Guia Ideogram 4](IDEOGRAM4.pt-BR.md) |
+| **ERNIE-Image** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [Guia ERNIE](ERNIE.md) |
 
 ### DiT / Transformador
 
-| Modelo | Parâmetros | Guia |
-|-------|------------|------|
-| **PixArt Sigma** | 0.6-0.9B | [Guia Sigma](SIGMA.md) |
-| **Cosmos2** | 2-14B | [Guia Cosmos2](COSMOS2IMAGE.md) |
-| **Cosmos3** | 4-65B | [Guia Cosmos3](COSMOS3.pt-BR.md) |
-| **OmniGen** | 3.8B | [Guia OmniGen](OMNIGEN.md) |
-| **Qwen Image** | 20B | [Guia Qwen](QWEN_IMAGE.md) |
-| **LongCat Image** | 6B | [Guia LongCat](LONGCAT_IMAGE.md) |
-| **Kandinsky 5** | - | [Guia Kandinsky](KANDINSKY5_IMAGE.md) |
+| Modelo | Parâmetros | Licença | Permite uso comercial | Guia |
+| ------- | ------------ | --- | :---: | ------ |
+| **PixArt Sigma** | 0.6-0.9B | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | Condições aplicáveis<sup>1</sup> | [Guia Sigma](SIGMA.md) |
+| **Cosmos2** | 2-14B | [NVIDIA Open Model License](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) | Sim<sup>9</sup> | [Guia Cosmos2](COSMOS2IMAGE.md) |
+| **Cosmos3** | 4-65B | [OpenMDW 1.1](https://github.com/OpenMDW/openmdw/blob/main/1.1/LICENSE.OpenMDW-1.1) | Sim | [Guia Cosmos3](COSMOS3.pt-BR.md) |
+| **OmniGen** | 3.8B | [MIT](https://opensource.org/license/mit) | Sim | [Guia OmniGen](OMNIGEN.md) |
+| **Qwen Image** | 20B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [Guia Qwen](QWEN_IMAGE.md) |
+| **LongCat Image** | 6B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [Guia LongCat](LONGCAT_IMAGE.md) |
+| **Kandinsky 5** | - | [MIT](https://opensource.org/license/mit) | Sim | [Guia Kandinsky](KANDINSKY5_IMAGE.md) |
 
 ### U-Net
 
-| Modelo | Parâmetros | Guia |
-|-------|------------|------|
-| **Stable Diffusion XL** | 3.5B | [Guia SDXL](SDXL.md) |
-| **Kolors** | 5B | [Guia Kolors](KOLORS.md) |
-| **Stable Cascade** | - | [Guia Cascade](STABLE_CASCADE_C.md) |
+| Modelo | Parâmetros | Licença | Permite uso comercial | Guia |
+| ------- | ------------ | --- | :---: | ------ |
+| **Stable Diffusion XL** | 3.5B | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | Condições aplicáveis<sup>1</sup> | [Guia SDXL](SDXL.md) |
+| **Kolors** | 5B | [Kwai Kolors License](https://huggingface.co/terminusresearch/kwai-kolors-1.0/blob/main/MODEL_LICENSE) | Condições aplicáveis<sup>7</sup> | [Guia Kolors](KOLORS.md) |
+| **Stable Cascade** | - | [Stable Cascade NC Community](https://huggingface.co/stabilityai/stable-cascade/blob/main/LICENSE) | Não<sup>5</sup> | [Guia Cascade](STABLE_CASCADE_C.md) |
 
 ### Edição de Imagem
 
-| Modelo | Guia |
-|-------|------|
-| **Qwen Edit** | [Guia Qwen Edit](QWEN_EDIT.md) |
-| **LongCat Edit** | [Guia LongCat Edit](LONGCAT_EDIT.md) |
+| Modelo | Licença | Permite uso comercial | Guia |
+| ------- | --- | :---: | ------ |
+| **Qwen Edit** | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [Guia Qwen Edit](QWEN_EDIT.md) |
+| **LongCat Edit** | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [Guia LongCat Edit](LONGCAT_EDIT.md) |
 
 ## Modelos de Vídeo
 
-| Modelo | Parâmetros | Guia |
-|-------|------------|------|
-| **Wan Video** | 1.3-14B | [Guia Wan](WAN.md) |
-| **LTX Video** | 5B | [Guia LTX](LTXVIDEO.md) |
-| **LTX Video 2** | 19B | [Guia LTX Video 2](LTXVIDEO2.md) |
-| **Cosmos3** | 4-65B | [Guia Cosmos3](COSMOS3.pt-BR.md) |
-| **Hunyuan Video** | 8.3B | [Guia Hunyuan](HUNYUANVIDEO.md) |
-| **Sana Video** | - | [Guia Sana Video](SANAVIDEO.md) |
-| **Kandinsky 5 Video** | - | [Guia Kandinsky Video](KANDINSKY5_VIDEO.md) |
-| **LongCat Video** | - | [Guia LongCat Video](LONGCAT_VIDEO.md) |
-| **LongCat Video Edit** | - | [Guia LongCat Video Edit](LONGCAT_VIDEO_EDIT.md) |
+| Modelo | Parâmetros | Licença | Permite uso comercial | Guia |
+| ------- | ------------ | --- | :---: | ------ |
+| **Wan Video** | 1.3-14B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [Guia Wan](WAN.md) |
+| **LTX Video** | 5B | [LTX Video OpenRAIL-M](https://huggingface.co/Lightricks/LTX-Video-0.9.5/blob/main/ltx-video-2b-v0.9.5.license.txt) | Condições aplicáveis<sup>10</sup> | [Guia LTX](LTXVIDEO.md) |
+| **LTX Video 2** | 19B | [LTX-2 Community](https://ltx.io/model/license) | Condições aplicáveis<sup>10</sup> | [Guia LTX Video 2](LTXVIDEO2.md) |
+| **Cosmos3** | 4-65B | [OpenMDW 1.1](https://github.com/OpenMDW/openmdw/blob/main/1.1/LICENSE.OpenMDW-1.1) | Sim | [Guia Cosmos3](COSMOS3.pt-BR.md) |
+| **Hunyuan Video** | 8.3B | [Tencent Hunyuan Community](https://huggingface.co/tencent/HunyuanVideo-1.5/blob/main/LICENSE) | Condições aplicáveis<sup>11</sup> | [Guia Hunyuan](HUNYUANVIDEO.md) |
+| **Sana Video** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | Sim | [Guia Sana Video](SANAVIDEO.md) |
+| **Kandinsky 5 Video** | - | [MIT](https://opensource.org/license/mit) | Sim | [Guia Kandinsky Video](KANDINSKY5_VIDEO.md) |
+| **LongCat Video** | - | [MIT](https://opensource.org/license/mit) | Sim | [Guia LongCat Video](LONGCAT_VIDEO.md) |
+| **LongCat Video Edit** | - | [MIT](https://opensource.org/license/mit) | Sim | [Guia LongCat Video Edit](LONGCAT_VIDEO_EDIT.md) |
+
+**Notas de licença:** O status de uso comercial cobre pesos do modelo, checkpoints derivados, fine-tunes e uso de modelo hospedado. Os direitos sobre saídas geradas podem diferir; leia o texto da licença vinculada antes de uma implantação comercial.
+
+<sup>1</sup> Licenças estilo OpenRAIL geralmente permitem uso comercial com restrições de uso que continuam aplicáveis ao modelo e seus derivados.
+
+<sup>2</sup> A Stability AI Community License está disponível para usuários qualificados abaixo do limite de receita; uso comercial maior exige termos empresariais da Stability.
+
+<sup>3</sup> Flux.1 varia por flavour: Schnell e LibreFlux são Apache-2.0, enquanto Dev, Krea e Kontext usam termos não comerciais da BFL; revise os metadados upstream do FluxBooru antes de uso comercial.
+
+<sup>4</sup> Flux.2 varia por flavour: Klein 4B é Apache-2.0, enquanto Dev e Klein 9B usam termos não comerciais da BFL.
+
+<sup>5</sup> Termos públicos de modelo não comercial não permitem uso comercial de pesos, checkpoints derivados ou serviços hospedados do modelo sem uma licença separada.
+
+<sup>6</sup> A Krea 2 Community License permite uso comercial apenas sob seus requisitos de receita e segurança/filtragem; caso contrário, é necessária uma licença empresarial.
+
+<sup>7</sup> O uso comercial do modelo Kolors ou de seus derivados exige solicitar e receber permissão explícita do licenciante.
+
+<sup>8</sup> AuraFlow aceita flavours upstream Apache-2.0 e um flavour Pony com uma licença personalizada separada; confira o flavour selecionado.
+
+<sup>9</sup> A NVIDIA Open Model License permite uso comercial, mas inclui termos de contrato, uso aceitável e controle de exportação.
+
+<sup>10</sup> LTX Video 0.9.5 usa OpenRAIL-M; LTX Video 2 usa termos comunitários da LTX com limite de receita para uso comercial.
+
+<sup>11</sup> A Tencent Hunyuan Community License inclui exclusões territoriais e um limite comercial para serviços muito grandes.
+
+<sup>12</sup> Este mirror publica `license: other` sem texto de licença padrão; revise os termos upstream antes de uso comercial.
 
 ## Modelos de Áudio
 

--- a/documentation/quickstart/index.zh.md
+++ b/documentation/quickstart/index.zh.md
@@ -6,65 +6,91 @@
 
 ### 流匹配
 
-| 模型 | 参数 | 指南 |
-|-------|------------|-------|
-| **Flux.1** | 12B | [Flux.1 指南](FLUX.md) |
-| **Flux.2** | 32B | [Flux.2 指南](FLUX2.md) |
-| **Flux Kontext** | 12B | [Kontext 指南](FLUX_KONTEXT.md) |
-| **Chroma** | 8.9B | [Chroma 指南](CHROMA.md) |
-| **Stable Diffusion 3** | 2-8B | [SD3 指南](SD3.md) |
-| **Auraflow** | 6.8B | [Auraflow 指南](AURAFLOW.md) |
-| **Sana** | 0.6-4.8B | [Sana 指南](SANA.md) |
-| **Lumina2** | 2B | [Lumina2 指南](LUMINA2.md) |
-| **HiDream** | 17B MoE | [HiDream 指南](HIDREAM.md) |
-| **Z-Image** | - | [Z-Image 指南](ZIMAGE.md) |
-| **Krea2** | - | [Krea2 指南](KREA2.zh.md) |
-| **Mage-Flow** | 4B | [Mage-Flow 指南](MAGEFLOW.zh.md) |
-| **Boogu-Image** | - | [Boogu-Image 指南](BOOGU_IMAGE.zh.md) |
-| **zlab i1** | 3B | [zlab i1 指南](ZLAB_i1.zh.md) |
-| **Ideogram 4** | 9B | [Ideogram 4 指南](IDEOGRAM4.zh.md) |
-| **ERNIE-Image** | - | [ERNIE 指南](ERNIE.md) |
+| 模型 | 参数 | 许可证 | 允许商用 | 指南 |
+| ------- | ------------ | --- | :---: | ------- |
+| **Flux.1** | 12B | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 有条件<sup>3</sup> | [Flux.1 指南](FLUX.md) |
+| **Flux.2** | 32B | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) / [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 有条件<sup>4</sup> | [Flux.2 指南](FLUX2.md) |
+| **Flux Kontext** | 12B | [BFL Non-Commercial](https://bfl.ai/legal/non-commercial-license-terms) | 否<sup>5</sup> | [Kontext 指南](FLUX_KONTEXT.md) |
+| **Chroma** | 8.9B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [Chroma 指南](CHROMA.md) |
+| **Stable Diffusion 3** | 2-8B | [Stability AI Community](https://stability.ai/license) | 有条件<sup>2</sup> | [SD3 指南](SD3.md) |
+| **Auraflow** | 6.8B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) / [Pony License](https://huggingface.co/purplesmartai/pony-v7-base/blob/main/LICENSE) | 有条件<sup>8</sup> | [Auraflow 指南](AURAFLOW.md) |
+| **Sana** | 0.6-4.8B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [Sana 指南](SANA.md) |
+| **Lumina2** | 2B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [Lumina2 指南](LUMINA2.md) |
+| **HiDream** | 17B MoE | [MIT](https://opensource.org/license/mit) | 是 | [HiDream 指南](HIDREAM.md) |
+| **Z-Image** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [Z-Image 指南](ZIMAGE.md) |
+| **Krea2** | - | [Krea 2 Community](https://www.krea.ai/krea-2-licensing) | 有条件<sup>6</sup> | [Krea2 指南](KREA2.zh.md) |
+| **Mage-Flow** | 4B | [MIT](https://opensource.org/license/mit) | 是 | [Mage-Flow 指南](MAGEFLOW.zh.md) |
+| **Boogu-Image** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [Boogu-Image 指南](BOOGU_IMAGE.zh.md) |
+| **zlab i1** | 3B | [Unspecified](https://huggingface.co/bghira/zlab-i1-diffusers) | 有条件<sup>12</sup> | [zlab i1 指南](ZLAB_i1.zh.md) |
+| **Ideogram 4** | 9B | [Ideogram 4 Non-Commercial](https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md) | 否<sup>5</sup> | [Ideogram 4 指南](IDEOGRAM4.zh.md) |
+| **ERNIE-Image** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [ERNIE 指南](ERNIE.md) |
 
 ### DiT / Transformer
 
-| 模型 | 参数 | 指南 |
-|-------|------------|-------|
-| **PixArt Sigma** | 0.6-0.9B | [Sigma 指南](SIGMA.md) |
-| **Cosmos2** | 2-14B | [Cosmos2 指南](COSMOS2IMAGE.md) |
-| **Cosmos3** | 4-65B | [Cosmos3 指南](COSMOS3.zh.md) |
-| **OmniGen** | 3.8B | [OmniGen 指南](OMNIGEN.md) |
-| **Qwen Image** | 20B | [Qwen 指南](QWEN_IMAGE.md) |
-| **LongCat Image** | 6B | [LongCat 指南](LONGCAT_IMAGE.md) |
-| **Kandinsky 5** | - | [Kandinsky 指南](KANDINSKY5_IMAGE.md) |
+| 模型 | 参数 | 许可证 | 允许商用 | 指南 |
+| ------- | ------------ | --- | :---: | ------- |
+| **PixArt Sigma** | 0.6-0.9B | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | 有条件<sup>1</sup> | [Sigma 指南](SIGMA.md) |
+| **Cosmos2** | 2-14B | [NVIDIA Open Model License](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/) | 是<sup>9</sup> | [Cosmos2 指南](COSMOS2IMAGE.md) |
+| **Cosmos3** | 4-65B | [OpenMDW 1.1](https://github.com/OpenMDW/openmdw/blob/main/1.1/LICENSE.OpenMDW-1.1) | 是 | [Cosmos3 指南](COSMOS3.zh.md) |
+| **OmniGen** | 3.8B | [MIT](https://opensource.org/license/mit) | 是 | [OmniGen 指南](OMNIGEN.md) |
+| **Qwen Image** | 20B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [Qwen 指南](QWEN_IMAGE.md) |
+| **LongCat Image** | 6B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [LongCat 指南](LONGCAT_IMAGE.md) |
+| **Kandinsky 5** | - | [MIT](https://opensource.org/license/mit) | 是 | [Kandinsky 指南](KANDINSKY5_IMAGE.md) |
 
 ### U-Net
 
-| 模型 | 参数 | 指南 |
-|-------|------------|-------|
-| **Stable Diffusion XL** | 3.5B | [SDXL 指南](SDXL.md) |
-| **Kolors** | 5B | [Kolors 指南](KOLORS.md) |
-| **Stable Cascade** | - | [Cascade 指南](STABLE_CASCADE_C.md) |
+| 模型 | 参数 | 许可证 | 允许商用 | 指南 |
+| ------- | ------------ | --- | :---: | ------- |
+| **Stable Diffusion XL** | 3.5B | [OpenRAIL++](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/LICENSE.md) | 有条件<sup>1</sup> | [SDXL 指南](SDXL.md) |
+| **Kolors** | 5B | [Kwai Kolors License](https://huggingface.co/terminusresearch/kwai-kolors-1.0/blob/main/MODEL_LICENSE) | 有条件<sup>7</sup> | [Kolors 指南](KOLORS.md) |
+| **Stable Cascade** | - | [Stable Cascade NC Community](https://huggingface.co/stabilityai/stable-cascade/blob/main/LICENSE) | 否<sup>5</sup> | [Cascade 指南](STABLE_CASCADE_C.md) |
 
 ### 图像编辑
 
-| 模型 | 指南 |
-|-------|-------|
-| **Qwen Edit** | [Qwen Edit 指南](QWEN_EDIT.md) |
-| **LongCat Edit** | [LongCat Edit 指南](LONGCAT_EDIT.md) |
+| 模型 | 许可证 | 允许商用 | 指南 |
+| ------- | --- | :---: | ------- |
+| **Qwen Edit** | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [Qwen Edit 指南](QWEN_EDIT.md) |
+| **LongCat Edit** | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [LongCat Edit 指南](LONGCAT_EDIT.md) |
 
 ## 视频模型
 
-| 模型 | 参数 | 指南 |
-|-------|------------|-------|
-| **Wan Video** | 1.3-14B | [Wan 指南](WAN.md) |
-| **LTX Video** | 5B | [LTX 指南](LTXVIDEO.md) |
-| **LTX Video 2** | 19B | [LTX Video 2 指南](LTXVIDEO2.md) |
-| **Cosmos3** | 4-65B | [Cosmos3 指南](COSMOS3.zh.md) |
-| **Hunyuan Video** | 8.3B | [Hunyuan 指南](HUNYUANVIDEO.md) |
-| **Sana Video** | - | [Sana Video 指南](SANAVIDEO.md) |
-| **Kandinsky 5 Video** | - | [Kandinsky Video 指南](KANDINSKY5_VIDEO.md) |
-| **LongCat Video** | - | [LongCat Video 指南](LONGCAT_VIDEO.md) |
-| **LongCat Video Edit** | - | [LongCat Video Edit 指南](LONGCAT_VIDEO_EDIT.md) |
+| 模型 | 参数 | 许可证 | 允许商用 | 指南 |
+| ------- | ------------ | --- | :---: | ------- |
+| **Wan Video** | 1.3-14B | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [Wan 指南](WAN.md) |
+| **LTX Video** | 5B | [LTX Video OpenRAIL-M](https://huggingface.co/Lightricks/LTX-Video-0.9.5/blob/main/ltx-video-2b-v0.9.5.license.txt) | 有条件<sup>10</sup> | [LTX 指南](LTXVIDEO.md) |
+| **LTX Video 2** | 19B | [LTX-2 Community](https://ltx.io/model/license) | 有条件<sup>10</sup> | [LTX Video 2 指南](LTXVIDEO2.md) |
+| **Cosmos3** | 4-65B | [OpenMDW 1.1](https://github.com/OpenMDW/openmdw/blob/main/1.1/LICENSE.OpenMDW-1.1) | 是 | [Cosmos3 指南](COSMOS3.zh.md) |
+| **Hunyuan Video** | 8.3B | [Tencent Hunyuan Community](https://huggingface.co/tencent/HunyuanVideo-1.5/blob/main/LICENSE) | 有条件<sup>11</sup> | [Hunyuan 指南](HUNYUANVIDEO.md) |
+| **Sana Video** | - | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 是 | [Sana Video 指南](SANAVIDEO.md) |
+| **Kandinsky 5 Video** | - | [MIT](https://opensource.org/license/mit) | 是 | [Kandinsky Video 指南](KANDINSKY5_VIDEO.md) |
+| **LongCat Video** | - | [MIT](https://opensource.org/license/mit) | 是 | [LongCat Video 指南](LONGCAT_VIDEO.md) |
+| **LongCat Video Edit** | - | [MIT](https://opensource.org/license/mit) | 是 | [LongCat Video Edit 指南](LONGCAT_VIDEO_EDIT.md) |
+
+**许可证说明：** 商用状态覆盖模型权重、派生 checkpoint、fine-tune 和托管模型使用。生成输出的权利可能不同；商业部署前请以链接的许可证正文为准。
+
+<sup>1</sup> OpenRAIL 风格许可证通常允许商用，但使用限制仍适用于模型和派生物。
+
+<sup>2</sup> Stability AI Community License 适用于低于收入门槛且符合条件的用户；更大规模商用需要 Stability 企业条款。
+
+<sup>3</sup> Flux.1 随 flavour 不同而不同：Schnell 和 LibreFlux 为 Apache-2.0，Dev、Krea 和 Kontext 使用 BFL 非商用条款；FluxBooru 商用前请检查 upstream metadata。
+
+<sup>4</sup> Flux.2 随 flavour 不同而不同：Klein 4B 为 Apache-2.0，Dev 和 Klein 9B 使用 BFL 非商用条款。
+
+<sup>5</sup> 公开的非商用模型条款不允许在没有单独许可证的情况下商用权重、派生 checkpoint 或托管模型服务。
+
+<sup>6</sup> Krea 2 Community License 只在满足收入和安全/过滤要求时允许商用；否则需要企业许可证。
+
+<sup>7</sup> Kolors 模型或派生物的商用需要向许可方申请并获得明确许可。
+
+<sup>8</sup> AuraFlow 支持 Apache-2.0 upstream flavour，以及带有单独自定义许可证的 Pony flavour；请检查所选 flavour。
+
+<sup>9</sup> NVIDIA Open Model License 允许商用，但包含协议、可接受使用和出口管制条款。
+
+<sup>10</sup> LTX Video 0.9.5 使用 OpenRAIL-M；LTX Video 2 使用带商用收入门槛的 LTX community terms。
+
+<sup>11</sup> Tencent Hunyuan Community License 包含地域排除，以及针对超大规模服务的商用门槛。
+
+<sup>12</sup> 此 mirror 发布 `license: other`，但没有标准许可证正文；商用前请检查 upstream terms。
 
 ## 音频模型
 


### PR DESCRIPTION
This pull request updates the model feature matrices in both the English (`README.md`) and Spanish (`documentation/QUICKSTART.es.md`) documentation to include detailed license and commercial-use information for each supported model. This helps users understand the legal terms for using, fine-tuning, or deploying each model, and ensures compliance with upstream license requirements. Additionally, it clarifies some documentation links.

The most important changes are:

**License and Commercial-Use Information:**

* Added new columns to the model feature tables in both `README.md` and `documentation/QUICKSTART.es.md` to specify the license type and whether commercial use is allowed for each model, with links to the relevant license texts. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R126) [[2]](diffhunk://#diff-b4bcc04d5d131540fad45196e0283d2d7734b0b5bdd930e2b3fc143871128a72L11-R79)
* Included detailed footnotes explaining the conditions and restrictions on commercial use for specific models and licenses. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R126) [[2]](diffhunk://#diff-b4bcc04d5d131540fad45196e0283d2d7734b0b5bdd930e2b3fc143871128a72L11-R79)

**Documentation Enhancements:**

* Added explanatory notes about the scope of commercial-use rights (covering model weights, derivatives, fine-tunes, and hosted use) and the need to check license texts for generated output rights. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R126) [[2]](diffhunk://#diff-b4bcc04d5d131540fad45196e0283d2d7734b0b5bdd930e2b3fc143871128a72L11-R79)
* Improved the clarity of license guidance and commercial-use restrictions for Spanish-speaking users in `documentation/QUICKSTART.es.md`, including translation of all relevant notes.

**Minor Fixes:**

* Fixed a broken anchor link in the Spanish quickstart guide to point to the correct troubleshooting section.