### PR TITLE
Fix Webshart video sample and cache handling

### DIFF
--- a/documentation/DATALOADER.md
+++ b/documentation/DATALOADER.md
@@ -1370,7 +1370,7 @@ Webshart datasets load WebDataset-style tar shards through the `webshart` packag
 - `metadata` is optional and points to a separate metadata location when captions or shard metadata are stored outside the shard source. For Hugging Face metadata repos such as `webshart/conceptual-captions-12m-webdataset-metadata`, pass the repo id; Webshart follows the source shard subfolder layout such as `data/`.
 - `metadata_backend` must be `webshart`; it reads dimensions and captions from Webshart metadata.
 - `caption_strategy` should be `webshart` to train from metadata captions, or `instanceprompt` to ignore stored captions.
-- `webshart.cache_dir` stores SimpleTuner metadata plus Webshart metadata and shard caches. `shard_cache_gb` and `parallel_downloads` are passed to Webshart's shard cache.
+- `webshart.cache_dir` stores SimpleTuner metadata plus Webshart metadata and shard caches. `shard_cache_gb` and `parallel_downloads` are passed to Webshart's shard cache; set `shard_cache_gb` to `0` to disable whole-shard caching and retain indexed range reads.
 
 This backend requires a Webshart build with `TarDataLoader.list_shard_sample_aspect_buckets()`.
 

--- a/simpletuner/helpers/caching/text_embeds.py
+++ b/simpletuner/helpers/caching/text_embeds.py
@@ -19,6 +19,7 @@ from simpletuner.helpers.prompts import PromptHandler
 from simpletuner.helpers.training.multi_process import rank_info
 from simpletuner.helpers.training.state_tracker import StateTracker
 from simpletuner.helpers.training.wrappers import gather_dict_of_tensors_shapes, move_dict_of_tensors_to_device
+from simpletuner.helpers.utils.pathing import canonicalize_data_uri
 from simpletuner.helpers.webhooks.mixin import WebhookMixin
 
 logger = logging.getLogger("TextEmbeddingCache")
@@ -129,8 +130,9 @@ class TextEmbeddingCache(WebhookMixin):
             if "://" not in normalized:
                 normalized = os.path.normcase(os.path.abspath(os.path.normpath(normalized)))
         elif self.key_type is TextEmbedCacheKey.DATASET_AND_FILENAME:
-            # Keys already include dataset identifiers; leave as-is.
-            pass
+            dataset_id, separator, data_path = normalized.partition(":")
+            if separator:
+                normalized = f"{dataset_id}:{canonicalize_data_uri(data_path)}"
         return normalized
 
     def create_hash(self, key_value):

--- a/simpletuner/helpers/caching/text_embeds.py
+++ b/simpletuner/helpers/caching/text_embeds.py
@@ -457,6 +457,7 @@ class TextEmbeddingCache(WebhookMixin):
         load_from_cache: bool = True,
         is_negative_prompt: bool = False,
         progress_callback=None,
+        split_between_processes: bool = True,
     ):
         if self.model is None:
             self.model = StateTracker.get_model()
@@ -535,6 +536,7 @@ class TextEmbeddingCache(WebhookMixin):
                 load_from_cache=load_from_cache,
                 is_negative_prompt=is_negative_prompt,
                 progress_callback=progress_callback,
+                split_between_processes=split_between_processes,
             )
         else:
             raise ValueError(f"No such text encoding backend for model type '{self.model_type}'")
@@ -559,12 +561,13 @@ class TextEmbeddingCache(WebhookMixin):
         load_from_cache: bool = True,
         is_negative_prompt: bool = False,
         progress_callback=None,
+        split_between_processes: bool = True,
     ):
         prompt_embeds_all = []
         should_encode = not load_from_cache
         args = StateTracker.get_args()
         records = self._normalize_prompt_records(prompt_records) if prompt_records is not None else self.prompt_records
-        if should_encode:
+        if should_encode and split_between_processes:
             local_records = self.split_prompt_records_between_processes(records)
         else:
             local_records = records

--- a/simpletuner/helpers/data_backend/base.py
+++ b/simpletuner/helpers/data_backend/base.py
@@ -136,6 +136,7 @@ class BaseDataBackend(ABC):
                 decompressed_data = file.read()
             except Exception as e:
                 # Handle decompression errors
+                gzip_data.seek(0)
                 return gzip_data
         return BytesIO(decompressed_data)
 

--- a/simpletuner/helpers/data_backend/builders/webshart.py
+++ b/simpletuner/helpers/data_backend/builders/webshart.py
@@ -29,6 +29,9 @@ class WebshartBackendBuilder(BaseBackendBuilder):
         is_mock_backend = hasattr(backend_cls, "_mock_children")
 
         webshart_config = getattr(config, "webshart", None) or {}
+        shard_cache_gb = getattr(config, "webshart_shard_cache_gb", None)
+        if shard_cache_gb is None:
+            shard_cache_gb = 25.0
         cache_dir = getattr(config, "webshart_cache_dir", None)
         if not cache_dir:
             cache_dir = self._default_cache_dir(config)
@@ -45,7 +48,7 @@ class WebshartBackendBuilder(BaseBackendBuilder):
             "cache_dir": str(cache_dir) if cache_dir is not None else None,
             "metadata_cache_dir": webshart_config.get("metadata_cache_dir"),
             "shard_cache_dir": webshart_config.get("shard_cache_dir"),
-            "shard_cache_gb": getattr(config, "webshart_shard_cache_gb", None) or 25.0,
+            "shard_cache_gb": shard_cache_gb,
             "parallel_downloads": getattr(config, "webshart_parallel_downloads", None) or 4,
             "buffer_size": getattr(config, "webshart_buffer_size", None) or 100,
             "max_file_size": getattr(config, "webshart_max_file_size", None) or 500 * 1024 * 1024,

--- a/simpletuner/helpers/data_backend/factory.py
+++ b/simpletuner/helpers/data_backend/factory.py
@@ -3254,11 +3254,10 @@ class FactoryRegistry:
         if self._is_multi_process():
             self.accelerator.wait_for_everyone()
 
-        # When the main process rebuilds buckets (e.g., after cache deletion), ensure
-        # other ranks reload the freshly written cache before splitting buckets.
+        # When the main process rebuilds buckets, make every rank partition the same
+        # serialized cache rather than mixing rank 0's in-memory order with reloaded order.
         if (
             self._is_multi_process()
-            and not self.accelerator.is_main_process
             and not backend.get("auto_generated", False)
             and "aspect" not in self.args.skip_file_discovery
             and "aspect" not in backend.get("skip_file_discovery", "")
@@ -3760,7 +3759,10 @@ class FactoryRegistry:
                 )
 
             init_backend["text_embed_cache"].compute_embeddings_for_prompts(
-                prompt_records, return_concat=False, load_from_cache=False
+                prompt_records,
+                return_concat=False,
+                load_from_cache=False,
+                split_between_processes=False,
             )
             info_log(f"(id={init_backend['id']}) Completed processing {len(captions)} captions.")
 
@@ -3878,7 +3880,10 @@ class FactoryRegistry:
                 prompt_records.append({"prompt": caption, "key": key_value, "metadata": metadata})
 
             init_backend["text_embed_cache"].compute_embeddings_for_prompts(
-                prompt_records, return_concat=False, load_from_cache=False
+                prompt_records,
+                return_concat=False,
+                load_from_cache=False,
+                split_between_processes=False,
             )
             info_log(f"(id={dataset_id}) Completed processing {len(captions)} captions with image context.")
 

--- a/simpletuner/helpers/data_backend/webshart.py
+++ b/simpletuner/helpers/data_backend/webshart.py
@@ -10,7 +10,8 @@ import torch
 
 from simpletuner.helpers.data_backend.base import BaseDataBackend
 from simpletuner.helpers.data_backend.dataset_types import DatasetType, ensure_dataset_type
-from simpletuner.helpers.image_manipulation.load import load_image
+from simpletuner.helpers.image_manipulation.load import load_image, load_video
+from simpletuner.helpers.training import video_file_extensions
 from simpletuner.helpers.training.multi_process import should_log
 
 logger = logging.getLogger("WebshartDataBackend")
