### PR TITLE
Extend metadata-only bucketing to still images in the discovery backend

### DIFF
--- a/simpletuner/helpers/metadata/backends/discovery.py
+++ b/simpletuner/helpers/metadata/backends/discovery.py
@@ -6,6 +6,8 @@ import traceback
 from io import BytesIO
 from typing import Optional
 
+from PIL import Image
+
 from simpletuner.helpers.data_backend.base import BaseDataBackend
 from simpletuner.helpers.data_backend.dataset_types import DatasetType
 from simpletuner.helpers.image_manipulation.load import load_image, load_video
@@ -94,16 +96,58 @@ class DiscoveryMetadataBackend(MetadataBackend):
             max_num_samples=max_num_samples,
         )
 
-    def _should_use_metadata_only_for_video(self) -> bool:
-        if not _is_ffprobe_available():
-            return False
-        if self.dataset_type is not DatasetType.VIDEO:
-            return False
+    def _should_use_metadata_only(self, is_video_file: bool) -> bool:
+        """Whether this sample can be bucketed from dimensions alone.
+
+        Bucketing needs only the sample dimensions: calculate_target_size() and
+        the crop coordinate maths derive everything from original_size, and no
+        pixel-derived metadata is stored. Videos already take this path via
+        ffprobe; still images can do the same from the file header.
+
+        Face cropping is the one crop style whose coordinates depend on pixel
+        content, so it always requires a full decode.
+        """
         crop_enabled = bool(self.dataset_config.get("crop", False))
         crop_style = str(self.dataset_config.get("crop_style") or "random").lower()
         if crop_enabled and crop_style == "face":
             return False
-        return True
+
+        if is_video_file:
+            return self.dataset_type is DatasetType.VIDEO and _is_ffprobe_available()
+        if self.dataset_type in (DatasetType.IMAGE, DatasetType.CONDITIONING):
+            # Header reads need a real path; remote backends stay on full reads.
+            return getattr(self.data_backend, "type", None) == "local"
+        return False
+
+    def _probe_image_dimensions(self, image_path_str: str) -> Optional[dict]:
+        """Read image dimensions from the file header, without decoding pixels.
+
+        PIL parses only the header on Image.open(); pixel data is loaded lazily
+        and never requested here. Returns None to signal that the caller should
+        fall back to a full decode.
+
+        EXIF orientations 5-8 transpose the image, so the stored dimensions are
+        swapped relative to what exif_transpose() produces on the full-decode
+        path. The orientation tag lives in the header too, so it is applied here
+        to keep both paths in agreement.
+        """
+        try:
+            with Image.open(image_path_str) as image:
+                width, height = image.size
+                orientation = image.getexif().get(0x0112)
+            if orientation in (5, 6, 7, 8):
+                width, height = height, width
+        except Exception as e:
+            logger.debug(
+                "(id=%s) Could not read image header for %s (%s); falling back to full decode.",
+                self.id,
+                image_path_str,
+                e,
+            )
+            return None
+        if not width or not height:
+            return None
+        return {"original_size": (width, height)}
 
     def _needs_video_frame_count(self) -> bool:
         if self.bucket_strategy == "resolution_frames":
@@ -382,7 +426,7 @@ class DiscoveryMetadataBackend(MetadataBackend):
             is_video_file = file_extension.strip(".") in video_file_extensions
 
             use_metadata_only = False
-            if is_video_file and self._should_use_metadata_only_for_video():
+            if is_video_file and self._should_use_metadata_only(is_video_file):
                 if getattr(self.data_backend, "type", None) == "local":
                     video_metadata = self._probe_video_metadata(image_path_str, None)
                 else:
@@ -428,6 +472,13 @@ class DiscoveryMetadataBackend(MetadataBackend):
                                 image_metadata["original_num_frames"] = original_frames
 
                     logger.debug("(id=%s) Using ffprobe metadata-only scan for %s", self.id, image_path_str)
+
+            elif not is_video_file and self._should_use_metadata_only(is_video_file):
+                image_dimensions = self._probe_image_dimensions(image_path_str)
+                if image_dimensions:
+                    use_metadata_only = True
+                    image_metadata.update(image_dimensions)
+                    logger.debug("(id=%s) Using header-only metadata scan for %s", self.id, image_path_str)
 
             if use_metadata_only:
                 if not self.meets_resolution_requirements(image_metadata=image_metadata):

--- a/tests/test_metadata_backend.py
+++ b/tests/test_metadata_backend.py
@@ -63,6 +63,76 @@ class TestMetadataBackend(unittest.TestCase):
         }
         self.assertEqual(len(self.metadata_backend), 3)
 
