### PR TITLE
fix(data): reject a rank the epoch-rollover re-split left with no samples

### DIFF
--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -5537,12 +5537,15 @@ class Trainer:
                     gradient_accumulation_steps=self.config.gradient_accumulation_steps,
                     apply_padding=(self.config.overrode_max_train_steps or self.config.allow_dataset_oversubscription),
                 )
-                if sum(len(b) for b in backend["metadata_backend"].aspect_ratio_bucket_indices.values()) == 0:
+                local_sample_count = sum(
+                    len(bucket) for bucket in backend["metadata_backend"].aspect_ratio_bucket_indices.values()
+                )
+                if local_sample_count == 0:
                     raise ValueError(
                         f"(id={backend_id}) Dataset produced no usable samples. The epoch rollover"
                         f" re-split left this rank with zero samples, so epoch {epoch} would train"
                         f" against an empty schedule here.\n"
-                        f"This usually means the per-epoch re-bucketing (crop_aspect=random) produced"
+                        f"This usually means per-epoch re-bucketing (e.g., crop_aspect=random) produced"
                         f" buckets too small to divide across the data-parallel ranks, or that samples"
                         f" were filtered out of the cache during the previous epoch.\n"
                         f"Enable --allow_dataset_oversubscription so short buckets are padded across"

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -5537,6 +5537,17 @@ class Trainer:
                     gradient_accumulation_steps=self.config.gradient_accumulation_steps,
                     apply_padding=(self.config.overrode_max_train_steps or self.config.allow_dataset_oversubscription),
                 )
+                if sum(len(b) for b in backend["metadata_backend"].aspect_ratio_bucket_indices.values()) == 0:
+                    raise ValueError(
+                        f"(id={backend_id}) Dataset produced no usable samples. The epoch rollover"
+                        f" re-split left this rank with zero samples, so epoch {epoch} would train"
+                        f" against an empty schedule here.\n"
+                        f"This usually means the per-epoch re-bucketing (crop_aspect=random) produced"
+                        f" buckets too small to divide across the data-parallel ranks, or that samples"
+                        f" were filtered out of the cache during the previous epoch.\n"
+                        f"Enable --allow_dataset_oversubscription so short buckets are padded across"
+                        f" ranks, use fewer GPUs, or add more samples to the dataset."
+                    )
                 # we have to rebuild the VAE cache if it exists.
                 if "vaecache" in backend:
                     logger.info("Rebuilding VAE cache..")

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -10,6 +10,7 @@ import tempfile
 import time
 import types
 import unittest
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
@@ -1862,6 +1863,7 @@ class TestTrainer(unittest.TestCase):
                     allow_dataset_oversubscription=allow_oversubscription,
                 )
                 metadata_backend = MagicMock(read_only=True)
+                metadata_backend.aspect_ratio_bucket_indices = {"1.0": ["image-0.jpg"]}
                 backends = {"train": {"metadata_backend": metadata_backend}}
                 backend_config = {
                     "crop": True,
@@ -1885,6 +1887,72 @@ class TestTrainer(unittest.TestCase):
                     gradient_accumulation_steps=3,
                     apply_padding=expected,
                 )