@@ -29,6 +30,7 @@ class WebshartSampleRef:
 
 class WebshartDataBackend(BaseDataBackend):
     SAMPLE_PREFIX = "webshart://"
+    PATH_NORMALIZED_SAMPLE_PREFIX = "webshart:/"
     CACHE_EXTENSIONS = {".json", ".pt", ".msgpack", ".safetensors"}
 
     def __init__(
@@ -69,8 +71,12 @@ class WebshartDataBackend(BaseDataBackend):
         self.metadata_cache_dir = (
             str(metadata_cache_dir) if metadata_cache_dir else str(Path(self.cache_dir) / "metadata_cache")
         )
-        self.shard_cache_dir = str(shard_cache_dir) if shard_cache_dir else str(Path(self.cache_dir) / "shard_cache")
         self.shard_cache_gb = float(shard_cache_gb)
+        if self.shard_cache_gb < 0:
+            raise ValueError("shard_cache_gb must be non-negative; use 0 to disable whole-shard caching.")
+        self.shard_cache_dir = str(shard_cache_dir) if shard_cache_dir else str(Path(self.cache_dir) / "shard_cache")
+        if self.shard_cache_gb == 0:
+            self.shard_cache_dir = None
         self.parallel_downloads = int(parallel_downloads)
         self.buffer_size = int(buffer_size)
         self.max_file_size = int(max_file_size)
@@ -88,7 +94,7 @@ class WebshartDataBackend(BaseDataBackend):
             metadata=self.metadata,
         )
         self.dataset.enable_metadata_cache(location=self.metadata_cache_dir)
-        if self.shard_cache_dir:
+        if self.shard_cache_dir is not None:
             Path(self.shard_cache_dir).mkdir(parents=True, exist_ok=True)
             self.dataset.enable_shard_cache(
                 location=self.shard_cache_dir,
@@ -117,6 +123,10 @@ class WebshartDataBackend(BaseDataBackend):
         marker = value.find(cls.SAMPLE_PREFIX)
         if marker >= 0:
             return value[marker:]
+        marker = value.find(cls.PATH_NORMALIZED_SAMPLE_PREFIX)
+        if marker >= 0:
+            remainder = value[marker + len(cls.PATH_NORMALIZED_SAMPLE_PREFIX) :]
+            return f"{cls.SAMPLE_PREFIX}{remainder}"
         return value
 
     @classmethod
@@ -137,10 +147,9 @@ class WebshartDataBackend(BaseDataBackend):
 
     @classmethod
     def is_sample_id(cls, identifier: Union[str, Path]) -> bool:
-        value = str(identifier)
-        if cls.SAMPLE_PREFIX not in value:
+        sample_id = cls.normalize_sample_id(identifier)
+        if not sample_id.startswith(cls.SAMPLE_PREFIX):
             return False
-        sample_id = cls.normalize_sample_id(value)
         filename = sample_id.split("/", 2)[-1] if "/" in sample_id else sample_id
         return Path(filename).suffix.lower() not in {".pt", ".safetensors"}
 
@@ -205,6 +214,11 @@ class WebshartDataBackend(BaseDataBackend):
             return None
 
         sample_ref = self.parse_sample_id(image_path)
+        sample_metadata = self.get_shard_metadata(sample_ref.shard_idx).get(sample_ref.filename, {}) or {}
+        caption = sample_metadata.get("captions")
+        if caption:
+            return str(caption).strip()
+
         caption_filename = Path(sample_ref.filename).with_suffix(".txt").name
         caption_sample_idx = self._sample_index_for_filename(sample_ref.shard_idx, caption_filename)
         if caption_sample_idx is None:
@@ -296,7 +310,9 @@ class WebshartDataBackend(BaseDataBackend):
 
     def read_image(self, filepath: str, delete_problematic_images: bool = False):
         try:
-            return load_image(self.read(filepath, as_byteIO=True))
+            file_extension = Path(self.normalize_sample_id(filepath)).suffix.lower().strip(".")
+            loader = load_video if file_extension in video_file_extensions else load_image
+            return loader(self.read(filepath, as_byteIO=True))
         except Exception as exc:
             logger.error("Error opening webshart sample %s: %s", filepath, exc)
             if delete_problematic_images:
@@ -322,6 +338,7 @@ class WebshartDataBackend(BaseDataBackend):
         data = self.read(filename, as_byteIO=True)
         if self.compress_cache:
             data = self._decompress_torch(data)
+        data.seek(0)
         return torch.load(data, map_location="cpu")
 
     def torch_save(self, data, filename):

--- a/simpletuner/helpers/data_backend/webshart.py
+++ b/simpletuner/helpers/data_backend/webshart.py
@@ -6,6 +6,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, List, Optional, Tuple, Union
 
+import requests
 import torch
 
 from simpletuner.helpers.data_backend.base import BaseDataBackend
@@ -199,6 +200,61 @@ class WebshartDataBackend(BaseDataBackend):
         sample_ref = self.parse_sample_id(identifier)
         entry = self.loader.load_sample(sample_ref.shard_idx, sample_ref.sample_idx)
         return bytes(entry.data)
+
+    def read_sample_head_tail(
+        self,
+        identifier: Union[str, Path],
+        *,
+        file_metadata: Optional[dict] = None,
+        head_bytes: int = 4096,
+        tail_bytes: int = 131072,
+    ) -> tuple[bytes, bytes, int]:
+        """Range-read the beginning and end of a sample without loading its full TAR member."""
+        sample_ref = self.parse_sample_id(identifier)
+        metadata = file_metadata or self.get_shard_metadata(sample_ref.shard_idx).get(sample_ref.filename, {})
+        offset = metadata.get("offset")
+        length = metadata.get("length", metadata.get("size"))
+        shard_info = self.dataset.get_shard_info(sample_ref.shard_idx)
+        tar_path = shard_info.get("tar_path") if isinstance(shard_info, dict) else None
+        if offset is None or length is None or not str(tar_path or "").startswith(("http://", "https://")):
+            raise ValueError(f"Range metadata is unavailable for Webshart sample {identifier}.")
+
+        offset = int(offset)
+        length = int(length)
+        if length <= 0:
+            raise ValueError(f"Invalid Webshart sample length for {identifier}: {length}")
+
+        token = self.hf_token
+        if token is True:
+            from huggingface_hub import get_token
+
+            token = get_token()
+        base_headers = {"Authorization": f"Bearer {token}"} if token else {}
+
+        def _read_range(relative_start: int, relative_end: int) -> bytes:
+            absolute_start = offset + relative_start
+            absolute_end = offset + relative_end
+            headers = {**base_headers, "Range": f"bytes={absolute_start}-{absolute_end}"}
+            response = requests.get(str(tar_path), headers=headers, stream=True, timeout=(10, 60))
+            try:
+                if response.status_code != 206:
+                    raise IOError(f"Range request for {identifier} returned HTTP {response.status_code} instead of 206.")
+                payload = response.content
+            finally:
+                response.close()
+            expected_size = relative_end - relative_start + 1
+            if len(payload) != expected_size:
+                raise IOError(f"Range request for {identifier} returned {len(payload)} bytes; expected {expected_size}.")
+            return payload
+
+        head_size = min(max(1, int(head_bytes)), length)
+        tail_size = min(max(1, int(tail_bytes)), length)
+        head = _read_range(0, head_size - 1)
+        if tail_size == length:
+            tail = head if head_size == length else _read_range(0, length - 1)
+        else:
+            tail = _read_range(length - tail_size, length - 1)
+        return head, tail, length
 
     def _sample_index_for_filename(self, shard_idx: int, filename: str) -> Optional[int]:
         shard_idx = int(shard_idx)

--- a/simpletuner/helpers/metadata/backends/base.py
+++ b/simpletuner/helpers/metadata/backends/base.py
@@ -191,7 +191,7 @@ class MetadataBackend:
 
         # Use dataset ID as seed for deterministic selection
         rng = random.Random(self.id)
-        shuffled = list(file_list)
+        shuffled = sorted(file_list, key=str)
         rng.shuffle(shuffled)
         limited = shuffled[: self.max_num_samples]
         logger.info(f"({self.id}) Applied max_num_samples limit: selected {len(limited)} of {len(file_list)} samples")
@@ -873,9 +873,10 @@ class MetadataBackend:
         if should_shuffle_contents:
             # Process-specific RNG seeding must not change the split input across ranks.
             shuffle_seed = getattr(StateTracker.get_args(), "seed", None)
-            if self.accelerator.is_main_process and shuffle_seed is None:
-                shuffle_seed = random.SystemRandom().getrandbits(64)
-            shuffle_seed = broadcast_object_from_main(shuffle_seed if self.accelerator.is_main_process else None)
+            if shuffle_seed is None:
+                if self.accelerator.is_main_process:
+                    shuffle_seed = random.SystemRandom().getrandbits(64)
+                shuffle_seed = broadcast_object_from_main(shuffle_seed if self.accelerator.is_main_process else None)
 
         for bucket, images in self.aspect_ratio_bucket_indices.items():
             if not images:
@@ -883,7 +884,9 @@ class MetadataBackend:
                 continue
             if should_shuffle_contents:
                 logger.debug(f"Shuffling bucket {bucket} contents.")
-                images = images.copy()
+                # Cache builders and cache reloads can preserve the same set in different
+                # orders. Canonicalize first so every rank shuffles an identical sequence.
+                images = sorted(images, key=str)
                 random.Random(f"{shuffle_seed}:{self.id}:{bucket}").shuffle(images)
 
             if auto_repeat_count is not None:

--- a/simpletuner/helpers/metadata/backends/webshart.py
+++ b/simpletuner/helpers/metadata/backends/webshart.py
@@ -1,8 +1,12 @@
 import json
 import logging
 import os
+import shutil
+import subprocess
+import tempfile
 import time
 from contextlib import nullcontext
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from tqdm import tqdm
@@ -11,6 +15,7 @@ from simpletuner.helpers.data_backend.dataset_types import DatasetType
 from simpletuner.helpers.data_backend.webshart import WebshartDataBackend
 from simpletuner.helpers.image_manipulation.training_sample import TrainingSample
 from simpletuner.helpers.metadata.backends.base import MetadataBackend
+from simpletuner.helpers.training import video_file_extensions
 from simpletuner.helpers.training.multi_process import should_log
 from simpletuner.helpers.training.state_tracker import StateTracker
 
@@ -82,8 +87,8 @@ class WebshartMetadataBackend(MetadataBackend):
         )
         if not isinstance(data_backend, WebshartDataBackend):
             raise ValueError("WebshartMetadataBackend requires WebshartDataBackend")