+    def test_probe_image_dimensions_applies_exif_orientation(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            image_path = Path(tmpdir) / "oriented.jpg"
+            exif = Image.Exif()
+            exif[0x0112] = 6
+            Image.new("RGB", (64, 32)).save(image_path, exif=exif)
+
+            metadata = self.metadata_backend._probe_image_dimensions(str(image_path))
+
+        self.assertEqual(metadata, {"original_size": (32, 64)})
+
+    def test_local_image_metadata_scan_skips_backend_read(self):
+        self.data_backend.type = "local"
+        self.metadata_backend.dataset_type = DatasetType.IMAGE
+        self.metadata_backend.dataset_config = {"dataset_type": "image", "crop": False}
+        self.data_backend.read.reset_mock()
+        prepared = SimpleNamespace(
+            crop_coordinates=(0, 0),
+            target_size=(512, 256),
+            intermediary_size=(512, 256),
+            aspect_ratio=2.0,
+        )
+
+        with (
+            patch.object(
+                self.metadata_backend,
+                "_probe_image_dimensions",
+                return_value={"original_size": (512, 256)},
+            ),
+            patch("simpletuner.helpers.metadata.backends.discovery.TrainingSample") as training_sample,
+        ):
+            training_sample.return_value.prepare.return_value = prepared
+            metadata_updates = {}
+            buckets = self.metadata_backend._process_for_bucket(
+                "image.png",
+                {},
+                metadata_updates=metadata_updates,
+            )
+
+        self.data_backend.read.assert_not_called()
+        self.assertEqual(buckets, {"2.0": ["image.png"]})
+        self.assertEqual(metadata_updates["image.png"]["original_size"], (512, 256))
+
+    def test_face_crop_forces_full_image_decode(self):
+        self.data_backend.type = "local"
+        self.metadata_backend.dataset_type = DatasetType.IMAGE
+        self.metadata_backend.dataset_config = {
+            "dataset_type": "image",
+            "crop": True,
+            "crop_style": "face",
+        }
+        self.data_backend.read = Mock(return_value=b"image payload")
+        prepared = SimpleNamespace(
+            crop_coordinates=(0, 0),
+            target_size=(512, 256),
+            intermediary_size=(512, 256),
+            aspect_ratio=2.0,
+        )
+
+        with (
+            patch.object(self.metadata_backend, "_probe_image_dimensions") as probe_dimensions,
+            patch("simpletuner.helpers.metadata.backends.discovery.load_image", return_value=self.test_image),
+            patch("simpletuner.helpers.metadata.backends.discovery.TrainingSample") as training_sample,
+        ):
+            training_sample.return_value.prepare.return_value = prepared
+            self.metadata_backend._process_for_bucket("image.png", {})
+
+        probe_dimensions.assert_not_called()
+        self.data_backend.read.assert_called_once_with("image.png")
+
     def test_discover_new_files(self):
         # Assuming that StateTracker.get_image_files returns known files
         # and list_files should return both known and potentially new files
@@ -483,10 +553,7 @@ class TestDistributedBucketPadding(unittest.TestCase):
 
     def test_cp_padding_fills_empty_dp_shards_from_final_global_item(self):
         images = ["img0", "img1", "img2", "img3"]
-        shards = [
-            self._split_rank(images, rank, cp_size=2, apply_padding=True, repeats=1)
-            for rank in range(8)
-        ]
+        shards = [self._split_rank(images, rank, cp_size=2, apply_padding=True, repeats=1) for rank in range(8)]
 
         self.assertEqual([len(shard) for shard in shards], [1] * 8)
         self.assertEqual([item for shard in shards for item in shard], images + ["img3"] * 4)


### PR DESCRIPTION
### Context

Metadata-only bucketing already exists in SimpleTuner — but not for still
images scanned from a local directory.

Where it does exist:

- `discovery.py` skips decoding **videos** via ffprobe
  (`_should_use_metadata_only_for_video` → `use_metadata_only = True`)
- the `parquet` backend reads `width_column` / `height_column`
- the `huggingface` backend reads width/height dataset columns
- the `webshart` backend reads dimensions from shard metadata

The gap: with the `discovery` backend on a plain local image folder — the most
common setup — every image is fully read and decoded just to reach
`image.size`:

```python
image_data = self.data_backend.read(image_path_str)
image = load_image(BytesIO(image_data))
...
image_metadata["original_size"] = image.size
```

Bucketing never needs those pixels. `calculate_target_size()` and the
crop-coordinate maths in `TrainingSample` derive everything from
`original_size`, and `PreparedSample` stores no pixel-derived metadata. On a
network filesystem this turns discovery into a multi-megabyte read per image
for data that is immediately discarded — and the only way to avoid it today is
to build and maintain an external parquet/JSONL of dimensions the file headers
already contain.

### Change

Still images now take the same metadata-only path as videos, reading
dimensions from the file header.

`use_metadata_only` already supports this downstream — `TrainingSample`
tolerates `image=None`:

- `crop()` guards its pixel work on
  `self.image is not None and isinstance(self.image, Image.Image)`
- the RGB/EXIF transform helper guards on `self.image is not None`
- `meets_resolution_requirements()` has an `image_metadata` branch reading
  `original_size`

So this only adds the entry point, plus a header probe.

The two per-media guards are folded into one
`_should_use_metadata_only(is_video_file)`, so the face-crop exclusion lives in
a single place rather than being duplicated. Videos keep the ffprobe route;
images take the header route. `is_video_file` is passed explicitly so a
video-extension file inside an `IMAGE` dataset still falls back to a full
decode, exactly as before.

`_probe_image_dimensions()` opens the file with PIL, which parses only the
header — pixel data is loaded lazily and never requested.

Guards, following the existing video precedent:

- local data backends only (a header read needs a real path)
- `IMAGE` and `CONDITIONING` dataset types
- **not** when crop is enabled with `crop_style="face"` — the one crop style
  whose coordinates depend on pixel content
- any header read failure returns `None` and falls back to a full decode, so
  truncated, corrupt or unsupported files behave as before

### EXIF correctness

EXIF orientations 5–8 transpose the image, so header dimensions are swapped
relative to what `exif_transpose()` yields on the decode path. The orientation
tag is in the header too, so it is applied in the probe.

Verified equal to the full-decode result across:

| Case | probe | full decode |
|---|---|---|
| no EXIF | (1200, 800) | (1200, 800) |
| orientations 1–4 | (1200, 800) | (1200, 800) |
| orientations 5–8 | (800, 1200) | (800, 1200) |
| PNG / WebP / 1×1 JPEG | match | match |
| corrupt header | `None` → fallback | — |