+
+    def _rollover_fixture(self, bucket_contents, usable_batches):
+        trainer = object.__new__(Trainer)
+        trainer.state = {"first_epoch": 1, "current_epoch": 1}
+        trainer.accelerator = MagicMock(is_main_process=True)
+        trainer.extra_lr_scheduler_kwargs = {}
+        trainer.get_steps_per_epoch_for_epoch = MagicMock(return_value=100)
+        trainer.config = SimpleNamespace(
+            num_train_epochs=5,
+            aspect_bucket_disable_rebuild=False,
+            lr_scheduler="constant",
+            num_update_steps_per_epoch=100,
+            gradient_accumulation_steps=1,
+            overrode_max_train_steps=False,
+            allow_dataset_oversubscription=False,
+        )
+        metadata_backend = MagicMock(read_only=True, batch_size=4)
+        metadata_backend.aspect_ratio_bucket_indices = bucket_contents
+        metadata_backend.__len__.return_value = usable_batches
+        vaecache = MagicMock()
+        backends = {"train": {"metadata_backend": metadata_backend, "vaecache": vaecache}}
+        return trainer, metadata_backend, vaecache, backends
+
+    @contextmanager
+    def _rollover_patches(self, backends):
+        with (
+            patch("simpletuner.helpers.training.trainer.StateTracker.set_epoch"),
+            patch(
+                "simpletuner.helpers.training.trainer.StateTracker.get_data_backends",
+                return_value=backends,
+            ),
+            patch(
+                "simpletuner.helpers.training.trainer.StateTracker.get_data_backend_config",
+                return_value={"crop": True, "crop_aspect": "random"},
+            ),
+        ):
+            yield
+
+    def test_epoch_rollover_rejects_a_rank_the_resplit_left_empty(self):
+        trainer, metadata_backend, vaecache, backends = self._rollover_fixture(
+            bucket_contents={"1.0": [], "1.5": []}, usable_batches=0
+        )
+
+        with self._rollover_patches(backends):
+            with self.assertRaises(ValueError) as context:
+                trainer._epoch_rollover(2)
+
+        self.assertIn("Dataset produced no usable samples", str(context.exception))
+        # The rejection must land after the re-split and before anything downstream
+        # consumes the new schedule.
+        metadata_backend.split_buckets_between_processes.assert_called_once()
+        vaecache.rebuild_cache.assert_not_called()
+
+    def test_epoch_rollover_keeps_a_rank_that_cannot_fill_a_batch(self):
+        # One sample against batch_size=4, so the startup guard's len() would read 0 here.
+        # This guard asks only whether the shard is empty, and this rank keeps training on
+        # recycled samples exactly as it does today.
+        trainer, metadata_backend, vaecache, backends = self._rollover_fixture(
+            bucket_contents={"1.0": ["image-0.jpg"]}, usable_batches=0
+        )
+
+        with self._rollover_patches(backends):
+            trainer._epoch_rollover(2)
+
+        metadata_backend.split_buckets_between_processes.assert_called_once()
+        vaecache.rebuild_cache.assert_called_once()
 
     @patch(
         "simpletuner.helpers.training.trainer.Trainer.parse_arguments",


### PR DESCRIPTION
## Summary

The bucket re-split that runs at every epoch rollover can leave a rank with no samples, and nothing
checks for it. Startup refuses the identical dataset state.

## Problem

`_handle_bucket_operations` always ends by calling `_handle_config_versioning` (`factory.py:3359`),
which closes with a check that raises `ValueError: Dataset produced no usable samples` when the split
left this rank's backend with nothing usable (`factory.py:3437-3476`).

`Trainer._epoch_rollover` splits a second time (`trainer.py:5536`) and has no equivalent follow-up.
The only diagnostic on that path is the warning at the end of `split_buckets_between_processes`
(`base.py:945-952`), and it is gated on `should_log()` — global rank 0 — while the rank that ends up
empty is not rank 0.

Measured with 16 images across 8 ranks, `train_batch_size=1`, `gradient_accumulation_steps=1`,
`repeats=1`, `--max_train_steps=100`, oversubscription off:

| path | dataset state | outcome |
|------|---------------|---------|
| startup | buckets `{1.0: 8, 1.5: 8}` | all 8 ranks start |
| **rollover** | re-bucketed to `{1.0: 4, 1.5: 4}` | ranks 4-7 hold zero samples. No error and no warning, on any rank |
| **startup** | the same `{1.0: 4, 1.5: 4}` | ranks 4-7 fail with `Dataset produced no usable samples` |

No data has to be deleted to get there. `crop_aspect="random"` is what puts a backend on this code
path in the first place, and re-bucketing the same 16 images is enough.

**Reproduction condition.** The pre-split validation inside `split_buckets_between_processes`
(`base.py:787-870`) does run at rollover, so what is missing is specifically a *post*-split check.
Staying silent requires `repeats >= train_batch_size * gradient_accumulation_steps`; with the default
`repeats=0` every rank is caught earlier by `Dataset configuration will produce zero usable batches`.

**What happens afterwards.** Not nothing. With prefetch off the emptied rank raises from
`MultiAspectSampler._reset_buckets` (`sampler.py:408`) at the first fetch of the new epoch — an
unattributed `No images found in the dataset` from a rank that started fine, some distance from the
split that caused it. Reading the prefetch path suggests that with `--dataloader_prefetch` the same
exception is swallowed into a DEBUG record (`batch_fetcher.py:83-85`); I have not verified that
variant on hardware.

## Resolution

Ten lines directly after the re-split in `_epoch_rollover`: if this rank's buckets hold no samples at
all, raise, naming the backend and the epoch it was about to enter.

Nothing else moves. `factory.py` is untouched, and the check does not import from or call into the
startup path, so the two guards stay independent — that is deliberate, and it is why the message is
written out here rather than shared. The only reason to couple them would be to keep one predicate,
and this PR does not want the startup predicate.

Raising rather than logging: the trainer already aborts mid-run by raising — a `None` batch
(`trainer.py:6481`) and an unrecognised gradient-clipping method (`trainer.py:6694`) raise
`ValueError`, a non-finite loss (`trainer.py:6602`) raises `RuntimeError`. A rank whose schedule is
empty cannot contribute a gradient for the epoch it is entering.

The message opens with `Dataset produced no usable samples`, the same phrase startup uses, so an
operator grepping logs or an existing alert finds both. The rest of it is rollover-specific: which
epoch, and the causes that actually apply here — per-epoch re-bucketing under `crop_aspect=random`,
or samples filtered out of the cache during the previous epoch.

The remedies it suggests are the ones that move a *physical* shard boundary.
`--allow_dataset_oversubscription` turns padding on (`trainer.py:5538`), which raises every non-empty
bucket's shard to `ceil(len / dp_size)` and so guarantees at least one sample per rank; fewer GPUs
lowers the divisor; more samples raises the dividend. It deliberately does not repeat startup's
advice to lower `batch_size` / `gradient_accumulation_steps` or raise `repeats`: none of those reach
`divmod(len(trimmed_images), effective_dp_size)`. `trim_limit` is always `>= len(images)`
(`base.py:903-906`), so `trimmed_images` is the full bucket regardless of effective batch size, and
`repeats` only multiplies the sampler's logical passes over a shard that is already empty.

### This guard is deliberately narrower than the startup one

It asks a literal question — did this rank end the split with zero samples — and nothing more.

The startup check uses `len(metadata_backend) == 0`, which counts buckets able to form a *complete
local batch* (`discovery.py:767-780`). Reusing that here would also abort a rank that still holds
samples but too few to fill one `train_batch_size`. Such a rank keeps training today on recycled
samples, and it keeps doing so after this PR. Aborting a run that is currently making progress is a
larger intervention than the defect requires, so the narrow predicate is the conservative choice:
the only state that newly aborts is the one that is already unusable.

The consequence is that this does not make the rollover fully agree with startup. A sub-batch shard
is still accepted here and refused there. That is a smaller divergence than the one being fixed, and
closing it means changing what startup considers fatal — a separate decision, not this PR's.

The startup check's `missing_instance_dir` escape hatch (`factory.py:3437-3440`) is not carried over.
It exists to tolerate a backend whose instance directory is not a local path — for `type: aws` it is
the S3 key prefix (`factory.py:3032-3033`), and `os.path.exists()` on that is always False. That is a
question about *configuration*, and it has already been answered by the time an epoch has finished
training. Whether the samples live on local disk or in a bucket has no bearing on whether this rank's
shard came back empty. Leaving it out also means the rollover guard actually covers remote backends,
where the startup one silently does not.

### What this does not do

The guard is rank-local, exactly as startup's is: any rank that still has data proceeds. It is not
only the partial case — a re-bucketing that empties the dataset globally reaches this check on every
rank, because the pre-split validation skips empty buckets (`base.py:790-791`) and so does not catch
it first. Whether the ranks that survive a partial case then block on a collective is not something
I can demonstrate — the reproduction is an 8-rank
simulation inside a single process — so no claim is made about hangs or NCCL timeouts.

It also leaves the rollover's padding policy alone.
`apply_padding=(self.config.overrode_max_train_steps or self.config.allow_dataset_oversubscription)`
at `trainer.py:5538` is a correct carry-forward of `not args.max_train_steps`, and
`test_epoch_rollover_reuses_initial_bucket_padding_policy` already pins it.

## Tests

`tests/test_trainer.py`

- `test_epoch_rollover_rejects_a_rank_the_resplit_left_empty` — recorded RED on `main`
  (`AssertionError: ValueError not raised`). It also asserts the rejection lands after the re-split
  and before `rebuild_cache()`, so a bad schedule is never handed downstream.
- `test_epoch_rollover_keeps_a_rank_that_cannot_fill_a_batch` — the other direction. One sample
  against `batch_size=4`, so `len(metadata_backend)` reads 0 and the startup predicate would fire.
  This rank must keep going. Passes before and after, and fails if the predicate is ever widened.

`test_epoch_rollover_reuses_initial_bucket_padding_policy` gains one fixture line: its `MagicMock`
backend now carries an `aspect_ratio_bucket_indices` dict, because a bare `MagicMock` iterates empty
and would read as a zero-sample shard. Its assertion is unchanged.