-        if self.dataset_type not in {DatasetType.IMAGE, DatasetType.CONDITIONING, DatasetType.EVAL}:
-            raise ValueError("WebshartMetadataBackend currently supports image-like datasets only.")
+        if self.dataset_type not in {DatasetType.IMAGE, DatasetType.VIDEO, DatasetType.CONDITIONING, DatasetType.EVAL}:
+            raise ValueError("WebshartMetadataBackend supports image, video, conditioning, and eval datasets only.")
 
         self.caption_cache: Dict[str, Union[str, List[str]]] = {}
 
@@ -202,15 +207,77 @@ class WebshartMetadataBackend(MetadataBackend):
             raise ValueError("Webshart sample bucket entries must include sample_idx.")
         return self.data_backend.sample_id(shard_idx, int(entry["sample_idx"]), str(entry["filename"]))
 
-    def _metadata_for_entry(self, shard_metadata: dict, filename: str, entry: dict) -> dict:
+    @staticmethod
+    def _coerce_positive_number(value: Any, value_type):
+        try:
+            result = value_type(value)
+        except (TypeError, ValueError):
+            return None
+        return result if result > 0 else None
+
+    def _probe_video_metadata(self, sample_path: str) -> dict:
+        if shutil.which("ffprobe") is None:
+            return {}
+
+        payload = self.data_backend.read(sample_path)
+        if not payload:
+            return {}
+
+        suffix = Path(self.data_backend.parse_sample_id(sample_path).filename).suffix or ".mp4"
+        probe_path = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as handle:
+                handle.write(payload)
+                probe_path = handle.name
+            result = subprocess.run(
+                [
+                    "ffprobe",
+                    "-v",
+                    "error",
+                    "-select_streams",
+                    "v:0",
+                    "-show_entries",
+                    "stream=width,height,nb_frames,avg_frame_rate,r_frame_rate,duration",
+                    "-show_entries",
+                    "format=duration",
+                    "-of",
+                    "json",
+                    probe_path,
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30,
+            )
+            probe = json.loads(result.stdout) if result.stdout else {}
+            streams = probe.get("streams") or []
+            stream = streams[0] if streams else {}
+            width = self._coerce_positive_number(stream.get("width"), int)
+            height = self._coerce_positive_number(stream.get("height"), int)
+            metadata = {"original_size": (width, height)} if width and height else {}
+
+            num_frames = self._coerce_positive_number(stream.get("nb_frames"), int)
+            if num_frames:
+                metadata["num_frames"] = num_frames
+            duration = self._coerce_positive_number(
+                stream.get("duration") or (probe.get("format") or {}).get("duration"),
+                float,
+            )
+            if duration:
+                metadata["video_duration"] = duration
+            return metadata
+        except Exception as exc:
+            logger.debug("Unable to probe Webshart video %s: %s", sample_path, exc)
+            return {}
+        finally:
+            if probe_path:
+                Path(probe_path).unlink(missing_ok=True)
+
+    def _metadata_for_entry(self, shard_metadata: dict, filename: str, entry: dict, sample_path: str) -> dict:
         file_metadata = shard_metadata.get(filename, {}) or {}
         width = entry.get("width", file_metadata.get("width"))
         height = entry.get("height", file_metadata.get("height"))
-        if width is None or height is None:
-            return {}
-
         metadata = {
-            "original_size": (int(width), int(height)),
             "webshart": {
                 "shard_idx": entry.get("shard_idx"),
                 "sample_idx": entry.get("sample_idx"),
@@ -220,12 +287,36 @@ class WebshartMetadataBackend(MetadataBackend):
                 "json_path": file_metadata.get("json_path"),
             },
         }
+        if width is not None and height is not None:
+            metadata["original_size"] = (int(width), int(height))
         if "captions" in file_metadata:
             metadata["captions"] = file_metadata["captions"]
-        if "json_metadata" in file_metadata:
-            metadata["json_metadata"] = file_metadata["json_metadata"]
+        json_metadata = file_metadata.get("json_metadata") or {}
+        if json_metadata:
+            metadata["json_metadata"] = json_metadata
         if "json_path" in file_metadata:
             metadata["json_path"] = file_metadata["json_path"]
+
+        if self.dataset_type is DatasetType.VIDEO:
+            fps = self._coerce_positive_number(json_metadata.get("fps"), float)
+            num_frames = self._coerce_positive_number(
+                json_metadata.get("frame", json_metadata.get("num_frames")),
+                int,
+            )
+            duration = self._coerce_positive_number(
+                json_metadata.get("seconds", json_metadata.get("duration")),
+                float,
+            )
+            if fps:
+                metadata["fps"] = fps
+            if num_frames:
+                metadata["num_frames"] = num_frames
+            if duration:
+                metadata["video_duration"] = duration
+            if "original_size" not in metadata:
+                probed = self._probe_video_metadata(sample_path)
+                for key, value in probed.items():
+                    metadata.setdefault(key, value)
         return metadata
 
     def _prepare_metadata(self, sample_path: str, sample_metadata: dict) -> Optional[tuple[float, dict]]:
@@ -249,7 +340,32 @@ class WebshartMetadataBackend(MetadataBackend):
                 "target_size": prepared_sample.target_size,
             }
         )
