### PR TITLE
Respect model flow target direction in distillers

### DIFF
--- a/simpletuner/helpers/distillation/anyflow/distiller.py
+++ b/simpletuner/helpers/distillation/anyflow/distiller.py
@@ -91,7 +91,7 @@ class AnyFlowDistiller(DistillationBase):
         r_timesteps = self._timesteps_from_sigmas(r_sigmas, timesteps)
         r_timesteps = r_timesteps.to(device=batch["timesteps"].device, dtype=batch["timesteps"].dtype)
 
-        target = self._base_flow_target(batch)
+        target = self._base_flow_target(batch, model=model)
         if self.config["target_mode"] == "online_teacher":
             target = self._online_teacher_average_velocity(
                 prepared_batch=batch,
@@ -261,12 +261,28 @@ class AnyFlowDistiller(DistillationBase):
                 "or use a sampler that leaves a positive interval."
             )
 
-    @staticmethod
-    def _base_flow_target(prepared_batch: Dict[str, Any]) -> torch.Tensor:
+    def _base_flow_target(self, prepared_batch: Dict[str, Any], model=None) -> torch.Tensor:
+        target_model = model or self.student_model or self.teacher_model
+        get_target = getattr(target_model, "get_flow_matching_target", None)
+        if callable(get_target):
+            target = get_target(prepared_batch, prefer_explicit_target=True)
+            return target.to(device=prepared_batch["latents"].device, dtype=prepared_batch["latents"].dtype)
         flow_target = prepared_batch.get("flow_target")
         if torch.is_tensor(flow_target):
             return flow_target.to(device=prepared_batch["latents"].device, dtype=prepared_batch["latents"].dtype)
         return prepared_batch["noise"] - prepared_batch["latents"]
+
+    def _teacher_prediction_to_noiseward_flow(self, prediction: torch.Tensor) -> torch.Tensor:
+        converter = getattr(self.teacher_model, "prediction_to_noiseward_flow", None)
+        if callable(converter):
+            return converter(prediction)
+        return prediction
+
+    def _noiseward_flow_to_student_prediction(self, flow: torch.Tensor) -> torch.Tensor:
+        converter = getattr(self.student_model, "noiseward_flow_to_prediction", None)
+        if callable(converter):
+            return converter(flow)
+        return flow
 
     def _online_teacher_average_velocity(
         self,
@@ -287,15 +303,17 @@ class AnyFlowDistiller(DistillationBase):
                     teacher_batch = self._teacher_batch(prepared_batch, current_latents, current_sigmas)
                     teacher_prediction = self.teacher_model.model_predict(teacher_batch)["model_prediction"]
                     teacher_prediction = teacher_prediction.to(device=current_latents.device, dtype=current_latents.dtype)
+                    noiseward_prediction = self._teacher_prediction_to_noiseward_flow(teacher_prediction)
                     step = self._broadcast_time(next_sigmas - current_sigmas, current_latents)
-                    current_latents = current_latents + step * teacher_prediction
+                    current_latents = current_latents + step * noiseward_prediction
                     current_sigmas = next_sigmas
         finally:
             self.toggle_adapter(enable=True)
 
         denominator = self._broadcast_time(r_sigmas - t_sigmas, current_latents)
         average_velocity = (current_latents - start_latents) / denominator
-        return average_velocity.to(device=base_target.device, dtype=base_target.dtype)
+        target = self._noiseward_flow_to_student_prediction(average_velocity)
+        return target.to(device=base_target.device, dtype=base_target.dtype)
 
     def _rollout_sigma_schedule(self, t_sigmas: torch.Tensor, r_sigmas: torch.Tensor):
         steps = int(self.config["teacher_rollout_steps"])

--- a/simpletuner/helpers/distillation/dmd/distiller.py
+++ b/simpletuner/helpers/distillation/dmd/distiller.py
@@ -85,6 +85,7 @@ class DMDDistiller(DistillationBase):
             self.fake_score_transformer,
             self.scheduler_adapter,
             self.weight_dtype,
+            foundation=self.teacher_model,
         )
 
         self.denoising_steps = self._parse_denoising_steps(self.config["dmd_denoising_steps"])

--- a/simpletuner/helpers/distillation/flow_dpo/distiller.py
+++ b/simpletuner/helpers/distillation/flow_dpo/distiller.py
@@ -85,8 +85,8 @@ class FlowDPODistiller(DistillationBase):
         finally:
             self.toggle_adapter(enable=True)
 
