### PR TITLE
Patch Diffusers LoRA and attention overrides

### DIFF
--- a/simpletuner/helpers/training/diffusers_overrides.py
+++ b/simpletuner/helpers/training/diffusers_overrides.py
@@ -478,11 +478,12 @@ def patch_attention_flexible():
     logger.info(f"Patched Attention with flexible fusion (permanent={PERMANENT_FUSION})")
 
 
-def _collect_physically_merged_lora_adapters(pipeline) -> set[str]:
+def _collect_physically_merged_lora_adapters(pipeline, components: Optional[Iterable[str]] = None) -> set[str]:
     from peft.tuners.tuners_utils import BaseTunerLayer
 
     merged_adapters: set[str] = set()
-    for component_name in getattr(pipeline, "_lora_loadable_modules", []):
+    component_names = components if components is not None else getattr(pipeline, "_lora_loadable_modules", [])
+    for component_name in component_names:
         component = getattr(pipeline, component_name, None)
         if not isinstance(component, nn.Module):
             continue
@@ -501,10 +502,20 @@ def patch_lora_unfuse_merged_adapters_tracking():
     original_unfuse_lora = LoraBaseMixin.unfuse_lora
 
     @wraps(original_unfuse_lora)
-    def unfuse_lora_with_merged_adapter_resync(self, components: list[str] = [], **kwargs):
+    def unfuse_lora_with_merged_adapter_resync(self, components: Optional[list[str]] = None, **kwargs):
+        components = components or []
         tracked_before = set(getattr(self, "_merged_adapters", set()) or set())
         result = original_unfuse_lora(self, components=components, **kwargs)
-        physically_merged = _collect_physically_merged_lora_adapters(self)
+        if components:
+            components_to_unfuse = set(components)
+            remaining_components = [
+                component_name
+                for component_name in getattr(self, "_lora_loadable_modules", [])
+                if component_name not in components_to_unfuse
+            ]
+        else:
+            remaining_components = None
+        physically_merged = _collect_physically_merged_lora_adapters(self, remaining_components)
         currently_tracked = set(getattr(self, "_merged_adapters", set()) or set())
         self._merged_adapters = (currently_tracked | tracked_before) & physically_merged
         return result

--- a/simpletuner/helpers/training/diffusers_overrides.py
+++ b/simpletuner/helpers/training/diffusers_overrides.py
@@ -514,6 +514,74 @@ def patch_lora_unfuse_merged_adapters_tracking():
     LoraBaseMixin._simpletuner_original_unfuse_lora = original_unfuse_lora
 
 
