### PR TITLE
Support mixed-rank LoRA adapter metadata

### DIFF
--- a/simpletuner/helpers/models/chroma/pipeline.py
+++ b/simpletuner/helpers/models/chroma/pipeline.py
@@ -29,7 +29,6 @@ from diffusers.utils import (
     convert_unet_state_dict_to_peft,
     deprecate,
     get_adapter_name,
-    get_peft_kwargs,
     is_peft_available,
     is_peft_version,
     is_torch_version,
@@ -45,6 +44,7 @@ from huggingface_hub.utils import validate_hf_hub_args
 from transformers import CLIPImageProcessor, CLIPVisionModelWithProjection, T5EncoderModel, T5TokenizerFast
 
 from simpletuner.helpers.models.chroma.transformer import ChromaTransformer2DModel
+from simpletuner.helpers.training.lora_format import get_peft_kwargs
 from simpletuner.helpers.training.lycoris import apply_tlora_inference_mask, clear_tlora_mask
 from simpletuner.helpers.utils.offloading import restore_offload_state, unpack_offload_state
 

--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -53,11 +53,14 @@ from simpletuner.helpers.training.flow_match import fix_flow_match_euler_schedul
 from simpletuner.helpers.training.layersync import LayerSyncRegularizer
 from simpletuner.helpers.training.lora_format import (
     PEFTLoRAFormat,
+    collect_lora_alphas,
     convert_comfyui_to_diffusers,
     convert_diffusers_to_comfyui,
     convert_diffusers_to_comfyui_sd_lora,
     detect_state_dict_format,
     normalize_lora_format,
+    peft_lora_config_kwargs_from_state_dict,
+    synthesize_missing_lora_alphas_from_ranks,
 )
 from simpletuner.helpers.training.min_snr_gamma import compute_snr
 from simpletuner.helpers.training.multi_process import _get_rank
@@ -951,9 +954,35 @@ class ModelFoundation(ABC):
                 combined.append(target)
         return combined
 
+    def _prepare_init_lora_state_dict(self, state_dict: dict) -> dict:
+        return state_dict
+
+    def _load_init_lora_state_dict(self) -> dict | None:
+        init_lora_path = getattr(self.config, "init_lora", None)
+        if not init_lora_path or not isinstance(init_lora_path, str) or not os.path.isfile(init_lora_path):
+            return None
+
+        import safetensors.torch
+
+        try:
+            state_dict = safetensors.torch.load_file(init_lora_path)
+        except Exception as exc:
+            raise ValueError(f"Unable to inspect init_lora checkpoint `{init_lora_path}` for LoRA rank metadata.") from exc
+        return self._prepare_init_lora_state_dict(state_dict)
+
+    def _init_lora_config_kwargs(self, state_dict: dict | None = None) -> dict:
+        state_dict = self._load_init_lora_state_dict() if state_dict is None else state_dict
+        if not state_dict:
+            return {}
+        key_to_replace = (
+            self.CONTROLNET_LORA_STATE_DICT_PREFIX if getattr(self.config, "controlnet", False) else self.MODEL_TYPE.value
+        )
+        return peft_lora_config_kwargs_from_state_dict(state_dict, prefix_to_strip=f"{key_to_replace}.")
+
     def add_lora_adapter(self):
         from peft import LoraConfig
 
+        init_lora_state_dict = self._load_init_lora_state_dict()
         target_modules = self.get_lora_target_layers()
         save_modules = self.get_lora_save_layers()
         addkeys, misskeys = [], []
@@ -989,9 +1018,15 @@ class ModelFoundation(ABC):
 
                     logger.info("Enabling SingLoRA for LoRA training.")
                     setup_singlora()
+            lora_config_kwargs.update(self._init_lora_config_kwargs(init_lora_state_dict))
+            lora_rank = lora_config_kwargs.pop("r", self.config.lora_rank)
+            lora_alpha = lora_config_kwargs.pop(
+                "lora_alpha",
+                self.config.lora_alpha if self.config.lora_alpha is not None else lora_rank,
+            )
             self.lora_config = lora_config_cls(
-                r=self.config.lora_rank,
-                lora_alpha=(self.config.lora_alpha if self.config.lora_alpha is not None else self.config.lora_rank),
+                r=lora_rank,
+                lora_alpha=lora_alpha,
                 lora_dropout=self.config.lora_dropout,
                 init_lora_weights=self.config.lora_initialisation_style,
                 target_modules=target_modules,
@@ -1020,6 +1055,7 @@ class ModelFoundation(ABC):
                 {self.MODEL_TYPE.value: (self.controlnet if getattr(self.config, "controlnet", False) else self.model)},
                 self.config.init_lora,
                 use_dora=use_dora,
+                state_dict=init_lora_state_dict,
             )
 
         return addkeys, misskeys
@@ -1865,6 +1901,15 @@ class ModelFoundation(ABC):
         from diffusers.utils import convert_unet_state_dict_to_peft
 
         denoiser_sd = convert_unet_state_dict_to_peft(denoiser_sd)
+        if not alpha_map:
+            explicit_alphas = collect_lora_alphas(denoiser_sd)
+            if explicit_alphas:
+                alpha_map.update(
+                    _normalise_alpha_map({f"{module_key}.alpha": alpha for module_key, alpha in explicit_alphas.items()})
+                )
+        if not alpha_map:
+            alpha_map.update(_normalise_alpha_map(synthesize_missing_lora_alphas_from_ranks(denoiser_sd)))
+        denoiser_sd = {key: value for key, value in denoiser_sd.items() if not key.endswith((".alpha", ".lora_alpha"))}
 
         from peft.utils import set_peft_model_state_dict
 

--- a/simpletuner/helpers/models/flux/pipeline.py
+++ b/simpletuner/helpers/models/flux/pipeline.py
@@ -42,7 +42,6 @@ from diffusers.utils import (
     convert_state_dict_to_peft,
     convert_unet_state_dict_to_peft,
     get_adapter_name,
-    get_peft_kwargs,
     is_peft_available,
     is_peft_version,
     is_torch_version,
@@ -70,6 +69,7 @@ from simpletuner.helpers.training.lora_format import (
     PEFTLoRAFormat,
     convert_comfyui_to_diffusers,
     detect_state_dict_format,
+    get_peft_kwargs,
     normalize_lora_format,
 )
 from simpletuner.helpers.training.lycoris import apply_tlora_inference_mask, clear_tlora_mask

--- a/simpletuner/helpers/models/flux/pipeline_controlnet.py
+++ b/simpletuner/helpers/models/flux/pipeline_controlnet.py
@@ -39,7 +39,6 @@ from diffusers.utils import (
     convert_state_dict_to_peft,
     convert_unet_state_dict_to_peft,
     get_adapter_name,
-    get_peft_kwargs,
     is_peft_available,
     is_peft_version,
     is_torch_version,

--- a/simpletuner/helpers/models/hidream/pipeline.py
+++ b/simpletuner/helpers/models/hidream/pipeline.py
@@ -23,7 +23,6 @@ from diffusers.utils import (
     convert_state_dict_to_peft,
     convert_unet_state_dict_to_peft,
     get_adapter_name,
-    get_peft_kwargs,
     is_peft_available,
     is_peft_version,
     is_torch_version,
@@ -46,6 +45,7 @@ from transformers import (
 )
 
 from simpletuner.helpers.models.hidream.schedule import FlowUniPCMultistepScheduler
+from simpletuner.helpers.training.lora_format import get_peft_kwargs
 from simpletuner.helpers.training.lycoris import apply_tlora_inference_mask, clear_tlora_mask
 from simpletuner.helpers.utils.offloading import restore_offload_state, unpack_offload_state
 

--- a/simpletuner/helpers/models/ideogram/pipeline.py
+++ b/simpletuner/helpers/models/ideogram/pipeline.py
@@ -12,7 +12,7 @@ from typing import Callable, Optional, Sequence
 
 import torch
 from diffusers.loaders.lora_base import LoraBaseMixin, _fetch_state_dict
-from diffusers.utils import USE_PEFT_BACKEND, get_adapter_name, get_peft_kwargs, is_peft_version
+from diffusers.utils import USE_PEFT_BACKEND, get_adapter_name, is_peft_version
 from huggingface_hub import hf_hub_download
 from huggingface_hub.errors import EntryNotFoundError
 from PIL import Image
@@ -54,6 +54,7 @@ from simpletuner.helpers.models.ideogram.scheduler import (
     make_step_intervals,
 )
 from simpletuner.helpers.models.ideogram.transformer import Ideogram4Config, Ideogram4Transformer
+from simpletuner.helpers.training.lora_format import get_peft_kwargs
 
 
 def _load_subfolder_state_dict(repo_id: str, subfolder: str, basename: str) -> dict[str, torch.Tensor]:

--- a/simpletuner/helpers/models/krea2/lora_pipeline.py
+++ b/simpletuner/helpers/models/krea2/lora_pipeline.py
@@ -9,7 +9,6 @@ from diffusers.utils import (
     USE_PEFT_BACKEND,
     convert_unet_state_dict_to_peft,
     get_adapter_name,
-    get_peft_kwargs,
     is_peft_available,
     is_peft_version,
     is_torch_version,
@@ -19,6 +18,7 @@ from diffusers.utils import (
 )
 from huggingface_hub.utils import validate_hf_hub_args
 
+from simpletuner.helpers.training.lora_format import get_peft_kwargs
 from simpletuner.helpers.utils.offloading import restore_offload_state, unpack_offload_state
 
 _LOW_CPU_MEM_USAGE_DEFAULT_LORA = False

--- a/simpletuner/helpers/models/longcat_video/pipeline.py
+++ b/simpletuner/helpers/models/longcat_video/pipeline.py
@@ -15,7 +15,6 @@ from diffusers.utils import (
     convert_state_dict_to_peft,
     convert_unet_state_dict_to_peft,
     get_adapter_name,
-    get_peft_kwargs,
     is_peft_version,
     logging,
     scale_lora_layers,

--- a/simpletuner/helpers/models/sd3/pipeline.py
+++ b/simpletuner/helpers/models/sd3/pipeline.py
@@ -37,7 +37,6 @@ from diffusers.utils import (
     convert_state_dict_to_peft,
     convert_unet_state_dict_to_peft,
     get_adapter_name,
-    get_peft_kwargs,
     is_peft_available,
     is_peft_version,
     is_torch_version,
@@ -53,6 +52,7 @@ from diffusers.utils.torch_utils import randn_tensor
 from huggingface_hub.utils import validate_hf_hub_args
 from transformers import CLIPTextModelWithProjection, CLIPTokenizer, T5EncoderModel, T5TokenizerFast
 
+from simpletuner.helpers.training.lora_format import get_peft_kwargs
 from simpletuner.helpers.training.lycoris import apply_tlora_inference_mask, clear_tlora_mask
 from simpletuner.helpers.utils.offloading import restore_offload_state, unpack_offload_state
 

--- a/simpletuner/helpers/training/adapter.py
+++ b/simpletuner/helpers/training/adapter.py
@@ -1,8 +1,27 @@
+import math
+
 import peft
 import safetensors.torch
 import torch
 
 ANYFLOW_SIDECAR_PREFIXES = ("condition_embedder.delta_embedder.",)
+
+
+def _alpha_value(value):
+    if torch.is_tensor(value):
+        return float(value.detach().float().cpu().item())
+    return float(value)
+
+
+def _set_lora_alpha(layer, adapter_name: str, alpha) -> None:
+    alpha = _alpha_value(alpha)
+    layer.lora_alpha[adapter_name] = alpha
+    rank_map = getattr(layer, "r", {})
+    rank = rank_map.get(adapter_name) if isinstance(rank_map, dict) else rank_map
+    if not rank:
+        return
+    scaling = alpha / math.sqrt(rank) if getattr(layer, "use_rslora", False) else alpha / rank
+    layer.scaling[adapter_name] = scaling
 
 
 def determine_adapter_target_modules(args, unet, transformer):
@@ -97,9 +116,10 @@ def determine_adapter_target_modules(args, unet, transformer):
 
 
 @torch.no_grad()
-def load_lora_weights(dictionary, filename, loraKey="default", use_dora=False):
+def load_lora_weights(dictionary, filename, loraKey="default", use_dora=False, state_dict=None):
     additional_keys = set()
-    state_dict = safetensors.torch.load_file(filename)
+    if state_dict is None:
+        state_dict = safetensors.torch.load_file(filename)
     for prefix, model in dictionary.items():
         lora_layers = {
             (prefix + "." + x): y for (x, y) in model.named_modules() if isinstance(y, peft.tuners.lora.layer.Linear)
@@ -130,11 +150,14 @@ def load_lora_weights(dictionary, filename, loraKey="default", use_dora=False):
         + [x + ".lora_B.weight" for x in lora_layers.keys()]
         + ([x + ".lora_magnitude_vector.weight" for x in lora_layers.keys()] if use_dora else [])
     )
+    loaded_ranks = {}
+    explicit_alpha_keys = False
     for k, v in state_dict.items():
         if "lora_A" in k:
             kk = k.replace(".lora_A.weight", "")
             if kk in lora_layers:
                 lora_layers[kk].lora_A[loraKey].weight.copy_(v)
+                loaded_ranks[kk] = int(v.shape[0])
                 missing_keys.remove(k)
             else:
                 additional_keys.add(k)
@@ -142,13 +165,15 @@ def load_lora_weights(dictionary, filename, loraKey="default", use_dora=False):
             kk = k.replace(".lora_B.weight", "")
             if kk in lora_layers:
                 lora_layers[kk].lora_B[loraKey].weight.copy_(v)
+                loaded_ranks[kk] = int(v.shape[1])
                 missing_keys.remove(k)
             else:
                 additional_keys.add(k)
         elif ".alpha" in k or ".lora_alpha" in k:
+            explicit_alpha_keys = True
             kk = k.replace(".lora_alpha", "").replace(".alpha", "")
             if kk in lora_layers:
-                lora_layers[kk].lora_alpha[loraKey] = v
+                _set_lora_alpha(lora_layers[kk], loraKey, v)
         elif ".lora_magnitude_vector" in k:
             kk = k.replace(".lora_magnitude_vector.weight", "")
             if kk in lora_layers:
@@ -156,4 +181,8 @@ def load_lora_weights(dictionary, filename, loraKey="default", use_dora=False):
                 missing_keys.remove(k)
             else:
                 additional_keys.add(k)
+    if not explicit_alpha_keys and len(set(loaded_ranks.values())) > 1:
+        for kk, rank in loaded_ranks.items():
+            if kk in lora_layers:
+                _set_lora_alpha(lora_layers[kk], loraKey, rank)
     return (additional_keys, missing_keys)

--- a/simpletuner/helpers/training/adapter.py
+++ b/simpletuner/helpers/training/adapter.py
@@ -157,7 +157,11 @@ def load_lora_weights(dictionary, filename, loraKey="default", use_dora=False, s
             kk = k.replace(".lora_A.weight", "")
             if kk in lora_layers:
                 lora_layers[kk].lora_A[loraKey].weight.copy_(v)
-                loaded_ranks[kk] = int(v.shape[0])
+                rank = int(v.shape[0])
+                existing_rank = loaded_ranks.get(kk)
+                if existing_rank is not None and existing_rank != rank:
+                    raise ValueError(f"LoRA checkpoint has conflicting ranks for `{kk}`: {existing_rank} and {rank}.")
+                loaded_ranks[kk] = rank
                 missing_keys.remove(k)
             else:
                 additional_keys.add(k)
@@ -165,14 +169,18 @@ def load_lora_weights(dictionary, filename, loraKey="default", use_dora=False, s
             kk = k.replace(".lora_B.weight", "")
             if kk in lora_layers:
                 lora_layers[kk].lora_B[loraKey].weight.copy_(v)
-                loaded_ranks[kk] = int(v.shape[1])
+                rank = int(v.shape[1])
+                existing_rank = loaded_ranks.get(kk)
+                if existing_rank is not None and existing_rank != rank:
+                    raise ValueError(f"LoRA checkpoint has conflicting ranks for `{kk}`: {existing_rank} and {rank}.")
+                loaded_ranks[kk] = rank
                 missing_keys.remove(k)
             else:
                 additional_keys.add(k)
         elif ".alpha" in k or ".lora_alpha" in k:
-            explicit_alpha_keys = True
             kk = k.replace(".lora_alpha", "").replace(".alpha", "")
             if kk in lora_layers:
+                explicit_alpha_keys = True
                 _set_lora_alpha(lora_layers[kk], loraKey, v)
         elif ".lora_magnitude_vector" in k:
             kk = k.replace(".lora_magnitude_vector.weight", "")

--- a/simpletuner/helpers/training/lora_format.py
+++ b/simpletuner/helpers/training/lora_format.py
@@ -1,7 +1,12 @@
+from collections import Counter
 from enum import Enum
 from typing import Any, Dict, Optional, Tuple
 
 import torch
+
+_LORA_DOWN_WEIGHT_SUFFIXES = (".lora.down.weight", ".lora_A.weight", ".lora_down.weight")
+_LORA_UP_WEIGHT_SUFFIXES = (".lora.up.weight", ".lora_B.weight", ".lora_up.weight")
+_LORA_ALPHA_SUFFIXES = (".alpha", ".lora_alpha")
 
 
 class PEFTLoRAFormat(str, Enum):
@@ -32,7 +37,7 @@ def detect_state_dict_format(state_dict: Dict[str, Any]) -> Optional[PEFTLoRAFor
         return None
 
     keys = list(state_dict.keys())
-    comfy_prefix_hits = sum(k.startswith("diffusion_model.") for k in keys)
+    comfy_prefix_hits = sum(k.startswith(("diffusion_model.", "model.diffusion_model.")) for k in keys)
     comfy_alpha_hits = sum(k.endswith(".alpha") for k in keys)
     diffusers_down_up_hits = sum(".lora.down" in k or ".lora.up" in k for k in keys)
 
@@ -45,6 +50,126 @@ def _as_float(value: Any) -> float:
     if torch.is_tensor(value):
         return float(value.detach().float().cpu().item())
     return float(value)
+
+
+def _strip_prefix(key: str, prefix_to_strip: Optional[str]) -> str:
+    if prefix_to_strip and key.startswith(prefix_to_strip):
+        return key[len(prefix_to_strip) :]
+    return key
+
+
+def _most_common(values: list[Any]) -> Any:
+    return Counter(values).most_common(1)[0][0]
+
+
+def collect_lora_ranks(state_dict: Dict[str, Any], *, prefix_to_strip: Optional[str] = None) -> Dict[str, int]:
+    ranks: Dict[str, int] = {}
+    for key, value in state_dict.items():
+        if not hasattr(value, "shape"):
+            continue
+        stripped_key = _strip_prefix(key, prefix_to_strip)
+        module_key = None
+        rank = None
+        for suffix in _LORA_DOWN_WEIGHT_SUFFIXES:
+            if stripped_key.endswith(suffix):
+                module_key = stripped_key[: -len(suffix)]
+                rank = int(value.shape[0])
+                break
+        if module_key is None:
+            for suffix in _LORA_UP_WEIGHT_SUFFIXES:
+                if stripped_key.endswith(suffix):
+                    module_key = stripped_key[: -len(suffix)]
+                    rank = int(value.shape[1])
+                    break
+        if module_key is None or rank is None:
+            continue
+        existing_rank = ranks.get(module_key)
+        if existing_rank is not None and existing_rank != rank:
+            raise ValueError(f"LoRA checkpoint has conflicting ranks for `{module_key}`: {existing_rank} and {rank}.")
+        ranks[module_key] = rank
+    return ranks
+
+
+def collect_lora_alphas(state_dict: Dict[str, Any], *, prefix_to_strip: Optional[str] = None) -> Dict[str, float]:
+    alphas: Dict[str, float] = {}
+    for key, value in state_dict.items():
+        stripped_key = _strip_prefix(key, prefix_to_strip)
+        for suffix in _LORA_ALPHA_SUFFIXES:
+            if stripped_key.endswith(suffix):
+                alphas[stripped_key[: -len(suffix)]] = _as_float(value)
+                break
+    return alphas
+
+
+def synthesize_missing_lora_alphas_from_ranks(
+    state_dict: Dict[str, Any],
+    *,
+    existing_alphas: Optional[Dict[str, Any]] = None,
+    prefix_to_strip: Optional[str] = None,
+) -> Dict[str, float]:
+    """
+    For mixed-rank LoRAs with no alpha data, synthesize alpha=rank per module.
+    Uniform-rank LoRAs keep the caller's configured/global alpha.
+    """
+    if existing_alphas:
+        return {}
+    if collect_lora_alphas(state_dict, prefix_to_strip=prefix_to_strip):
+        return {}
+
+    ranks = collect_lora_ranks(state_dict, prefix_to_strip=prefix_to_strip)
+    if len(set(ranks.values())) <= 1:
+        return {}
+    return {f"{module_key}.alpha": float(rank) for module_key, rank in ranks.items()}
+
+
+def peft_lora_config_kwargs_from_state_dict(
+    state_dict: Dict[str, Any],
+    *,
+    prefix_to_strip: Optional[str] = None,
+) -> Dict[str, Any]:
+    ranks = collect_lora_ranks(state_dict, prefix_to_strip=prefix_to_strip)
+    if not ranks:
+        return {}
+
+    default_rank = _most_common(list(ranks.values()))
+    rank_pattern = {module_key: rank for module_key, rank in ranks.items() if rank != default_rank}
+    alphas = collect_lora_alphas(state_dict, prefix_to_strip=prefix_to_strip)
+    if alphas:
+        default_alpha = _most_common(list(alphas.values()))
+        alpha_pattern = {
+            module_key: alpha for module_key, alpha in alphas.items() if module_key in ranks and alpha != default_alpha
+        }
+    else:
+        default_alpha = float(default_rank)
+        alpha_pattern = (
+            {module_key: float(rank) for module_key, rank in ranks.items() if rank != default_rank}
+            if len(set(ranks.values())) > 1
+            else {}
+        )
+
+    kwargs: Dict[str, Any] = {
+        "r": default_rank,
+        "lora_alpha": default_alpha,
+    }
+    if rank_pattern:
+        kwargs["rank_pattern"] = rank_pattern
+    if alpha_pattern:
+        kwargs["alpha_pattern"] = alpha_pattern
+    return kwargs
+
+
+def get_peft_kwargs(rank, network_alpha_dict=None, peft_state_dict=None, *args, **kwargs):
+    from diffusers.utils import get_peft_kwargs as diffusers_get_peft_kwargs
+
+    if peft_state_dict is not None and not network_alpha_dict:
+        explicit_alphas = collect_lora_alphas(peft_state_dict)
+        if explicit_alphas:
+            network_alpha_dict = {f"{module_key}.alpha": alpha for module_key, alpha in explicit_alphas.items()}
+        else:
+            inferred_alphas = synthesize_missing_lora_alphas_from_ranks(peft_state_dict)
+            if inferred_alphas:
+                network_alpha_dict = inferred_alphas
+    return diffusers_get_peft_kwargs(rank, network_alpha_dict, peft_state_dict, *args, **kwargs)
 
 
 def convert_comfyui_to_diffusers(

--- a/simpletuner/helpers/training/lora_format.py
+++ b/simpletuner/helpers/training/lora_format.py
@@ -59,7 +59,7 @@ def _strip_prefix(key: str, prefix_to_strip: Optional[str]) -> str:
 
 
 def _most_common(values: list[Any]) -> Any:
-    return Counter(values).most_common(1)[0][0]
+    return max(Counter(values).items(), key=lambda item: (item[1], item[0]))[0]
 
 
 def collect_lora_ranks(state_dict: Dict[str, Any], *, prefix_to_strip: Optional[str] = None) -> Dict[str, int]:

--- a/tests/test_lora_format.py
+++ b/tests/test_lora_format.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 import torch
 
@@ -7,6 +8,9 @@ from simpletuner.helpers.training.lora_format import (
     convert_diffusers_to_comfyui,
     convert_diffusers_to_comfyui_sd_lora,
     detect_state_dict_format,
+    get_peft_kwargs,
+    peft_lora_config_kwargs_from_state_dict,
+    synthesize_missing_lora_alphas_from_ranks,
 )
 
 DOWN = torch.full((4, 8), 1.0)
@@ -92,6 +96,123 @@ class DetectStateDictFormatTests(unittest.TestCase):
             detect_state_dict_format(_peft_named("diffusion_model.blocks.0.attn.to_q")),
             PEFTLoRAFormat.COMFYUI,
         )
+
+    def test_model_diffusion_model_peft_named_dict_is_reported_as_comfyui(self):
+        self.assertEqual(
+            detect_state_dict_format(_peft_named("model.diffusion_model.blocks.0.attn.to_q")),
+            PEFTLoRAFormat.COMFYUI,
+        )
+
+
+class MixedRankAlphaInferenceTests(unittest.TestCase):
+    def _ranked(self, ranks):
+        state_dict = {}
+        for module_key, rank in ranks:
+            state_dict[f"{module_key}.lora_A.weight"] = torch.zeros(rank, 8)
+            state_dict[f"{module_key}.lora_B.weight"] = torch.zeros(16, rank)
+        return state_dict
+
+    def test_mixed_rank_without_alphas_synthesizes_rank_alphas(self):
+        state_dict = self._ranked(
+            [
+                ("transformer.blocks.0.attn.to_q", 64),
+                ("transformer.blocks.0.adaln", 16),
+            ]
+        )
+
+        alphas = synthesize_missing_lora_alphas_from_ranks(state_dict)
+
+        self.assertEqual(alphas["transformer.blocks.0.attn.to_q.alpha"], 64.0)
+        self.assertEqual(alphas["transformer.blocks.0.adaln.alpha"], 16.0)
+
+    def test_uniform_rank_without_alphas_keeps_global_scale(self):
+        state_dict = self._ranked(
+            [
+                ("transformer.blocks.0.attn.to_q", 64),
+                ("transformer.blocks.0.attn.to_k", 64),
+            ]
+        )
+
+        self.assertEqual(synthesize_missing_lora_alphas_from_ranks(state_dict), {})
+
+    def test_explicit_alpha_suppresses_synthesis(self):
+        state_dict = self._ranked(
+            [
+                ("transformer.blocks.0.attn.to_q", 64),
+                ("transformer.blocks.0.adaln", 16),
+            ]
+        )
+        state_dict["transformer.blocks.0.adaln.alpha"] = torch.tensor(8.0)
+
+        self.assertEqual(synthesize_missing_lora_alphas_from_ranks(state_dict), {})
+
+    def test_init_lora_config_kwargs_use_rank_patterns_for_mixed_ranks(self):
+        state_dict = self._ranked(
+            [
+                ("unet.to_q", 64),
+                ("unet.to_k", 64),
+                ("unet.adaln", 16),
+            ]
+        )
+
+        kwargs = peft_lora_config_kwargs_from_state_dict(state_dict, prefix_to_strip="unet.")
+
+        self.assertEqual(kwargs["r"], 64)
+        self.assertEqual(kwargs["lora_alpha"], 64.0)
+        self.assertEqual(kwargs["rank_pattern"], {"adaln": 16})
+        self.assertEqual(kwargs["alpha_pattern"], {"adaln": 16.0})
+
+    def test_explicit_init_lora_alpha_pattern_wins(self):
+        state_dict = self._ranked(
+            [
+                ("unet.to_q", 64),
+                ("unet.to_k", 16),
+            ]
+        )
+        state_dict["unet.to_q.alpha"] = torch.tensor(32.0)
+        state_dict["unet.to_k.alpha"] = torch.tensor(8.0)
+
+        kwargs = peft_lora_config_kwargs_from_state_dict(state_dict, prefix_to_strip="unet.")
+
+        self.assertEqual(kwargs["r"], 64)
+        self.assertEqual(kwargs["lora_alpha"], 32.0)
+        self.assertEqual(kwargs["rank_pattern"], {"to_k": 16})
+        self.assertEqual(kwargs["alpha_pattern"], {"to_k": 8.0})
+
+    def test_get_peft_kwargs_wrapper_passes_inferred_alphas(self):
+        state_dict = self._ranked(
+            [
+                ("transformer.to_q", 64),
+                ("transformer.adaln", 16),
+            ]
+        )
+
+        with patch("diffusers.utils.get_peft_kwargs", return_value={"ok": True}) as diffusers_get_peft_kwargs:
+            result = get_peft_kwargs({"rank": 64}, network_alpha_dict=None, peft_state_dict=state_dict)
+
+        self.assertEqual(result, {"ok": True})
+        _, network_alphas, peft_state_dict = diffusers_get_peft_kwargs.call_args.args[:3]
+        self.assertIs(peft_state_dict, state_dict)
+        self.assertEqual(network_alphas["transformer.to_q.alpha"], 64.0)
+        self.assertEqual(network_alphas["transformer.adaln.alpha"], 16.0)
+
+    def test_get_peft_kwargs_wrapper_promotes_explicit_state_dict_alphas(self):
+        state_dict = self._ranked(
+            [
+                ("transformer.to_q", 64),
+                ("transformer.adaln", 16),
+            ]
+        )
+        state_dict["transformer.to_q.alpha"] = torch.tensor(32.0)
+        state_dict["transformer.adaln.alpha"] = torch.tensor(8.0)
+
+        with patch("diffusers.utils.get_peft_kwargs", return_value={"ok": True}) as diffusers_get_peft_kwargs:
+            result = get_peft_kwargs({"rank": 64}, network_alpha_dict=None, peft_state_dict=state_dict)
+
+        self.assertEqual(result, {"ok": True})
+        _, network_alphas, _ = diffusers_get_peft_kwargs.call_args.args[:3]
+        self.assertEqual(network_alphas["transformer.to_q.alpha"], 32.0)
+        self.assertEqual(network_alphas["transformer.adaln.alpha"], 8.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_lora_loading_regression.py
+++ b/tests/test_lora_loading_regression.py
@@ -1,7 +1,11 @@
 import os
 import sys
+import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
+
+import torch
+from safetensors.torch import save_file
 
 # Add project root to path
 sys.path.append(os.getcwd())
@@ -87,6 +91,32 @@ class TestLoraLoadingRegression(unittest.TestCase):
         key = keys[0]
         self.assertIsInstance(key, str, f"Key passed to load_lora_weights must be str, got {type(key)}")
         self.assertEqual(key, "unet")
+
+    @patch("simpletuner.helpers.models.common.load_lora_weights")
+    def test_init_lora_mixed_rank_checkpoint_sets_peft_patterns(self, mock_load_lora_weights):
+        mock_load_lora_weights.return_value = (set(), set())
+        model_instance = TestModel()
+        model_instance.config.lora_alpha = None
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            init_lora_path = os.path.join(tmpdir, "mixed-rank.safetensors")
+            save_file(
+                {
+                    "unet.to_k.lora_A.weight": torch.zeros(64, 8),
+                    "unet.to_k.lora_B.weight": torch.zeros(8, 64),
+                    "unet.to_v.lora_A.weight": torch.zeros(16, 8),
+                    "unet.to_v.lora_B.weight": torch.zeros(8, 16),
+                },
+                init_lora_path,
+            )
+            model_instance.config.init_lora = init_lora_path
+
+            model_instance.add_lora_adapter()
+
+        self.assertEqual(model_instance.lora_config.r, 64)
+        self.assertEqual(model_instance.lora_config.lora_alpha, 64.0)
+        self.assertEqual(model_instance.lora_config.rank_pattern, {"to_v": 16})
+        self.assertEqual(model_instance.lora_config.alpha_pattern, {"to_v": 16.0})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds mixed-rank LoRA metadata handling so init_lora and validation adapter loading can preserve per-layer rank and alpha values instead of forcing everything through the global rank.

## Details

- Infers rank_pattern and alpha_pattern from LoRA checkpoint tensors during adapter initialization.
- Synthesizes alpha=rank for mixed-rank checkpoints that do not carry explicit alpha tensors, while preserving explicit alpha tensors when present.
- Routes vendored pipeline LoRA loading through SimpleTuner's get_peft_kwargs wrapper so layerwise rank/alpha metadata survives Diffusers loader behavior.

## Validation

- `.venv/bin/python -m unittest -v -f tests.test_lora_format tests.test_lora_loading_regression`