-        win_target = prepared_batch["noise"] - win_latents
-        lose_target = prepared_batch["noise"] - lose_latents
+        win_target = self._flow_target(prepared_batch, win_latents)
+        lose_target = self._flow_target(lose_batch, lose_latents)
         mask = self._mask_for_loss(prepared_batch, policy_win)
 
         policy_win_err = self._per_sample_error(policy_win, win_target, mask)
@@ -174,6 +174,13 @@ class FlowDPODistiller(DistillationBase):
             "sigmas"
         ] * prepared_batch["input_noise"]
         return rejected_batch
+
+    def _flow_target(self, prepared_batch: Dict[str, Any], latents: torch.Tensor) -> torch.Tensor:
+        get_target = getattr(self.student_model, "get_flow_matching_target", None)
+        if callable(get_target):
+            target = get_target(prepared_batch, latents=latents, prefer_explicit_target=False)
+            return target.to(device=latents.device, dtype=latents.dtype)
+        return prepared_batch["noise"] - latents
 
     def _mask_for_loss(self, prepared_batch: Dict[str, Any], prediction: torch.Tensor) -> Optional[torch.Tensor]:
         loss_mask_type = prepared_batch.get("loss_mask_type")

--- a/simpletuner/helpers/distillation/perflow/distiller.py
+++ b/simpletuner/helpers/distillation/perflow/distiller.py
@@ -249,15 +249,15 @@ class PerFlowDistiller(DistillationBase):
         noisy_latents = self._distillation_scheduler.add_noise(latents.float(), noise.float(), timesteps).to(
             device=device, dtype=dtype
         )
-        flow_target = noise - latents
-
         batch["latents"] = latents
         batch["clean_latents"] = latents
         batch["noise"] = noise
         batch["input_noise"] = noise
         batch["timesteps"] = timesteps
         batch["noisy_latents"] = noisy_latents
+        flow_target = self._flow_target(batch)
         batch["flow_target"] = flow_target
+        batch["target"] = flow_target
         batch["distillation_metadata"] = [entry.get("metadata", {}) for entry in cache_entries]
         batch["distillation_cache_entries"] = cache_entries
         return batch
@@ -284,7 +284,7 @@ class PerFlowDistiller(DistillationBase):
 
         flow_target = prepared_batch.get("flow_target")
         if flow_target is None:
-            flow_target = prepared_batch["noise"] - prepared_batch["latents"]
+            flow_target = self._flow_target(prepared_batch)
 
         loss_type = str(self.config.get("loss_type", "l2")).lower()
         if loss_type in ("huber", "smooth_l1"):
@@ -302,6 +302,14 @@ class PerFlowDistiller(DistillationBase):
             "total": float(loss.detach()),
         }
         return loss, logs