+def _patched_cudnn_attention_backward_op(ctx, grad_out: torch.Tensor, *args, **kwargs):
+    query, key, value, out, lse, cum_seq_q, cum_seq_k, philox_seed, philox_offset = ctx.saved_tensors
+
+    grad_out = grad_out.transpose(1, 2).contiguous()
+
+    grad_query, grad_key, grad_value = torch.ops.aten._scaled_dot_product_cudnn_attention_backward(
+        grad_out,
+        query,
+        key,
+        value,
+        out,
+        logsumexp=lse,
+        philox_seed=philox_seed,
+        philox_offset=philox_offset,
+        attn_bias=ctx.attn_mask,
+        cum_seq_q=cum_seq_q,
+        cum_seq_k=cum_seq_k,
+        max_q=ctx.max_q,
+        max_k=ctx.max_k,
+        dropout_p=ctx.dropout_p,
+        is_causal=ctx.is_causal,
+        scale=ctx.scale,
+    )
+    grad_query, grad_key, grad_value = (x.transpose(1, 2).contiguous() for x in (grad_query, grad_key, grad_value))
+
+    return grad_query, grad_key, grad_value
+
+
+def _patched_native_flash_attention_backward_op(ctx, grad_out: torch.Tensor, *args, **kwargs):
+    query, key, value, out, lse, cum_seq_q, cum_seq_k, philox_seed, philox_offset = ctx.saved_tensors
+
+    grad_out = grad_out.transpose(1, 2).contiguous()
+
+    grad_query, grad_key, grad_value = torch.ops.aten._scaled_dot_product_flash_attention_backward(
+        grad_out,
+        query,
+        key,
+        value,
+        out,
+        logsumexp=lse,
+        philox_seed=philox_seed,
+        philox_offset=philox_offset,
+        cum_seq_q=cum_seq_q,
+        cum_seq_k=cum_seq_k,
+        max_q=ctx.max_q,
+        max_k=ctx.max_k,
+        dropout_p=ctx.dropout_p,
+        is_causal=ctx.is_causal,
+        scale=ctx.scale,
+    )
+    grad_query, grad_key, grad_value = (x.transpose(1, 2).contiguous() for x in (grad_query, grad_key, grad_value))
+
+    return grad_query, grad_key, grad_value
+
+
+def patch_templated_attention_backward_layout():
+    if getattr(attention_dispatch, "_simpletuner_templated_attention_backward_layout_patch", False):
+        return
+
+    attention_dispatch._simpletuner_original_cudnn_attention_backward_op = attention_dispatch._cudnn_attention_backward_op
+    attention_dispatch._simpletuner_original_native_flash_attention_backward_op = (
+        attention_dispatch._native_flash_attention_backward_op
+    )
+    attention_dispatch._cudnn_attention_backward_op = _patched_cudnn_attention_backward_op
+    attention_dispatch._native_flash_attention_backward_op = _patched_native_flash_attention_backward_op
+    attention_dispatch._simpletuner_templated_attention_backward_layout_patch = True
+
+
 # Convenience functions for different use cases
 def enable_permanent_fusion():
     """Enable permanent fusion mode globally"""
@@ -533,6 +601,7 @@ patch_flash_attn2_hub_kernel_attrs()
 patch_ring_anything_attention_lse_shape()
 patch_attention_flexible()
 patch_lora_unfuse_merged_adapters_tracking()