-        return round(aspect_ratio, 2), sample_metadata
+        if self.dataset_type is DatasetType.VIDEO and self.bucket_strategy == "resolution_frames":
+            target_width, target_height = prepared_sample.target_size
+            bucket_key, rounded_frames = self._compute_video_bucket(
+                target_width,
+                target_height,
+                sample_metadata["num_frames"],
+            )
+            sample_metadata["bucket_frames"] = rounded_frames
+        else:
+            bucket_key = round(aspect_ratio, 2)
+        return bucket_key, sample_metadata
+
+    def _entries_for_shard(self, shard_idx: int) -> list[dict]:
+        if self.dataset_type is not DatasetType.VIDEO:
+            shard_bucket_results = self.data_backend.list_shard_sample_aspect_buckets([shard_idx])
+            if not shard_bucket_results:
+                return []
+            shard_bucket_data = shard_bucket_results[0]
+            return [entry for entries in shard_bucket_data.get("buckets", {}).values() for entry in entries]
+
+        entries = []
+        for sample_idx, filename in enumerate(self.data_backend.dataset.list_samples_in_shard(shard_idx)):
+            if Path(filename).suffix.lower().strip(".") not in video_file_extensions:
+                continue
+            entries.append({"sample_idx": sample_idx, "filename": filename})
+        return entries
 
     def compute_aspect_ratio_bucket_indices(self, ignore_existing_cache: bool = False, progress_callback=None):
         logger.info("Building aspect ratio buckets from webshart metadata...")
@@ -296,61 +412,54 @@ class WebshartMetadataBackend(MetadataBackend):
             ):
                 break
 
-            shard_bucket_results = self.data_backend.list_shard_sample_aspect_buckets([shard_idx])
-            if not shard_bucket_results:
+            shard_entries = self._entries_for_shard(shard_idx)
+            if not shard_entries:
                 continue
-            shard_bucket_data = shard_bucket_results[0]
             shard_metadata = shard_metadata_cache.setdefault(shard_idx, self.data_backend.get_shard_metadata(shard_idx))
-            for entries in shard_bucket_data.get("buckets", {}).values():
-                for entry in entries:
-                    if (
-                        self.max_num_samples is not None
-                        and statistics["total_processed"] + len(existing_files) >= self.max_num_samples
-                    ):
-                        break
-                    processed_entries += 1
-                    try:
-                        filename = str(entry["filename"])
-                        entry = {**entry, "shard_idx": shard_idx}
-                        sample_path = self._sample_id_from_entry(shard_idx, entry)
-                        if sample_path in existing_files:
-                            continue
-
-                        sample_metadata = self._metadata_for_entry(shard_metadata, filename, entry)
-                        prepared = self._prepare_metadata(sample_path, sample_metadata)
-                        if prepared is None:
-                            if sample_metadata:
-                                statistics["skipped"]["too_small"] += 1
-                            else:
-                                statistics["skipped"]["metadata_missing"] += 1
-                            continue
-                        bucket_key, sample_metadata = prepared
-                        aspect_ratio_bucket_updates.setdefault(bucket_key, []).append(sample_path)
-                        metadata_updates[sample_path] = sample_metadata
-                        if sample_metadata.get("captions"):
-                            self.caption_cache[sample_path] = sample_metadata["captions"]
-                        statistics["total_processed"] += 1
-                    except Exception as exc:
-                        logger.error("Error processing webshart bucket entry %s: %s", entry, exc)
-                        statistics["skipped"]["error"] += 1
-
-                    current_time = time.time()
-                    if (current_time - last_save_time) >= self.metadata_update_interval:
-                        for key, value in aspect_ratio_bucket_updates.items():
-                            self.aspect_ratio_bucket_indices.setdefault(key, []).extend(value)
-                        aspect_ratio_bucket_updates = {}
-                        for path, metadata in metadata_updates.items():
-                            self.set_metadata_by_filepath(path, metadata, update_json=False)
-                        metadata_updates = {}
-                        self.save_cache(enforce_constraints=False)
-                        self.save_image_metadata()
-                        self._save_caption_cache()
-                        last_save_time = current_time
+            for entry in shard_entries:
                 if (
                     self.max_num_samples is not None
                     and statistics["total_processed"] + len(existing_files) >= self.max_num_samples
                 ):
                     break
+                processed_entries += 1
+                try:
+                    filename = str(entry["filename"])
+                    entry = {**entry, "shard_idx": shard_idx}
+                    sample_path = self._sample_id_from_entry(shard_idx, entry)
+                    if sample_path in existing_files:
+                        continue
+
+                    sample_metadata = self._metadata_for_entry(shard_metadata, filename, entry, sample_path)
+                    prepared = self._prepare_metadata(sample_path, sample_metadata)
+                    if prepared is None:
+                        if sample_metadata:
+                            statistics["skipped"]["too_small"] += 1
+                        else:
+                            statistics["skipped"]["metadata_missing"] += 1
+                        continue
+                    bucket_key, sample_metadata = prepared
+                    aspect_ratio_bucket_updates.setdefault(bucket_key, []).append(sample_path)
+                    metadata_updates[sample_path] = sample_metadata
+                    if sample_metadata.get("captions"):
+                        self.caption_cache[sample_path] = sample_metadata["captions"]
+                    statistics["total_processed"] += 1
+                except Exception as exc:
+                    logger.error("Error processing webshart bucket entry %s: %s", entry, exc)
+                    statistics["skipped"]["error"] += 1
+
+                current_time = time.time()
+                if (current_time - last_save_time) >= self.metadata_update_interval:
+                    for key, value in aspect_ratio_bucket_updates.items():
+                        self.aspect_ratio_bucket_indices.setdefault(key, []).extend(value)
+                    aspect_ratio_bucket_updates = {}
+                    for path, metadata in metadata_updates.items():
+                        self.set_metadata_by_filepath(path, metadata, update_json=False)
+                    metadata_updates = {}
+                    self.save_cache(enforce_constraints=False)
+                    self.save_image_metadata()
+                    self._save_caption_cache()
+                    last_save_time = current_time
             if progress_callback is not None:
                 progress_callback(shard_idx + 1, len(shard_indices))
 

--- a/simpletuner/helpers/metadata/backends/webshart.py
+++ b/simpletuner/helpers/metadata/backends/webshart.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -215,57 +216,81 @@ class WebshartMetadataBackend(MetadataBackend):
             return None
         return result if result > 0 else None
 
-    def _probe_video_metadata(self, sample_path: str) -> dict:
-        if shutil.which("ffprobe") is None:
-            return {}
+    @staticmethod
+    def _ffprobe_video_path(probe_path: str) -> dict:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=width,height,nb_frames,avg_frame_rate,r_frame_rate,duration",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "json",
+                probe_path,
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+        probe = json.loads(result.stdout) if result.stdout else {}
+        streams = probe.get("streams") or []
+        stream = streams[0] if streams else {}
+        width = WebshartMetadataBackend._coerce_positive_number(stream.get("width"), int)
+        height = WebshartMetadataBackend._coerce_positive_number(stream.get("height"), int)
+        metadata = {"original_size": (width, height)} if width and height else {}
 
-        payload = self.data_backend.read(sample_path)
-        if not payload:
+        num_frames = WebshartMetadataBackend._coerce_positive_number(stream.get("nb_frames"), int)
+        if num_frames:
+            metadata["num_frames"] = num_frames
+        duration = WebshartMetadataBackend._coerce_positive_number(
+            stream.get("duration") or (probe.get("format") or {}).get("duration"),
+            float,
+        )
+        if duration:
+            metadata["video_duration"] = duration
+        return metadata
+
+    def _probe_video_metadata(self, sample_path: str, file_metadata: Optional[dict] = None) -> dict:
+        if shutil.which("ffprobe") is None:
             return {}
 
         suffix = Path(self.data_backend.parse_sample_id(sample_path).filename).suffix or ".mp4"
         probe_path = None
         try:
+            range_reader = getattr(self.data_backend, "read_sample_head_tail", None)
+            if callable(range_reader):
+                try:
+                    head, tail, total_size = range_reader(sample_path, file_metadata=file_metadata)
+                    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as handle:
+                        probe_path = handle.name
+                        handle.truncate(total_size)
+                        handle.seek(0)
+                        handle.write(head)
+                        handle.seek(total_size - len(tail))
+                        handle.write(tail)
+                    metadata = self._ffprobe_video_path(probe_path)
+                    if metadata.get("original_size"):
+                        return metadata
+                except Exception as exc:
+                    logger.debug("Unable to range-probe Webshart video %s: %s", sample_path, exc)
+                finally:
+                    if probe_path:
+                        Path(probe_path).unlink(missing_ok=True)
+                        probe_path = None
+
+            payload = self.data_backend.read(sample_path)
+            if not payload:
+                return {}
             with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as handle:
                 handle.write(payload)
                 probe_path = handle.name
