### PR TITLE
(#2990 continued) LoRA state dict key naming cleanup

### DIFF
--- a/simpletuner/helpers/training/lora_format.py
+++ b/simpletuner/helpers/training/lora_format.py
@@ -34,12 +34,9 @@ def detect_state_dict_format(state_dict: Dict[str, Any]) -> Optional[PEFTLoRAFor
     keys = list(state_dict.keys())
     comfy_prefix_hits = sum(k.startswith("diffusion_model.") for k in keys)
     comfy_alpha_hits = sum(k.endswith(".alpha") for k in keys)
-    comfy_ab_hits = sum(".lora_A" in k or ".lora_B" in k for k in keys)
     diffusers_down_up_hits = sum(".lora.down" in k or ".lora.up" in k for k in keys)
 
     if comfy_prefix_hits or (comfy_alpha_hits and diffusers_down_up_hits == 0):
-        return PEFTLoRAFormat.COMFYUI
-    if comfy_ab_hits and diffusers_down_up_hits == 0 and comfy_prefix_hits >= 0:
         return PEFTLoRAFormat.COMFYUI
     return PEFTLoRAFormat.DIFFUSERS
 

--- a/simpletuner/helpers/training/lora_format.py
+++ b/simpletuner/helpers/training/lora_format.py
@@ -233,24 +233,16 @@ def convert_diffusers_to_comfyui(
 
         if ".lora.down." in new_key:
             new_key = new_key.replace(".lora.down.", ".lora_A.")
+        elif ".lora.up." in new_key:
+            new_key = new_key.replace(".lora.up.", ".lora_B.")
+
+        if ".lora_A." in new_key:
             module_key = new_key[: new_key.rfind(".lora_A.")]
             alpha_value = _resolve_alpha_for_module(
                 module_key.removeprefix(f"{diffusion_prefix}."), weight, adapter_metadata
             )
             if alpha_value is not None and module_key not in alpha_entries:
                 alpha_entries[module_key] = torch.tensor(alpha_value, dtype=torch.float32)
-        elif new_key.endswith(".lora.down.weight"):
-            new_key = new_key.replace(".lora.down.weight", ".lora_A.weight")
-            module_key = new_key[: new_key.rfind(".lora_A.weight")]
-            alpha_value = _resolve_alpha_for_module(
-                module_key.removeprefix(f"{diffusion_prefix}."), weight, adapter_metadata
-            )
-            if alpha_value is not None and module_key not in alpha_entries:
-                alpha_entries[module_key] = torch.tensor(alpha_value, dtype=torch.float32)
-        elif ".lora.up." in new_key:
-            new_key = new_key.replace(".lora.up.", ".lora_B.")
-        elif new_key.endswith(".lora.up.weight"):
-            new_key = new_key.replace(".lora.up.weight", ".lora_B.weight")
 
         converted[new_key] = weight
 

--- a/simpletuner/helpers/training/save_hooks.py
+++ b/simpletuner/helpers/training/save_hooks.py
@@ -742,10 +742,7 @@ class SaveHookManager:
             self.ema_model.copy_to(trainable_parameters)
             ema_trained_component = unwrap_model(self.accelerator, self.model.get_trained_component())
             lora_save_parameters = {
-                f"{self.model.MODEL_SUBFOLDER}_lora_layers": convert_state_dict_to_diffusers(
-                    get_peft_model_state_dict(ema_trained_component),
-                    original_type=StateDictType.PEFT,
-                ),
+                f"{self.model.MODEL_SUBFOLDER}_lora_layers": get_peft_model_state_dict(ema_trained_component),
             }
             ema_modules_to_save = {self.model.MODEL_SUBFOLDER: ema_trained_component}
             ema_metadata = _collate_lora_metadata(ema_modules_to_save)
@@ -792,9 +789,8 @@ class SaveHookManager:
                 modules_to_save["controlnet"] = unwrapped_model
             elif isinstance(unwrapped_model, tuple(trained_component_classes)):
                 # unet_lora_layers or transformer_lora_layers
-                lora_save_parameters[f"{self.model.MODEL_SUBFOLDER}_lora_layers"] = convert_state_dict_to_diffusers(
-                    get_peft_model_state_dict(unwrapped_model),
-                    original_type=StateDictType.PEFT,
+                lora_save_parameters[f"{self.model.MODEL_SUBFOLDER}_lora_layers"] = get_peft_model_state_dict(
+                    unwrapped_model
                 )
                 modules_to_save[self.model.MODEL_SUBFOLDER] = unwrapped_model
             elif text_encoder_0_cls is not None and isinstance(unwrapped_model, text_encoder_0_cls):

--- a/tests/test_lora_format.py
+++ b/tests/test_lora_format.py
@@ -1,0 +1,93 @@
+import unittest
+
+import torch
+
+from simpletuner.helpers.training.lora_format import (
+    PEFTLoRAFormat,
+    convert_diffusers_to_comfyui,
+    convert_diffusers_to_comfyui_sd_lora,
+    detect_state_dict_format,
+)
+
+
+DOWN = torch.full((4, 8), 1.0)
+UP = torch.full((8, 4), 2.0)
+
+
+def _diffusers_named(module_key):
+    return {
+        f"{module_key}.lora.down.weight": DOWN,
+        f"{module_key}.lora.up.weight": UP,
+    }
+
+
+def _peft_named(module_key):
+    return {
+        f"{module_key}.lora_A.weight": DOWN,
+        f"{module_key}.lora_B.weight": UP,
+    }
+
+
+SPELLINGS = (("diffusers", _diffusers_named), ("peft", _peft_named))
+
+
+class ConvertDiffusersToComfyUITests(unittest.TestCase):
+    MODULE = "transformer.blocks.0.attn.to_q"
+    CONVERTED = "diffusion_model.blocks.0.attn.to_q"
+    ALPHA_KEY = "diffusion_model.blocks.0.attn.to_q.alpha"
+    METADATA = {"lora_alpha": 16}
+
+    def _convert(self, state_dict):
+        return convert_diffusers_to_comfyui(state_dict, adapter_metadata=self.METADATA)
+
+    def test_both_spellings_convert_to_the_same_keys(self):
+        converted = {name: set(self._convert(build(self.MODULE))) for name, build in SPELLINGS}
+        self.assertEqual(converted["diffusers"], converted["peft"])
+
+    def test_alpha_is_emitted_for_both_spellings(self):
+        for name, build in SPELLINGS:
+            with self.subTest(spelling=name):
+                converted = self._convert(build(self.MODULE))
+                self.assertIn(self.ALPHA_KEY, converted)
+                self.assertEqual(float(converted[self.ALPHA_KEY]), float(self.METADATA["lora_alpha"]))
+
+    def test_down_and_up_weights_keep_their_roles(self):
+        for name, build in SPELLINGS:
+            with self.subTest(spelling=name):
+                converted = self._convert(build(self.MODULE))
+                self.assertTrue(torch.equal(converted[f"{self.CONVERTED}.lora_A.weight"], DOWN))
+                self.assertTrue(torch.equal(converted[f"{self.CONVERTED}.lora_B.weight"], UP))
+
+
+class ConvertDiffusersToComfyUISDLoraTests(unittest.TestCase):
+    MODULE = "unet.down_blocks.1.attentions.0.transformer_blocks.0.attn1.to_k"
+    ALPHA_KEY = "lora_unet_down_blocks_1_attentions_0_transformer_blocks_0_attn1_to_k.alpha"
+    METADATA = {"lora_alpha": 8}
+
+    def _convert(self, state_dict):
+        return convert_diffusers_to_comfyui_sd_lora(state_dict, adapter_metadata=self.METADATA)
+
+    def test_both_spellings_convert_to_the_same_keys(self):
+        converted = {name: set(self._convert(build(self.MODULE))) for name, build in SPELLINGS}
+        self.assertEqual(converted["diffusers"], converted["peft"])
+
+    def test_alpha_is_emitted_for_both_spellings(self):
+        for name, build in SPELLINGS:
+            with self.subTest(spelling=name):
+                converted = self._convert(build(self.MODULE))
+                self.assertIn(self.ALPHA_KEY, converted)
+                self.assertEqual(float(converted[self.ALPHA_KEY]), float(self.METADATA["lora_alpha"]))
+
+
+class DetectStateDictFormatTests(unittest.TestCase):
+    MODULE = "transformer.blocks.0.attn.to_q"
+
+    def test_peft_named_dict_is_reported_as_comfyui(self):
+        self.assertEqual(detect_state_dict_format(_peft_named(self.MODULE)), PEFTLoRAFormat.COMFYUI)
+
+    def test_diffusers_named_dict_is_reported_as_diffusers(self):
+        self.assertEqual(detect_state_dict_format(_diffusers_named(self.MODULE)), PEFTLoRAFormat.DIFFUSERS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lora_format.py
+++ b/tests/test_lora_format.py
@@ -9,7 +9,6 @@ from simpletuner.helpers.training.lora_format import (
     detect_state_dict_format,
 )
 
-
 DOWN = torch.full((4, 8), 1.0)
 UP = torch.full((8, 4), 2.0)
 
@@ -82,11 +81,17 @@ class ConvertDiffusersToComfyUISDLoraTests(unittest.TestCase):
 class DetectStateDictFormatTests(unittest.TestCase):
     MODULE = "transformer.blocks.0.attn.to_q"
 
-    def test_peft_named_dict_is_reported_as_comfyui(self):
-        self.assertEqual(detect_state_dict_format(_peft_named(self.MODULE)), PEFTLoRAFormat.COMFYUI)
+    def test_peft_named_dict_is_reported_as_diffusers(self):
+        self.assertEqual(detect_state_dict_format(_peft_named(self.MODULE)), PEFTLoRAFormat.DIFFUSERS)
 
     def test_diffusers_named_dict_is_reported_as_diffusers(self):
         self.assertEqual(detect_state_dict_format(_diffusers_named(self.MODULE)), PEFTLoRAFormat.DIFFUSERS)
+
+    def test_diffusion_model_peft_named_dict_is_reported_as_comfyui(self):
+        self.assertEqual(
+            detect_state_dict_format(_peft_named("diffusion_model.blocks.0.attn.to_q")),
+            PEFTLoRAFormat.COMFYUI,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_lora_metadata.py
+++ b/tests/test_lora_metadata.py
@@ -41,7 +41,8 @@ class _DummyBaseModule:
 
 
 class _DummyTrainedComponent(_DummyBaseModule):
-    pass
+    def parameters(self):
+        return []
 
 
 class _DummyControlNet(_DummyTrainedComponent):
@@ -131,6 +132,14 @@ class _DummySavePipeline:
         save_function(packed, filename)
 
 
+class _DummyDiffusersSavePipeline(_DummySavePipeline):
+    @classmethod
+    def save_lora_weights(cls, save_directory, transformer_lora_layers=None, save_function=None, **kwargs):
+        filename = os.path.join(save_directory, kwargs.get("weight_name") or "pytorch_lora_weights.safetensors")
+        packed = {f"transformer.{key}": value for key, value in (transformer_lora_layers or {}).items()}
+        (save_function or save_file)(packed, filename)
+
+
 class _DummySDXLSavePipeline:
     @classmethod
     def save_lora_weights(
@@ -163,6 +172,20 @@ class _DummySaveModel:
 
 class _DummySDXLSaveModel(_DummySaveModel):
     PIPELINE_CLASSES = {PipelineTypes.TEXT2IMG: _DummySDXLSavePipeline, PipelineTypes.CONTROLNET: _DummySDXLSavePipeline}
+
+
+class _DummyArtifactModel(_DummyModel):
+    """Routes _save_lora through the real ModelFoundation.save_lora_weights so a file is written."""
+
+    PIPELINE_CLASSES = {
+        PipelineTypes.TEXT2IMG: _DummyDiffusersSavePipeline,
+        PipelineTypes.CONTROLNET: _DummyDiffusersSavePipeline,
+    }
+
+    def __init__(self, trained_component, text_encoder=None):
+        super().__init__(trained_component=trained_component, text_encoder=text_encoder)
+        self.config = SimpleNamespace(model_family="sdxl", lora_format="diffusers", controlnet=False)
+        self.save_lora_weights = lambda *args, **kwargs: ModelFoundation.save_lora_weights(self, *args, **kwargs)
 
 
 _ema_stub = SimpleNamespace(
@@ -434,6 +457,111 @@ class SaveHookMetadataTests(unittest.TestCase):
         self.assertEqual(kwargs["controlnet_lora_adapter_metadata"], {"name": "controlnet"})
         self.assertNotIn("transformer_lora_adapter_metadata", kwargs)
         self.assertIn("text_encoder_lora_adapter_metadata", kwargs)
+
+    def test_save_hook_writes_denoiser_lora_in_peft_naming(self):
+        manager, model, trained_component = self._make_manager()
+
+        lora_state = {
+            "transformer_blocks.0.attn.to_q.lora_A.weight": torch.zeros(4, 8),
+            "transformer_blocks.0.attn.to_q.lora_B.weight": torch.zeros(8, 4),
+            "transformer_blocks.0.ff.up.lora_A.weight": torch.zeros(4, 8),
+            "transformer_blocks.0.ff.up.lora_B.weight": torch.zeros(8, 4),
+        }
+        with patch("simpletuner.helpers.training.save_hooks.get_peft_model_state_dict", return_value=lora_state):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                manager._save_lora(models=[trained_component], weights=[object()], output_dir=tmpdir)
+
+        written = model.save_lora_weights.call_args.kwargs["transformer_lora_layers"]
+        self.assertEqual(set(written), set(lora_state))
+        for key in written:
+            self.assertTrue(key.endswith((".lora_A.weight", ".lora_B.weight")), key)
+            self.assertNotIn(".lora.down", key)
+            self.assertNotIn(".lora.up", key)
+
+    def test_save_hook_never_writes_a_mixed_naming_scheme(self):
+        lora_state = {
+            "transformer_blocks.0.attn.to_q.lora_A.weight": torch.zeros(4, 8),
+            "transformer_blocks.0.attn.to_q.lora_B.weight": torch.zeros(8, 4),
+            "transformer_blocks.0.ff.up.lora_A.weight": torch.zeros(4, 8),
+            "transformer_blocks.0.ff.up.lora_B.weight": torch.zeros(8, 4),
+        }
+
+        for use_ema in (False, True):
+            with self.subTest(use_ema=use_ema):
+                manager, model, trained_component = self._make_manager(args_overrides={"use_ema": use_ema})
+                with patch(
+                    "simpletuner.helpers.training.save_hooks.get_peft_model_state_dict", return_value=lora_state
+                ):
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        manager._save_lora(models=[trained_component], weights=[object()], output_dir=tmpdir)
+
+                calls = model.save_lora_weights.call_args_list
+                self.assertEqual(len(calls), 2 if use_ema else 1)
+                for call in calls:
+                    written = call.kwargs["transformer_lora_layers"]
+                    schemes = {"peft" if (".lora_A." in key or ".lora_B." in key) else "diffusers" for key in written}
+                    self.assertEqual(schemes, {"peft"}, written)
+
+    def test_saved_denoiser_file_uses_peft_naming(self):
+        args = SimpleNamespace(
+            use_ema=False,
+            model_type="lora",
+            lora_type="standard",
+            controlnet=False,
+            validation_using_datasets=False,
+            model_family="sdxl",
+            model_flavour="base-1.0",
+            tracker_run_name="run-name",
+            resolution=1024,
+        )
+        trained_component = _DummyTrainedComponent("transformer")
+        manager = SaveHookManager(
+            args=args,
+            model=_DummyArtifactModel(trained_component=trained_component),
+            ema_model=_ema_stub,
+            accelerator=_DummyAccelerator(),
+            use_deepspeed_optimizer=False,
+        )
+
+        lora_state = {
+            "transformer_blocks.0.attn.to_q.lora_A.weight": torch.zeros(4, 8),
+            "transformer_blocks.0.attn.to_q.lora_B.weight": torch.zeros(8, 4),
+            "transformer_blocks.0.ff.up.lora_A.weight": torch.zeros(4, 8),
+            "transformer_blocks.0.ff.up.lora_B.weight": torch.zeros(8, 4),
+        }
+        with patch("simpletuner.helpers.training.save_hooks.get_peft_model_state_dict", return_value=lora_state):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                manager._save_lora(models=[trained_component], weights=[object()], output_dir=tmpdir)
+                lora_path = os.path.join(tmpdir, "pytorch_lora_weights.safetensors")
+                with safe_open(lora_path, framework="pt", device="cpu") as handle:
+                    written = list(handle.keys())
+
+        self.assertEqual(len(written), len(lora_state))
+        for key in written:
+            self.assertTrue(key.endswith((".lora_A.weight", ".lora_B.weight")), key)
+
+    def test_legacy_mixed_checkpoint_normalises_for_resume(self):
+        from diffusers.utils import convert_unet_state_dict_to_peft
+
+        mixed = {
+            "transformer_blocks.0.attn.to_gate.lora_A.weight": torch.zeros(4, 8),
+            "transformer_blocks.0.attn.to_gate.lora_B.weight": torch.zeros(8, 4),
+            "transformer_blocks.0.attn.to_q.lora.down.weight": torch.zeros(4, 8),
+            "transformer_blocks.0.attn.to_q.lora.up.weight": torch.zeros(8, 4),
+        }
+
+        # safetensors sorts keys, and diffusers' loader gates conversion on the first one alone.
+        self.assertIn("lora_A", sorted(mixed)[0])
+
+        converted = convert_unet_state_dict_to_peft(mixed)
+
+        self.assertEqual(len(converted), len(mixed))
+        for key in converted:
+            self.assertTrue(key.endswith((".lora_A.weight", ".lora_B.weight")), key)
+        self.assertEqual(
+            {key.rsplit(".lora_", 1)[0] for key in converted},
+            {"transformer_blocks.0.attn.to_gate", "transformer_blocks.0.attn.to_q"},
+        )
 
     def test_models_spec_metadata_written_to_lora_file(self):
         manager, _, _ = self._make_manager(

--- a/tests/test_lora_metadata.py
+++ b/tests/test_lora_metadata.py
@@ -489,9 +489,7 @@ class SaveHookMetadataTests(unittest.TestCase):
         for use_ema in (False, True):
             with self.subTest(use_ema=use_ema):
                 manager, model, trained_component = self._make_manager(args_overrides={"use_ema": use_ema})
-                with patch(
-                    "simpletuner.helpers.training.save_hooks.get_peft_model_state_dict", return_value=lora_state
-                ):
+                with patch("simpletuner.helpers.training.save_hooks.get_peft_model_state_dict", return_value=lora_state):
                     with tempfile.TemporaryDirectory() as tmpdir:
                         manager._save_lora(models=[trained_component], weights=[object()], output_dir=tmpdir)
 
@@ -539,6 +537,86 @@ class SaveHookMetadataTests(unittest.TestCase):
         self.assertEqual(len(written), len(lora_state))
         for key in written:
             self.assertTrue(key.endswith((".lora_A.weight", ".lora_B.weight")), key)
+
+    def test_save_hook_peft_output_loads_through_diffusers_with_model_prefix(self):
+        from diffusers.loaders.peft import PeftAdapterMixin
+        from peft import LoraConfig, inject_adapter_in_model
+        from peft.utils import get_peft_model_state_dict
+
+        class Block(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.to_gate = torch.nn.Linear(8, 8, bias=False)
+                self.to_q = torch.nn.Linear(8, 8, bias=False)
+
+        class Denoiser(PeftAdapterMixin, torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.model = torch.nn.Module()
+                self.model.transformer = torch.nn.Module()
+                self.model.transformer.foo = Block()
+
+        class Pipeline:
+            pass
+
+        class Model:
+            MODEL_CLASS = Denoiser
+            MODEL_SUBFOLDER = "model"
+            PIPELINE_CLASSES = {PipelineTypes.TEXT2IMG: Pipeline}
+
+            def __init__(self, trained_component):
+                self.trained_component = trained_component
+                self.saved_lora_layers = None
+
+            def get_trained_component(self, unwrap_model=False, base_model=False):
+                return self.trained_component
+
+            def get_text_encoder(self, index):
+                return None
+
+            def save_lora_weights(self, output_dir, **kwargs):
+                self.saved_lora_layers = kwargs["model_lora_layers"]
+
+        def make_trained_component():
+            component = Denoiser()
+            inject_adapter_in_model(
+                LoraConfig(r=2, lora_alpha=2, target_modules=["to_gate", "to_q"]),
+                component,
+                adapter_name="default",
+            )
+            return component
+
+        def load_with_diffusers_from_safetensors(state_dict):
+            target = Denoiser()
+            with tempfile.TemporaryDirectory() as tmpdir:
+                save_file(state_dict, os.path.join(tmpdir, "pytorch_lora_weights.safetensors"))
+                target.load_lora_adapter(
+                    tmpdir,
+                    prefix=None,
+                    weight_name="pytorch_lora_weights.safetensors",
+                    use_safetensors=True,
+                    adapter_name="loaded",
+                )
+            return sorted(name for name, module in target.named_modules() if hasattr(module, "lora_A"))
+
+        expected_modules = ["model.transformer.foo.to_gate", "model.transformer.foo.to_q"]
+        raw_peft_state = get_peft_model_state_dict(make_trained_component())
+        self.assertEqual(load_with_diffusers_from_safetensors(raw_peft_state), expected_modules)
+
+        trained_component = make_trained_component()
+        model = Model(trained_component)
+        manager = SaveHookManager(
+            args=SimpleNamespace(use_ema=False, controlnet=False, validation_using_datasets=False),
+            model=model,
+            ema_model=_ema_stub,
+            accelerator=_DummyAccelerator(),
+            use_deepspeed_optimizer=False,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager._save_lora(models=[trained_component], weights=[object()], output_dir=tmpdir, write=True)
+
+        self.assertEqual(load_with_diffusers_from_safetensors(model.saved_lora_layers), expected_modules)
 
     def test_legacy_mixed_checkpoint_normalises_for_resume(self):
         from diffusers.utils import convert_unet_state_dict_to_peft


### PR DESCRIPTION
This pull request makes several important improvements to LoRA (Low-Rank Adaptation) format handling, conversion, and testing. The main focus is on standardizing the naming conventions for LoRA weights, ensuring compatibility between PEFT and Diffusers formats, and adding comprehensive tests to guarantee correct conversions and saves. It also introduces new test utilities and fixes to ensure consistent behavior when saving and loading LoRA weights.

**LoRA Format Handling and Conversion:**

* The detection logic in `detect_state_dict_format` was simplified by removing redundant checks for mixed or ambiguous LoRA naming schemes, making format detection more robust.
* The `convert_diffusers_to_comfyui` function was refactored to consistently map `.lora.down.` to `.lora_A.` and `.lora.up.` to `.lora_B.`, and to ensure that alpha values are attached correctly. Legacy handling for mixed naming conventions was removed.

**Saving LoRA Weights:**

* The LoRA saving logic in `_save_lora` was updated to always use the PEFT naming scheme (i.e., `.lora_A.weight` and `.lora_B.weight`) when saving LoRA weights, instead of converting to the Diffusers format. This prevents mixed or ambiguous naming in saved checkpoints. [[1]](diffhunk://#diff-ac3fd13d7c7aec8ae0ac09890a4abf96651b04a8b6f2f85a0559ed18889a1b7eL745-R745) [[2]](diffhunk://#diff-ac3fd13d7c7aec8ae0ac09890a4abf96651b04a8b6f2f85a0559ed18889a1b7eL795-R793)

**Testing and Test Utilities:**

* A comprehensive new test suite (`tests/test_lora_format.py`) was added to verify that LoRA format conversions are correct, that both PEFT and Diffusers spellings are handled consistently, and that saved weights maintain their intended structure and can be loaded as expected.
* Additional test helpers and dummy classes were added or improved in `tests/test_lora_metadata.py` to facilitate testing of save hooks and ensure that LoRA weights are always written and loaded in a consistent, compatible manner. [[1]](diffhunk://#diff-90fa178555ef97194d0bf8768d40eeefbf6cc438d958c2a87b24fe70800ff5a2L44-R45) [[2]](diffhunk://#diff-90fa178555ef97194d0bf8768d40eeefbf6cc438d958c2a87b24fe70800ff5a2R135-R142) [[3]](diffhunk://#diff-90fa178555ef97194d0bf8768d40eeefbf6cc438d958c2a87b24fe70800ff5a2R177-R190)

**Regression and Compatibility Tests:**

* New tests were added to guarantee that the save hook never writes a mixed naming scheme, that PEFT-named weights are accepted by Diffusers loaders, and that legacy mixed checkpoints are normalized for resume.

These changes improve reliability and interoperability when training, saving, and loading LoRA weights across different toolkits and workflows.