+
+    def _flow_target(self, prepared_batch: Dict[str, Any]) -> torch.Tensor:
+        latents = prepared_batch["latents"]
+        get_target = getattr(self.student_model, "get_flow_matching_target", None)
+        if callable(get_target):
+            target = get_target(prepared_batch, prefer_explicit_target=False)
+            return target.to(device=latents.device, dtype=latents.dtype)
+        return prepared_batch["noise"] - latents
 
 
 DistillationRegistry.register(

--- a/simpletuner/helpers/distillation/self_forcing/wrappers.py
+++ b/simpletuner/helpers/distillation/self_forcing/wrappers.py
@@ -61,9 +61,11 @@ class FoundationModelWrapper:
         prediction = self.foundation.model_predict(prepared)["model_prediction"]
 
         flow_pred = prediction
+        converter = getattr(self.foundation, "prediction_to_noiseward_flow", None)
+        scheduler_flow = converter(flow_pred) if callable(converter) else flow_pred
         latent_shape = flow_pred.shape
 
-        flat_flow, _ = _flatten_video(flow_pred)
+        flat_flow, _ = _flatten_video(scheduler_flow)
         flat_xt, _ = _flatten_video(noisy_latents)
         flat_timestep = timesteps.reshape(-1)
 
@@ -81,12 +83,13 @@ class FoundationModelWrapper:
 @dataclass
 class ModuleWrapper:
     """
-    Wraps a raw Wan transformer module (teacher/fake score) to expose the same API.
+    Wraps a raw transformer module (teacher/fake score) to expose the same API.
     """
 
     module: torch.nn.Module
     scheduler: FlowMatchingSchedulerAdapter
     weight_dtype: torch.dtype
+    foundation: object | None = None
 
     def forward(
         self,
@@ -117,10 +120,14 @@ class ModuleWrapper:
                 kwargs[f"{key}"] = conditional_dict[key].to(dtype=self.weight_dtype)
 
         outputs = self.module(**kwargs)
-        flow_pred = outputs[0]
+        raw_prediction = outputs[0]
+        converter = getattr(self.foundation, "raw_model_prediction_to_model_prediction", None)
+        flow_pred = converter(raw_prediction) if callable(converter) else raw_prediction
+        noiseward_converter = getattr(self.foundation, "prediction_to_noiseward_flow", None)
+        scheduler_flow = noiseward_converter(flow_pred) if callable(noiseward_converter) else flow_pred
         latent_shape = flow_pred.shape
 
-        flat_flow, _ = _flatten_video(flow_pred)
+        flat_flow, _ = _flatten_video(scheduler_flow)
         flat_xt, _ = _flatten_video(latents)
         flat_timestep = timesteps.reshape(-1)
 

--- a/simpletuner/helpers/models/boogu_image/model.py
+++ b/simpletuner/helpers/models/boogu_image/model.py
@@ -173,10 +173,13 @@ class BooguImage(ImageModelFoundation):
         boogu_timesteps = 1.0 - noise_sigmas
         return noise_sigmas, boogu_timesteps
 
+    def flow_matching_target_direction(self) -> float:
+        return -1.0
+
     def get_prediction_target(self, prepared_batch: dict):
         if prepared_batch.get("target") is not None:
             return prepared_batch["target"]
-        return prepared_batch["latents"] - prepared_batch["noise"]
+        return self.get_flow_matching_target(prepared_batch, prefer_explicit_target=False)
 
     def text_embed_cache_key(self):
         if self._is_edit_flavour():

--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -4254,6 +4254,63 @@ class ModelFoundation(ABC):
         self.diff2flow_bridge = DiffusionToFlowBridge(alphas_cumprod=alphas_cumprod)
         self.diff2flow_bridge.to(device=self.accelerator.device, dtype=self.config.weight_dtype)
 
+    def flow_matching_target_direction(self) -> float:
+        """
+        Return +1 for the common noise-ward velocity convention (`noise - latents`),
+        or -1 for models trained on the inverse data-ward convention.
+        """
+        return 1.0
+
+    def raw_model_prediction_to_model_prediction(self, raw_prediction: torch.Tensor) -> torch.Tensor:
+        """
+        Convert the denoiser's raw output into SimpleTuner's public `model_prediction`
+        convention. Most models already emit the public convention.
+        """
+        return raw_prediction
+
+    def noiseward_flow_to_prediction(self, flow: torch.Tensor) -> torch.Tensor:
+        direction = float(self.flow_matching_target_direction())
+        if direction == 1.0:
+            return flow
+        if direction == -1.0:
+            return -flow
+        return flow * direction
+
+    def prediction_to_noiseward_flow(self, prediction: torch.Tensor) -> torch.Tensor:
+        direction = float(self.flow_matching_target_direction())
+        if direction == 1.0:
+            return prediction
+        if direction == -1.0:
+            return -prediction
+        if direction == 0.0:
+            raise ValueError("Flow-matching target direction may not be zero.")
+        return prediction / direction
+
+    def flow_matching_target(self, latents: torch.Tensor, noise: torch.Tensor) -> torch.Tensor:
+        return self.noiseward_flow_to_prediction(noise - latents)
+
+    def get_flow_matching_target(
+        self,
+        prepared_batch: dict,
+        *,
+        latents: Optional[torch.Tensor] = None,
+        noise: Optional[torch.Tensor] = None,
+        prefer_explicit_target: bool = True,
+    ) -> torch.Tensor:
+        if prefer_explicit_target:
+            target = prepared_batch.get("target")
+            if target is not None:
+                return target
+            flow_target = prepared_batch.get("flow_target")
+            if flow_target is not None:
+                return flow_target
+
+        if latents is None:
+            latents = prepared_batch["latents"]
+        if noise is None:
+            noise = prepared_batch["noise"]
+        return self.flow_matching_target(latents, noise)
+
     def get_prediction_target(self, prepared_batch: dict):
         """
         Returns the target used in the loss function.
@@ -4264,7 +4321,7 @@ class ModelFoundation(ABC):
             # Parent-student training
             target = prepared_batch["target"]
         elif self.PREDICTION_TYPE is PredictionTypes.FLOW_MATCHING:
-            target = prepared_batch["noise"] - prepared_batch["latents"]
+            target = self.get_flow_matching_target(prepared_batch, prefer_explicit_target=False)
         elif self.PREDICTION_TYPE is PredictionTypes.EPSILON:
             target = prepared_batch["noise"]
         elif self.PREDICTION_TYPE is PredictionTypes.V_PREDICTION:
@@ -4885,8 +4942,8 @@ class ModelFoundation(ABC):
                 use_grad=False,
             )
 
-        # Integrate one step: x_fake = z - F_fake (from t=1 to t=0)
-        x_fake = z - F_fake
+        # Integrate one step from t=1 to t=0 using the canonical noise-ward velocity.
+        x_fake = z - self.prediction_to_noiseward_flow(F_fake)
         return x_fake.detach(), z
 
     def _twinflow_compute_adversarial_loss(
@@ -4913,8 +4970,8 @@ class ModelFoundation(ABC):
         # Construct fake trajectory interpolation
         x_t_fake = t_b * z + (1 - t_b) * x_fake
 
-        # Target velocity for fake trajectory
-        target_fake = z - x_fake
+        # Target velocity for fake trajectory in this model's prediction convention.
+        target_fake = self.noiseward_flow_to_prediction(z - x_fake)
 
         # Forward with NEGATIVE time (sign embedding handles distinction)
         neg_t = -t
@@ -5176,15 +5233,15 @@ class ModelFoundation(ABC):
 
         return pred
 
-    @staticmethod
-    def _twinflow_reconstruct_states(x_t: torch.Tensor, sigma: torch.Tensor, flow_pred: torch.Tensor):
+    def _twinflow_reconstruct_states(self, x_t: torch.Tensor, sigma: torch.Tensor, flow_pred: torch.Tensor):
         """
         Recover x_hat and z_hat from the predicted flow under linear interpolation x_t = t*z + (1-t)*x.
         """
         sigma_b = ModelFoundation._twinflow_match_time_shape(sigma, x_t)
         gamma = 1 - sigma_b
-        x_hat = x_t - sigma_b * flow_pred
-        z_hat = x_t + gamma * flow_pred
+        noiseward_flow = self.prediction_to_noiseward_flow(flow_pred)
+        x_hat = x_t - sigma_b * noiseward_flow
+        z_hat = x_t + gamma * noiseward_flow
         return x_hat, z_hat
 
     def _twinflow_rcgm_target(
@@ -5330,7 +5387,9 @@ class ModelFoundation(ABC):
         batch["noise"] = noise
 
         if getattr(self.config, "diff2flow_enabled", False):
-            batch["flow_target"] = (batch["noise"] - batch["latents"]).to(**target_device_kwargs)
+            batch["flow_target"] = self.get_flow_matching_target(batch, prefer_explicit_target=False).to(
+                **target_device_kwargs
+            )
 
         # Possibly add input perturbation to input noise only
         if self.config.input_perturbation != 0 and (
@@ -5881,7 +5940,9 @@ class ModelFoundation(ABC):
             rcgm_latents = (1 - sigmas) * latents + sigmas * noise
         prepared_batch["twinflow_tt"] = tt
 
-        target = (noise - latents).to(device=self.accelerator.device, dtype=self.config.weight_dtype)
+        target = self.get_flow_matching_target(prepared_batch, prefer_explicit_target=False).to(
+            device=self.accelerator.device, dtype=self.config.weight_dtype
+        )
 
         if self._twinflow_diffusion_bridge:
             if self.diff2flow_bridge is None:

--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -4274,6 +4274,8 @@ class ModelFoundation(ABC):
             return flow
         if direction == -1.0:
             return -flow
+        if direction == 0.0:
+            raise ValueError("Flow-matching target direction may not be zero.")
         return flow * direction
 
     def prediction_to_noiseward_flow(self, prediction: torch.Tensor) -> torch.Tensor:

--- a/simpletuner/helpers/models/hidream/model.py
+++ b/simpletuner/helpers/models/hidream/model.py
@@ -118,6 +118,9 @@ class HiDream(ImageModelFoundation):
     def supports_crepa_self_flow(self) -> bool:
         return True
 
+    def raw_model_prediction_to_model_prediction(self, raw_prediction: torch.Tensor) -> torch.Tensor:
+        return raw_prediction * -1
+
     def _prepare_crepa_self_flow_batch(self, batch: dict, state: dict) -> dict:
         patch_size = int(max(getattr(self.unwrap_model(model=self.model).config, "patch_size", 2), 1))
         return self._prepare_image_crepa_self_flow_batch(batch, state, patch_size=patch_size)
@@ -739,7 +742,7 @@ class HiDream(ImageModelFoundation):
         # Forward pass through the transformer with ControlNet residuals
         model_pred = self.model(**hidream_transformer_kwargs)[0]
 
-        return {"model_prediction": model_pred * -1}  # the model is trained with inverted velocity :(
+        return {"model_prediction": self.raw_model_prediction_to_model_prediction(model_pred)}
 
     def get_lora_target_layers(self):
         manual_targets = self._get_peft_lora_target_modules()

--- a/simpletuner/helpers/models/ideogram/model.py
+++ b/simpletuner/helpers/models/ideogram/model.py
@@ -64,6 +64,9 @@ class Ideogram4(ImageModelFoundation):
     def max_swappable_blocks(cls, config=None) -> Optional[int]:
         return 33
 
+    def raw_model_prediction_to_model_prediction(self, raw_prediction: torch.Tensor) -> torch.Tensor:
+        return raw_prediction * -1
+
     def setup_model_flavour(self):
         super().setup_model_flavour()
         flavour = getattr(self.config, "model_flavour", None) or self.DEFAULT_MODEL_FLAVOUR
@@ -662,7 +665,7 @@ class Ideogram4(ImageModelFoundation):
         )
         packed_prediction = model_output[:, text_tokens:]
         model_prediction = self._unpack_latents(packed_prediction, latent_height, latent_width)
-        return {"model_prediction": model_prediction * -1}
+        return {"model_prediction": self.raw_model_prediction_to_model_prediction(model_prediction)}
 
     def sample_flow_sigmas(self, batch: dict, state: dict) -> tuple[torch.Tensor, torch.Tensor]:
         bsz = batch["latents"].shape[0]

--- a/simpletuner/helpers/models/omnigen/model.py
+++ b/simpletuner/helpers/models/omnigen/model.py
@@ -161,6 +161,9 @@ class OmniGen(ImageModelFoundation):
     def supports_crepa_self_flow(self) -> bool:
         return True
 
+    def flow_matching_target_direction(self) -> float:
+        return -1.0
+
     def uses_text_embeddings_cache(self) -> bool:
         return False
 
@@ -326,7 +329,7 @@ class OmniGen(ImageModelFoundation):
         model_pred = model_output["model_prediction"]
 
         # Calculate target as in OmniGen
-        target = prepared_batch["latents"] - prepared_batch["noise"]
+        target = self.get_flow_matching_target(prepared_batch)
         # print(f"Model pred: min={model_pred.min().item():.4f}, max={model_pred.max().item():.4f}, mean={model_pred.mean().item():.4f}, std={model_pred.std().item():.4f}")
         # print(f"Target: min={target.min().item():.4f}, max={target.max().item():.4f}, mean={target.mean().item():.4f}, std={target.std().item():.4f}")
         # print(f"Loss contribution: {((model_pred - target)**2).mean().item():.4f}")

--- a/simpletuner/helpers/models/zlab_i1/model.py
+++ b/simpletuner/helpers/models/zlab_i1/model.py
@@ -347,12 +347,15 @@ class ZLabI1(ImageModelFoundation):
         }
 
     def get_loss_target(self, noise: torch.Tensor, batch: dict) -> torch.Tensor:
-        return (batch["latents"] - noise).detach()
+        return self.flow_matching_target(batch["latents"], noise).detach()
+
+    def flow_matching_target_direction(self) -> float:
+        return -1.0
 
     def get_prediction_target(self, prepared_batch: dict):
         if prepared_batch.get("target") is not None:
             return prepared_batch["target"]
-        return (prepared_batch["latents"] - prepared_batch["noise"]).detach()
+        return self.get_flow_matching_target(prepared_batch, prefer_explicit_target=False).detach()
 
     def setup_training_noise_schedule(self):
         from diffusers import FlowMatchEulerDiscreteScheduler

--- a/tests/helpers/distillation/test_anyflow_distiller.py
+++ b/tests/helpers/distillation/test_anyflow_distiller.py
@@ -61,6 +61,32 @@ class _EpsilonModel(_FlowModel):
     PREDICTION_TYPE = PredictionTypes.EPSILON
 
 
+class _InverseFlowModel(_FlowModel):
+    def get_flow_matching_target(
+        self,
+        prepared_batch,
+        *,
+        latents=None,
+        noise=None,
+        prefer_explicit_target=True,
+    ):
+        if prefer_explicit_target and prepared_batch.get("target") is not None:
+            return prepared_batch["target"]
+        if prefer_explicit_target and prepared_batch.get("flow_target") is not None:
+            return prepared_batch["flow_target"]
+        if latents is None:
+            latents = prepared_batch["latents"]
+        if noise is None:
+            noise = prepared_batch["noise"]
+        return latents - noise
+
+    def prediction_to_noiseward_flow(self, prediction):
+        return -prediction
+
+    def noiseward_flow_to_prediction(self, flow):
+        return -flow
+
+
 class _NoFlowMapModel(_FlowModel):
     def __init__(self):
         super().__init__()
@@ -139,6 +165,19 @@ class AnyFlowDistillerTests(unittest.TestCase):
 
         self.assertTrue(torch.equal(batch["flowmap_r_timesteps"], torch.zeros(2)))
         self.assertTrue(torch.equal(batch["target"], torch.ones_like(batch["latents"])))
+        self.assertIs(batch["flow_target"], batch["target"])
+
+    def test_linear_prepare_batch_uses_model_flow_target_convention(self):
+        model = _InverseFlowModel()
+        distiller = AnyFlowDistiller(
+            teacher_model=model,
+            noise_scheduler=None,
+            config={"model_type": "lora", "target_mode": "linear", "r_timestep_sampler": "zero"},
+        )
+
+        batch = distiller.prepare_batch(_prepared_batch(), model=model, state={})
+
+        self.assertTrue(torch.equal(batch["target"], -torch.ones_like(batch["latents"])))
         self.assertIs(batch["flow_target"], batch["target"])
 
     def test_linear_prepare_batch_preserves_normalized_timestep_parameterization(self):

--- a/tests/helpers/distillation/test_dmd_components.py
+++ b/tests/helpers/distillation/test_dmd_components.py
@@ -8,6 +8,7 @@ import torch.nn as nn
 from simpletuner.helpers.distillation.dmd.distiller import DMDDistiller
 from simpletuner.helpers.distillation.self_forcing.pipeline import SelfForcingTrainingPipeline
 from simpletuner.helpers.distillation.self_forcing.scheduler import FlowMatchingSchedulerAdapter
+from simpletuner.helpers.distillation.self_forcing.wrappers import FoundationModelWrapper, ModuleWrapper
 from simpletuner.helpers.models.common import PredictionTypes
 
 
@@ -69,6 +70,98 @@ class PipelineTests(unittest.TestCase):
         self.assertIsNotNone(denoised_to)
         self.assertTrue(torch.all(torch.isfinite(output)))
         self.assertFalse(torch.allclose(output, noise))
+
+
+class _InverseFlowFoundation:
+    def model_predict(self, prepared_batch):
+        return {"model_prediction": -torch.ones_like(prepared_batch["noisy_latents"])}
+
+    def prediction_to_noiseward_flow(self, prediction):
+        return -prediction
+
+
+class _RawInvertedFoundation:
+    def raw_model_prediction_to_model_prediction(self, raw_prediction):
+        return -raw_prediction
+
+
+class _RawInverseFlowFoundation:
+    def raw_model_prediction_to_model_prediction(self, raw_prediction):
+        return raw_prediction
+
+    def prediction_to_noiseward_flow(self, prediction):
+        return -prediction
+
+
+class _ConstantRawModule(nn.Module):
+    def __init__(self, value: float):
+        super().__init__()
+        self.value = value
+
+    def forward(self, hidden_states, **_kwargs):
+        return (torch.full_like(hidden_states, self.value),)
+
+
+class FoundationWrapperTests(unittest.TestCase):
+    def test_inverse_flow_prediction_reconstructs_clean_latents(self):
+        scheduler = FlowMatchingSchedulerAdapter(_StubScheduler())
+        foundation = _InverseFlowFoundation()
+        wrapper = FoundationModelWrapper(foundation, scheduler)
+        clean = torch.zeros(1, 2, 1, 4, 4)
+        noise = torch.ones_like(clean)
+        timesteps = torch.full((1, 1), 500, dtype=torch.long)
+        noisy = scheduler.add_noise(
+            clean.reshape(1, 2, 4, 4),
+            noise.reshape(1, 2, 4, 4),
+            timesteps.reshape(-1),
+        ).reshape_as(clean)
+
+        _, pred_x0 = wrapper.forward(noisy, timesteps, {"prompt_embeds": torch.zeros(1, 1)})
+
+        torch.testing.assert_close(pred_x0, clean, atol=1e-5, rtol=1e-5)
+
+
+class ModuleWrapperTests(unittest.TestCase):
+    def _noisy_latents(self, scheduler):
+        clean = torch.zeros(1, 2, 1, 4, 4)
+        noise = torch.ones_like(clean)
+        timesteps = torch.full((1, 1), 500, dtype=torch.long)
+        noisy = scheduler.add_noise(
+            clean.reshape(1, 2, 4, 4),
+            noise.reshape(1, 2, 4, 4),
+            timesteps.reshape(-1),
+        ).reshape_as(clean)
+        return clean, noisy, timesteps
+
+    def test_raw_inverted_prediction_reconstructs_clean_latents(self):
+        scheduler = FlowMatchingSchedulerAdapter(_StubScheduler())
+        clean, noisy, timesteps = self._noisy_latents(scheduler)
+        wrapper = ModuleWrapper(
+            _ConstantRawModule(value=-1.0),
+            scheduler,
+            torch.float32,
+            foundation=_RawInvertedFoundation(),
+        )
+
+        flow_pred, pred_x0 = wrapper.forward(noisy, timesteps, {"prompt_embeds": torch.zeros(1, 1)})
+
+        torch.testing.assert_close(flow_pred, torch.ones_like(noisy))
+        torch.testing.assert_close(pred_x0, clean, atol=1e-5, rtol=1e-5)
+
+    def test_inverse_flow_prediction_reconstructs_clean_latents(self):
+        scheduler = FlowMatchingSchedulerAdapter(_StubScheduler())
+        clean, noisy, timesteps = self._noisy_latents(scheduler)
+        wrapper = ModuleWrapper(
+            _ConstantRawModule(value=-1.0),
+            scheduler,
+            torch.float32,
+            foundation=_RawInverseFlowFoundation(),
+        )
+
+        flow_pred, pred_x0 = wrapper.forward(noisy, timesteps, {"prompt_embeds": torch.zeros(1, 1)})
+
+        torch.testing.assert_close(flow_pred, -torch.ones_like(noisy))
+        torch.testing.assert_close(pred_x0, clean, atol=1e-5, rtol=1e-5)
 
 
 class _StubTransformer(nn.Module):

--- a/tests/helpers/distillation/test_flow_dpo_distiller.py
+++ b/tests/helpers/distillation/test_flow_dpo_distiller.py
@@ -45,6 +45,23 @@ class _FlowModel:
         return {"model_prediction": target + offset * torch.ones_like(target)}
 
 
+class _InverseFlowModel(_FlowModel):
+    def get_flow_matching_target(
+        self,
+        prepared_batch,
+        *,
+        latents=None,
+        noise=None,
+        prefer_explicit_target=True,
+    ):
+        del prefer_explicit_target
+        if latents is None:
+            latents = prepared_batch["latents"]
+        if noise is None:
+            noise = prepared_batch["noise"]
+        return latents - noise
+
+
 class _ConfigCaptureDistiller:
     last_config = None
 
@@ -237,6 +254,20 @@ class FlowDPODistillerTests(unittest.TestCase):
 
         expected = (1 - batch["sigmas"]) * rejected_latents + batch["sigmas"] * batch["input_noise"]
         torch.testing.assert_close(rejected_batch["noisy_latents"], expected)
+
+    def test_flow_target_uses_model_convention(self):
+        adapter = _Adapter()
+        model = _InverseFlowModel(adapter)
+        distiller = FlowDPODistiller(
+            teacher_model=model,
+            noise_scheduler=None,
+            config={"model_type": "lora", "auto_beta": False},
+        )
+        batch = _prepared_batch()
+
+        target = distiller._flow_target(batch, batch["latents"])
+
+        self.assertTrue(torch.equal(target, batch["latents"] - batch["noise"]))
 
     def test_mask_for_loss_handles_video_mask_and_dilation(self):
         adapter = _Adapter()

--- a/tests/test_omnigen_model.py
+++ b/tests/test_omnigen_model.py
@@ -38,6 +38,23 @@ class OmniGenModelTests(unittest.TestCase):
     def test_model_does_not_use_text_embedding_cache(self):
         self.assertFalse(self.model.uses_text_embeddings_cache())
 
+    def test_flow_matching_target_uses_omnigen_direction(self):
+        latents = torch.tensor([1.0, 2.0])
+        noise = torch.tensor([3.0, 5.0])
+
+        target = self.model.get_flow_matching_target({"latents": latents, "noise": noise})
+
+        self.assertTrue(torch.equal(target, latents - noise))
+
+    def test_loss_uses_flow_matching_target_helper(self):
+        latents = torch.tensor([1.0, 2.0])
+        noise = torch.tensor([3.0, 5.0])
+        prediction = latents - noise
+
+        loss = self.model.loss({"latents": latents, "noise": noise}, {"model_prediction": prediction})
+
+        self.assertEqual(loss.item(), 0.0)
+
     def test_prepare_crepa_self_flow_batch_creates_tokenwise_timesteps(self):
         self.model.config.crepa_self_flow_mask_ratio = 0.5
         batch = {

--- a/tests/test_twinflow_adversarial.py
+++ b/tests/test_twinflow_adversarial.py
@@ -26,6 +26,29 @@ def _twinflow_settings_for(**config_values):
     return model._twinflow_settings()
 
 
+def _flow_contract_model(direction: float):
+    from simpletuner.helpers.models.common import ModelFoundation
+
+    class _Model(ModelFoundation):
+        def _encode_prompts(self, *args, **kwargs):
+            raise NotImplementedError
+
+        def convert_negative_text_embed_for_pipeline(self, *args, **kwargs):
+            raise NotImplementedError
+
+        def convert_text_embed_for_pipeline(self, *args, **kwargs):
+            raise NotImplementedError
+
+        def model_predict(self, *args, **kwargs):
+            raise NotImplementedError
+
+        def flow_matching_target_direction(self) -> float:
+            return direction
+
+    model = object.__new__(_Model)
+    return model
+
+
 class TwinFlowAdversarialTest(unittest.TestCase):
     """Tests for TwinFlow adversarial losses (L_adv and L_rectify)."""
 
@@ -124,6 +147,21 @@ class TwinFlowAdversarialTest(unittest.TestCase):
         # Verify target is the velocity from x_fake to z
         self.assertEqual(target_fake.shape, x_fake.shape)
         self.assertTrue(torch.allclose(x_fake + target_fake, z))
+
+    def test_inverse_flow_target_and_reconstruction_use_prediction_convention(self):
+        model = _flow_contract_model(direction=-1.0)
+        latents = torch.zeros(1, 1, 1, 1)
+        noise = torch.ones_like(latents)
+        sigma = torch.full((1, 1, 1, 1), 0.25)
+        x_t = (1 - sigma) * latents + sigma * noise
+        prediction = latents - noise
+
+        target = model.get_flow_matching_target({"latents": latents, "noise": noise}, prefer_explicit_target=False)
+        x_hat, z_hat = model._twinflow_reconstruct_states(x_t, sigma, prediction)
+
+        self.assertTrue(torch.equal(target, prediction))
+        self.assertTrue(torch.allclose(x_hat, latents))
+        self.assertTrue(torch.allclose(z_hat, noise))
 
     def test_rectify_loss_gradient_computation(self):
         """Test that rectify loss computes F_grad = F_neg - F_pos correctly."""


### PR DESCRIPTION
## Summary

Adds a shared flow-target convention hook for models that train or emit reverse-flow predictions, then uses it in distillers and TwinFlow paths.

## Details

- Adds ModelFoundation helpers for converting between model prediction convention and canonical noise-ward flow.
- Updates AnyFlow, Flow DPO, PerFlow, DMD/self-forcing wrappers, diffusion-to-flow targets, and TwinFlow reconstruction to use the model convention instead of assuming noise - latents.
- Marks existing reverse-flow model families through the shared contract.

## Validation

- `.venv/bin/python -m unittest -v -f tests.helpers.distillation.test_anyflow_distiller tests.helpers.distillation.test_dmd_components tests.helpers.distillation.test_flow_dpo_distiller tests.test_omnigen_model tests.test_twinflow_adversarial`