-            result = subprocess.run(
-                [
-                    "ffprobe",
-                    "-v",
-                    "error",
-                    "-select_streams",
-                    "v:0",
-                    "-show_entries",
-                    "stream=width,height,nb_frames,avg_frame_rate,r_frame_rate,duration",
-                    "-show_entries",
-                    "format=duration",
-                    "-of",
-                    "json",
-                    probe_path,
-                ],
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=30,
-            )
-            probe = json.loads(result.stdout) if result.stdout else {}
-            streams = probe.get("streams") or []
-            stream = streams[0] if streams else {}
-            width = self._coerce_positive_number(stream.get("width"), int)
-            height = self._coerce_positive_number(stream.get("height"), int)
-            metadata = {"original_size": (width, height)} if width and height else {}
-
-            num_frames = self._coerce_positive_number(stream.get("nb_frames"), int)
-            if num_frames:
-                metadata["num_frames"] = num_frames
-            duration = self._coerce_positive_number(
-                stream.get("duration") or (probe.get("format") or {}).get("duration"),
-                float,
-            )
-            if duration:
-                metadata["video_duration"] = duration
-            return metadata
+            return self._ffprobe_video_path(probe_path)
         except Exception as exc:
             logger.debug("Unable to probe Webshart video %s: %s", sample_path, exc)
             return {}
@@ -314,10 +339,23 @@ class WebshartMetadataBackend(MetadataBackend):
             if duration:
                 metadata["video_duration"] = duration
             if "original_size" not in metadata:
-                probed = self._probe_video_metadata(sample_path)
+                probed = self._probe_video_metadata(sample_path, file_metadata=file_metadata)
                 for key, value in probed.items():
                     metadata.setdefault(key, value)
         return metadata
+
+    def _prepare_bucket_entry(
+        self,
+        shard_metadata: dict,
+        entry: dict,
+        sample_path: str,
+    ) -> tuple[dict, Optional[tuple[float, dict]], Optional[Exception]]:
+        try:
+            filename = str(entry["filename"])
+            sample_metadata = self._metadata_for_entry(shard_metadata, filename, entry, sample_path)
+            return sample_metadata, self._prepare_metadata(sample_path, sample_metadata), None
+        except Exception as exc:
+            return {}, None, exc
 
     def _prepare_metadata(self, sample_path: str, sample_metadata: dict) -> Optional[tuple[float, dict]]:
         if not sample_metadata or "original_size" not in sample_metadata:
@@ -398,70 +436,101 @@ class WebshartMetadataBackend(MetadataBackend):
         metadata_updates: Dict[str, dict] = {}
         shard_metadata_cache: Dict[int, dict] = {}
         shard_indices = self._all_shard_indices()
+        worker_count = max(1, int(getattr(self.data_backend, "parallel_downloads", 1)))
+        executor = (
+            ThreadPoolExecutor(max_workers=worker_count)
+            if self.dataset_type is DatasetType.VIDEO and worker_count > 1
+            else None
+        )
 
