### PR TITLE
fix KeyError in VAE cache disabling

### DIFF
--- a/simpletuner/helpers/data_backend/factory.py
+++ b/simpletuner/helpers/data_backend/factory.py
@@ -64,6 +64,16 @@ def _as_bool(value: Any) -> bool:
     return bool(value)
 
 
+def _normalise_vae_cache_config(config: Dict[str, Any]) -> Tuple[bool, bool]:
+    """Normalize optional VAE cache booleans and preserve disable-implies-ondemand."""
+
+    vae_cache_disable = _as_bool(config.get("vae_cache_disable", False))
+    vae_cache_ondemand = _as_bool(config.get("vae_cache_ondemand", False)) or vae_cache_disable
+    config["vae_cache_disable"] = vae_cache_disable
+    config["vae_cache_ondemand"] = vae_cache_ondemand
+    return vae_cache_disable, vae_cache_ondemand
+
+
 def _coerce_bucket_keys(indices: Dict[Any, Iterable]) -> Dict[Any, list]:
     """Return a copy of aspect ratio bucket indices with numeric keys coerced to float."""
     coerced: Dict[Any, list] = {}
@@ -3997,7 +4007,8 @@ class FactoryRegistry:
                 f"{len(init_backend['conditioning_image_embed_cache'].image_path_to_embed_path)} entries."
             )
 
-        if not init_backend["config"]["vae_cache_ondemand"]:
+        _, vae_cache_ondemand = _normalise_vae_cache_config(init_backend["config"])
+        if not vae_cache_ondemand:
             pending_files = init_backend["conditioning_image_embed_cache"].discover_unprocessed_files()
             logger.info(f"Conditioning image embed cache has {len(pending_files)} unprocessed files.")
             if is_i2v_video:
@@ -4135,8 +4146,7 @@ class FactoryRegistry:
             if vae_batch_size is None:
                 vae_batch_size = self.args.vae_batch_size
 
-        dataset_vae_cache_disable = init_backend["config"]["vae_cache_disable"]
-        dataset_vae_cache_ondemand = init_backend["config"]["vae_cache_ondemand"]
+        dataset_vae_cache_disable, dataset_vae_cache_ondemand = _normalise_vae_cache_config(init_backend["config"])
 
         init_backend["vaecache"] = VAECache(
             id=init_backend["id"],

--- a/tests/test_factory_edge_cases.py
+++ b/tests/test_factory_edge_cases.py
@@ -249,12 +249,13 @@ class TestFactoryEdgeCases(unittest.TestCase):
             model=self.model,
         )
         modes = [
-            ({"vae_cache_ondemand": True}, False),
-            ({"vae_cache_disable": True}, True),
+            ({"vae_cache_ondemand": True}, False, ()),
+            ({"vae_cache_disable": True}, True, ()),
+            ({"vae_cache_ondemand": True}, False, ("vae_cache_disable",)),
         ]
 
-        for backend_mode, expected_disable in modes:
-            with self.subTest(backend_mode=backend_mode):
+        for backend_mode, expected_disable, missing_config_keys in modes:
+            with self.subTest(backend_mode=backend_mode, missing_config_keys=missing_config_keys):
                 backend = {
                     "id": "dataset-ondemand-cache",
                     "type": "local",
@@ -264,6 +265,8 @@ class TestFactoryEdgeCases(unittest.TestCase):
                     **backend_mode,
                 }
                 init_backend = init_backend_config(backend, self.args, self.accelerator)
+                for key in missing_config_keys:
+                    init_backend["config"].pop(key)
                 init_backend.update(
                     {
                         "data_backend": MagicMock(id=backend["id"], type="local"),


### PR DESCRIPTION
This pull request refactors how VAE cache configuration is normalized and accessed throughout the codebase, ensuring consistent handling of related config flags and improving test coverage for edge cases. The main changes introduce a helper function to centralize normalization logic, update all relevant usages, and enhance test cases to cover missing config keys.

**VAE Cache Configuration Normalization:**

* Added a new helper function `_normalise_vae_cache_config` in `factory.py` to consistently interpret and update the `vae_cache_disable` and `vae_cache_ondemand` flags, ensuring that disabling the cache implies on-demand mode.
* Updated usages in `_configure_vae_cache` and `_count_entries` to use the new normalization function instead of directly accessing the config dictionary. [[1]](diffhunk://#diff-57615ebb58fa92a702515b29c5d3dcee1e1ac481ee2f71564229f128a28894feL4138-R4149) [[2]](diffhunk://#diff-57615ebb58fa92a702515b29c5d3dcee1e1ac481ee2f71564229f128a28894feL4000-R4011)

**Test Improvements:**

* Enhanced `test_dataset_vae_cache_modes_use_dataset_ondemand_mode` to include cases with missing config keys, ensuring robust behavior when certain flags are absent. [[1]](diffhunk://#diff-76b36622613fc20144aacf6438c431a3340da4894d1b36ac9f8fef4a56bd840dL252-R258) [[2]](diffhunk://#diff-76b36622613fc20144aacf6438c431a3340da4894d1b36ac9f8fef4a56bd840dR268-R269)