### PR TITLE
Avoid double-quantizing SDNQ base models

### DIFF
--- a/simpletuner/helpers/training/quantisation/__init__.py
+++ b/simpletuner/helpers/training/quantisation/__init__.py
@@ -1059,8 +1059,12 @@ def _sdnq_model(
         logging.getLogger("sdnq").setLevel(logging.WARNING)
         import sdnq.common as sdnq_common
         from sdnq.training import sdnq_training_post_load_quant
+
+        from simpletuner.helpers.training.sdnq_workarounds import apply_sdnq_workarounds
     except ImportError as e:
         raise ImportError(f"To use SDNQ, please install the sdnq library: `pip install sdnq`: {e}")
+
+    apply_sdnq_workarounds()
 
     sdnq_fp8_mm_supported = getattr(sdnq_common, "is_fp8_mm_supported", False)
     if callable(sdnq_fp8_mm_supported):

--- a/simpletuner/helpers/training/quantisation/quanto_workarounds.py
+++ b/simpletuner/helpers/training/quantisation/quanto_workarounds.py
@@ -60,9 +60,9 @@ def _same_device(actual: torch.device, expected: torch.device) -> bool:
 _original_include_paths = torch.utils.cpp_extension.include_paths
 
 
-def _patched_include_paths(device_type: str = "cpu") -> list:
+def _patched_include_paths(device_type: str = "cpu", *args, **kwargs) -> list:
     """Patched include_paths that filters out /usr/include for HIP/ROCm."""
-    paths = _original_include_paths(device_type)
+    paths = _original_include_paths(device_type, *args, **kwargs)
 
     # Filter out /usr/include - it breaks #include_next in GCC's C++ headers
     # when passed as -isystem. The compiler already knows about /usr/include.

--- a/simpletuner/helpers/training/sdnq_workarounds.py
+++ b/simpletuner/helpers/training/sdnq_workarounds.py
@@ -1,0 +1,34 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+_PATCHED_FROM_FLOAT_ATTR = "_simpletuner_patched_from_float"
+
+
+def _detect_fake_mode(tensor) -> object | None:
+    try:
+        from torch._guards import detect_fake_mode
+    except Exception:
+        return None
+    return detect_fake_mode(tensor)
+
+
+def apply_sdnq_workarounds() -> None:
+    try:
+        from sdnq.training.tensor import SDNQTensor
+    except ImportError:
+        return
+
+    if getattr(SDNQTensor, _PATCHED_FROM_FLOAT_ATTR, False):
+        return
+
+    original_from_float = SDNQTensor.from_float
+
+    def from_float_dequantizing_existing_sdnq(weight, *args, **kwargs):
+        if isinstance(weight, SDNQTensor) and _detect_fake_mode(weight) is None:
+            weight = weight.dequantize()
+        return original_from_float(weight, *args, **kwargs)
+
+    SDNQTensor.from_float = staticmethod(from_float_dequantizing_existing_sdnq)
+    setattr(SDNQTensor, _PATCHED_FROM_FLOAT_ATTR, True)
+    logger.debug("Patched SDNQTensor.from_float to dequantize existing SDNQTensor inputs before requantizing.")

--- a/simpletuner/helpers/training/sdnq_workarounds.py
+++ b/simpletuner/helpers/training/sdnq_workarounds.py
@@ -8,7 +8,7 @@ _PATCHED_FROM_FLOAT_ATTR = "_simpletuner_patched_from_float"
 def _detect_fake_mode(tensor) -> object | None:
     try:
         from torch._guards import detect_fake_mode
-    except Exception:
+    except ImportError:
         return None
     return detect_fake_mode(tensor)
 

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -2828,7 +2828,9 @@ class Trainer:
                 if self.config.controlnet:
                     logger.info(f"Moving ControlNet to dtype={self.config.base_weight_dtype}, device={quantization_device}")
                     self.model.controlnet.to(quantization_device, dtype=self.config.base_weight_dtype)
-        if self.config.is_quanto:
+        # SDNQ base models may still use Quanto text encoders. Let the SDNQ
+        # branch handle that mixed setup so the base model is not quantized twice.
+        if self.config.is_quanto and not self.config.is_sdnq:
             with self.accelerator.local_main_process_first():
                 if ema_only:
                     if not pipeline_base_quantization:


### PR DESCRIPTION
## Summary

Avoids sending SDNQ base models through the Quanto quantization path a second time and patches SDNQ requantization of already-quantized tensors.

## Details

- Applies an SDNQ workaround before post-load quantization so existing SDNQTensor inputs are dequantized before requantization outside fake tensor mode.
- Keeps Quanto text-encoder handling available in mixed SDNQ setups while skipping duplicate Quanto base-model quantization.
- Allows the Quanto include_paths workaround to forward newer torch include_paths arguments.

## Validation

- `.venv/bin/python -m unittest -v -f tests.test_trainer.TestTrainer.test_misc_init`