-        for shard_idx in tqdm(
-            shard_indices,
-            desc="Processing webshart metadata",
-            total=len(shard_indices),
-            leave=False,
-            ncols=100,
-        ):
-            if (
-                self.max_num_samples is not None
-                and statistics["total_processed"] + len(existing_files) >= self.max_num_samples
+        try:
+            for shard_idx in tqdm(
+                shard_indices,
+                desc="Processing webshart metadata",
+                total=len(shard_indices),
+                leave=False,
+                ncols=100,
             ):
-                break
-
-            shard_entries = self._entries_for_shard(shard_idx)
-            if not shard_entries:
-                continue
-            shard_metadata = shard_metadata_cache.setdefault(shard_idx, self.data_backend.get_shard_metadata(shard_idx))
-            for entry in shard_entries:
                 if (
                     self.max_num_samples is not None
                     and statistics["total_processed"] + len(existing_files) >= self.max_num_samples
                 ):
                     break
-                processed_entries += 1
-                try:
-                    filename = str(entry["filename"])
+
+                shard_entries = self._entries_for_shard(shard_idx)
+                if not shard_entries:
+                    continue
+                shard_metadata = shard_metadata_cache.setdefault(shard_idx, self.data_backend.get_shard_metadata(shard_idx))
+                candidates = []
+                for entry in shard_entries:
                     entry = {**entry, "shard_idx": shard_idx}
                     sample_path = self._sample_id_from_entry(shard_idx, entry)
                     if sample_path in existing_files:
                         continue
+                    candidates.append((entry, sample_path))
 
-                    sample_metadata = self._metadata_for_entry(shard_metadata, filename, entry, sample_path)
-                    prepared = self._prepare_metadata(sample_path, sample_metadata)
-                    if prepared is None:
-                        if sample_metadata:
-                            statistics["skipped"]["too_small"] += 1
-                        else:
-                            statistics["skipped"]["metadata_missing"] += 1
-                        continue
-                    bucket_key, sample_metadata = prepared
-                    aspect_ratio_bucket_updates.setdefault(bucket_key, []).append(sample_path)
-                    metadata_updates[sample_path] = sample_metadata
-                    if sample_metadata.get("captions"):
-                        self.caption_cache[sample_path] = sample_metadata["captions"]
-                    statistics["total_processed"] += 1
-                except Exception as exc:
-                    logger.error("Error processing webshart bucket entry %s: %s", entry, exc)
-                    statistics["skipped"]["error"] += 1
+                chunk_size = max(1, worker_count * 2)
+                candidate_idx = 0
+                while candidate_idx < len(candidates):
+                    if (
+                        self.max_num_samples is not None
+                        and statistics["total_processed"] + len(existing_files) >= self.max_num_samples
+                    ):
+                        break
+                    remaining = (
+                        self.max_num_samples - statistics["total_processed"] - len(existing_files)
+                        if self.max_num_samples is not None
+                        else chunk_size
+                    )
+                    current_chunk_size = min(chunk_size, remaining)
+                    chunk = candidates[candidate_idx : candidate_idx + current_chunk_size]
+                    candidate_idx += len(chunk)
+                    if executor is None:
+                        results = [
+                            self._prepare_bucket_entry(shard_metadata, entry, sample_path) for entry, sample_path in chunk
+                        ]
+                    else:
+                        results = executor.map(
+                            lambda item: self._prepare_bucket_entry(shard_metadata, item[0], item[1]),
+                            chunk,
+                        )
 
-                current_time = time.time()
-                if (current_time - last_save_time) >= self.metadata_update_interval:
-                    for key, value in aspect_ratio_bucket_updates.items():
-                        self.aspect_ratio_bucket_indices.setdefault(key, []).extend(value)
-                    aspect_ratio_bucket_updates = {}
-                    for path, metadata in metadata_updates.items():
-                        self.set_metadata_by_filepath(path, metadata, update_json=False)
-                    metadata_updates = {}
-                    self.save_cache(enforce_constraints=False)
-                    self.save_image_metadata()
-                    self._save_caption_cache()
-                    last_save_time = current_time
-            if progress_callback is not None:
-                progress_callback(shard_idx + 1, len(shard_indices))
+                    for (entry, sample_path), (sample_metadata, prepared, error) in zip(chunk, results):
+                        processed_entries += 1
+                        if error is not None:
+                            logger.error("Error processing webshart bucket entry %s: %s", entry, error)
+                            statistics["skipped"]["error"] += 1
+                            continue
+                        if prepared is None:
+                            if sample_metadata:
+                                statistics["skipped"]["too_small"] += 1
+                            else:
+                                statistics["skipped"]["metadata_missing"] += 1
+                            continue
+                        bucket_key, sample_metadata = prepared
+                        aspect_ratio_bucket_updates.setdefault(bucket_key, []).append(sample_path)
+                        metadata_updates[sample_path] = sample_metadata
+                        if sample_metadata.get("captions"):
+                            self.caption_cache[sample_path] = sample_metadata["captions"]
+                        statistics["total_processed"] += 1
+
+                    current_time = time.time()
+                    if (current_time - last_save_time) >= self.metadata_update_interval:
+                        for key, value in aspect_ratio_bucket_updates.items():
+                            self.aspect_ratio_bucket_indices.setdefault(key, []).extend(value)
+                        aspect_ratio_bucket_updates = {}
+                        for path, metadata in metadata_updates.items():
+                            self.set_metadata_by_filepath(path, metadata, update_json=False)
+                        metadata_updates = {}
+                        self.save_cache(enforce_constraints=False)
+                        self.save_image_metadata()
+                        self._save_caption_cache()
+                        last_save_time = current_time
+                if progress_callback is not None:
+                    progress_callback(shard_idx + 1, len(shard_indices))
+        finally:
+            if executor is not None:
+                executor.shutdown(wait=True)
 
         for key, value in aspect_ratio_bucket_updates.items():
             self.aspect_ratio_bucket_indices.setdefault(key, []).extend(value)

--- a/simpletuner/helpers/utils/pathing.py
+++ b/simpletuner/helpers/utils/pathing.py
@@ -2,6 +2,13 @@ import os
 from urllib.parse import urlparse
 
 
+def canonicalize_data_uri(path: str) -> str:
+    """Repair URI identifiers that pathlib normalizes to a single slash."""
+    if path.startswith("webshart:/") and not path.startswith("webshart://"):
+        return f"webshart://{path[len('webshart:/') :]}"
+    return path
+
+
 def _is_uri(path: str) -> bool:
     if not isinstance(path, str):
         return False
@@ -14,6 +21,7 @@ def normalize_data_path(path: str, root: str | None = None) -> str:
     if not isinstance(path, str):
         return ""
 
+    path = canonicalize_data_uri(path)
     if _is_uri(path):
         return path
 

--- a/tests/test_backend_builders.py
+++ b/tests/test_backend_builders.py
@@ -726,6 +726,24 @@ class TestWebshartBackendBuilder(unittest.TestCase):
         self.assertEqual(Path(call_kwargs["cache_dir"]), expected_cache)
         self.assertEqual(Path(config.webshart_cache_dir), expected_cache)
 
+    @patch("simpletuner.helpers.data_backend.builders.webshart.WebshartDataBackend")
+    def test_build_preserves_zero_shard_cache_size(self, mock_webshart_backend_class):
+        mock_webshart_backend_class.return_value = Mock()
+        config = ImageBackendConfig.from_dict(
+            {
+                "id": "test_webshart",
+                "type": "webshart",
+                "source": "/datasets/shards",
+                "webshart": {"shard_cache_gb": 0},
+            },
+            self.args,
+        )
+
+        self.builder.build(config)
+
+        call_kwargs = mock_webshart_backend_class.call_args[1]
+        self.assertEqual(call_kwargs["shard_cache_gb"], 0)
+
     def test_validate_webshart_config_success(self):
         """Test Webshart config validation with valid configuration"""
         config = ImageBackendConfig.from_dict(

--- a/tests/test_factory_edge_cases.py
+++ b/tests/test_factory_edge_cases.py
@@ -1231,6 +1231,41 @@ class TestFactoryEdgeCases(unittest.TestCase):
                     apply_padding=expected,
                 )
 
+    def test_main_process_reloads_refreshed_bucket_cache_before_split(self):
+        from simpletuner.helpers.data_backend.factory import FactoryRegistry
+
+        self.accelerator.num_processes = 8
+        self.accelerator.is_main_process = True
+        self.accelerator.is_local_main_process = True
+        self.args.skip_file_discovery = ""
+        self.args.eval_dataset_id = None
+        self.args.max_train_steps = 100
+        self.args.allow_dataset_oversubscription = False
+        metadata_backend = MagicMock()
+        metadata_backend.aspect_ratio_bucket_indices = {"1.0": [f"sample-{index}" for index in range(8)]}
+        init_backend = {
+            "id": "train",
+            "config": {},
+            "dataset_type": "image",
+            "metadata_backend": metadata_backend,
+        }
+        factory = FactoryRegistry(
+            args=self.args,
+            accelerator=self.accelerator,
+            text_encoders=self.text_encoders,
+            tokenizers=self.tokenizers,
+            model=self.model,
+        )
+        factory._handle_config_versioning = MagicMock()
+
+        factory._handle_bucket_operations(
+            backend={"id": "train"},
+            init_backend=init_backend,
+            conditioning_type=None,
+        )
+
+        metadata_backend.reload_cache.assert_called_once_with()
+
     def test_image_embeds_backend_configuration(self):
         """Image embed configuration should not instantiate VAE cache directly."""
         from simpletuner.helpers.data_backend.factory import FactoryRegistry

--- a/tests/test_metadata_backend.py
+++ b/tests/test_metadata_backend.py
@@ -225,6 +225,20 @@ class TestMaxNumSamplesLimit(unittest.TestCase):
         self.assertEqual(result1, result2)
         self.assertEqual(result2, result3)
 
+    def test_max_num_samples_is_independent_of_discovery_order(self):
+        """Equivalent listings should produce the same bounded subset regardless of order."""
+        from simpletuner.helpers.metadata.backends.base import MetadataBackend
+
+        mock_backend = MagicMock(spec=MetadataBackend)
+        mock_backend.id = "ordered_sample_limit"
+        mock_backend.max_num_samples = 3
+        file_list = [f"image_{index}.jpg" for index in range(10)]
+
+        forward = MetadataBackend._apply_max_num_samples_limit(mock_backend, file_list)
+        reversed_order = MetadataBackend._apply_max_num_samples_limit(mock_backend, list(reversed(file_list)))
+
+        self.assertEqual(forward, reversed_order)
+
     def test_max_num_samples_different_ids_different_selection(self):
         """Different dataset IDs should produce different selections."""
         from simpletuner.helpers.metadata.backends.base import MetadataBackend
@@ -483,10 +497,7 @@ class TestDistributedBucketPadding(unittest.TestCase):
 
     def test_cp_padding_fills_empty_dp_shards_from_final_global_item(self):
         images = ["img0", "img1", "img2", "img3"]
-        shards = [
-            self._split_rank(images, rank, cp_size=2, apply_padding=True, repeats=1)
-            for rank in range(8)
-        ]
+        shards = [self._split_rank(images, rank, cp_size=2, apply_padding=True, repeats=1) for rank in range(8)]
 
         self.assertEqual([len(shard) for shard in shards], [1] * 8)
         self.assertEqual([item for shard in shards for item in shard], images + ["img3"] * 4)
@@ -511,6 +522,33 @@ class TestDistributedBucketPadding(unittest.TestCase):
 
         self.assertEqual([len(shard) for shard in shards], [1] * 8)
         self.assertEqual([item for shard in shards for item in shard], images)
+
+    def test_shuffled_split_is_independent_of_input_order(self):
+        images = [f"img{index:02d}" for index in range(16)]
+        shards = []
+        for rank in range(8):
+            rank_images = images if rank % 2 == 0 else list(reversed(images))
+            backend = self._backend(rank_images)
+            backend.accelerator.is_main_process = rank == 0
+            with (
+                patch.dict("os.environ", {"SIMPLETUNER_SHUFFLE_BUCKETS": "1"}),
+                patch.object(
+                    StateTracker,
+                    "get_args",
+                    return_value=SimpleNamespace(allow_dataset_oversubscription=False, seed=42),
+                ),
+                patch.object(StateTracker, "get_data_backend_config", return_value={}),
+                patch(
+                    "simpletuner.helpers.metadata.backends.base.get_cp_aware_dp_info",
+                    return_value=(8, rank, 1),
+                ),
+            ):
+                MetadataBackend.split_buckets_between_processes(backend)
+            shards.append(backend.aspect_ratio_bucket_indices["1.0"])
+
+        flattened = [item for shard in shards for item in shard]
+        self.assertEqual(len(flattened), len(images))
+        self.assertEqual(set(flattened), set(images))
 
     def test_padding_non_divisible_preserves_qr_boundaries(self):
         images = [f"img{index}" for index in range(10)]

--- a/tests/test_text_embeds.py
+++ b/tests/test_text_embeds.py
@@ -273,6 +273,40 @@ class TextEmbeddingCacheKeyTests(unittest.TestCase):
         )
         self.assertEqual(len(saved), 1)
 
