### PR TITLE
Detect Klein FLUX.2 checkpoints loaded from an explicit model path

### DIFF
--- a/simpletuner/helpers/models/flux2/model.py
+++ b/simpletuner/helpers/models/flux2/model.py
@@ -425,9 +425,18 @@ class Flux2(ImageModelFoundation):
         return vae
 
     def _is_klein_flavour(self) -> bool:
-        """Check if current model flavour is a Klein variant."""
+        """Check if current model flavour is a Klein variant.
+
+        When the user supplies ``pretrained_model_name_or_path`` directly,
+        ``setup_model_flavour`` never resolves a flavour, leaving
+        ``model_flavour`` as None. Fall back to inspecting the model path so a
+        Klein checkpoint is not silently treated as FLUX.2-dev.
+        """
         flavour = getattr(self.config, "model_flavour", None)
-        return flavour in KLEIN_FLAVOURS
+        if flavour is not None:
+            return flavour in KLEIN_FLAVOURS
+        model_path = str(getattr(self.config, "pretrained_model_name_or_path", "") or "")
+        return "klein" in model_path.lower()
 
     def load_text_tokenizer(self):
         """Tokenizer is loaded alongside the text encoder, so this is a no-op."""


### PR DESCRIPTION
### Problem

`Flux2._is_klein_flavour()` only consults `config.model_flavour`:

```python
flavour = getattr(self.config, "model_flavour", None)
return flavour in KLEIN_FLAVOURS
```

But `model_flavour` is never populated when the user supplies
`pretrained_model_name_or_path` directly. In
`helpers/models/common.py::setup_model_flavour()`, the entire
flavour-resolution block is guarded by:

```python
if self.config.pretrained_model_name_or_path is None:
```

So when a path *is* provided, no default flavour is applied and no validation
error is raised — `model_flavour` stays `None`, and `_is_klein_flavour()`
returns `False`.

A local or mirrored FLUX.2-klein checkpoint is therefore silently treated as
FLUX.2-dev, which selects:

- the wrong text encoder stack — Mistral-3 instead of Qwen3
  (`load_text_encoder`)
- the wrong hidden-state output layers — `OUTPUT_LAYERS` (10, 20, 30) instead
  of `KLEIN_OUTPUT_LAYERS` (9, 18, 27)
- no Klein true-CFG handling for validation guidance

Nothing warns; training proceeds with a mismatched conditioning pipeline.

This is easy to hit because `DEFAULT_MODEL_FLAVOUR = "klein-9b"`: a user who
passes **no** path at all gets Klein support, while a user pointing at a local
Klein checkpoint does not.

### Fix

Fall back to matching `"klein"` in the model path when no flavour is set:

```python
if flavour is not None:
    return flavour in KLEIN_FLAVOURS
model_path = str(getattr(self.config, "pretrained_model_name_or_path", "") or "")
return "klein" in model_path.lower()
```

An explicitly configured flavour still takes precedence, so setting
`model_flavour=dev` against a Klein-named path preserves current behaviour.

### Alternative considered

The deeper fix is in `setup_model_flavour()` — either resolve/validate the
flavour even when a path is supplied, or warn when it cannot be determined.
That touches every model family, so this PR keeps the change local to Flux2.
Happy to rework it that way if you prefer the central fix.