+patch_templated_attention_backward_layout()
 
 
 def _pad_qwen_hidden_states_to_fixed_length(

--- a/simpletuner/helpers/training/diffusers_overrides.py
+++ b/simpletuner/helpers/training/diffusers_overrides.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from functools import wraps
 from typing import Dict, Iterable, Optional
 
 import torch
@@ -477,6 +478,42 @@ def patch_attention_flexible():
     logger.info(f"Patched Attention with flexible fusion (permanent={PERMANENT_FUSION})")
 
 
+def _collect_physically_merged_lora_adapters(pipeline) -> set[str]:
+    from peft.tuners.tuners_utils import BaseTunerLayer
+
+    merged_adapters: set[str] = set()
+    for component_name in getattr(pipeline, "_lora_loadable_modules", []):
+        component = getattr(pipeline, component_name, None)
+        if not isinstance(component, nn.Module):
+            continue
+        for module in component.modules():
+            if isinstance(module, BaseTunerLayer):
+                merged_adapters.update(adapter for adapter in module.merged_adapters if adapter)
+    return merged_adapters
+
+
+def patch_lora_unfuse_merged_adapters_tracking():
+    from diffusers.loaders.lora_base import LoraBaseMixin
+
+    if getattr(LoraBaseMixin, "_simpletuner_unfuse_lora_tracking_patch", False):
+        return
+
+    original_unfuse_lora = LoraBaseMixin.unfuse_lora
+
+    @wraps(original_unfuse_lora)
+    def unfuse_lora_with_merged_adapter_resync(self, components: list[str] = [], **kwargs):
+        tracked_before = set(getattr(self, "_merged_adapters", set()) or set())
+        result = original_unfuse_lora(self, components=components, **kwargs)
+        physically_merged = _collect_physically_merged_lora_adapters(self)
+        currently_tracked = set(getattr(self, "_merged_adapters", set()) or set())
+        self._merged_adapters = (currently_tracked | tracked_before) & physically_merged
+        return result
+
+    LoraBaseMixin.unfuse_lora = unfuse_lora_with_merged_adapter_resync
+    LoraBaseMixin._simpletuner_unfuse_lora_tracking_patch = True
+    LoraBaseMixin._simpletuner_original_unfuse_lora = original_unfuse_lora
+
+
 # Convenience functions for different use cases
 def enable_permanent_fusion():
     """Enable permanent fusion mode globally"""
@@ -495,6 +532,7 @@ def enable_reversible_fusion():
 patch_flash_attn2_hub_kernel_attrs()
 patch_ring_anything_attention_lse_shape()
 patch_attention_flexible()
+patch_lora_unfuse_merged_adapters_tracking()
 
 
 def _pad_qwen_hidden_states_to_fixed_length(

--- a/tests/test_diffusers_overrides_attention_dispatch.py
+++ b/tests/test_diffusers_overrides_attention_dispatch.py
@@ -1,0 +1,74 @@
+import types
+import unittest
+from unittest.mock import patch
+
+import torch
+from diffusers.models import attention_dispatch
+
+from simpletuner.helpers.training import diffusers_overrides  # noqa: F401
+
+
+def _fake_attention_ctx() -> types.SimpleNamespace:
+    batch_size, num_heads, seq_len, head_dim = 2, 3, 5, 7
+    saved_layout = (batch_size, num_heads, seq_len, head_dim)
+    saved_tensors = (
+        torch.randn(saved_layout),
+        torch.randn(saved_layout),
+        torch.randn(saved_layout),
+        torch.randn(saved_layout),
+        torch.randn(batch_size, num_heads, seq_len),
+        torch.empty(0, dtype=torch.int32),
+        torch.empty(0, dtype=torch.int32),
+        torch.zeros((), dtype=torch.int64),
+        torch.zeros((), dtype=torch.int64),
+    )
+    return types.SimpleNamespace(
+        saved_tensors=saved_tensors,
+        attn_mask=None,
+        max_q=seq_len,
+        max_k=seq_len,
+        dropout_p=0.0,
+        is_causal=False,
+        scale=None,
+    )
+
+
+class DiffusersTemplatedAttentionBackwardOverrideTests(unittest.TestCase):
+    def _assert_backward_uses_saved_bhsd_layout(self, backward_op, aten_op_name: str):
+        ctx = _fake_attention_ctx()
+        grad_out = torch.randn(2, 5, 3, 7)
+        captured = {}
+
+        def fake_aten_backward(grad_out_arg, query, key, value, out, **kwargs):
+            captured["grad_out_shape"] = tuple(grad_out_arg.shape)
+            captured["query_shape"] = tuple(query.shape)
+            captured["key_shape"] = tuple(key.shape)
+            captured["value_shape"] = tuple(value.shape)
+            return torch.zeros_like(query), torch.zeros_like(key), torch.zeros_like(value)
+
+        with patch.object(torch.ops.aten, aten_op_name, fake_aten_backward):
+            grad_query, grad_key, grad_value = backward_op(ctx, grad_out)
+
+        self.assertEqual(captured["grad_out_shape"], (2, 3, 5, 7))
+        self.assertEqual(captured["query_shape"], (2, 3, 5, 7))
+        self.assertEqual(captured["key_shape"], (2, 3, 5, 7))
+        self.assertEqual(captured["value_shape"], (2, 3, 5, 7))
+        self.assertEqual(tuple(grad_query.shape), (2, 5, 3, 7))
+        self.assertEqual(tuple(grad_key.shape), (2, 5, 3, 7))
+        self.assertEqual(tuple(grad_value.shape), (2, 5, 3, 7))
+
+    def test_cudnn_backward_does_not_transpose_saved_key_value_twice(self):
+        self._assert_backward_uses_saved_bhsd_layout(
+            attention_dispatch._cudnn_attention_backward_op,
+            "_scaled_dot_product_cudnn_attention_backward",
+        )
+
+    def test_native_flash_backward_does_not_transpose_saved_key_value_twice(self):
+        self._assert_backward_uses_saved_bhsd_layout(
+            attention_dispatch._native_flash_attention_backward_op,
+            "_scaled_dot_product_flash_attention_backward",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_diffusers_overrides_attention_dispatch.py
+++ b/tests/test_diffusers_overrides_attention_dispatch.py
@@ -46,7 +46,7 @@ class DiffusersTemplatedAttentionBackwardOverrideTests(unittest.TestCase):
             captured["value_shape"] = tuple(value.shape)
             return torch.zeros_like(query), torch.zeros_like(key), torch.zeros_like(value)
 
-        with patch.object(torch.ops.aten, aten_op_name, fake_aten_backward):
+        with patch.object(torch.ops.aten, aten_op_name, fake_aten_backward, create=True):
             grad_query, grad_key, grad_value = backward_op(ctx, grad_out)
 
         self.assertEqual(captured["grad_out_shape"], (2, 3, 5, 7))

--- a/tests/test_diffusers_overrides_lora.py
+++ b/tests/test_diffusers_overrides_lora.py
@@ -1,0 +1,58 @@
+import unittest
+
+import torch.nn as nn
+from diffusers.configuration_utils import ConfigMixin
+from diffusers.loaders.lora_base import LoraBaseMixin
+from diffusers.loaders.peft import PeftAdapterMixin
+from diffusers.models.modeling_utils import ModelMixin
+from peft import LoraConfig
+from peft.tuners.tuners_utils import BaseTunerLayer
+
+from simpletuner.helpers.training import diffusers_overrides  # noqa: F401
+
+
+class TinyPeftModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
+    config_name = "config.json"
+
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(8, 8)
+
+
+class TwoComponentLoraPipeline(LoraBaseMixin):
+    _lora_loadable_modules = ["unet", "text_encoder"]
+
+    def __init__(self, unet, text_encoder):
+        self._merged_adapters = set()
+        self.unet = unet
+        self.text_encoder = text_encoder
+
+
+class DiffusersLoraOverrideTests(unittest.TestCase):
+    def test_partial_unfuse_keeps_adapter_tracked_until_all_components_are_unmerged(self):
+        unet = TinyPeftModel()
+        text_encoder = TinyPeftModel()
+        config = LoraConfig(r=4, lora_alpha=4, target_modules=["linear"], init_lora_weights=False)
+        unet.add_adapter(config, adapter_name="adapter")
+        text_encoder.add_adapter(config, adapter_name="adapter")
+
+        pipeline = TwoComponentLoraPipeline(unet, text_encoder)
+        pipeline.fuse_lora(components=["unet", "text_encoder"], adapter_names=["adapter"])
+        self.assertEqual(pipeline.num_fused_loras, 1)
+
+        pipeline.unfuse_lora(components=["text_encoder"])
+
+        unet_still_merged = any(
+            isinstance(module, BaseTunerLayer) and bool(module.merged_adapters) for module in unet.modules()
+        )
+        self.assertTrue(unet_still_merged)
+        self.assertIn("adapter", pipeline.fused_loras)
+        self.assertEqual(pipeline.num_fused_loras, 1)
+
+        pipeline.unfuse_lora(components=["unet"])
+        self.assertEqual(pipeline.fused_loras, set())
+        self.assertEqual(pipeline.num_fused_loras, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Patches two Diffusers compatibility regressions in SimpleTuner overrides: partial LoRA unfuse tracking and templated attention backward tensor layout.

## Details

- Keeps pipeline fused_loras and num_fused_loras in sync with adapters that remain physically merged after unfusing only one component.
- Patches templated CUDNN/native-flash attention backward wrappers so saved query/key/value tensors are passed in the layout they were stored with, avoiding a double transpose.
- Adds focused regression tests for both override paths.

## Validation

- `.venv/bin/python -m unittest -v -f tests.test_diffusers_overrides_lora tests.test_diffusers_overrides_attention_dispatch`