+    @patch("simpletuner.helpers.caching.text_embeds.StateTracker.get_text_cache_files", return_value={})
+    def test_compute_embeddings_does_not_resplit_rank_local_records(self, _mock_cache_files):
+        cache = _make_cache(TextEmbedCacheKey.CAPTION)
+        cache.split_prompt_records_between_processes = MagicMock(return_value=[])
+        cache.save_to_cache = MagicMock()
+
+        class BatchModel(_DummyModel):
+            TEXT_ENCODER_CONFIGURATION = {"text_encoder": {}}
+
+            def __init__(self):
+                super().__init__(TextEmbedCacheKey.CAPTION)
+                self.encode_text_batch = MagicMock(
+                    side_effect=lambda prompts, **_kwargs: {
+                        "prompt_embeds": torch.ones(len(prompts), 2, 3),
+                        "attention_mask": torch.ones(len(prompts), 2, dtype=torch.bool),
+                    }
+                )
+
+        cache.model = BatchModel()
+
+        cache.compute_embeddings_for_prompts(
+            [
+                {"prompt": "rank-local one", "key": "one"},
+                {"prompt": "rank-local two", "key": "two"},
+            ],
+            return_concat=False,
+            load_from_cache=False,
+            split_between_processes=False,
+        )
+
+        cache.split_prompt_records_between_processes.assert_not_called()
+        self.assertEqual(cache.model.encode_text_batch.call_count, 2)
+        self.assertEqual(cache.save_to_cache.call_count, 2)
+
     def test_batched_encode_saves_trimmed_per_caption_outputs(self):
         cache = _make_cache(TextEmbedCacheKey.CAPTION)
         saved = []

--- a/tests/test_text_embeds.py
+++ b/tests/test_text_embeds.py
@@ -171,6 +171,14 @@ class TextEmbeddingCacheKeyTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             cache._resolve_cache_key_value(record)
 
+    def test_dataset_filename_hash_canonicalizes_path_normalized_webshart_uri(self):
+        cache = _make_cache(TextEmbedCacheKey.DATASET_AND_FILENAME)
+
+        canonical = cache.create_hash("dataset-1:webshart://0/3/sample.mp4")
+        path_normalized = cache.create_hash("dataset-1:webshart:/0/3/sample.mp4")
+
+        self.assertEqual(path_normalized, canonical)
+
     def test_normalize_prompts_infers_key_from_metadata(self):
         cache = _make_cache(TextEmbedCacheKey.DATASET_AND_FILENAME)
         record = {

--- a/tests/test_utils_pathing.py
+++ b/tests/test_utils_pathing.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from pathlib import Path
 
 from simpletuner.helpers.utils.pathing import normalize_data_path
 
@@ -18,6 +19,11 @@ class NormalizeDataPathTests(unittest.TestCase):
     def test_relative_with_root_returns_relative_to_root(self):
         result = normalize_data_path("subdir/img.png", "/dataset/root")
         self.assertEqual(result, os.path.normcase("subdir/img.png"))
+
+    def test_path_normalized_webshart_uri_is_canonicalized(self):
+        path_normalized_id = str(Path("webshart://0/3/sample.mp4"))
+
+        self.assertEqual(normalize_data_path(path_normalized_id), "webshart://0/3/sample.mp4")
 
 
 if __name__ == "__main__":

--- a/tests/test_webshart_backend.py
+++ b/tests/test_webshart_backend.py
@@ -11,6 +11,30 @@ from simpletuner.helpers.metadata.backends.webshart import WebshartMetadataBacke
 
 
 class TestWebshartDataBackend(unittest.TestCase):
+    @patch("simpletuner.helpers.data_backend.webshart.requests.get")
+    def test_read_sample_head_tail_uses_tar_member_ranges(self, requests_get):
+        head_response = Mock(status_code=206, content=b"head")
+        tail_response = Mock(status_code=206, content=b"tailtail")
+        requests_get.side_effect = [head_response, tail_response]
+        backend = WebshartDataBackend.__new__(WebshartDataBackend)
+        backend.hf_token = None
+        backend.dataset = Mock()
+        backend.dataset.get_shard_info.return_value = {"tar_path": "https://example.test/shard.tar"}
+        file_metadata = {"offset": 1000, "length": 200000}
+
+        head, tail, length = backend.read_sample_head_tail(
+            "webshart://2/7/sample.mp4",
+            file_metadata=file_metadata,
+            head_bytes=4,
+            tail_bytes=8,
+        )
+
+        self.assertEqual((head, tail, length), (b"head", b"tailtail", 200000))
+        self.assertEqual(requests_get.call_args_list[0].kwargs["headers"]["Range"], "bytes=1000-1003")
+        self.assertEqual(requests_get.call_args_list[1].kwargs["headers"]["Range"], "bytes=200992-200999")
+        head_response.close.assert_called_once()
+        tail_response.close.assert_called_once()
+
     def test_zero_shard_cache_size_disables_whole_shard_cache(self):
         dataset = Mock()
         loader = Mock()
@@ -128,6 +152,22 @@ class TestWebshartDataBackend(unittest.TestCase):
         self.assertEqual(metadata["fps"], 24.0)
         self.assertEqual(metadata["video_duration"], 2.67)
         self.assertEqual(metadata["captions"], "A moving subject.")
+
+    @patch("simpletuner.helpers.metadata.backends.webshart.shutil.which", return_value="/usr/bin/ffprobe")
+    def test_video_metadata_probe_prefers_sparse_range_payload(self, _which):
+        backend = WebshartMetadataBackend.__new__(WebshartMetadataBackend)
+        backend.data_backend = Mock()
+        backend.data_backend.parse_sample_id.return_value = Mock(filename="sample.mp4")
+        backend.data_backend.read_sample_head_tail.return_value = (b"head", b"tail", 1024 * 1024)
+        backend._ffprobe_video_path = Mock(return_value={"original_size": (1920, 1080), "num_frames": 64})
+
+        metadata = backend._probe_video_metadata("webshart://0/3/sample.mp4", file_metadata={"offset": 10})
+
+        self.assertEqual(metadata["original_size"], (1920, 1080))
+        backend.data_backend.read_sample_head_tail.assert_called_once_with(
+            "webshart://0/3/sample.mp4", file_metadata={"offset": 10}
+        )
+        backend.data_backend.read.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_webshart_backend.py
+++ b/tests/test_webshart_backend.py
@@ -1,10 +1,63 @@
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import Mock, patch
 
+import torch
+
+from simpletuner.helpers.data_backend.dataset_types import DatasetType
 from simpletuner.helpers.data_backend.webshart import WebshartDataBackend
+from simpletuner.helpers.metadata.backends.webshart import WebshartMetadataBackend
 
 
 class TestWebshartDataBackend(unittest.TestCase):
+    def test_zero_shard_cache_size_disables_whole_shard_cache(self):
+        dataset = Mock()
+        loader = Mock()
+        loader.list_shard_sample_aspect_buckets = Mock()
+        webshart = Mock()
+        webshart.discover_dataset.return_value = dataset
+        webshart.TarDataLoader.return_value = loader
+
+        with TemporaryDirectory() as cache_dir, patch.dict("sys.modules", {"webshart": webshart}):
+            backend = WebshartDataBackend(
+                accelerator=None,
+                id="range-reads-only",
+                source="source",
+                cache_dir=cache_dir,
+                shard_cache_gb=0,
+            )
+
+        self.assertIsNone(backend.shard_cache_dir)
+        dataset.enable_shard_cache.assert_not_called()
+
+    def test_compressed_torch_cache_round_trip_allows_internal_metadata(self):
+        with TemporaryDirectory() as cache_dir:
+            backend = WebshartDataBackend.__new__(WebshartDataBackend)
+            backend.cache_dir = cache_dir
+            backend.id = "cache-round-trip"
+            backend.compress_cache = True
+            value = {"latents": torch.ones(1), "metadata": "sample.mp4"}
+
+            backend.torch_save(value, "sample.pt")
+            loaded = backend.torch_load("sample.pt")
+
+        self.assertTrue(torch.equal(loaded["latents"], value["latents"]))
+        self.assertEqual(loaded["metadata"], value["metadata"])
+
+    def test_torch_cache_load_resets_uncompressed_fallback_stream(self):
+        with TemporaryDirectory() as cache_dir:
+            backend = WebshartDataBackend.__new__(WebshartDataBackend)
+            backend.cache_dir = cache_dir
+            backend.id = "cache-fallback"
+            backend.compress_cache = False
+            backend.torch_save(torch.ones(1), "sample.pt")
+
+            backend.compress_cache = True
+            loaded = backend.torch_load("sample.pt")
+
+        self.assertTrue(torch.equal(loaded, torch.ones(1)))
+
     def test_sample_id_round_trips_nested_filenames(self):
         sample_id = WebshartDataBackend.sample_id(2, 17, "nested/path/sample.webp")
 
@@ -14,9 +67,67 @@ class TestWebshartDataBackend(unittest.TestCase):
         self.assertEqual(ref.sample_idx, 17)
         self.assertEqual(ref.filename, "nested/path/sample.webp")
 
+    def test_path_normalized_sample_id_round_trips(self):
+        path_normalized_id = Path("webshart://2/17/nested/path/sample.mp4")
+
+        ref = WebshartDataBackend.parse_sample_id(path_normalized_id)
+
+        self.assertEqual(
+            WebshartDataBackend.normalize_sample_id(path_normalized_id),
+            "webshart://2/17/nested/path/sample.mp4",
+        )
+        self.assertTrue(WebshartDataBackend.is_sample_id(path_normalized_id))
+        self.assertEqual(ref.shard_idx, 2)
+        self.assertEqual(ref.sample_idx, 17)
+        self.assertEqual(ref.filename, "nested/path/sample.mp4")
+
     def test_parse_sample_id_rejects_non_webshart_identifier(self):
         with self.assertRaises(ValueError):
             WebshartDataBackend.parse_sample_id(Path("/tmp/sample.webp"))
+
+    @patch("simpletuner.helpers.data_backend.webshart.load_video")
+    def test_read_image_decodes_video_samples(self, load_video):
+        backend = WebshartDataBackend.__new__(WebshartDataBackend)
+        backend.dataset_type = DatasetType.VIDEO
+        backend.read = Mock(return_value=Mock())
+        load_video.return_value = "decoded-video"
+
+        result = backend.read_image("webshart://0/3/sample.mp4")
+
+        self.assertEqual(result, "decoded-video")
+        load_video.assert_called_once_with(backend.read.return_value)
+
+    def test_get_caption_uses_indexed_sample_metadata(self):
+        backend = WebshartDataBackend.__new__(WebshartDataBackend)
+        backend.get_shard_metadata = Mock(return_value={"sample.mp4": {"captions": "A moving subject."}})
+
+        caption = backend.get_caption("webshart://2/7/sample.mp4")
+
+        self.assertEqual(caption, "A moving subject.")
+
+    def test_video_metadata_uses_indexed_frame_fields_and_probe_geometry(self):
+        backend = WebshartMetadataBackend.__new__(WebshartMetadataBackend)
+        backend.dataset_type = DatasetType.VIDEO
+        backend._probe_video_metadata = Mock(return_value={"original_size": (1280, 720)})
+        shard_metadata = {
+            "sample.mp4": {
+                "captions": "A moving subject.",
+                "json_metadata": {"fps": 24.0, "frame": 64, "seconds": 2.67},
+            }
+        }
+
+        metadata = backend._metadata_for_entry(
+            shard_metadata,
+            "sample.mp4",
+            {"shard_idx": 0, "sample_idx": 3, "filename": "sample.mp4"},
+            "webshart://0/3/sample.mp4",
+        )
+
+        self.assertEqual(metadata["original_size"], (1280, 720))
+        self.assertEqual(metadata["num_frames"], 64)
+        self.assertEqual(metadata["fps"], 24.0)
+        self.assertEqual(metadata["video_duration"], 2.67)
+        self.assertEqual(metadata["captions"], "A moving subject.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the Webshart data backend and related caching, sharding, and embedding logic. The main focus is on enhancing deterministic shuffling and partitioning across distributed processes, improving sample and cache handling, and adding range-read support for large samples. There are also improvements to video sample handling and error handling for decompression and loading. Below are the most important changes:

### Webshart Data Backend Improvements

* Added a `read_sample_head_tail` method to `WebshartDataBackend` to efficiently range-read the head and tail of large samples from remote tar shards, supporting partial reads without loading the entire file.
* Improved sample ID normalization and detection to handle both canonical and path-normalized forms, ensuring consistent sample identification. [[1]](diffhunk://#diff-2d43dd2e148fb77ab38e8f439dea47f4b58980fa7a158fae05358d248217a961R34) [[2]](diffhunk://#diff-2d43dd2e148fb77ab38e8f439dea47f4b58980fa7a158fae05358d248217a961R127-R130) [[3]](diffhunk://#diff-2d43dd2e148fb77ab38e8f439dea47f4b58980fa7a158fae05358d248217a961L140-L143)
* Improved caption retrieval: now attempts to get the caption directly from sample metadata before looking for a companion `.txt` file.
* Added support for video sample loading by dispatching to the appropriate loader based on file extension.

### Caching, Sharding, and Distributed Consistency

* Deterministic shuffling: When applying a sample limit or shuffling bucket contents, input lists are now sorted before shuffling to guarantee all ranks see the same order, preventing inconsistencies due to cache reloads or builder differences. [[1]](diffhunk://#diff-05a1e3df70530b5a9bbf255a7a84fb8d7cd4c979c8b6a74b8180af877e387ff5L194-R194) [[2]](diffhunk://#diff-05a1e3df70530b5a9bbf255a7a84fb8d7cd4c979c8b6a74b8180af877e387ff5L886-R889)
* Improved distributed bucket partitioning: Ensures all processes partition the same serialized cache after main process bucket rebuilds, preventing mismatches between in-memory and reloaded orderings.

### Embedding and Prompt Handling

* Added a `split_between_processes` parameter to embedding computation functions, allowing explicit control over whether prompts are split for distributed processing. Used in factory code to ensure correct behavior during deferred or initial embedding computation. [[1]](diffhunk://#diff-f8ca30b914bf6067832f4dcd621fc3fcae30c785ac6daf7737f042f9448c4003R460) [[2]](diffhunk://#diff-f8ca30b914bf6067832f4dcd621fc3fcae30c785ac6daf7737f042f9448c4003R539) [[3]](diffhunk://#diff-f8ca30b914bf6067832f4dcd621fc3fcae30c785ac6daf7737f042f9448c4003R564-R570) [[4]](diffhunk://#diff-57615ebb58fa92a702515b29c5d3dcee1e1ac481ee2f71564229f128a28894feL3763-R3765) [[5]](diffhunk://#diff-57615ebb58fa92a702515b29c5d3dcee1e1ac481ee2f71564229f128a28894feL3881-R3886)
* Improved key normalization for dataset-and-filename keys by canonicalizing data URIs, ensuring cache consistency. [[1]](diffhunk://#diff-f8ca30b914bf6067832f4dcd621fc3fcae30c785ac6daf7737f042f9448c4003R22) [[2]](diffhunk://#diff-f8ca30b914bf6067832f4dcd621fc3fcae30c785ac6daf7737f042f9448c4003L132-R135)

### Configuration and Documentation

* Updated the documentation to clarify that setting `shard_cache_gb` to `0` disables whole-shard caching and enables indexed range reads.
* Added validation for `shard_cache_gb` to prevent negative values and ensure correct cache directory handling when disabled. [[1]](diffhunk://#diff-2d43dd2e148fb77ab38e8f439dea47f4b58980fa7a158fae05358d248217a961L72-R80) [[2]](diffhunk://#diff-2d43dd2e148fb77ab38e8f439dea47f4b58980fa7a158fae05358d248217a961L91-R98) [[3]](diffhunk://#diff-f6e2a7e397c07afd690e05363ca06df9e6966d803595a03c752bb06cfbca399bR32-R34) [[4]](diffhunk://#diff-f6e2a7e397c07afd690e05363ca06df9e6966d803595a03c752bb06cfbca399bL48-R51)

### Error Handling and Robustness

* Improved error handling for decompression: If decompression fails, the original data buffer is rewound and returned to prevent data loss.
* Ensured `torch.load` always seeks to the start of the buffer after decompression for reliable loading.

These changes collectively improve the reliability, determinism, and efficiency of data loading and processing in distributed training scenarios.