### PR TITLE
Fix AnyFlow objective implementation

### DIFF
--- a/documentation/experimental/ANYFLOW.es.md
+++ b/documentation/experimental/ANYFLOW.es.md
@@ -1,19 +1,17 @@
 # AnyFlow
 
-AnyFlow es un modo experimental de destilación para modelos de flow matching. Entrena el modelo con dos tiempos de flujo, el timestep normal `t` y un timestep de referencia menor `r`, para que aprenda un mapa de flujo sobre un intervalo en vez de solo una velocidad rectified-flow puntual.
+SimpleTuner implementa NVIDIA AnyFlow como dos etapas de entrenamiento explícitas para modelos de flow matching. Ambas
+etapas entrenan un modelo que recibe el tiempo de flujo actual `t` y un extremo de intervalo `r`.
 
-En SimpleTuner:
+- `stage=forward` implementa el objetivo forward MeanFlow de NVIDIA.
+- `stage=onpolicy` implementa Flow Map Backward Simulation y DMD on-policy mientras coentrena el objetivo forward.
 
-- `--distillation_method=anyflow` activa `AnyFlowDistiller`.
-- El distiller llama `enable_flowmap_time_conditioning()` en el componente entrenado durante el arranque.
-- Cada batch preparado recibe `flowmap_r_timesteps`.
-- El target normal se reemplaza por un target AnyFlow antes de calcular la pérdida.
+Los modos eliminados `online_teacher` y `linear` eran objetivos específicos de SimpleTuner y ya no se aceptan.
 
-AnyFlow es online en SimpleTuner. No requiere una caché ODE precalculada.
+Para un ejemplo de continuación Wan usando los checkpoints publicados por NVIDIA, consulta
+[Guía rápida de continuación AnyFlow](/documentation/quickstart/ANYFLOW.es.md).
 
-Para un ejemplo de continuación Wan usando los checkpoints AnyFlow publicados por NVIDIA, consulta [Guía rápida de continuación AnyFlow](/documentation/quickstart/ANYFLOW.es.md).
-
-## Configuración rápida
+## Etapa forward
 
 ```json
 {
@@ -21,10 +19,12 @@ Para un ejemplo de continuación Wan usando los checkpoints AnyFlow publicados p
   "distillation_method": "anyflow",
   "distillation_config": {
     "anyflow": {
-      "target_mode": "online_teacher",
-      "teacher_rollout_steps": 1,
-      "r_timestep_sampler": "uniform",
-      "min_interval_ratio": 0.02,
+      "stage": "forward",
+      "diffusion_ratio": 0.5,
+      "consistency_ratio": 0.25,
+      "central_difference_epsilon": 0.005,
+      "meanflow_weight_type": "beta08",
+      "meanflow_adaptive_weighting": true,
       "gate_value": 0.25,
       "deltatime_type": "r",
       "loss_weight": 1.0
@@ -33,37 +33,85 @@ Para un ejemplo de continuación Wan usando los checkpoints AnyFlow publicados p
 }
 ```
 
-El entrenamiento del text encoder está bloqueado para todos los métodos de destilación de SimpleTuner, incluido AnyFlow.
+Para cada batch global, la etapa forward:
 
-## Cómo funciona
+1. Muestrea dos tiempos de flujo uniformes y los ordena como `t >= r`.
+2. Asigna 50% de las muestras a intervalos de difusión (`r=t`), 25% a intervalos de endpoint (`r=0`) y el resto a intervalos arbitrarios.
+3. Aplica el flow shift del scheduler del modelo a ambos extremos.
+4. Evalúa una diferencia central a lo largo de la ruta latente recta.
+5. Construye el target tangente MeanFlow y aplica el weighting normalizado `beta08` de NVIDIA.
+6. Balancea cada muestra no-diffusion contra la media global de pérdida de la rama diffusion.
 
-Para cada batch de flow matching, SimpleTuner:
+## Etapa on-policy
 
-1. Usa el `prepare_batch()` normal para muestrear `sigmas`, `timesteps`, `noisy_latents` y el target base.
-2. Muestrea `r < t` dentro del intervalo actual.
-3. Escribe `flowmap_r_timesteps` en el batch para que el wrapper lo pase como `r_timestep`.
-4. Construye el target de entrenamiento.
-5. Deja que la pérdida normal compare la predicción contra ese target.
+Inicia esta etapa desde un adapter AnyFlow de etapa forward usando `init_lora` o reanudando su checkpoint:
 
-Con `target_mode=online_teacher`, el target es una velocidad media desde el latent ruidoso en `t` hacia `r`. En LoRA y LyCORIS, el distiller desactiva temporalmente el adapter para el rollout del teacher y lo reactiva después.
+```json
+{
+  "model_type": "lora",
+  "lora_type": "standard",
+  "init_lora": "path-or-repo-to-forward-anyflow-adapter",
+  "learning_rate": 0.000002,
+  "optimizer_beta1": 0.0,
+  "optimizer_beta2": 0.999,
+  "optimizer_weight_decay": 0.0,
+  "distillation_method": "anyflow",
+  "distillation_config": {
+    "anyflow": {
+      "stage": "onpolicy",
+      "cotrain_forward": true,
+      "rollout_step_counts": [2, 4, 8, 16, 50],
+      "dmd_weight": 1.0,
+      "dmd_batch_size": 1,
+      "real_score_guidance_scale": 0.0,
+      "discriminator_lr": 0.000002,
+      "discriminator_betas": [0.0, 0.999],
+      "discriminator_weight_decay": 0.0,
+      "discriminator_grad_clip": 1.0
+    }
+  }
+}
+```
 
-Con `target_mode=linear`, no se usa rollout del teacher. El target es `noise - latents`. Sirve para smoke tests y ablaciones, pero no es el objetivo completo de mapa AnyFlow.
+La etapa on-policy usa tres roles de score. El entrenamiento LoRA estándar comparte un transformer base congelado entre ellos:
 
-## Opciones
+- El adapter AnyFlow cargado es el generador.
+- El modelo base con adapters desactivados es el score real congelado.
+- Un adapter `anyflow_discriminator` optimizado por separado es el score fake.
 
-- `target_mode`: `online_teacher` o `linear`. Predeterminado: `online_teacher`.
-- `teacher_rollout_steps`: pasos Euler online entre `t` y `r`. Predeterminado: `1`.
-- `r_timestep_sampler`: `uniform` o `zero`. Predeterminado: `uniform`.
-- `min_interval_ratio`: intervalo normalizado mínimo entre `t` y `r`. Predeterminado: `0.02`.
-- `gate_value`: peso de mezcla para el embedding delta FlowMap. Predeterminado: `0.25`.
+Cada actualización del generador selecciona un presupuesto de rollout de `rollout_step_counts`, ejecuta un rollout
+FlowMap diferenciable, añade ruido al latent generado en un tiempo uniforme desplazado y aplica el gradiente DMD
+normalizado de NVIDIA. Cada actualización del discriminador ejecuta un rollout del student sin gradientes, muestrea un
+tiempo desplazado logit-normal y entrena el score fake sobre el target flow normal. El adapter y optimizador del
+discriminador se guardan junto a cada checkpoint de SimpleTuner como `anyflow_discriminator.safetensors` y
+`anyflow_discriminator_optim.pt`.
+
+MiniMax-H3 ya contiene destilación CFG, por lo que sus ejecuciones on-policy normalmente deben mantener
+`real_score_guidance_scale=0`. Los modelos que requieren una pasada CFG externa para el score real deben cachear
+embeddings de texto negativos y pueden configurar la escala explícitamente.
+
+## Configuración compartida
+
+- `stage`: `forward` u `onpolicy`. Predeterminado: `forward`.
+- `diffusion_ratio`: fracción del batch global que usa `r=t`. Predeterminado: `0.5`.
+- `consistency_ratio`: fracción del batch global que usa `r=0`. Predeterminado: `0.25`.
+- `central_difference_epsilon`: offset normalizado en tiempo desplazado. Predeterminado: `0.005`, igual a `5/1000` de NVIDIA.
+- `meanflow_weight_type`: `beta08` o `uniform`. Predeterminado: `beta08`.
+- `meanflow_adaptive_weighting`: balancea muestras no-diffusion contra la rama diffusion. Predeterminado: `true`.
+- `gate_value`: mezcla del embedding delta-timestep FlowMap. Predeterminado: `0.25`.
 - `deltatime_type`: `r` o `t-r`. Predeterminado: `r`.
-- `loss_weight`: multiplicador de la pérdida ya calculada. Predeterminado: `1.0`.
-- `timestep_scale`: override para modelos con escala de timestep personalizada. Déjalo sin definir normalmente.
+- `loss_weight`: multiplicador de la pérdida forward MeanFlow. Predeterminado: `1.0`.
 
 ## Límites
 
-- Requiere un modelo flow-matching.
-- Requiere timesteps escalares por muestra. Los intervalos tokenwise aún no están cableados.
-- Requiere `r_timestep < timestep`; timestep cero se rechaza.
-- El modo online teacher actual está pensado para LoRA/LyCORIS. Full-rank online teacher necesita cableado separado de student/teacher.
-- La validación está conectada mediante el hook de scheduler del distiller AnyFlow. El scheduler activo del pipeline se proxifica, y el transformer/UNet de validación recibe el siguiente extremo del intervalo como `r_timestep` o `timestep_r`. Esto cubre los pipelines de validación registrados con soporte FlowMap; las rutas de validación custom o externas aún deben pasar el kwarg de timestep FlowMap por su cuenta.
+- AnyFlow requiere un modelo flow-matching con conditioning de intervalo FlowMap específico del modelo.
+- El entrenamiento on-policy actualmente requiere LoRA PEFT estándar. Compartir la base evita asignar copias del generador, score real y discriminador de un transformer grande en cada rank DDP.
+- El entrenamiento MiniMax-H3 audio-video conjunto se rechaza. Video usa schedule shift 12 y audio usa shift 3; se necesitan targets MeanFlow y rollouts nativos de doble schedule antes de que el entrenamiento AV sea válido.
+- El entrenamiento del text encoder está desactivado para todos los métodos de destilación de SimpleTuner.
+- La validación usa `AnyFlowValidationScheduler`, que suministra el siguiente endpoint de intervalo a los componentes FlowMap registrados.
+
+## Logs
+
+El entrenamiento forward añade `anyflow_forward_loss`, valores de timestep e intervalo, y fracciones globales de rama.
+El entrenamiento on-policy también añade `anyflow_dmd_loss`, `anyflow_dmd_gradient_norm`, `anyflow_dmd_sigma` y
+`anyflow_rollout_steps`.

--- a/documentation/experimental/ANYFLOW.hi.md
+++ b/documentation/experimental/ANYFLOW.hi.md
@@ -1,19 +1,17 @@
 # AnyFlow
 
-AnyFlow flow-matching models के लिए experimental distillation mode है। यह model को दो flow times पर condition करता है: normal timestep `t` और उससे छोटा reference timestep `r`, ताकि model सिर्फ single rectified-flow velocity नहीं, बल्कि interval पर flow map सीखे।
+SimpleTuner NVIDIA AnyFlow को flow-matching models के लिए दो स्पष्ट training stages के रूप में implement करता है। दोनों
+stages ऐसे model को train करते हैं जो current flow time `t` और interval endpoint `r` प्राप्त करता है।
 
-SimpleTuner में:
+- `stage=forward` NVIDIA का forward MeanFlow objective implement करता है।
+- `stage=onpolicy` forward objective को co-train करते हुए Flow Map Backward Simulation और on-policy DMD implement करता है।
 
-- `--distillation_method=anyflow` `AnyFlowDistiller` चालू करता है।
-- distiller startup पर trained component में `enable_flowmap_time_conditioning()` call करता है।
-- हर prepared batch में `flowmap_r_timesteps` जोड़ा जाता है।
-- normal target को model loss से पहले AnyFlow target से replace किया जाता है।
+हटाए गए `online_teacher` और `linear` target modes SimpleTuner-specific objectives थे और अब accept नहीं किए जाते।
 
-SimpleTuner में AnyFlow online है। इसे precomputed ODE cache की जरूरत नहीं है।
+NVIDIA के released checkpoints के साथ Wan continuation example के लिए
+[AnyFlow Continuation Quickstart](/documentation/quickstart/ANYFLOW.hi.md) देखें।
 
-NVIDIA के released AnyFlow checkpoints के साथ Wan continuation example के लिए [AnyFlow continuation quickstart](/documentation/quickstart/ANYFLOW.hi.md) देखें।
-
-## Quick Setup
+## Forward Stage
 
 ```json
 {
@@ -21,10 +19,12 @@ NVIDIA के released AnyFlow checkpoints के साथ Wan continuation exa
   "distillation_method": "anyflow",
   "distillation_config": {
     "anyflow": {
-      "target_mode": "online_teacher",
-      "teacher_rollout_steps": 1,
-      "r_timestep_sampler": "uniform",
-      "min_interval_ratio": 0.02,
+      "stage": "forward",
+      "diffusion_ratio": 0.5,
+      "consistency_ratio": 0.25,
+      "central_difference_epsilon": 0.005,
+      "meanflow_weight_type": "beta08",
+      "meanflow_adaptive_weighting": true,
       "gate_value": 0.25,
       "deltatime_type": "r",
       "loss_weight": 1.0
@@ -33,37 +33,82 @@ NVIDIA के released AnyFlow checkpoints के साथ Wan continuation exa
 }
 ```
 
-SimpleTuner के सभी distillation methods की तरह AnyFlow के साथ text encoder training blocked है।
+हर global batch के लिए forward stage:
 
-## कैसे काम करता है
+1. दो uniform flow times sample करता है और उन्हें `t >= r` में sort करता है।
+2. 50% samples को diffusion intervals (`r=t`), 25% को endpoint intervals (`r=0`), और बाकी को arbitrary intervals देता है।
+3. दोनों endpoints पर model scheduler का flow shift apply करता है।
+4. straight latent flow path पर central difference evaluate करता है।
+5. MeanFlow tangent target बनाता है और NVIDIA का normalized `beta08` timestep weighting apply करता है।
+6. हर non-diffusion sample को global diffusion-branch loss mean के विरुद्ध balance करता है।
 
-हर flow-matching batch के लिए SimpleTuner:
+## On-Policy Stage
 
-1. normal `prepare_batch()` से `sigmas`, `timesteps`, `noisy_latents`, और base flow target बनाता है।
-2. current interval से `r < t` sample करता है।
-3. batch में `flowmap_r_timesteps` लिखता है ताकि model wrapper इसे `r_timestep` की तरह pass करे।
-4. training target बनाता है।
-5. normal model loss से prediction को target से compare करता है।
+इस stage को forward-stage AnyFlow adapter से `init_lora` सेट करके या उसका checkpoint resume करके शुरू करें:
 
-`target_mode=online_teacher` में target, `t` पर current noisy latent से `r` की ओर average velocity होता है। LoRA और LyCORIS training में distiller teacher rollout के लिए adapter temporarily disable करता है और बाद में enable करता है।
+```json
+{
+  "model_type": "lora",
+  "lora_type": "standard",
+  "init_lora": "path-or-repo-to-forward-anyflow-adapter",
+  "learning_rate": 0.000002,
+  "optimizer_beta1": 0.0,
+  "optimizer_beta2": 0.999,
+  "optimizer_weight_decay": 0.0,
+  "distillation_method": "anyflow",
+  "distillation_config": {
+    "anyflow": {
+      "stage": "onpolicy",
+      "cotrain_forward": true,
+      "rollout_step_counts": [2, 4, 8, 16, 50],
+      "dmd_weight": 1.0,
+      "dmd_batch_size": 1,
+      "real_score_guidance_scale": 0.0,
+      "discriminator_lr": 0.000002,
+      "discriminator_betas": [0.0, 0.999],
+      "discriminator_weight_decay": 0.0,
+      "discriminator_grad_clip": 1.0
+    }
+  }
+}
+```
 
-`target_mode=linear` में teacher rollout नहीं होता। target straight flow target `noise - latents` होता है। यह smoke tests और ablations के लिए उपयोगी है, लेकिन full AnyFlow teacher-map objective नहीं है।
+on-policy stage तीन score roles इस्तेमाल करता है। Standard LoRA training इनके बीच एक frozen base transformer share करती है:
 
-## Options
+- loaded AnyFlow adapter generator है।
+- adapters disabled वाला base model frozen real score है।
+- अलग से optimized `anyflow_discriminator` adapter fake score है।
 
-- `target_mode`: `online_teacher` या `linear`। Default: `online_teacher`.
-- `teacher_rollout_steps`: `t` और `r` के बीच online teacher Euler steps। Default: `1`.
-- `r_timestep_sampler`: `uniform` या `zero`। Default: `uniform`.
-- `min_interval_ratio`: `t` और `r` के बीच minimum normalized interval। Default: `0.02`.
-- `gate_value`: FlowMap delta timestep embedding blend weight। Default: `0.25`.
-- `deltatime_type`: `r` या `t-r`। Default: `r`.
-- `loss_weight`: computed training loss multiplier। Default: `1.0`.
-- `timestep_scale`: custom timestep scale वाले models के लिए override। Normal use में unset रखें।
+हर generator update `rollout_step_counts` से rollout budget चुनता है, differentiable FlowMap rollout चलाता है, shifted uniform
+time पर generated latent में noise जोड़ता है, और NVIDIA का normalized DMD gradient apply करता है। हर discriminator update
+no-grad student rollout चलाता है, logit-normal shifted time sample करता है, और normal flow target पर fake score train करता
+है। discriminator adapter और optimizer हर SimpleTuner checkpoint के साथ `anyflow_discriminator.safetensors` और
+`anyflow_discriminator_optim.pt` के रूप में save होते हैं।
+
+MiniMax-H3 में पहले से CFG distillation है, इसलिए इसके on-policy runs में आम तौर पर `real_score_guidance_scale=0` रखा जाना चाहिए।
+जिन models को external real-score CFG pass चाहिए, उन्हें negative text embeddings cache करने होंगे और scale explicitly set किया जा सकता है।
+
+## Shared Configuration
+
+- `stage`: `forward` या `onpolicy`। Default: `forward`।
+- `diffusion_ratio`: `r=t` use करने वाला global batch fraction। Default: `0.5`।
+- `consistency_ratio`: `r=0` use करने वाला global batch fraction। Default: `0.25`।
+- `central_difference_epsilon`: normalized shifted-time offset। Default: `0.005`, NVIDIA के `5/1000` से matching।
+- `meanflow_weight_type`: `beta08` या `uniform`। Default: `beta08`।
+- `meanflow_adaptive_weighting`: non-diffusion samples को diffusion branch के विरुद्ध balance करता है। Default: `true`।
+- `gate_value`: FlowMap delta-timestep embedding blend। Default: `0.25`।
+- `deltatime_type`: `r` या `t-r`। Default: `r`।
+- `loss_weight`: forward MeanFlow loss multiplier। Default: `1.0`।
 
 ## Limits
 
-- flow-matching model चाहिए।
-- scalar per-sample timesteps चाहिए। Tokenwise AnyFlow intervals अभी wired नहीं हैं।
-- `r_timestep < timestep` चाहिए; timestep zero reject होता है।
-- current online teacher mode LoRA/LyCORIS के लिए है। Full-rank online teacher के लिए अलग student/teacher wiring चाहिए।
-- validation अब AnyFlow distiller scheduler hook से wired है। active pipeline scheduler proxy होता है, और validation transformer/UNet को अगला interval endpoint `r_timestep` या `timestep_r` के रूप में मिलता है। registered FlowMap-capable validation pipelines covered हैं; custom या external validation paths को FlowMap timestep kwarg खुद pass करना होगा।
+- AnyFlow को model-specific FlowMap interval conditioning वाला flow-matching model चाहिए।
+- on-policy training अभी standard PEFT LoRA मांगता है। Base share करने से हर DDP rank पर generator, real-score, और discriminator के बड़े transformer copies allocate नहीं होते।
+- Joint MiniMax-H3 audio-video training reject की जाती है। Video schedule shift 12 use करता है और audio shift 3; AV training valid होने से पहले native dual-schedule MeanFlow targets और rollouts implement करने होंगे।
+- Text encoder training SimpleTuner के सभी distillation methods में disabled है।
+- Validation `AnyFlowValidationScheduler` use करता है, जो registered FlowMap model components को अगला interval endpoint देता है।
+
+## Logs
+
+Forward training `anyflow_forward_loss`, timestep और interval values, और global branch fractions जोड़ती है। On-policy
+training `anyflow_dmd_loss`, `anyflow_dmd_gradient_norm`, `anyflow_dmd_sigma`, और `anyflow_rollout_steps` भी जोड़ती है।

--- a/documentation/experimental/ANYFLOW.ja.md
+++ b/documentation/experimental/ANYFLOW.ja.md
@@ -1,19 +1,17 @@
 # AnyFlow
 
-AnyFlow は flow-matching モデル向けの実験的な distillation モードです。通常の training timestep `t` と、それより小さい reference timestep `r` の 2 つで条件付けし、単一の rectified-flow velocity ではなく interval 上の flow map を学習します。
+SimpleTuner は NVIDIA AnyFlow を、flow-matching モデル向けの 2 つの明示的な training stage として実装します。どちらの
+stage でも、現在の flow time `t` と interval endpoint `r` を受け取るモデルを学習します。
 
-SimpleTuner では次のように動作します。
+- `stage=forward` は NVIDIA の forward MeanFlow objective を実装します。
+- `stage=onpolicy` は forward objective を co-train しながら、Flow Map Backward Simulation と on-policy DMD を実装します。
 
-- `--distillation_method=anyflow` で `AnyFlowDistiller` を有効化します。
-- distiller は起動時に trained component の `enable_flowmap_time_conditioning()` を呼びます。
-- 各 prepared batch に `flowmap_r_timesteps` を追加します。
-- 通常の target を AnyFlow target に置き換えてから model loss を計算します。
+削除された `online_teacher` と `linear` target mode は SimpleTuner 固有の objective で、現在は受け付けません。
 
-SimpleTuner の AnyFlow は online です。事前計算された ODE cache は不要です。
+NVIDIA が公開した checkpoint を使った Wan continuation の例は
+[AnyFlow Continuation Quickstart](/documentation/quickstart/ANYFLOW.ja.md) を参照してください。
 
-NVIDIA が公開した AnyFlow checkpoints を使う Wan continuation example は [AnyFlow 継続学習クイックスタート](/documentation/quickstart/ANYFLOW.ja.md) を参照してください。
-
-## Quick Setup
+## Forward Stage
 
 ```json
 {
@@ -21,10 +19,12 @@ NVIDIA が公開した AnyFlow checkpoints を使う Wan continuation example �
   "distillation_method": "anyflow",
   "distillation_config": {
     "anyflow": {
-      "target_mode": "online_teacher",
-      "teacher_rollout_steps": 1,
-      "r_timestep_sampler": "uniform",
-      "min_interval_ratio": 0.02,
+      "stage": "forward",
+      "diffusion_ratio": 0.5,
+      "consistency_ratio": 0.25,
+      "central_difference_epsilon": 0.005,
+      "meanflow_weight_type": "beta08",
+      "meanflow_adaptive_weighting": true,
       "gate_value": 0.25,
       "deltatime_type": "r",
       "loss_weight": 1.0
@@ -33,37 +33,82 @@ NVIDIA が公開した AnyFlow checkpoints を使う Wan continuation example �
 }
 ```
 
-AnyFlow を含む SimpleTuner の distillation methods では text encoder training は使えません。
+各 global batch で、forward stage は次を行います。
 
-## 仕組み
+1. 2 つの一様な flow time をサンプリングし、`t >= r` になるように並べます。
+2. サンプルの 50% を diffusion interval (`r=t`)、25% を endpoint interval (`r=0`)、残りを arbitrary interval に割り当てます。
+3. 両方の endpoint にモデル scheduler の flow shift を適用します。
+4. 直線 latent flow path に沿って central difference を評価します。
+5. MeanFlow tangent target を構築し、NVIDIA の正規化された `beta08` timestep weighting を適用します。
+6. 非 diffusion サンプルを global diffusion-branch loss mean に対してバランスします。
 
-flow-matching batch ごとに SimpleTuner は次を行います。
+## On-Policy Stage
 
-1. 通常の `prepare_batch()` で `sigmas`, `timesteps`, `noisy_latents`, base flow target を作ります。
-2. 現在の interval から `r < t` をサンプルします。
-3. model wrapper が `r_timestep` として渡せるように `flowmap_r_timesteps` を batch に書き込みます。
-4. training target を構築します。
-5. 通常の model loss で prediction と target を比較します。
+`init_lora` を設定するか checkpoint から resume して、forward-stage AnyFlow adapter からこの stage を開始します。
 
-`target_mode=online_teacher` では、target は `t` の noisy latent から `r` へ向かう平均 velocity です。LoRA / LyCORIS では teacher rollout 中だけ adapter を無効化し、その後で再度有効化します。
+```json
+{
+  "model_type": "lora",
+  "lora_type": "standard",
+  "init_lora": "path-or-repo-to-forward-anyflow-adapter",
+  "learning_rate": 0.000002,
+  "optimizer_beta1": 0.0,
+  "optimizer_beta2": 0.999,
+  "optimizer_weight_decay": 0.0,
+  "distillation_method": "anyflow",
+  "distillation_config": {
+    "anyflow": {
+      "stage": "onpolicy",
+      "cotrain_forward": true,
+      "rollout_step_counts": [2, 4, 8, 16, 50],
+      "dmd_weight": 1.0,
+      "dmd_batch_size": 1,
+      "real_score_guidance_scale": 0.0,
+      "discriminator_lr": 0.000002,
+      "discriminator_betas": [0.0, 0.999],
+      "discriminator_weight_decay": 0.0,
+      "discriminator_grad_clip": 1.0
+    }
+  }
+}
+```
 
-`target_mode=linear` では teacher rollout を使いません。target は straight flow target の `noise - latents` です。smoke test や ablation には便利ですが、完全な AnyFlow teacher-map objective ではありません。
+on-policy stage は 3 つの score role を使います。標準 LoRA training では、凍結された base transformer をそれらの間で共有します。
 
-## Options
+- 読み込まれた AnyFlow adapter が generator です。
+- adapter を無効にした base model が凍結 real score です。
+- 別途最適化される `anyflow_discriminator` adapter が fake score です。
 
-- `target_mode`: `online_teacher` または `linear`。既定値: `online_teacher`。
-- `teacher_rollout_steps`: `t` から `r` までの online teacher Euler step 数。既定値: `1`。
-- `r_timestep_sampler`: `uniform` または `zero`。既定値: `uniform`。
-- `min_interval_ratio`: `t` と `r` の最小 normalized interval。既定値: `0.02`。
-- `gate_value`: FlowMap delta timestep embedding の blend weight。既定値: `0.25`。
-- `deltatime_type`: `r` または `t-r`。既定値: `r`。
-- `loss_weight`: 計算済み training loss への倍率。既定値: `1.0`。
-- `timestep_scale`: custom timestep scale 用の override。通常は未設定にします。
+各 generator update は `rollout_step_counts` から rollout budget を選び、微分可能な FlowMap rollout を実行し、shifted uniform
+time で生成 latent に noise を加え、NVIDIA の正規化 DMD gradient を適用します。各 discriminator update は no-grad student
+rollout を実行し、logit-normal shifted time をサンプリングして、通常の flow target で fake score を学習します。discriminator
+adapter と optimizer は、各 SimpleTuner checkpoint の横に `anyflow_discriminator.safetensors` と
+`anyflow_discriminator_optim.pt` として保存されます。
+
+MiniMax-H3 はすでに CFG distillation を含むため、on-policy run では通常 `real_score_guidance_scale=0` のままにします。
+外部 real-score CFG pass が必要なモデルでは negative text embeddings を cache し、scale を明示的に設定できます。
+
+## 共通設定
+
+- `stage`: `forward` または `onpolicy`。デフォルト: `forward`。
+- `diffusion_ratio`: `r=t` を使う global batch fraction。デフォルト: `0.5`。
+- `consistency_ratio`: `r=0` を使う global batch fraction。デフォルト: `0.25`。
+- `central_difference_epsilon`: 正規化された shifted-time offset。デフォルト: NVIDIA の `5/1000` に対応する `0.005`。
+- `meanflow_weight_type`: `beta08` または `uniform`。デフォルト: `beta08`。
+- `meanflow_adaptive_weighting`: 非 diffusion サンプルを diffusion branch に対してバランスします。デフォルト: `true`。
+- `gate_value`: FlowMap delta-timestep embedding の blend。デフォルト: `0.25`。
+- `deltatime_type`: `r` または `t-r`。デフォルト: `r`。
+- `loss_weight`: forward MeanFlow loss multiplier。デフォルト: `1.0`。
 
 ## 制限
 
-- flow-matching model が必要です。
-- sample ごとの scalar timestep が必要です。Tokenwise AnyFlow interval はまだ未対応です。
-- `r_timestep < timestep` が必要です。timestep zero は拒否されます。
-- 現在の online teacher mode は LoRA / LyCORIS 向けです。Full-rank online teacher には別の student/teacher wiring が必要です。
-- validation は AnyFlow distiller の scheduler hook で接続されています。active pipeline scheduler は proxy され、validation transformer/UNet には次の interval endpoint が `r_timestep` または `timestep_r` として渡されます。registered FlowMap-capable validation pipelines はこの経路で動作します。custom/external validation path では FlowMap timestep kwarg を自前で渡す必要があります。
+- AnyFlow には、モデル固有の FlowMap interval conditioning を持つ flow-matching model が必要です。
+- on-policy training は現在、標準 PEFT LoRA が必要です。base を共有することで、各 DDP rank に generator、real-score、discriminator の大型 transformer コピーを割り当てずに済みます。
+- MiniMax-H3 の joint audio-video training は拒否されます。video は schedule shift 12、audio は shift 3 を使うため、AV training を有効にするには native dual-schedule MeanFlow target と rollout の実装が必要です。
+- text encoder training は SimpleTuner のすべての distillation method で無効です。
+- validation は `AnyFlowValidationScheduler` を使い、登録済み FlowMap model component に次の interval endpoint を渡します。
+
+## Logs
+
+Forward training は `anyflow_forward_loss`、timestep と interval の値、global branch fraction を追加します。On-policy training
+ではさらに `anyflow_dmd_loss`、`anyflow_dmd_gradient_norm`、`anyflow_dmd_sigma`、`anyflow_rollout_steps` が追加されます。

--- a/documentation/experimental/ANYFLOW.md
+++ b/documentation/experimental/ANYFLOW.md
@@ -1,19 +1,18 @@
 # AnyFlow
 
-AnyFlow is an experimental distillation mode for flow-matching models. It trains the model to condition on a pair of flow times, the normal training timestep `t` and a lower reference timestep `r`, so the network learns a flow map across an interval instead of only a single rectified-flow velocity.
+SimpleTuner implements NVIDIA AnyFlow as two explicit training stages for flow-matching models. Both stages train a
+model that receives the current flow time `t` and an interval endpoint `r`.
 
-SimpleTuner implements this through the existing FlowMap model hooks:
+- `stage=forward` implements NVIDIA's forward MeanFlow objective.
+- `stage=onpolicy` implements Flow Map Backward Simulation and on-policy DMD while co-training the forward objective.
 
-- `--distillation_method=anyflow` enables the `AnyFlowDistiller`.
-- The distiller calls `enable_flowmap_time_conditioning()` on the trained component during startup.
-- Each prepared batch receives `flowmap_r_timesteps`.
-- The normal training target is replaced with an AnyFlow target before the model loss is computed.
+The removed `online_teacher` and `linear` target modes were SimpleTuner-specific objectives and are no longer
+accepted.
 
-AnyFlow is online in SimpleTuner. It does not require a precomputed ODE cache.
+For a Wan continuation example using NVIDIA's released checkpoints, see
+[AnyFlow Continuation Quickstart](/documentation/quickstart/ANYFLOW.md).
 
-For a Wan continuation example using NVIDIA's released AnyFlow checkpoints, see [AnyFlow Continuation Quickstart](/documentation/quickstart/ANYFLOW.md).
-
-## Quick Setup
+## Forward Stage
 
 ```json
 {
@@ -21,10 +20,12 @@ For a Wan continuation example using NVIDIA's released AnyFlow checkpoints, see 
   "distillation_method": "anyflow",
   "distillation_config": {
     "anyflow": {
-      "target_mode": "online_teacher",
-      "teacher_rollout_steps": 1,
-      "r_timestep_sampler": "uniform",
-      "min_interval_ratio": 0.02,
+      "stage": "forward",
+      "diffusion_ratio": 0.5,
+      "consistency_ratio": 0.25,
+      "central_difference_epsilon": 0.005,
+      "meanflow_weight_type": "beta08",
+      "meanflow_adaptive_weighting": true,
       "gate_value": 0.25,
       "deltatime_type": "r",
       "loss_weight": 1.0
@@ -33,58 +34,88 @@ For a Wan continuation example using NVIDIA's released AnyFlow checkpoints, see 
 }
 ```
 
-Text encoder training is blocked for all SimpleTuner distillation methods, including AnyFlow.
+For each global batch, the forward stage:
 
-## How It Works
+1. Samples two uniform flow times and sorts them into `t >= r`.
+2. Assigns 50% of samples to diffusion intervals (`r=t`), 25% to endpoint intervals (`r=0`), and the remainder to
+   arbitrary intervals.
+3. Applies the model scheduler's flow shift to both endpoints.
+4. Evaluates a central difference along the straight latent flow path.
+5. Builds the MeanFlow tangent target and applies NVIDIA's normalized `beta08` timestep weighting.
+6. Balances each non-diffusion sample against the global diffusion-branch loss mean.
 
-For each flow-matching batch, SimpleTuner:
+## On-Policy Stage
 
-1. Uses the model's normal `prepare_batch()` path to sample `sigmas`, `timesteps`, `noisy_latents`, and the base flow target.
-2. Samples `r < t` from the current sigma interval.
-3. Writes `flowmap_r_timesteps` into the batch so model wrappers can pass it as `r_timestep`.
-4. Builds the training target.
-5. Lets the normal model loss compare the prediction to that target.
+Start this stage from a forward-stage AnyFlow adapter by setting `init_lora` or resuming its checkpoint:
 
-In `target_mode=online_teacher`, the target is an average velocity from the current noisy latent at `t` toward `r`. For LoRA and LyCORIS training, the distiller temporarily disables the adapter for the teacher rollout and re-enables it afterward.
+```json
+{
+  "model_type": "lora",
+  "lora_type": "standard",
+  "init_lora": "path-or-repo-to-forward-anyflow-adapter",
+  "learning_rate": 0.000002,
+  "optimizer_beta1": 0.0,
+  "optimizer_beta2": 0.999,
+  "optimizer_weight_decay": 0.0,
+  "distillation_method": "anyflow",
+  "distillation_config": {
+    "anyflow": {
+      "stage": "onpolicy",
+      "cotrain_forward": true,
+      "rollout_step_counts": [2, 4, 8, 16, 50],
+      "dmd_weight": 1.0,
+      "dmd_batch_size": 1,
+      "real_score_guidance_scale": 0.0,
+      "discriminator_lr": 0.000002,
+      "discriminator_betas": [0.0, 0.999],
+      "discriminator_weight_decay": 0.0,
+      "discriminator_grad_clip": 1.0
+    }
+  }
+}
+```
 
-In `target_mode=linear`, no teacher rollout is used. The target is the straight flow target `noise - latents`. This is useful for smoke tests and controlled ablations, but it is not the full AnyFlow teacher-map objective.
+The on-policy stage uses three score roles. Standard LoRA training shares one frozen base transformer between them:
 
-## Configuration
+- The loaded AnyFlow adapter is the generator.
+- The base model with adapters disabled is the frozen real score.
+- A separately optimized `anyflow_discriminator` adapter is the fake score.
 
-Common `distillation_config.anyflow` keys:
+Each generator update selects a rollout budget from `rollout_step_counts`, performs a differentiable FlowMap rollout,
+noises the generated latent at a shifted uniform time, and applies NVIDIA's normalized DMD gradient. Each discriminator
+update performs a no-grad student rollout, samples a logit-normal shifted time, and trains the fake score on the normal
+flow target. The discriminator adapter and optimizer are saved beside every SimpleTuner checkpoint as
+`anyflow_discriminator.safetensors` and `anyflow_discriminator_optim.pt`.
 
-- `target_mode`: `online_teacher` or `linear`. Default: `online_teacher`.
-- `teacher_rollout_steps`: number of online teacher Euler steps between `t` and `r`. Default: `1`.
-- `r_timestep_sampler`: `uniform` or `zero`. Default: `uniform`.
-- `min_interval_ratio`: minimum normalized interval left between `t` and `r`. Default: `0.02`.
-- `gate_value`: blend weight for the FlowMap delta timestep embedding. Default: `0.25`.
-- `deltatime_type`: `r` or `t-r`, matching the model FlowMap embedding mode. Default: `r`.
-- `loss_weight`: multiplier applied to the already-computed training loss. Default: `1.0`.
-- `timestep_scale`: override for models that use a custom timestep scale. Leave unset for normal operation.
+MiniMax-H3 already contains CFG distillation, so its on-policy runs should normally keep
+`real_score_guidance_scale=0`. Models that require an external real-score CFG pass must cache negative text embeddings
+and can set the scale explicitly.
 
-`r_timestep_sampler=zero` always maps toward the clean endpoint. It is deterministic and useful for debugging. `uniform` samples inside the available interval.
+## Shared Configuration
 
-## Supported Models
-
-AnyFlow requires a flow-matching model whose trained component implements `enable_flowmap_time_conditioning()` and whose model wrapper forwards `flowmap_r_timesteps` to the model as `r_timestep`.
-
-The current implementation covers the registered FlowMap-capable transformer families and the legacy Diffusers UNet families that use `FlowMapUNet2DConditionModel`.
+- `stage`: `forward` or `onpolicy`. Default: `forward`.
+- `diffusion_ratio`: global batch fraction using `r=t`. Default: `0.5`.
+- `consistency_ratio`: global batch fraction using `r=0`. Default: `0.25`.
+- `central_difference_epsilon`: normalized shifted-time offset. Default: `0.005`, matching NVIDIA's `5/1000`.
+- `meanflow_weight_type`: `beta08` or `uniform`. Default: `beta08`.
+- `meanflow_adaptive_weighting`: balance non-diffusion samples against the diffusion branch. Default: `true`.
+- `gate_value`: FlowMap delta-timestep embedding blend. Default: `0.25`.
+- `deltatime_type`: `r` or `t-r`. Default: `r`.
+- `loss_weight`: forward MeanFlow loss multiplier. Default: `1.0`.
 
 ## Limits
 
-- Requires a flow-matching prediction type.
-- Requires scalar per-sample timesteps. Tokenwise AnyFlow intervals are not wired yet.
-- Requires `r_timestep < timestep`; timestep zero is rejected for AnyFlow training.
-- The default online teacher mode is intended for LoRA/LyCORIS in the current trainer path. Full-rank online teacher training needs a separate student/teacher wiring pass.
-- Validation is wired through the AnyFlow distiller scheduler hook. The active pipeline scheduler is proxied, and the validation transformer/UNet receives the next interval endpoint as `r_timestep` or `timestep_r`. This covers registered FlowMap-capable validation pipelines; custom or external validation paths still need to pass the FlowMap timestep kwarg themselves.
+- AnyFlow requires a flow-matching model with model-specific FlowMap interval conditioning.
+- On-policy training currently requires standard PEFT LoRA. Sharing the base avoids allocating generator, real-score,
+  and discriminator copies of a large transformer on every DDP rank.
+- Joint MiniMax-H3 audio-video training is rejected. Video uses schedule shift 12 while audio uses shift 3; native
+  dual-schedule MeanFlow targets and rollouts need to be implemented before AV training is valid.
+- Text encoder training is disabled for all SimpleTuner distillation methods.
+- Validation uses `AnyFlowValidationScheduler`, which supplies the next interval endpoint to registered FlowMap model
+  components.
 
 ## Logs
 
-AnyFlow adds:
-
-- `anyflow_loss`
-- `anyflow_timestep`
-- `anyflow_r_timestep`
-- `anyflow_interval`
-
-These are emitted alongside the normal training loss metrics.
+Forward training adds `anyflow_forward_loss`, timestep and interval values, and global branch fractions. On-policy
+training also adds `anyflow_dmd_loss`, `anyflow_dmd_gradient_norm`, `anyflow_dmd_sigma`, and
+`anyflow_rollout_steps`.

--- a/documentation/experimental/ANYFLOW.pt-BR.md
+++ b/documentation/experimental/ANYFLOW.pt-BR.md
@@ -1,19 +1,17 @@
 # AnyFlow
 
-AnyFlow e um modo experimental de destilacao para modelos flow-matching. Ele condiciona o modelo em dois tempos de fluxo, o timestep normal `t` e um timestep de referencia menor `r`, para aprender um mapa de fluxo ao longo de um intervalo em vez de apenas uma velocidade rectified-flow pontual.
+O SimpleTuner implementa o NVIDIA AnyFlow como duas etapas explícitas de treinamento para modelos de flow matching. As
+duas etapas treinam um modelo que recebe o tempo de fluxo atual `t` e um endpoint de intervalo `r`.
 
-No SimpleTuner:
+- `stage=forward` implementa o objetivo forward MeanFlow da NVIDIA.
+- `stage=onpolicy` implementa Flow Map Backward Simulation e DMD on-policy enquanto co-treina o objetivo forward.
 
-- `--distillation_method=anyflow` ativa o `AnyFlowDistiller`.
-- O distiller chama `enable_flowmap_time_conditioning()` no componente treinado durante a inicializacao.
-- Cada batch preparado recebe `flowmap_r_timesteps`.
-- O target normal e substituido por um target AnyFlow antes do calculo da loss.
+Os modos removidos `online_teacher` e `linear` eram objetivos específicos do SimpleTuner e não são mais aceitos.
 
-AnyFlow e online no SimpleTuner. Ele nao requer cache ODE precomputado.
+Para um exemplo de continuação Wan usando os checkpoints publicados pela NVIDIA, veja
+[Quickstart de continuação AnyFlow](/documentation/quickstart/ANYFLOW.pt-BR.md).
 
-Para um exemplo de continuacao Wan usando os checkpoints AnyFlow publicados pela NVIDIA, veja [Quickstart de continuacao AnyFlow](/documentation/quickstart/ANYFLOW.pt-BR.md).
-
-## Configuracao rapida
+## Etapa forward
 
 ```json
 {
@@ -21,10 +19,12 @@ Para um exemplo de continuacao Wan usando os checkpoints AnyFlow publicados pela
   "distillation_method": "anyflow",
   "distillation_config": {
     "anyflow": {
-      "target_mode": "online_teacher",
-      "teacher_rollout_steps": 1,
-      "r_timestep_sampler": "uniform",
-      "min_interval_ratio": 0.02,
+      "stage": "forward",
+      "diffusion_ratio": 0.5,
+      "consistency_ratio": 0.25,
+      "central_difference_epsilon": 0.005,
+      "meanflow_weight_type": "beta08",
+      "meanflow_adaptive_weighting": true,
       "gate_value": 0.25,
       "deltatime_type": "r",
       "loss_weight": 1.0
@@ -33,37 +33,84 @@ Para um exemplo de continuacao Wan usando os checkpoints AnyFlow publicados pela
 }
 ```
 
-Treinamento de text encoder e bloqueado para todos os metodos de destilacao do SimpleTuner, incluindo AnyFlow.
+Para cada batch global, a etapa forward:
 
-## Como funciona
+1. Amostra dois tempos de fluxo uniformes e os ordena como `t >= r`.
+2. Atribui 50% das amostras a intervalos de difusão (`r=t`), 25% a intervalos de endpoint (`r=0`) e o restante a intervalos arbitrários.
+3. Aplica o flow shift do scheduler do modelo aos dois endpoints.
+4. Avalia uma diferença central ao longo da trajetória latente reta.
+5. Constrói o target tangente MeanFlow e aplica o weighting normalizado `beta08` da NVIDIA.
+6. Balanceia cada amostra não-diffusion contra a média global de loss da ramificação diffusion.
 
-Para cada batch flow-matching, o SimpleTuner:
+## Etapa on-policy
 
-1. Usa o `prepare_batch()` normal para amostrar `sigmas`, `timesteps`, `noisy_latents` e o target base.
-2. Amostra `r < t` no intervalo atual.
-3. Escreve `flowmap_r_timesteps` no batch para que o wrapper passe isso como `r_timestep`.
-4. Constroi o target de treinamento.
-5. Usa a loss normal para comparar a predicao com esse target.
+Inicie esta etapa a partir de um adapter AnyFlow da etapa forward usando `init_lora` ou retomando seu checkpoint:
 
-Com `target_mode=online_teacher`, o target e uma velocidade media do noisy latent em `t` ate `r`. Em LoRA e LyCORIS, o distiller desativa temporariamente o adapter para o rollout teacher e reativa depois.
+```json
+{
+  "model_type": "lora",
+  "lora_type": "standard",
+  "init_lora": "path-or-repo-to-forward-anyflow-adapter",
+  "learning_rate": 0.000002,
+  "optimizer_beta1": 0.0,
+  "optimizer_beta2": 0.999,
+  "optimizer_weight_decay": 0.0,
+  "distillation_method": "anyflow",
+  "distillation_config": {
+    "anyflow": {
+      "stage": "onpolicy",
+      "cotrain_forward": true,
+      "rollout_step_counts": [2, 4, 8, 16, 50],
+      "dmd_weight": 1.0,
+      "dmd_batch_size": 1,
+      "real_score_guidance_scale": 0.0,
+      "discriminator_lr": 0.000002,
+      "discriminator_betas": [0.0, 0.999],
+      "discriminator_weight_decay": 0.0,
+      "discriminator_grad_clip": 1.0
+    }
+  }
+}
+```
 
-Com `target_mode=linear`, nenhum rollout teacher e usado. O target e `noise - latents`. Isso e util para smoke tests e ablations, mas nao e o objetivo completo de mapa teacher do AnyFlow.
+A etapa on-policy usa três papéis de score. O treinamento LoRA padrão compartilha um transformer base congelado entre eles:
 
-## Opcoes
+- O adapter AnyFlow carregado é o gerador.
+- O modelo base com adapters desativados é o score real congelado.
+- Um adapter `anyflow_discriminator` otimizado separadamente é o score fake.
 
-- `target_mode`: `online_teacher` ou `linear`. Padrao: `online_teacher`.
-- `teacher_rollout_steps`: passos Euler online entre `t` e `r`. Padrao: `1`.
-- `r_timestep_sampler`: `uniform` ou `zero`. Padrao: `uniform`.
-- `min_interval_ratio`: intervalo normalizado minimo entre `t` e `r`. Padrao: `0.02`.
-- `gate_value`: peso de mistura do embedding delta FlowMap. Padrao: `0.25`.
-- `deltatime_type`: `r` ou `t-r`. Padrao: `r`.
-- `loss_weight`: multiplicador da loss ja calculada. Padrao: `1.0`.
-- `timestep_scale`: override para modelos com escala de timestep customizada. Normalmente deixe sem definir.
+Cada atualização do gerador escolhe um orçamento de rollout de `rollout_step_counts`, executa um rollout FlowMap
+diferenciável, adiciona ruído ao latent gerado em um tempo uniforme deslocado e aplica o gradiente DMD normalizado da
+NVIDIA. Cada atualização do discriminador executa um rollout do student sem gradientes, amostra um tempo deslocado
+logit-normal e treina o score fake no target flow normal. O adapter e o otimizador do discriminador são salvos ao lado
+de cada checkpoint do SimpleTuner como `anyflow_discriminator.safetensors` e `anyflow_discriminator_optim.pt`.
+
+MiniMax-H3 já contém destilação CFG, então suas execuções on-policy normalmente devem manter
+`real_score_guidance_scale=0`. Modelos que exigem uma passada CFG externa para o score real precisam cachear embeddings
+de texto negativos e podem configurar a escala explicitamente.
+
+## Configuração compartilhada
+
+- `stage`: `forward` ou `onpolicy`. Padrão: `forward`.
+- `diffusion_ratio`: fração do batch global usando `r=t`. Padrão: `0.5`.
+- `consistency_ratio`: fração do batch global usando `r=0`. Padrão: `0.25`.
+- `central_difference_epsilon`: offset normalizado no tempo deslocado. Padrão: `0.005`, igual ao `5/1000` da NVIDIA.
+- `meanflow_weight_type`: `beta08` ou `uniform`. Padrão: `beta08`.
+- `meanflow_adaptive_weighting`: balanceia amostras não-diffusion contra a ramificação diffusion. Padrão: `true`.
+- `gate_value`: mistura do embedding delta-timestep FlowMap. Padrão: `0.25`.
+- `deltatime_type`: `r` ou `t-r`. Padrão: `r`.
+- `loss_weight`: multiplicador da loss forward MeanFlow. Padrão: `1.0`.
 
 ## Limites
 
-- Requer modelo flow-matching.
-- Requer timesteps escalares por amostra. Intervalos AnyFlow tokenwise ainda nao estao conectados.
-- Requer `r_timestep < timestep`; timestep zero e rejeitado.
-- O modo online teacher atual e pensado para LoRA/LyCORIS. Full-rank online teacher precisa de wiring separado de student/teacher.
-- A validacao esta conectada pelo hook de scheduler do distiller AnyFlow. O scheduler ativo da pipeline e proxied, e o transformer/UNet de validacao recebe o proximo endpoint do intervalo como `r_timestep` ou `timestep_r`. Isso cobre pipelines de validacao FlowMap-capable registradas; caminhos custom ou external de validacao ainda precisam passar o FlowMap timestep kwarg por conta propria.
+- AnyFlow requer um modelo flow-matching com conditioning de intervalo FlowMap específico do modelo.
+- O treinamento on-policy atualmente requer LoRA PEFT padrão. Compartilhar a base evita alocar cópias do gerador, score real e discriminador de um transformer grande em cada rank DDP.
+- Treinamento conjunto MiniMax-H3 audio-video é rejeitado. Video usa schedule shift 12 e audio usa shift 3; targets MeanFlow e rollouts nativos de duplo schedule precisam ser implementados antes que treinamento AV seja válido.
+- Treinamento do text encoder é desativado para todos os métodos de destilação do SimpleTuner.
+- A validação usa `AnyFlowValidationScheduler`, que fornece o próximo endpoint de intervalo aos componentes FlowMap registrados.
+
+## Logs
+
+O treinamento forward adiciona `anyflow_forward_loss`, valores de timestep e intervalo, e frações globais de ramificação.
+O treinamento on-policy também adiciona `anyflow_dmd_loss`, `anyflow_dmd_gradient_norm`, `anyflow_dmd_sigma` e
+`anyflow_rollout_steps`.

--- a/documentation/experimental/ANYFLOW.zh.md
+++ b/documentation/experimental/ANYFLOW.zh.md
@@ -1,19 +1,16 @@
 # AnyFlow
 
-AnyFlow 是面向 flow-matching 模型的实验性蒸馏模式。它让模型同时条件化在普通训练 timestep `t` 和更低的参考 timestep `r` 上，使网络学习一个跨 interval 的 flow map，而不是只学习单点 rectified-flow velocity。
+SimpleTuner 将 NVIDIA AnyFlow 实现为面向 flow-matching 模型的两个显式训练阶段。这两个阶段都会训练一个模型，使其同时接收当前 flow 时间 `t` 和区间端点 `r`。
 
-在 SimpleTuner 中：
+- `stage=forward` 实现 NVIDIA 的 forward MeanFlow 目标。
+- `stage=onpolicy` 在共同训练 forward 目标的同时，实现 Flow Map Backward Simulation 和 on-policy DMD。
 
-- `--distillation_method=anyflow` 启用 `AnyFlowDistiller`。
-- distiller 在启动时调用训练组件的 `enable_flowmap_time_conditioning()`。
-- 每个 prepared batch 会加入 `flowmap_r_timesteps`。
-- 常规 target 会在计算 model loss 之前替换为 AnyFlow target。
+已移除的 `online_teacher` 和 `linear` target mode 是 SimpleTuner 过去的自定义目标，现在不再接受。
 
-SimpleTuner 的 AnyFlow 是 online 的，不需要预先计算 ODE cache。
+使用 NVIDIA 已发布 checkpoint 继续训练 Wan 的示例，请参阅
+[AnyFlow Continuation Quickstart](/documentation/quickstart/ANYFLOW.zh.md)。
 
-关于使用 NVIDIA 发布的 AnyFlow checkpoints 继续训练 Wan 的示例，见 [AnyFlow 继续训练快速入门](/documentation/quickstart/ANYFLOW.zh.md)。
-
-## 快速配置
+## Forward 阶段
 
 ```json
 {
@@ -21,10 +18,12 @@ SimpleTuner 的 AnyFlow 是 online 的，不需要预先计算 ODE cache。
   "distillation_method": "anyflow",
   "distillation_config": {
     "anyflow": {
-      "target_mode": "online_teacher",
-      "teacher_rollout_steps": 1,
-      "r_timestep_sampler": "uniform",
-      "min_interval_ratio": 0.02,
+      "stage": "forward",
+      "diffusion_ratio": 0.5,
+      "consistency_ratio": 0.25,
+      "central_difference_epsilon": 0.005,
+      "meanflow_weight_type": "beta08",
+      "meanflow_adaptive_weighting": true,
       "gate_value": 0.25,
       "deltatime_type": "r",
       "loss_weight": 1.0
@@ -33,37 +32,81 @@ SimpleTuner 的 AnyFlow 是 online 的，不需要预先计算 ODE cache。
 }
 ```
 
-SimpleTuner 的所有 distillation methods 都会禁止 text encoder training，AnyFlow 也一样。
+对于每个全局 batch，forward 阶段会：
 
-## 工作方式
+1. 采样两个均匀 flow 时间，并排序为 `t >= r`。
+2. 将 50% 样本分配到 diffusion 区间 (`r=t`)，25% 分配到 endpoint 区间 (`r=0`)，其余分配到任意区间。
+3. 对两个端点应用模型 scheduler 的 flow shift。
+4. 沿直线 latent flow 路径计算中心差分。
+5. 构造 MeanFlow tangent target，并应用 NVIDIA 归一化的 `beta08` timestep weighting。
+6. 将每个非 diffusion 样本与全局 diffusion 分支 loss 均值进行平衡。
 
-对每个 flow-matching batch，SimpleTuner 会：
+## On-Policy 阶段
 
-1. 使用正常的 `prepare_batch()` 采样 `sigmas`、`timesteps`、`noisy_latents` 和 base flow target。
-2. 从当前 interval 中采样 `r < t`。
-3. 将 `flowmap_r_timesteps` 写入 batch，让 model wrapper 作为 `r_timestep` 传入。
-4. 构建训练 target。
-5. 使用正常 model loss 比较 prediction 和 target。
+通过设置 `init_lora` 或从 checkpoint 恢复，从 forward 阶段 AnyFlow adapter 启动此阶段：
 
-在 `target_mode=online_teacher` 下，target 是从 `t` 处 noisy latent 指向 `r` 的平均 velocity。LoRA 和 LyCORIS 训练时，distiller 会在 teacher rollout 期间临时禁用 adapter，然后再启用。
+```json
+{
+  "model_type": "lora",
+  "lora_type": "standard",
+  "init_lora": "path-or-repo-to-forward-anyflow-adapter",
+  "learning_rate": 0.000002,
+  "optimizer_beta1": 0.0,
+  "optimizer_beta2": 0.999,
+  "optimizer_weight_decay": 0.0,
+  "distillation_method": "anyflow",
+  "distillation_config": {
+    "anyflow": {
+      "stage": "onpolicy",
+      "cotrain_forward": true,
+      "rollout_step_counts": [2, 4, 8, 16, 50],
+      "dmd_weight": 1.0,
+      "dmd_batch_size": 1,
+      "real_score_guidance_scale": 0.0,
+      "discriminator_lr": 0.000002,
+      "discriminator_betas": [0.0, 0.999],
+      "discriminator_weight_decay": 0.0,
+      "discriminator_grad_clip": 1.0
+    }
+  }
+}
+```
 
-在 `target_mode=linear` 下，不使用 teacher rollout。target 是 straight flow target `noise - latents`。它适合 smoke test 和 ablation，但不是完整的 AnyFlow teacher-map objective。
+on-policy 阶段使用三个 score 角色。标准 LoRA 训练会在它们之间共享一个冻结的 base transformer：
 
-## 选项
+- 已加载的 AnyFlow adapter 是 generator。
+- 禁用 adapter 的 base model 是冻结的 real score。
+- 单独优化的 `anyflow_discriminator` adapter 是 fake score。
 
-- `target_mode`：`online_teacher` 或 `linear`。默认：`online_teacher`。
-- `teacher_rollout_steps`：`t` 到 `r` 之间的 online teacher Euler steps。默认：`1`。
-- `r_timestep_sampler`：`uniform` 或 `zero`。默认：`uniform`。
-- `min_interval_ratio`：`t` 和 `r` 之间保留的最小 normalized interval。默认：`0.02`。
-- `gate_value`：FlowMap delta timestep embedding 的混合权重。默认：`0.25`。
-- `deltatime_type`：`r` 或 `t-r`。默认：`r`。
-- `loss_weight`：已计算 training loss 的乘数。默认：`1.0`。
-- `timestep_scale`：用于自定义 timestep scale 的模型。通常保持未设置。
+每次 generator 更新都会从 `rollout_step_counts` 中选择 rollout 预算，执行可微 FlowMap rollout，在一个 shifted uniform
+时间点给生成 latent 加噪，并应用 NVIDIA 的归一化 DMD 梯度。每次 discriminator 更新都会执行无梯度 student rollout，采样
+logit-normal shifted 时间，并用普通 flow target 训练 fake score。discriminator adapter 和 optimizer 会随每个 SimpleTuner
+checkpoint 保存为 `anyflow_discriminator.safetensors` 和 `anyflow_discriminator_optim.pt`。
+
+MiniMax-H3 已经包含 CFG distillation，因此它的 on-policy 运行通常应保持 `real_score_guidance_scale=0`。需要外部 real-score
+CFG pass 的模型必须缓存 negative text embeddings，并可以显式设置该 scale。
+
+## 共享配置
+
+- `stage`: `forward` 或 `onpolicy`。默认：`forward`。
+- `diffusion_ratio`: 使用 `r=t` 的全局 batch 比例。默认：`0.5`。
+- `consistency_ratio`: 使用 `r=0` 的全局 batch 比例。默认：`0.25`。
+- `central_difference_epsilon`: 归一化 shifted-time offset。默认：`0.005`，对应 NVIDIA 的 `5/1000`。
+- `meanflow_weight_type`: `beta08` 或 `uniform`。默认：`beta08`。
+- `meanflow_adaptive_weighting`: 将非 diffusion 样本与 diffusion 分支平衡。默认：`true`。
+- `gate_value`: FlowMap delta-timestep embedding 混合权重。默认：`0.25`。
+- `deltatime_type`: `r` 或 `t-r`。默认：`r`。
+- `loss_weight`: forward MeanFlow loss 乘数。默认：`1.0`。
 
 ## 限制
 
-- 需要 flow-matching 模型。
-- 需要每个样本一个 scalar timestep。Tokenwise AnyFlow intervals 还没有接入。
-- 需要 `r_timestep < timestep`；timestep zero 会被拒绝。
-- 当前 online teacher 模式面向 LoRA/LyCORIS。Full-rank online teacher 需要单独的 student/teacher wiring。
-- validation 已通过 AnyFlow distiller 的 scheduler hook 接入。当前 pipeline scheduler 会被代理，validation transformer/UNet 会收到下一个 interval endpoint，作为 `r_timestep` 或 `timestep_r` 传入。已注册的 FlowMap-capable validation pipeline 会覆盖；自定义或 external validation path 仍需自行传递 FlowMap timestep kwarg。
+- AnyFlow 需要 flow-matching 模型，并且该模型要有模型专用的 FlowMap 区间 conditioning。
+- on-policy 训练目前需要标准 PEFT LoRA。共享 base 可以避免在每个 DDP rank 上分配 generator、real-score 和 discriminator 三份大型 transformer。
+- 目前拒绝 MiniMax-H3 audio-video 联合训练。video 使用 schedule shift 12，audio 使用 shift 3；需要先实现原生双 schedule MeanFlow target 和 rollout，AV 训练才有效。
+- 所有 SimpleTuner distillation 方法都禁用 text encoder training。
+- 验证使用 `AnyFlowValidationScheduler`，它会把下一个区间端点传给已注册的 FlowMap 模型组件。
+
+## Logs
+
+Forward 训练会添加 `anyflow_forward_loss`、timestep 和 interval 值，以及全局分支比例。On-policy 训练还会添加
+`anyflow_dmd_loss`、`anyflow_dmd_gradient_norm`、`anyflow_dmd_sigma` 和 `anyflow_rollout_steps`。

--- a/documentation/quickstart/ANYFLOW.es.md
+++ b/documentation/quickstart/ANYFLOW.es.md
@@ -42,10 +42,10 @@ Empieza con la configuración normal de Wan y cambia los campos de modelo y dest
   "distillation_method": "anyflow",
   "distillation_config": {
     "anyflow": {
-      "target_mode": "online_teacher",
-      "teacher_rollout_steps": 1,
-      "r_timestep_sampler": "uniform",
-      "min_interval_ratio": 0.02,
+      "stage": "forward",
+      "diffusion_ratio": 0.5,
+      "consistency_ratio": 0.25,
+      "central_difference_epsilon": 0.005,
       "gate_value": 0.25,
       "deltatime_type": "r",
       "loss_weight": 1.0
@@ -104,4 +104,4 @@ Es una aproximación dependiente del rank. El target por defecto coincide con lo
 
 - La licencia pública de los modelos NVIDIA AnyFlow es no comercial; revisa la model card antes de publicar adaptadores derivados.
 - La validación AnyFlow está conectada mediante el hook de scheduler del distiller para pipelines registrados con soporte FlowMap. Las rutas de validación custom o externas aún deben pasar `r_timestep` o `timestep_r` al componente del modelo.
-- La continuación full-rank con online teacher aún necesita cableado separado de student y teacher. Por ahora, LoRA es la ruta soportada.
+- La etapa on-policy actualmente requiere un LoRA PEFT estándar para que su discriminador pueda compartir el transformer base congelado.

--- a/documentation/quickstart/ANYFLOW.hi.md
+++ b/documentation/quickstart/ANYFLOW.hi.md
@@ -42,10 +42,10 @@ normal Wan quickstart config से शुरू करें और model त�
   "distillation_method": "anyflow",
   "distillation_config": {
     "anyflow": {
-      "target_mode": "online_teacher",
-      "teacher_rollout_steps": 1,
-      "r_timestep_sampler": "uniform",
-      "min_interval_ratio": 0.02,
+      "stage": "forward",
+      "diffusion_ratio": 0.5,
+      "consistency_ratio": 0.25,
+      "central_difference_epsilon": 0.005,
       "gate_value": 0.25,
       "deltatime_type": "r",
       "loss_weight": 1.0
@@ -104,4 +104,4 @@ conversion matching Wan base transformer और AnyFlow transformer load कर�
 
 - public NVIDIA AnyFlow model license noncommercial है; derived adapters publish करने से पहले upstream model card देखें।
 - AnyFlow validation registered FlowMap-capable pipelines के लिए distiller scheduler hook से wired है। custom या external validation paths को model component में `r_timestep` या `timestep_r` pass करना होगा।
-- full-rank online-teacher continuation के लिए अलग student और teacher wiring चाहिए। अभी supported path LoRA continuation है।
+- on-policy stage अभी standard PEFT LoRA मांगता है, ताकि उसका discriminator frozen base transformer share कर सके।

--- a/documentation/quickstart/ANYFLOW.ja.md
+++ b/documentation/quickstart/ANYFLOW.ja.md
@@ -42,10 +42,10 @@ FAR checkpoints (`nvidia/AnyFlow-FAR-*`) は causal AnyFlow transformer architec
   "distillation_method": "anyflow",
   "distillation_config": {
     "anyflow": {
-      "target_mode": "online_teacher",
-      "teacher_rollout_steps": 1,
-      "r_timestep_sampler": "uniform",
-      "min_interval_ratio": 0.02,
+      "stage": "forward",
+      "diffusion_ratio": 0.5,
+      "consistency_ratio": 0.25,
+      "central_difference_epsilon": 0.005,
       "gate_value": 0.25,
       "deltatime_type": "r",
       "loss_weight": 1.0
@@ -104,4 +104,4 @@ conversion は matching Wan base transformer と AnyFlow transformer を読み�
 
 - public NVIDIA AnyFlow model license は noncommercial です。derived adapters を公開する前に upstream model card を確認してください。
 - AnyFlow validation は registered FlowMap-capable pipelines 向けに distiller scheduler hook で接続されています。custom/external validation path では `r_timestep` または `timestep_r` を model component に渡す必要があります。
-- full-rank online-teacher continuation には separate student/teacher wiring が必要です。現時点の supported path は LoRA continuation です。
+- on-policy stage は現在、その discriminator が凍結 base transformer を共有できるように、標準 PEFT LoRA を必要とします。

--- a/documentation/quickstart/ANYFLOW.md
+++ b/documentation/quickstart/ANYFLOW.md
@@ -42,10 +42,10 @@ Start from the normal Wan quickstart config, then change the model and distillat
   "distillation_method": "anyflow",
   "distillation_config": {
     "anyflow": {
-      "target_mode": "online_teacher",
-      "teacher_rollout_steps": 1,
-      "r_timestep_sampler": "uniform",
-      "min_interval_ratio": 0.02,
+      "stage": "forward",
+      "diffusion_ratio": 0.5,
+      "consistency_ratio": 0.25,
+      "central_difference_epsilon": 0.005,
       "gate_value": 0.25,
       "deltatime_type": "r",
       "loss_weight": 1.0
@@ -110,4 +110,4 @@ This is approximate and rank-dependent. The default script target set matches Si
 
 - The public NVIDIA AnyFlow model license is noncommercial; check the upstream model card before publishing derived adapters.
 - AnyFlow validation is wired through the distiller scheduler hook for registered FlowMap-capable pipelines. Custom or external validation paths still need to pass `r_timestep` or `timestep_r` into the model component.
-- Full-rank online-teacher continuation still needs separate student and teacher wiring. LoRA continuation is the supported path for now.
+- The on-policy stage currently requires a standard PEFT LoRA so its discriminator can share the frozen base transformer.

--- a/documentation/quickstart/ANYFLOW.pt-BR.md
+++ b/documentation/quickstart/ANYFLOW.pt-BR.md
@@ -42,10 +42,10 @@ Comece com a config normal do Wan quickstart e altere os campos de modelo e dest
   "distillation_method": "anyflow",
   "distillation_config": {
     "anyflow": {
-      "target_mode": "online_teacher",
-      "teacher_rollout_steps": 1,
-      "r_timestep_sampler": "uniform",
-      "min_interval_ratio": 0.02,
+      "stage": "forward",
+      "diffusion_ratio": 0.5,
+      "consistency_ratio": 0.25,
+      "central_difference_epsilon": 0.005,
       "gate_value": 0.25,
       "deltatime_type": "r",
       "loss_weight": 1.0
@@ -104,4 +104,4 @@ Isso e aproximado e depende do rank. O target padrao corresponde aos defaults PE
 
 - A licenca publica dos modelos NVIDIA AnyFlow e noncommercial; confira a model card upstream antes de publicar adapters derivados.
 - A validacao AnyFlow esta conectada pelo hook de scheduler do distiller para pipelines FlowMap-capable registradas. Caminhos custom ou external de validacao ainda precisam passar `r_timestep` ou `timestep_r` ao componente do modelo.
-- Continuacao full-rank com online teacher ainda precisa de wiring separado de student e teacher. Por enquanto, LoRA continuation e o caminho suportado.
+- A etapa on-policy atualmente requer LoRA PEFT padrão para que seu discriminador possa compartilhar o transformer base congelado.

--- a/documentation/quickstart/ANYFLOW.zh.md
+++ b/documentation/quickstart/ANYFLOW.zh.md
@@ -42,10 +42,10 @@ FAR checkpoints (`nvidia/AnyFlow-FAR-*`) 使用 causal AnyFlow transformer archi
   "distillation_method": "anyflow",
   "distillation_config": {
     "anyflow": {
-      "target_mode": "online_teacher",
-      "teacher_rollout_steps": 1,
-      "r_timestep_sampler": "uniform",
-      "min_interval_ratio": 0.02,
+      "stage": "forward",
+      "diffusion_ratio": 0.5,
+      "consistency_ratio": 0.25,
+      "central_difference_epsilon": 0.005,
       "gate_value": 0.25,
       "deltatime_type": "r",
       "loss_weight": 1.0
@@ -104,4 +104,4 @@ LyCORIS/LoCon 可使用 `scripts/extract_lycoris_adapter.py`，参数相同并�
 
 - NVIDIA AnyFlow 公开模型 license 是 noncommercial；发布 derived adapters 前请检查 upstream model card。
 - AnyFlow validation 已通过 distiller scheduler hook 为已注册的 FlowMap-capable pipeline 接入。自定义或 external validation path 仍需把 `r_timestep` 或 `timestep_r` 传入 model component。
-- full-rank online-teacher continuation 仍需要单独的 student/teacher wiring。目前支持的路径是 LoRA continuation。
+- on-policy 阶段目前需要标准 PEFT LoRA，这样它的 discriminator 才能共享冻结的 base transformer。

--- a/simpletuner/examples/anima-anyflow.peft-lora/config.json
+++ b/simpletuner/examples/anima-anyflow.peft-lora/config.json
@@ -9,10 +9,12 @@
   "distillation_method": "anyflow",
   "distillation_config": {
     "anyflow": {
-      "target_mode": "online_teacher",
-      "teacher_rollout_steps": 1,
-      "r_timestep_sampler": "uniform",
-      "min_interval_ratio": 0.02,
+      "stage": "forward",
+      "diffusion_ratio": 0.5,
+      "consistency_ratio": 0.25,
+      "central_difference_epsilon": 0.005,
+      "meanflow_weight_type": "beta08",
+      "meanflow_adaptive_weighting": true,
       "gate_value": 0.25,
       "deltatime_type": "r",
       "loss_weight": 1.0

--- a/simpletuner/helpers/distillation/anyflow/distiller.py
+++ b/simpletuner/helpers/distillation/anyflow/distiller.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+import copy
+import os
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, Optional, Sequence
 
 import torch
+import torch.nn.functional as F
+from safetensors.torch import load_file, save_file
 
 from simpletuner.helpers.data_backend.dataset_types import DatasetType
 from simpletuner.helpers.distillation.anyflow.scheduler import AnyFlowValidationScheduler
@@ -10,29 +15,42 @@ from simpletuner.helpers.distillation.common import DistillationBase
 from simpletuner.helpers.distillation.registry import DistillationRegistry
 from simpletuner.helpers.models.flowmap import validate_flowmap_deltatime_type
 
+ANYFLOW_DISCRIMINATOR_FILENAME = "anyflow_discriminator.safetensors"
+ANYFLOW_DISCRIMINATOR_OPTIMIZER_FILENAME = "anyflow_discriminator_optim.pt"
+
 
 class AnyFlowDistiller(DistillationBase):
-    """Online AnyFlow/FlowMap target preparation for flow-matching models."""
+    """NVIDIA AnyFlow forward MeanFlow and on-policy DMD training stages."""
 
     FLOWMAP_R_TIMESTEP_BATCH_KEY = "flowmap_r_timesteps"
+    DISCRIMINATOR_ADAPTER_NAME = "anyflow_discriminator"
 
     _DEFAULTS: Dict[str, Any] = {
         "distillation_type": "anyflow",
-        "target_mode": "online_teacher",
-        "r_timestep_sampler": "uniform",
-        "min_interval_ratio": 0.02,
-        "teacher_rollout_steps": 1,
+        "stage": "forward",
         "gate_value": 0.25,
         "deltatime_type": "r",
         "loss_weight": 1.0,
         "timestep_scale": None,
-    }
-    _TARGET_MODE_ALIASES = {
-        "online": "online_teacher",
-        "online_teacher": "online_teacher",
-        "teacher": "online_teacher",
-        "linear": "linear",
-        "straight": "linear",
+        "diffusion_ratio": 0.5,
+        "consistency_ratio": 0.25,
+        "central_difference_epsilon": 0.005,
+        "meanflow_weight_type": "beta08",
+        "meanflow_adaptive_weighting": True,
+        "cotrain_forward": True,
+        "rollout_step_counts": (2, 4, 8, 16, 50),
+        "dmd_weight": 1.0,
+        "dmd_batch_size": 1,
+        "dmd_min_timestep_ratio": 0.0,
+        "dmd_max_timestep_ratio": 1.0,
+        "real_score_guidance_scale": 0.0,
+        "discriminator_lr": 2e-6,
+        "discriminator_weight_decay": 0.0,
+        "discriminator_betas": (0.0, 0.999),
+        "discriminator_eps": 1e-8,
+        "discriminator_grad_clip": 1.0,
+        "student_adapter_name": None,
+        "discriminator_adapter_name": DISCRIMINATOR_ADAPTER_NAME,
     }
 
     def __init__(
@@ -43,68 +61,69 @@ class AnyFlowDistiller(DistillationBase):
         noise_scheduler=None,
         config: Optional[Dict[str, Any]] = None,
     ):
+        if config and "target_mode" in config:
+            raise ValueError(
+                "AnyFlow target_mode was removed. Use stage='forward' for NVIDIA MeanFlow pretraining or "
+                "stage='onpolicy' for NVIDIA's on-policy DMD stage."
+            )
+
         merged_config = dict(self._DEFAULTS)
         if config:
             merged_config.update(config)
-
         super().__init__(teacher_model, student_model, merged_config)
+
         self.noise_scheduler = noise_scheduler
         self.num_train_timesteps = self._resolve_timestep_scale(noise_scheduler)
-
         if not self.is_flow_matching:
             raise ValueError("AnyFlow requires a flow-matching model.")
 
-        self.config["target_mode"] = self._normalize_target_mode(self.config["target_mode"])
-        self.config["r_timestep_sampler"] = self._normalize_r_timestep_sampler(self.config["r_timestep_sampler"])
+        self.config["stage"] = self._normalize_stage(self.config["stage"])
         self.config["deltatime_type"] = validate_flowmap_deltatime_type(
             str(self.config["deltatime_type"]),
             model_name="AnyFlow",
         )
-        self.config["teacher_rollout_steps"] = max(1, int(self.config.get("teacher_rollout_steps", 1) or 1))
-
-        min_interval_ratio = float(self.config.get("min_interval_ratio", 0.0) or 0.0)
-        if min_interval_ratio < 0.0 or min_interval_ratio >= 1.0:
-            raise ValueError("AnyFlow min_interval_ratio must be in [0.0, 1.0).")
-        self.config["min_interval_ratio"] = min_interval_ratio
-
-        model_type = str(self.config.get("model_type") or "").lower()
-        if self.config["target_mode"] == "online_teacher" and self.low_rank_distillation and model_type not in ("", "lora"):
-            raise ValueError("AnyFlow online_teacher mode requires low-rank training or a separate student_model.")
-
+        self._validate_forward_config()
         self._flowmap_component = self._enable_flowmap_time_conditioning()
 
-    def prepare_batch(self, batch: Dict[str, Any], model, state) -> Dict[str, Any]:
-        self._validate_prepared_batch(batch)
-        del state
+        self._student_adapter_name: Optional[str] = None
+        self._discriminator_adapter_name: Optional[str] = None
+        self._current_adapter_role = "student"
+        self._discriminator_parameters: list[torch.nn.Parameter] = []
+        self.discriminator_optimizer: Optional[torch.optim.Optimizer] = None
+        if self.config["stage"] == "onpolicy":
+            self._init_onpolicy_stage()
 
-        latents = batch["latents"]
-        timesteps = batch["timesteps"].to(device=latents.device, dtype=torch.float32)
+    # ------------------------------------------------------------------
+    # DistillationBase API
+    # ------------------------------------------------------------------
+    def prepare_batch(self, batch: Dict[str, Any], model, state) -> Dict[str, Any]:
+        del state
+        self._validate_video_batch(batch)
+        timesteps = batch["timesteps"]
         if timesteps.ndim != 1:
             raise ValueError(
                 "AnyFlow currently expects per-sample scalar flow timesteps. "
                 f"Received timestep shape {tuple(timesteps.shape)}."
             )
 
-        t_sigmas = self._scalar_sigmas(batch)
-        r_sigmas = self._sample_r_sigmas(t_sigmas)
-        self._validate_interval(t_sigmas, r_sigmas)
-        r_timesteps = self._timesteps_from_sigmas(r_sigmas, timesteps)
-        r_timesteps = r_timesteps.to(device=batch["timesteps"].device, dtype=batch["timesteps"].dtype)
-
-        target = self._base_flow_target(batch, model=model)
-        if self.config["target_mode"] == "online_teacher":
-            target = self._online_teacher_average_velocity(
-                prepared_batch=batch,
-                t_sigmas=t_sigmas,
-                r_sigmas=r_sigmas,
-                base_target=target,
-            )
-
+        t_sigmas, r_sigmas = self._prepare_meanflow_pair(batch, model)
+        r_timesteps = self._timesteps_from_sigmas(r_sigmas, timesteps).to(
+            device=timesteps.device,
+            dtype=timesteps.dtype,
+        )
         flowmap_key = getattr(model, "FLOWMAP_R_TIMESTEP_BATCH_KEY", self.FLOWMAP_R_TIMESTEP_BATCH_KEY)
         batch[flowmap_key] = r_timesteps
         batch["anyflow_r_timesteps"] = r_timesteps
-        batch["anyflow_timestep_interval"] = batch["timesteps"].to(dtype=r_timesteps.dtype) - r_timesteps
-        batch["target"] = target.detach()
+        batch["anyflow_timestep_interval"] = (batch["timesteps"].to(r_timesteps.dtype) - r_timesteps).abs()
+
+        base_target = self._base_flow_target(batch, model=model)
+        batch["target"] = self._meanflow_target(
+            prepared_batch=batch,
+            model=model,
+            t_sigmas=t_sigmas,
+            r_sigmas=r_sigmas,
+            base_target=base_target,
+        ).detach()
         batch["flow_target"] = batch["target"]
         return batch
 
@@ -114,21 +133,66 @@ class AnyFlowDistiller(DistillationBase):
         model_output: Dict[str, Any],
         original_loss: torch.Tensor,
     ):
-        del model_output
+        del original_loss
+        forward_loss = self._meanflow_loss(prepared_batch, model_output)
+        forward_loss = forward_loss * float(self.config["loss_weight"])
+        total_loss = forward_loss
+        logs = self._forward_logs(prepared_batch, forward_loss)
 
-        loss = original_loss * float(self.config.get("loss_weight", 1.0))
-        r_timesteps = prepared_batch.get("anyflow_r_timesteps", prepared_batch.get(self.FLOWMAP_R_TIMESTEP_BATCH_KEY))
-        logs = {
-            "anyflow_loss": float(loss.detach()),
-            "anyflow_timestep": float(torch.mean(prepared_batch["timesteps"].float()).detach()),
-            "total": float(loss.detach()),
-        }
-        if r_timesteps is not None:
-            logs["anyflow_r_timestep"] = float(torch.mean(r_timesteps.float()).detach())
-            logs["anyflow_interval"] = float(
-                torch.mean((prepared_batch["timesteps"].float() - r_timesteps.float())).detach()
-            )
-        return loss, logs
+        if self.config["stage"] == "onpolicy":
+            if not bool(self.config["cotrain_forward"]):
+                total_loss = forward_loss.new_zeros(())
+            dmd_loss, dmd_logs = self._onpolicy_generator_loss(prepared_batch)
+            total_loss = total_loss + dmd_loss
+            logs.update(dmd_logs)
+
+        logs["total"] = float(total_loss.detach())
+        return total_loss, logs
+
+    def discriminator_step(self, prepared_batch: Dict[str, Any], **_: Any) -> None:
+        if self.config["stage"] != "onpolicy" or self.discriminator_optimizer is None:
+            return
+
+        self.discriminator_optimizer.zero_grad(set_to_none=True)
+        with self._adapter_role("discriminator"):
+            discriminator_loss = self._onpolicy_discriminator_loss(prepared_batch)
+            discriminator_loss.backward()
+        self._sync_discriminator_gradients()
+        torch.nn.utils.clip_grad_norm_(
+            self._discriminator_parameters,
+            float(self.config["discriminator_grad_clip"]),
+        )
+        self.discriminator_optimizer.step()
+        self.discriminator_optimizer.zero_grad(set_to_none=True)
+
+    def on_save_checkpoint(self, step: int, ckpt_dir: str) -> None:
+        if self.config["stage"] != "onpolicy" or self.discriminator_optimizer is None:
+            return
+        accelerator = getattr(self.teacher_model, "accelerator", None)
+        if accelerator is not None and not bool(getattr(accelerator, "is_main_process", True)):
+            return
+
+        os.makedirs(ckpt_dir, exist_ok=True)
+        state = self._discriminator_state_dict()
+        save_file(state, os.path.join(ckpt_dir, ANYFLOW_DISCRIMINATOR_FILENAME))
+        torch.save(
+            {"step": int(step), "state": self.discriminator_optimizer.state_dict()},
+            os.path.join(ckpt_dir, ANYFLOW_DISCRIMINATOR_OPTIMIZER_FILENAME),
+        )
+
+    def on_load_checkpoint(self, ckpt_dir: str) -> None:
+        if self.config["stage"] != "onpolicy" or self.discriminator_optimizer is None:
+            return
+
+        weight_path = os.path.join(ckpt_dir, ANYFLOW_DISCRIMINATOR_FILENAME)
+        if os.path.exists(weight_path):
+            self._load_discriminator_state_dict(load_file(weight_path, device="cpu"))
+
+        optimizer_path = os.path.join(ckpt_dir, ANYFLOW_DISCRIMINATOR_OPTIMIZER_FILENAME)
+        if os.path.exists(optimizer_path):
+            payload = torch.load(optimizer_path, map_location="cpu", weights_only=True)
+            self.discriminator_optimizer.load_state_dict(payload["state"])
+            self._move_optimizer_state(self.discriminator_optimizer, self._device)
 
     def get_scheduler(self, scheduler=None):
         pipeline = getattr(self.teacher_model, "pipeline", None)
@@ -151,6 +215,423 @@ class AnyFlowDistiller(DistillationBase):
             )
         return validation_scheduler
 
+    # ------------------------------------------------------------------
+    # Configuration and adapter roles
+    # ------------------------------------------------------------------
+    @property
+    def _device(self) -> torch.device:
+        accelerator = getattr(self.teacher_model, "accelerator", None)
+        return torch.device(getattr(accelerator, "device", "cpu"))
+
+    @staticmethod
+    def _normalize_stage(value: Any) -> str:
+        stage = str(value).strip().lower().replace("-", "_")
+        aliases = {"forward": "forward", "meanflow": "forward", "pretrain": "forward", "onpolicy": "onpolicy"}
+        try:
+            return aliases[stage]
+        except KeyError as exc:
+            raise ValueError("AnyFlow stage must be one of: forward, onpolicy.") from exc
+
+    def _validate_forward_config(self) -> None:
+        diffusion_ratio = float(self.config["diffusion_ratio"])
+        consistency_ratio = float(self.config["consistency_ratio"])
+        if diffusion_ratio < 0.0 or consistency_ratio < 0.0 or diffusion_ratio + consistency_ratio > 1.0:
+            raise ValueError("AnyFlow diffusion_ratio and consistency_ratio must be non-negative and sum to at most 1.")
+        self.config["diffusion_ratio"] = diffusion_ratio
+        self.config["consistency_ratio"] = consistency_ratio
+
+        epsilon = float(self.config["central_difference_epsilon"])
+        if epsilon <= 0.0 or epsilon >= 0.5:
+            raise ValueError("AnyFlow central_difference_epsilon must be in (0.0, 0.5).")
+        self.config["central_difference_epsilon"] = epsilon
+
+        weight_type = str(self.config["meanflow_weight_type"]).strip().lower()
+        if weight_type not in {"beta08", "uniform"}:
+            raise ValueError("AnyFlow meanflow_weight_type must be one of: beta08, uniform.")
+        self.config["meanflow_weight_type"] = weight_type
+
+    def _init_onpolicy_stage(self) -> None:
+        if not bool(self.config["cotrain_forward"]):
+            raise ValueError("NVIDIA AnyFlow on-policy training requires cotrain_forward=true in SimpleTuner.")
+        if not self.low_rank_distillation or str(self.config.get("model_type", "lora")).lower() != "lora":
+            raise ValueError("AnyFlow on-policy training currently requires a standard PEFT LoRA student.")
+        lora_type = str(getattr(self.teacher_model.config, "lora_type", "standard")).lower()
+        if lora_type != "standard":
+            raise ValueError("AnyFlow on-policy training currently requires lora_type=standard.")
+
+        steps = self._parse_step_counts(self.config["rollout_step_counts"])
+        self.config["rollout_step_counts"] = steps
+        dmd_batch_size = int(self.config["dmd_batch_size"])
+        if dmd_batch_size < 1:
+            raise ValueError("AnyFlow dmd_batch_size must be at least 1.")
+        self.config["dmd_batch_size"] = dmd_batch_size
+
+        min_ratio = float(self.config["dmd_min_timestep_ratio"])
+        max_ratio = float(self.config["dmd_max_timestep_ratio"])
+        if min_ratio < 0.0 or max_ratio > 1.0 or max_ratio <= min_ratio:
+            raise ValueError("AnyFlow DMD timestep ratios must satisfy 0 <= min < max <= 1.")
+
+        component = self._flowmap_component
+        peft_config = getattr(component, "peft_config", None)
+        if not isinstance(peft_config, dict) or not peft_config:
+            raise ValueError("AnyFlow on-policy training requires an initialized PEFT adapter on the student.")
+
+        configured_student = self.config.get("student_adapter_name")
+        self._student_adapter_name = str(configured_student or next(iter(peft_config)))
+        if self._student_adapter_name not in peft_config:
+            raise ValueError(f"AnyFlow student adapter {self._student_adapter_name!r} does not exist.")
+
+        discriminator_name = str(self.config["discriminator_adapter_name"])
+        if discriminator_name == self._student_adapter_name:
+            raise ValueError("AnyFlow discriminator_adapter_name must differ from the student adapter name.")
+        if discriminator_name not in peft_config:
+            component.add_adapter(copy.deepcopy(peft_config[self._student_adapter_name]), adapter_name=discriminator_name)
+        self._discriminator_adapter_name = discriminator_name
+
+        self._discriminator_parameters = [
+            parameter
+            for name, parameter in component.named_parameters()
+            if self._parameter_belongs_to_adapter(name, discriminator_name)
+        ]
+        if not self._discriminator_parameters:
+            raise ValueError("AnyFlow could not locate the discriminator adapter parameters.")
+
+        self.discriminator_optimizer = torch.optim.AdamW(
+            self._discriminator_parameters,
+            lr=float(self.config["discriminator_lr"]),
+            betas=tuple(float(value) for value in self.config["discriminator_betas"]),
+            weight_decay=float(self.config["discriminator_weight_decay"]),
+            eps=float(self.config["discriminator_eps"]),
+        )
+        component.set_adapter(self._student_adapter_name)
+
+    @staticmethod
+    def _parse_step_counts(value: str | Sequence[int]) -> tuple[int, ...]:
+        if isinstance(value, str):
+            steps = tuple(int(item.strip()) for item in value.split(",") if item.strip())
+        else:
+            steps = tuple(int(item) for item in value)
+        if not steps or any(step < 1 for step in steps):
+            raise ValueError("AnyFlow rollout_step_counts must contain positive integers.")
+        return steps
+
+    @staticmethod
+    def _parameter_belongs_to_adapter(parameter_name: str, adapter_name: str) -> bool:
+        return f".{adapter_name}." in parameter_name or parameter_name.endswith(f".{adapter_name}")
+
+    @contextmanager
+    def _adapter_role(self, role: str) -> Iterator[None]:
+        if self.config["stage"] != "onpolicy":
+            yield
+            return
+
+        component = self._flowmap_component
+        previous_role = self._current_adapter_role
+        was_training = component.training
+        try:
+            self._set_adapter_role(role)
+            yield
+        finally:
+            self._set_adapter_role(previous_role)
+            component.train(was_training)
+
+    def _set_adapter_role(self, role: str) -> None:
+        component = self._flowmap_component
+        if role == "student":
+            component.enable_lora()
+            component.set_adapter(self._student_adapter_name)
+            component.train()
+        elif role == "discriminator":
+            component.enable_lora()
+            component.set_adapter(self._discriminator_adapter_name)
+            component.train()
+        elif role == "real":
+            component.disable_lora()
+            component.eval()
+        else:
+            raise ValueError(f"Unknown AnyFlow adapter role: {role}")
+        self._current_adapter_role = role
+
+    # ------------------------------------------------------------------
+    # NVIDIA forward MeanFlow stage
+    # ------------------------------------------------------------------
+    def _prepare_meanflow_pair(self, prepared_batch: Dict[str, Any], model) -> tuple[torch.Tensor, torch.Tensor]:
+        latents = prepared_batch["latents"]
+        batch_size = int(latents.shape[0])
+        device = latents.device
+        first = torch.rand(batch_size, device=device, dtype=torch.float32)
+        second = torch.rand(batch_size, device=device, dtype=torch.float32)
+        t_base = torch.maximum(first, second)
+        r_base = torch.minimum(first, second)
+
+        accelerator = getattr(model, "accelerator", getattr(self.teacher_model, "accelerator", None))
+        process_index = int(getattr(accelerator, "process_index", 0) or 0)
+        num_processes = int(getattr(accelerator, "num_processes", 1) or 1)
+        global_batch_size = batch_size * num_processes
+        global_indices = process_index * batch_size + torch.arange(batch_size, device=device)
+        diffusion_count = round(float(self.config["diffusion_ratio"]) * global_batch_size)
+        consistency_count = round(float(self.config["consistency_ratio"]) * global_batch_size)
+        diffusion_mask = global_indices < diffusion_count
+        consistency_mask = (global_indices >= diffusion_count) & (global_indices < diffusion_count + consistency_count)
+        arbitrary_mask = ~(diffusion_mask | consistency_mask)
+        r_base = torch.where(diffusion_mask, t_base, r_base)
+        r_base = torch.where(consistency_mask, torch.zeros_like(r_base), r_base)
+
+        t_sigmas = self._apply_scheduler_shift(t_base)
+        r_sigmas = self._apply_scheduler_shift(r_base)
+        prepared_batch["anyflow_diffusion_mask"] = diffusion_mask
+        prepared_batch["anyflow_consistency_mask"] = consistency_mask
+        prepared_batch["anyflow_arbitrary_mask"] = arbitrary_mask
+        prepared_batch["anyflow_t_base"] = t_base
+        prepared_batch["anyflow_r_base"] = r_base
+        self._set_batch_sigma_path(prepared_batch, t_sigmas)
+        return t_sigmas, r_sigmas
+
+    def _meanflow_target(
+        self,
+        *,
+        prepared_batch: Dict[str, Any],
+        model,
+        t_sigmas: torch.Tensor,
+        r_sigmas: torch.Tensor,
+        base_target: torch.Tensor,
+    ) -> torch.Tensor:
+        epsilon = float(self.config["central_difference_epsilon"])
+        plus_sigmas = t_sigmas + epsilon
+        minus_sigmas = t_sigmas - epsilon
+
+        with torch.no_grad():
+            plus_output = model.model_predict(self._batch_at_sigmas(prepared_batch, plus_sigmas))
+            plus_prediction = plus_output["model_prediction"].detach()
+            self._clear_prediction_buffers(plus_output)
+            minus_output = model.model_predict(self._batch_at_sigmas(prepared_batch, minus_sigmas))
+            minus_prediction = minus_output["model_prediction"].detach()
+            self._clear_prediction_buffers(minus_output)
+
+        denominator = self._broadcast_time(plus_sigmas - minus_sigmas, plus_prediction).to(
+            device=plus_prediction.device,
+            dtype=plus_prediction.dtype,
+        )
+        total_derivative = (plus_prediction - minus_prediction) / denominator
+        interval = self._broadcast_time(t_sigmas - r_sigmas, total_derivative).to(
+            device=total_derivative.device,
+            dtype=total_derivative.dtype,
+        )
+        target = base_target.to(device=total_derivative.device, dtype=total_derivative.dtype) - interval * total_derivative
+        return target.to(device=base_target.device, dtype=base_target.dtype)
+
+    def _meanflow_loss(self, prepared_batch: Dict[str, Any], model_output: Dict[str, Any]) -> torch.Tensor:
+        prediction = model_output.get("model_prediction")
+        target = prepared_batch.get("target")
+        if not torch.is_tensor(prediction) or not torch.is_tensor(target):
+            raise ValueError("AnyFlow MeanFlow loss requires tensor model_prediction and target values.")
+        if prediction.shape != target.shape:
+            raise ValueError(
+                f"AnyFlow MeanFlow target shape {tuple(target.shape)} does not match prediction {tuple(prediction.shape)}."
+            )
+
+        per_sample = (prediction.float() - target.float()).square().flatten(1).mean(dim=1)
+        t_sigmas = self._scalar_sigmas(prepared_batch).to(device=per_sample.device, dtype=per_sample.dtype)
+        per_sample = per_sample * self._meanflow_timestep_weight(t_sigmas)
+
+        diffusion_mask = prepared_batch.get("anyflow_diffusion_mask")
+        if bool(self.config["meanflow_adaptive_weighting"]) and torch.is_tensor(diffusion_mask):
+            diffusion_mask = diffusion_mask.to(device=per_sample.device, dtype=torch.bool)
+            global_loss = self._gather_detached(per_sample)
+            global_diffusion_mask = self._gather_detached(diffusion_mask)
+            if bool(global_diffusion_mask.any()):
+                diffusion_mean = global_loss[global_diffusion_mask].mean()
+                non_diffusion_mask = ~diffusion_mask
+                if bool(non_diffusion_mask.any()):
+                    scale = diffusion_mean / (per_sample.detach()[non_diffusion_mask] + 1e-5)
+                    per_sample = per_sample.clone()
+                    per_sample[non_diffusion_mask] = per_sample[non_diffusion_mask] * scale
+        return per_sample.mean()
+
+    def _meanflow_timestep_weight(self, t_sigmas: torch.Tensor) -> torch.Tensor:
+        if self.config["meanflow_weight_type"] == "uniform":
+            return torch.ones_like(t_sigmas)
+        weight = t_sigmas * torch.sqrt((1.0 - t_sigmas).clamp_min(0.0))
+        grid = torch.linspace(1.0, 0.0, int(self.num_train_timesteps) + 1, device=t_sigmas.device)[:-1]
+        shifted_grid = self._apply_scheduler_shift(grid)
+        grid_weight = shifted_grid * torch.sqrt((1.0 - shifted_grid).clamp_min(0.0))
+        normalization = grid_weight.numel() / grid_weight.sum().clamp_min(torch.finfo(grid_weight.dtype).eps)
+        return weight * normalization.to(dtype=weight.dtype)
+
+    # ------------------------------------------------------------------
+    # NVIDIA on-policy DMD / Flow Map Backward Simulation stage
+    # ------------------------------------------------------------------
+    def _onpolicy_generator_loss(self, prepared_batch: Dict[str, Any]) -> tuple[torch.Tensor, Dict[str, float]]:
+        dmd_batch = self._slice_batch(prepared_batch, int(self.config["dmd_batch_size"]))
+        step_count = self._distributed_rollout_step_count()
+        with self._adapter_role("student"):
+            generated = self._training_rollout(dmd_batch, step_count=step_count)
+
+        sigma = self._sample_dmd_sigma(generated.shape[0], logit_normal=False, device=generated.device)
+        noise = torch.randn_like(generated)
+        sigma_broadcast = self._broadcast_time(sigma, generated).to(generated.dtype)
+        noisy = ((1.0 - sigma_broadcast) * generated + sigma_broadcast * noise).detach()
+
+        with torch.no_grad():
+            with self._adapter_role("discriminator"):
+                fake_x0 = self._score_x0(dmd_batch, noisy, sigma)
+            with self._adapter_role("real"):
+                real_x0 = self._score_x0(dmd_batch, noisy, sigma)
+                real_x0 = self._apply_real_score_guidance(dmd_batch, noisy, sigma, real_x0)
+
+            gradient = fake_x0 - real_x0
+            dimensions = tuple(range(1, generated.ndim))
+            normalizer = torch.abs(generated.detach() - real_x0).mean(dim=dimensions, keepdim=True)
+            gradient = torch.nan_to_num(gradient / normalizer)
+
+        target = (generated.double() - gradient.double()).detach()
+        loss = float(self.config["dmd_weight"]) * F.mse_loss(generated.double(), target, reduction="mean")
+        logs = {
+            "anyflow_dmd_loss": float(loss.detach()),
+            "anyflow_dmd_gradient_norm": float(gradient.float().abs().mean().detach()),
+            "anyflow_dmd_sigma": float(sigma.float().mean().detach()),
+            "anyflow_rollout_steps": float(step_count),
+        }
+        return loss, logs
+
+    def _onpolicy_discriminator_loss(self, prepared_batch: Dict[str, Any]) -> torch.Tensor:
+        dmd_batch = self._slice_batch(prepared_batch, int(self.config["dmd_batch_size"]))
+        step_count = self._distributed_rollout_step_count()
+        with torch.no_grad(), self._adapter_role("student"):
+            generated = self._training_rollout(dmd_batch, step_count=step_count).detach()
+
+        sigma = self._sample_dmd_sigma(generated.shape[0], logit_normal=True, device=generated.device)
+        noise = torch.randn_like(generated)
+        sigma_broadcast = self._broadcast_time(sigma, generated).to(generated.dtype)
+        noisy = (1.0 - sigma_broadcast) * generated + sigma_broadcast * noise
+        prediction = self._predict_at_sigmas(dmd_batch, noisy, sigma, sigma)
+        target = self._flow_target(generated, noise).to(device=prediction.device, dtype=prediction.dtype)
+        return (prediction.float() - target.float()).square().flatten(1).mean(dim=1).mean()
+
+    def _training_rollout(self, prepared_batch: Dict[str, Any], *, step_count: int) -> torch.Tensor:
+        latents = torch.randn_like(prepared_batch["latents"])
+        base_sigmas = torch.linspace(1.0, 0.0, step_count + 1, device=latents.device, dtype=torch.float32)
+        sigmas = self._apply_scheduler_shift(base_sigmas)
+        for index in range(step_count):
+            t_sigma = sigmas[index].expand(latents.shape[0])
+            r_sigma = sigmas[index + 1].expand(latents.shape[0])
+            prediction = self._predict_at_sigmas(prepared_batch, latents, t_sigma, r_sigma)
+            velocity = self._prediction_to_noiseward_flow(prediction)
+            step = self._broadcast_time(r_sigma - t_sigma, latents).to(dtype=latents.dtype)
+            latents = latents + step * velocity.to(dtype=latents.dtype)
+        return latents
+
+    def _score_x0(
+        self,
+        prepared_batch: Dict[str, Any],
+        noisy_latents: torch.Tensor,
+        sigmas: torch.Tensor,
+    ) -> torch.Tensor:
+        prediction = self._predict_at_sigmas(prepared_batch, noisy_latents, sigmas, sigmas)
+        velocity = self._prediction_to_noiseward_flow(prediction)
+        sigma = self._broadcast_time(sigmas, noisy_latents).to(device=noisy_latents.device, dtype=noisy_latents.dtype)
+        return noisy_latents - sigma * velocity.to(dtype=noisy_latents.dtype)
+
+    def _apply_real_score_guidance(
+        self,
+        prepared_batch: Dict[str, Any],
+        noisy_latents: torch.Tensor,
+        sigmas: torch.Tensor,
+        conditional_x0: torch.Tensor,
+    ) -> torch.Tensor:
+        guidance = float(self.config["real_score_guidance_scale"])
+        if guidance == 0.0:
+            return conditional_x0
+        negative = prepared_batch.get("negative_encoder_hidden_states")
+        if not torch.is_tensor(negative):
+            raise ValueError("AnyFlow real_score_guidance_scale requires cached negative_encoder_hidden_states.")
+        unconditional_batch = dict(prepared_batch)
+        unconditional_batch["encoder_hidden_states"] = negative
+        negative_tags = prepared_batch.get("negative_text_token_tags")
+        if torch.is_tensor(negative_tags):
+            unconditional_batch["text_token_tags"] = negative_tags
+        unconditional_x0 = self._score_x0(unconditional_batch, noisy_latents, sigmas)
+        return conditional_x0 + (conditional_x0 - unconditional_x0) * guidance
+
+    def _distributed_rollout_step_count(self) -> int:
+        steps = self.config["rollout_step_counts"]
+        device = self._device
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            if torch.distributed.get_rank() == 0:
+                index = torch.randint(len(steps), (1,), device=device, dtype=torch.long)
+            else:
+                index = torch.zeros(1, device=device, dtype=torch.long)
+            torch.distributed.broadcast(index, src=0)
+            return int(steps[int(index.item())])
+        return int(steps[int(torch.randint(len(steps), (1,)).item())])
+
+    def _sample_dmd_sigma(self, batch_size: int, *, logit_normal: bool, device: torch.device) -> torch.Tensor:
+        base = (
+            torch.sigmoid(torch.randn(batch_size, device=device)) if logit_normal else torch.rand(batch_size, device=device)
+        )
+        sigma = self._apply_scheduler_shift(base)
+        return sigma.clamp(
+            min=float(self.config["dmd_min_timestep_ratio"]),
+            max=float(self.config["dmd_max_timestep_ratio"]),
+        )
+
+    # ------------------------------------------------------------------
+    # Shared model and tensor helpers
+    # ------------------------------------------------------------------
+    def _predict_at_sigmas(
+        self,
+        prepared_batch: Dict[str, Any],
+        noisy_latents: torch.Tensor,
+        t_sigmas: torch.Tensor,
+        r_sigmas: torch.Tensor,
+    ) -> torch.Tensor:
+        batch = dict(prepared_batch)
+        batch.pop("target", None)
+        batch.pop("flow_target", None)
+        batch["noisy_latents"] = noisy_latents
+        batch["sigmas"] = self._sigma_for_reference(t_sigmas, prepared_batch.get("sigmas"), noisy_latents)
+        batch["timesteps"] = self._timesteps_from_sigmas(t_sigmas, prepared_batch["timesteps"]).to(
+            device=prepared_batch["timesteps"].device,
+            dtype=prepared_batch["timesteps"].dtype,
+        )
+        r_timesteps = self._timesteps_from_sigmas(r_sigmas, prepared_batch["timesteps"]).to(
+            device=prepared_batch["timesteps"].device,
+            dtype=prepared_batch["timesteps"].dtype,
+        )
+        flowmap_key = getattr(self.teacher_model, "FLOWMAP_R_TIMESTEP_BATCH_KEY", self.FLOWMAP_R_TIMESTEP_BATCH_KEY)
+        batch[flowmap_key] = r_timesteps
+        batch["anyflow_r_timesteps"] = r_timesteps
+        output = self.teacher_model.model_predict(batch)
+        prediction = output["model_prediction"]
+        self._clear_prediction_buffers(output)
+        return prediction
+
+    def _slice_batch(self, prepared_batch: Dict[str, Any], requested_batch_size: int) -> Dict[str, Any]:
+        source_batch_size = int(prepared_batch["latents"].shape[0])
+        batch_size = min(source_batch_size, requested_batch_size)
+
+        def slice_value(value):
+            if torch.is_tensor(value) and value.ndim > 0 and int(value.shape[0]) == source_batch_size:
+                return value[:batch_size]
+            if isinstance(value, dict):
+                return {key: slice_value(item) for key, item in value.items()}
+            return value
+
+        return {key: slice_value(value) for key, value in prepared_batch.items()}
+
+    def _forward_logs(self, prepared_batch: Dict[str, Any], loss: torch.Tensor) -> Dict[str, float]:
+        r_timesteps = prepared_batch["anyflow_r_timesteps"]
+        logs = {
+            "anyflow_forward_loss": float(loss.detach()),
+            "anyflow_timestep": float(prepared_batch["timesteps"].float().mean().detach()),
+            "anyflow_r_timestep": float(r_timesteps.float().mean().detach()),
+            "anyflow_interval": float(prepared_batch["anyflow_timestep_interval"].float().mean().detach()),
+        }
+        for branch in ("diffusion", "consistency", "arbitrary"):
+            mask = prepared_batch[f"anyflow_{branch}_mask"]
+            logs[f"anyflow_{branch}_fraction"] = float(mask.float().mean().detach())
+        return logs
+
     def _validation_component_names(self) -> tuple[str, ...]:
         names: list[str] = []
         model_type = getattr(getattr(self.teacher_model, "MODEL_TYPE", None), "value", None)
@@ -161,26 +642,13 @@ class AnyFlowDistiller(DistillationBase):
                 names.append(fallback_name)
         return tuple(names)
 
-    @staticmethod
-    def _normalize_target_mode(value: Any) -> str:
-        mode = str(value).strip().lower().replace("-", "_")
-        try:
-            return AnyFlowDistiller._TARGET_MODE_ALIASES[mode]
-        except KeyError as exc:
-            raise ValueError("AnyFlow target_mode must be one of: online_teacher, linear.") from exc
-
-    @staticmethod
-    def _normalize_r_timestep_sampler(value: Any) -> str:
-        sampler = str(value).strip().lower().replace("-", "_")
-        if sampler not in {"uniform", "zero"}:
-            raise ValueError("AnyFlow r_timestep_sampler must be one of: uniform, zero.")
-        return sampler
-
     def _resolve_timestep_scale(self, noise_scheduler) -> float:
         configured = self.config.get("timestep_scale")
         if configured not in (None, ""):
             return float(configured)
         scheduler_config = getattr(noise_scheduler, "config", None)
+        if isinstance(scheduler_config, dict):
+            return float(scheduler_config.get("num_train_timesteps", 1000))
         return float(getattr(scheduler_config, "num_train_timesteps", 1000))
 
     def _enable_flowmap_time_conditioning(self):
@@ -192,7 +660,7 @@ class AnyFlowDistiller(DistillationBase):
                 "Add enable_flowmap_time_conditioning() to the trained component before enabling AnyFlow."
             )
         enable_flowmap(
-            gate_value=float(self.config.get("gate_value", 0.25)),
+            gate_value=float(self.config["gate_value"]),
             deltatime_type=self.config["deltatime_type"],
         )
         return component
@@ -211,7 +679,7 @@ class AnyFlowDistiller(DistillationBase):
         raise ValueError("AnyFlow requires a model with get_trained_component() or a `.model` component.")
 
     @staticmethod
-    def _validate_prepared_batch(batch: Dict[str, Any]) -> None:
+    def _validate_video_batch(batch: Dict[str, Any]) -> None:
         required_keys = ("latents", "noise", "noisy_latents", "sigmas", "timesteps")
         missing = [key for key in required_keys if key not in batch or batch[key] is None]
         if missing:
@@ -219,6 +687,12 @@ class AnyFlowDistiller(DistillationBase):
         for key in required_keys:
             if not torch.is_tensor(batch[key]):
                 raise ValueError(f"AnyFlow prepared batch field `{key}` must be a tensor.")
+        for key in ("audio_latents", "audio_noisy_latents", "audio_timesteps", "audio_sigmas"):
+            if torch.is_tensor(batch.get(key)):
+                raise ValueError(
+                    "AnyFlow does not yet support joint audio-video batches. MiniMax-H3 audio requires its native "
+                    "shift-3 schedule while video uses shift 12."
+                )
 
     @staticmethod
     def _broadcast_time(time_tensor: torch.Tensor, like: torch.Tensor) -> torch.Tensor:
@@ -235,118 +709,126 @@ class AnyFlowDistiller(DistillationBase):
             return sigmas.expand(batch_size)
         if sigmas.shape[0] != batch_size:
             raise ValueError(f"AnyFlow expected {batch_size} sigma values, got shape {tuple(sigmas.shape)}.")
-        return sigmas.reshape(batch_size, -1)[:, 0].clamp(0.0, 1.0)
+        return sigmas.reshape(batch_size, -1)[:, 0]
 
     def _timesteps_from_sigmas(self, sigmas: torch.Tensor, reference_timesteps: torch.Tensor) -> torch.Tensor:
+        converter = getattr(self.teacher_model, "flow_matching_timesteps_from_sigmas", None)
+        if callable(converter):
+            return converter(sigmas, reference_timesteps=reference_timesteps)
         if torch.max(reference_timesteps.detach().float()) <= 1.0:
             return sigmas
         return sigmas * self.num_train_timesteps
 
-    def _sample_r_sigmas(self, t_sigmas: torch.Tensor) -> torch.Tensor:
-        sampler = self.config["r_timestep_sampler"]
-        if sampler == "zero":
-            return torch.zeros_like(t_sigmas)
+    def _apply_scheduler_shift(self, sigmas: torch.Tensor) -> torch.Tensor:
+        scheduler_config = getattr(self.noise_scheduler, "config", None)
+        shift = (
+            scheduler_config.get("shift", 1.0)
+            if isinstance(scheduler_config, dict)
+            else getattr(scheduler_config, "shift", 1.0)
+        )
+        shift = float(shift or 1.0)
+        if shift == 1.0:
+            return sigmas
+        return shift * sigmas / (1.0 + (shift - 1.0) * sigmas)
 
-        min_interval = float(self.config["min_interval_ratio"])
-        max_r = (t_sigmas - min_interval).clamp_min(0.0)
-        return torch.rand_like(t_sigmas) * max_r
+    def _set_batch_sigma_path(self, batch: Dict[str, Any], sigmas: torch.Tensor) -> None:
+        latents = batch["latents"]
+        noise = batch["noise"].to(device=latents.device, dtype=latents.dtype)
+        sigma_for_latents = self._broadcast_time(sigmas, latents).to(device=latents.device, dtype=latents.dtype)
+        batch["noisy_latents"] = (1.0 - sigma_for_latents) * latents + sigma_for_latents * noise
+        batch["sigmas"] = self._sigma_for_reference(sigmas, batch.get("sigmas"), latents)
+        batch["timesteps"] = self._timesteps_from_sigmas(sigmas, batch["timesteps"]).to(
+            device=batch["timesteps"].device,
+            dtype=batch["timesteps"].dtype,
+        )
 
-    @staticmethod
-    def _validate_interval(t_sigmas: torch.Tensor, r_sigmas: torch.Tensor) -> None:
-        interval = t_sigmas - r_sigmas
-        eps = torch.finfo(interval.dtype).eps if torch.is_floating_point(interval) else 0.0
-        if torch.any(interval <= eps):
-            raise ValueError(
-                "AnyFlow requires r_timestep < timestep. Avoid timestep 0 in flow_custom_timesteps "
-                "or use a sampler that leaves a positive interval."
-            )
+    def _sigma_for_reference(
+        self,
+        sigmas: torch.Tensor,
+        reference_sigmas: Any,
+        latents: torch.Tensor,
+    ) -> torch.Tensor:
+        if not torch.is_tensor(reference_sigmas):
+            return sigmas
+        sigma_for_model = sigmas
+        while sigma_for_model.ndim < reference_sigmas.ndim:
+            sigma_for_model = sigma_for_model.unsqueeze(-1)
+        return sigma_for_model.expand_as(reference_sigmas).to(
+            device=latents.device,
+            dtype=reference_sigmas.dtype,
+        )
+
+    def _batch_at_sigmas(self, prepared_batch: Dict[str, Any], sigmas: torch.Tensor) -> Dict[str, Any]:
+        batch = dict(prepared_batch)
+        self._set_batch_sigma_path(batch, sigmas)
+        batch.pop("target", None)
+        batch.pop("flow_target", None)
+        return batch
 
     def _base_flow_target(self, prepared_batch: Dict[str, Any], model=None) -> torch.Tensor:
         target_model = model or self.student_model or self.teacher_model
         get_target = getattr(target_model, "get_flow_matching_target", None)
         if callable(get_target):
-            target = get_target(prepared_batch, prefer_explicit_target=True)
+            target = get_target(prepared_batch, prefer_explicit_target=False)
             return target.to(device=prepared_batch["latents"].device, dtype=prepared_batch["latents"].dtype)
-        flow_target = prepared_batch.get("flow_target")
-        if torch.is_tensor(flow_target):
-            return flow_target.to(device=prepared_batch["latents"].device, dtype=prepared_batch["latents"].dtype)
-        return prepared_batch["noise"] - prepared_batch["latents"]
+        return self._flow_target(prepared_batch["latents"], prepared_batch["noise"])
 
-    def _teacher_prediction_to_noiseward_flow(self, prediction: torch.Tensor) -> torch.Tensor:
+    def _flow_target(self, latents: torch.Tensor, noise: torch.Tensor) -> torch.Tensor:
+        target_fn = getattr(self.teacher_model, "flow_matching_target", None)
+        if callable(target_fn):
+            return target_fn(latents, noise)
+        return noise - latents
+
+    def _prediction_to_noiseward_flow(self, prediction: torch.Tensor) -> torch.Tensor:
         converter = getattr(self.teacher_model, "prediction_to_noiseward_flow", None)
-        if callable(converter):
-            return converter(prediction)
-        return prediction
+        return converter(prediction) if callable(converter) else prediction
 
-    def _noiseward_flow_to_student_prediction(self, flow: torch.Tensor) -> torch.Tensor:
-        converter = getattr(self.student_model, "noiseward_flow_to_prediction", None)
-        if callable(converter):
-            return converter(flow)
-        return flow
+    @staticmethod
+    def _clear_prediction_buffers(output: Dict[str, Any]) -> None:
+        hidden_states_buffer = output.get("hidden_states_buffer")
+        if isinstance(hidden_states_buffer, dict):
+            hidden_states_buffer.clear()
 
-    def _online_teacher_average_velocity(
-        self,
-        *,
-        prepared_batch: Dict[str, Any],
-        t_sigmas: torch.Tensor,
-        r_sigmas: torch.Tensor,
-        base_target: torch.Tensor,
-    ) -> torch.Tensor:
-        start_latents = prepared_batch["noisy_latents"].detach()
-        current_latents = start_latents
-        current_sigmas = t_sigmas
+    @staticmethod
+    def _gather_detached(tensor: torch.Tensor) -> torch.Tensor:
+        if not torch.distributed.is_available() or not torch.distributed.is_initialized():
+            return tensor.detach()
+        gathered = [torch.empty_like(tensor) for _ in range(torch.distributed.get_world_size())]
+        torch.distributed.all_gather(gathered, tensor.detach())
+        return torch.cat(gathered, dim=0)
 
-        try:
-            self.toggle_adapter(enable=False)
-            with torch.no_grad():
-                for next_sigmas in self._rollout_sigma_schedule(t_sigmas, r_sigmas):
-                    teacher_batch = self._teacher_batch(prepared_batch, current_latents, current_sigmas)
-                    teacher_prediction = self.teacher_model.model_predict(teacher_batch)["model_prediction"]
-                    teacher_prediction = teacher_prediction.to(device=current_latents.device, dtype=current_latents.dtype)
-                    noiseward_prediction = self._teacher_prediction_to_noiseward_flow(teacher_prediction)
-                    step = self._broadcast_time(next_sigmas - current_sigmas, current_latents)
-                    current_latents = current_latents + step * noiseward_prediction
-                    current_sigmas = next_sigmas
-        finally:
-            self.toggle_adapter(enable=True)
+    def _discriminator_state_dict(self) -> Dict[str, torch.Tensor]:
+        adapter_name = str(self._discriminator_adapter_name)
+        return {
+            name: tensor.detach().cpu().contiguous()
+            for name, tensor in self._flowmap_component.state_dict().items()
+            if self._parameter_belongs_to_adapter(name, adapter_name)
+        }
 
-        denominator = self._broadcast_time(r_sigmas - t_sigmas, current_latents)
-        average_velocity = (current_latents - start_latents) / denominator
-        target = self._noiseward_flow_to_student_prediction(average_velocity)
-        return target.to(device=base_target.device, dtype=base_target.dtype)
+    def _sync_discriminator_gradients(self) -> None:
+        if not torch.distributed.is_available() or not torch.distributed.is_initialized():
+            return
+        world_size = torch.distributed.get_world_size()
+        for parameter in self._discriminator_parameters:
+            if parameter.grad is None:
+                continue
+            torch.distributed.all_reduce(parameter.grad, op=torch.distributed.ReduceOp.SUM)
+            parameter.grad.div_(world_size)
 
-    def _rollout_sigma_schedule(self, t_sigmas: torch.Tensor, r_sigmas: torch.Tensor):
-        steps = int(self.config["teacher_rollout_steps"])
-        for index in range(steps):
-            ratio = float(index + 1) / float(steps)
-            yield t_sigmas + (r_sigmas - t_sigmas) * ratio
+    def _load_discriminator_state_dict(self, state: Dict[str, torch.Tensor]) -> None:
+        component_state = self._flowmap_component.state_dict()
+        unexpected = sorted(set(state) - set(component_state))
+        if unexpected:
+            raise ValueError(f"Unexpected AnyFlow discriminator checkpoint keys: {unexpected[:5]}")
+        for name, tensor in state.items():
+            component_state[name].copy_(tensor.to(device=component_state[name].device, dtype=component_state[name].dtype))
 
-    def _teacher_batch(
-        self,
-        prepared_batch: Dict[str, Any],
-        noisy_latents: torch.Tensor,
-        sigmas: torch.Tensor,
-    ) -> Dict[str, Any]:
-        teacher_batch = dict(prepared_batch)
-        teacher_batch.pop("target", None)
-        teacher_batch.pop("flow_target", None)
-        teacher_batch.pop(self.FLOWMAP_R_TIMESTEP_BATCH_KEY, None)
-        teacher_batch.pop("anyflow_r_timesteps", None)
-        teacher_batch.pop("anyflow_timestep_interval", None)
-
-        teacher_batch["noisy_latents"] = noisy_latents
-        teacher_batch["timesteps"] = self._timesteps_from_sigmas(
-            sigmas,
-            prepared_batch["timesteps"].to(device=sigmas.device, dtype=torch.float32),
-        ).to(
-            device=prepared_batch["timesteps"].device,
-            dtype=prepared_batch["timesteps"].dtype,
-        )
-        teacher_batch["sigmas"] = self._broadcast_time(sigmas, noisy_latents).to(
-            device=noisy_latents.device,
-            dtype=noisy_latents.dtype,
-        )
-        return teacher_batch
+    @staticmethod
+    def _move_optimizer_state(optimizer: torch.optim.Optimizer, device: torch.device) -> None:
+        for state in optimizer.state.values():
+            for key, value in state.items():
+                if torch.is_tensor(value):
+                    state[key] = value.to(device=device)
 
 
 DistillationRegistry.register(
@@ -354,5 +836,5 @@ DistillationRegistry.register(
     AnyFlowDistiller,
     requires_distillation_cache=False,
     data_requirements=[[DatasetType.IMAGE, DatasetType.VIDEO]],
-    requirement_notes="Requires model-specific FlowMap interval conditioning on the trained component.",
+    requirement_notes="Requires model-specific FlowMap interval conditioning; joint H3 audio-video is not yet supported.",
 )

--- a/simpletuner/helpers/distillation/anyflow/scheduler.py
+++ b/simpletuner/helpers/distillation/anyflow/scheduler.py
@@ -151,14 +151,6 @@ class AnyFlowValidationScheduler:
             return timesteps.detach().to(device=device, dtype=torch.float32).reshape(-1)
         return torch.tensor(list(timesteps), device=device, dtype=torch.float32).reshape(-1)
 
-    def _scheduler_sigmas(self, device: torch.device) -> Optional[torch.Tensor]:
-        sigmas = getattr(self.scheduler, "sigmas", None)
-        if sigmas is None:
-            return None
-        if torch.is_tensor(sigmas):
-            return sigmas.detach().to(device=device, dtype=torch.float32).reshape(-1)
-        return torch.tensor(list(sigmas), device=device, dtype=torch.float32).reshape(-1)
-
     def _train_timestep_scale(self, schedule: torch.Tensor) -> float:
         if self.num_train_timesteps is not None:
             return float(self.num_train_timesteps)
@@ -176,13 +168,8 @@ class AnyFlowValidationScheduler:
         train_scale: float,
         device: torch.device,
     ) -> torch.Tensor:
-        sigmas = self._scheduler_sigmas(device)
-        if sigmas is not None and sigmas.numel() == schedule.numel() + 1:
-            sigma_max = torch.max(torch.abs(sigmas)).item()
-            endpoint_schedule = sigmas[1:] * train_scale if sigma_max <= 1.5 else sigmas[1:]
-            return endpoint_schedule.to(device=device, dtype=torch.float32)
-
-        final_raw_timestep = 0.0 if schedule[0] >= schedule[-1] else train_scale
+        schedule_scale = 1.0 if torch.max(torch.abs(schedule)).item() <= 1.5 else train_scale
+        final_raw_timestep = 0.0 if schedule[0] >= schedule[-1] else schedule_scale
         final = torch.tensor([final_raw_timestep], device=device, dtype=torch.float32)
         return torch.cat([schedule[1:], final])
 

--- a/tests/helpers/distillation/test_anyflow_distiller.py
+++ b/tests/helpers/distillation/test_anyflow_distiller.py
@@ -1,6 +1,9 @@
 import inspect
+import tempfile
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 
@@ -15,6 +18,9 @@ class _FlowMapComponent(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self.adapter_enabled = True
+        self.active_adapter = "default"
+        self.adapter_params = torch.nn.ParameterDict({"default": torch.nn.Parameter(torch.tensor([5.0]))})
+        self.peft_config = {"default": SimpleNamespace(name="default")}
         self.flowmap_enabled = False
         self.flowmap_gate_value = None
         self.flowmap_deltatime_type = None
@@ -29,6 +35,15 @@ class _FlowMapComponent(torch.nn.Module):
 
     def disable_lora(self):
         self.adapter_enabled = False
+
+    def add_adapter(self, adapter_config, adapter_name="default"):
+        self.peft_config[adapter_name] = adapter_config
+        self.adapter_params[adapter_name] = torch.nn.Parameter(torch.zeros(1))
+
+    def set_adapter(self, adapter_name):
+        self.active_adapter = adapter_name
+        for name, parameter in self.adapter_params.items():
+            parameter.requires_grad_(name == adapter_name)
 
     def forward(self, timestep=None, r_timestep=None, **kwargs):
         del kwargs
@@ -45,7 +60,12 @@ class _FlowModel:
         self.teacher_adapter_states = []
         self.teacher_timesteps = []
         self.config = SimpleNamespace(lora_type="standard", weight_dtype=torch.float32)
-        self.accelerator = SimpleNamespace(device=torch.device("cpu"), num_processes=1)
+        self.accelerator = SimpleNamespace(
+            device=torch.device("cpu"),
+            is_main_process=True,
+            num_processes=1,
+            process_index=0,
+        )
 
     def get_trained_component(self, unwrap_model=False):
         return self.component
@@ -53,8 +73,13 @@ class _FlowModel:
     def model_predict(self, batch):
         self.teacher_adapter_states.append(self.component.adapter_enabled)
         self.teacher_timesteps.append(batch["timesteps"].detach().clone())
-        value = 7.0 if self.component.adapter_enabled else 2.0
-        return {"model_prediction": torch.full_like(batch["noisy_latents"], value)}
+        value = batch["noisy_latents"].new_tensor(2.0)
+        if self.component.adapter_enabled:
+            value = value + self.component.adapter_params[self.component.active_adapter]
+        return {"model_prediction": torch.ones_like(batch["noisy_latents"]) * value}
+
+    def flow_matching_target(self, latents, noise):
+        return noise - latents
 
 
 class _EpsilonModel(_FlowModel):
@@ -86,6 +111,41 @@ class _InverseFlowModel(_FlowModel):
     def noiseward_flow_to_prediction(self, flow):
         return -flow
 
+    def flow_matching_target(self, latents, noise):
+        return latents - noise
+
+
+class _DatawardTimeFlowModel(_FlowModel):
+    def flow_matching_timesteps_from_sigmas(self, sigmas, *, reference_timesteps=None):
+        del reference_timesteps
+        return 1.0 - sigmas
+
+
+class _SigmaPredictionFlowModel(_FlowModel):
+    def model_predict(self, batch):
+        return {"model_prediction": batch["noisy_latents"].clone()}
+
+
+class _DatawardSigmaPredictionFlowModel(_InverseFlowModel):
+    def flow_matching_timesteps_from_sigmas(self, sigmas, *, reference_timesteps=None):
+        del reference_timesteps
+        return 1.0 - sigmas
+
+    def model_predict(self, batch):
+        return {"model_prediction": -batch["noisy_latents"].clone()}
+
+
+class _DatawardRoleFlowModel(_InverseFlowModel):
+    def flow_matching_timesteps_from_sigmas(self, sigmas, *, reference_timesteps=None):
+        del reference_timesteps
+        return 1.0 - sigmas
+
+    def model_predict(self, batch):
+        value = batch["noisy_latents"].new_tensor(2.0)
+        if self.component.adapter_enabled:
+            value = value + self.component.adapter_params[self.component.active_adapter]
+        return {"model_prediction": -torch.ones_like(batch["noisy_latents"]) * value}
+
 
 class _NoFlowMapModel(_FlowModel):
     def __init__(self):
@@ -108,6 +168,12 @@ class _ValidationScheduler:
         self.step_args = args
         self.step_kwargs = kwargs
         return ("stepped",)
+
+
+class _DatawardValidationScheduler(_ValidationScheduler):
+    def __init__(self):
+        super().__init__()
+        self.timesteps = torch.tensor([0.0, 0.5])
 
 
 class _TParameterComponent(torch.nn.Module):
@@ -146,7 +212,7 @@ class AnyFlowDistillerTests(unittest.TestCase):
         distiller = AnyFlowDistiller(
             teacher_model=model,
             noise_scheduler=None,
-            config={"model_type": "lora", "gate_value": 0.5, "deltatime_type": "t-r", "target_mode": "linear"},
+            config={"model_type": "lora", "gate_value": 0.5, "deltatime_type": "t-r"},
         )
 
         self.assertIs(distiller._flowmap_component, model.component)
@@ -154,97 +220,249 @@ class AnyFlowDistillerTests(unittest.TestCase):
         self.assertEqual(model.component.flowmap_gate_value, 0.5)
         self.assertEqual(model.component.flowmap_deltatime_type, "t-r")
 
-    def test_linear_prepare_batch_sets_r_timesteps_and_target(self):
-        model = _FlowModel()
-        distiller = AnyFlowDistiller(
-            teacher_model=model,
-            noise_scheduler=None,
-            config={"model_type": "lora", "target_mode": "linear", "r_timestep_sampler": "zero"},
-        )
-        batch = distiller.prepare_batch(_prepared_batch(), model=model, state={})
+    def test_removed_legacy_target_modes_are_rejected(self):
+        for target_mode in ("online_teacher", "linear"):
+            with self.subTest(target_mode=target_mode), self.assertRaisesRegex(ValueError, "target_mode was removed"):
+                AnyFlowDistiller(
+                    teacher_model=_FlowModel(),
+                    noise_scheduler=None,
+                    config={"model_type": "lora", "target_mode": target_mode},
+                )
 
-        self.assertTrue(torch.equal(batch["flowmap_r_timesteps"], torch.zeros(2)))
-        self.assertTrue(torch.equal(batch["target"], torch.ones_like(batch["latents"])))
-        self.assertIs(batch["flow_target"], batch["target"])
-
-    def test_linear_prepare_batch_uses_model_flow_target_convention(self):
-        model = _InverseFlowModel()
-        distiller = AnyFlowDistiller(
-            teacher_model=model,
-            noise_scheduler=None,
-            config={"model_type": "lora", "target_mode": "linear", "r_timestep_sampler": "zero"},
-        )
-
-        batch = distiller.prepare_batch(_prepared_batch(), model=model, state={})
-
-        self.assertTrue(torch.equal(batch["target"], -torch.ones_like(batch["latents"])))
-        self.assertIs(batch["flow_target"], batch["target"])
-
-    def test_linear_prepare_batch_preserves_normalized_timestep_parameterization(self):
-        model = _FlowModel()
-        distiller = AnyFlowDistiller(
-            teacher_model=model,
-            noise_scheduler=None,
-            config={"model_type": "lora", "target_mode": "linear", "r_timestep_sampler": "zero"},
-        )
-        batch = _prepared_batch()
-        batch["timesteps"] = torch.tensor([1.0, 0.5])
-
-        batch = distiller.prepare_batch(batch, model=model, state={})
-
-        self.assertTrue(torch.equal(batch["flowmap_r_timesteps"], torch.zeros(2)))
-        self.assertTrue(torch.equal(batch["anyflow_timestep_interval"], torch.tensor([1.0, 0.5])))
-
-    def test_online_teacher_target_uses_disabled_adapter(self):
+    def test_meanflow_uses_official_interval_mixture_and_central_target(self):
         model = _FlowModel()
         distiller = AnyFlowDistiller(
             teacher_model=model,
             noise_scheduler=None,
             config={
                 "model_type": "lora",
-                "target_mode": "online_teacher",
-                "r_timestep_sampler": "zero",
-                "teacher_rollout_steps": 3,
+                "diffusion_ratio": 0.5,
+                "consistency_ratio": 0.5,
             },
         )
+        draws = [
+            torch.tensor([0.8, 0.7]),
+            torch.tensor([0.2, 0.4]),
+        ]
 
-        batch = distiller.prepare_batch(_prepared_batch(), model=model, state={})
+        with patch("torch.rand", side_effect=draws):
+            batch = distiller.prepare_batch(_prepared_batch(), model=model, state={})
 
-        self.assertTrue(torch.allclose(batch["target"], torch.full_like(batch["latents"], 2.0)))
-        self.assertEqual(model.teacher_adapter_states, [False, False, False])
+        self.assertTrue(torch.equal(batch["anyflow_diffusion_mask"], torch.tensor([True, False])))
+        self.assertTrue(torch.equal(batch["anyflow_consistency_mask"], torch.tensor([False, True])))
+        self.assertTrue(torch.equal(batch["anyflow_arbitrary_mask"], torch.tensor([False, False])))
+        self.assertTrue(torch.allclose(batch["anyflow_t_base"], torch.tensor([0.8, 0.7])))
+        self.assertTrue(torch.allclose(batch["anyflow_r_base"], torch.tensor([0.8, 0.0])))
+        self.assertTrue(torch.allclose(batch["target"], torch.ones_like(batch["latents"])))
+        self.assertEqual(len(model.teacher_timesteps), 2)
         self.assertTrue(model.component.adapter_enabled)
-        self.assertEqual(len(model.teacher_timesteps), 3)
 
-    def test_compute_distill_loss_scales_precomputed_training_loss(self):
+    def test_meanflow_central_difference_uses_noise_sigma_coordinate(self):
+        model = _SigmaPredictionFlowModel()
+        distiller = AnyFlowDistiller(
+            teacher_model=model,
+            noise_scheduler=None,
+            config={
+                "model_type": "lora",
+                "diffusion_ratio": 0.0,
+                "consistency_ratio": 1.0,
+                "central_difference_epsilon": 0.01,
+            },
+        )
+        draws = [
+            torch.tensor([0.8, 0.7]),
+            torch.tensor([0.2, 0.4]),
+        ]
+
+        with patch("torch.rand", side_effect=draws):
+            batch = distiller.prepare_batch(_prepared_batch(), model=model, state={})
+
+        expected = 1.0 - torch.tensor([0.8, 0.7]).view(2, 1, 1, 1)
+        self.assertTrue(torch.allclose(batch["target"], expected.expand_as(batch["target"]), atol=1e-5))
+
+    def test_meanflow_preserves_h3_dataward_prediction_convention(self):
+        model = _DatawardSigmaPredictionFlowModel()
+        distiller = AnyFlowDistiller(
+            teacher_model=model,
+            noise_scheduler=None,
+            config={
+                "model_type": "lora",
+                "diffusion_ratio": 0.0,
+                "consistency_ratio": 1.0,
+                "central_difference_epsilon": 0.01,
+            },
+        )
+        draws = [
+            torch.tensor([0.8, 0.7]),
+            torch.tensor([0.2, 0.4]),
+        ]
+
+        with patch("torch.rand", side_effect=draws):
+            batch = distiller.prepare_batch(_prepared_batch(), model=model, state={})
+
+        expected = -1.0 + torch.tensor([0.8, 0.7]).view(2, 1, 1, 1)
+        self.assertTrue(torch.allclose(batch["target"], expected.expand_as(batch["target"]), atol=1e-5))
+        self.assertTrue(torch.allclose(batch["timesteps"], torch.tensor([0.2, 0.3])))
+
+    def test_meanflow_rejects_joint_audio_video_batch(self):
         model = _FlowModel()
         distiller = AnyFlowDistiller(
             teacher_model=model,
             noise_scheduler=None,
-            config={"model_type": "lora", "target_mode": "linear", "loss_weight": 0.5},
+            config={"model_type": "lora"},
         )
         batch = _prepared_batch()
-        batch["anyflow_r_timesteps"] = torch.zeros(2)
+        batch["audio_latents"] = torch.zeros(2, 2, 3, 4)
 
-        loss, logs = distiller.compute_distill_loss(batch, {}, torch.tensor(4.0))
-
-        self.assertEqual(float(loss), 2.0)
-        self.assertEqual(logs["anyflow_loss"], 2.0)
-        self.assertIn("anyflow_interval", logs)
-
-    def test_zero_length_interval_is_rejected(self):
-        model = _FlowModel()
-        distiller = AnyFlowDistiller(
-            teacher_model=model,
-            noise_scheduler=None,
-            config={"model_type": "lora", "target_mode": "linear", "r_timestep_sampler": "zero"},
-        )
-        batch = _prepared_batch()
-        batch["timesteps"] = torch.tensor([0.0, 500.0])
-        batch["sigmas"][0] = 0.0
-        batch["noisy_latents"] = (1 - batch["sigmas"]) * batch["latents"] + batch["sigmas"] * batch["noise"]
-
-        with self.assertRaisesRegex(ValueError, "r_timestep < timestep"):
+        with self.assertRaisesRegex(ValueError, "joint audio-video"):
             distiller.prepare_batch(batch, model=model, state={})
+
+    def test_meanflow_loss_uses_per_sample_target_and_interval_logs(self):
+        model = _FlowModel()
+        distiller = AnyFlowDistiller(
+            teacher_model=model,
+            noise_scheduler=None,
+            config={
+                "model_type": "lora",
+                "diffusion_ratio": 0.5,
+                "consistency_ratio": 0.5,
+                "meanflow_weight_type": "uniform",
+                "meanflow_adaptive_weighting": False,
+                "loss_weight": 0.5,
+            },
+        )
+        draws = [
+            torch.tensor([0.8, 0.7]),
+            torch.tensor([0.2, 0.4]),
+        ]
+        with patch("torch.rand", side_effect=draws):
+            batch = distiller.prepare_batch(_prepared_batch(), model=model, state={})
+        prediction = batch["target"] + 2.0
+
+        loss, logs = distiller.compute_distill_loss(
+            batch,
+            {"model_prediction": prediction},
+            original_loss=torch.tensor(99.0),
+        )
+
+        self.assertAlmostEqual(float(loss), 2.0)
+        self.assertAlmostEqual(logs["anyflow_diffusion_fraction"], 0.5)
+        self.assertAlmostEqual(logs["anyflow_consistency_fraction"], 0.5)
+        self.assertAlmostEqual(logs["anyflow_arbitrary_fraction"], 0.0)
+
+    def test_onpolicy_initializes_separate_discriminator_adapter_and_optimizer(self):
+        model = _FlowModel()
+        distiller = AnyFlowDistiller(
+            teacher_model=model,
+            noise_scheduler=None,
+            config={"model_type": "lora", "stage": "onpolicy", "rollout_step_counts": [2]},
+        )
+
+        self.assertIn("anyflow_discriminator", model.component.peft_config)
+        self.assertEqual(model.component.active_adapter, "default")
+        self.assertIsNotNone(distiller.discriminator_optimizer)
+        self.assertEqual(distiller.discriminator_optimizer.defaults["betas"], (0.0, 0.999))
+
+    def test_onpolicy_rollout_integrates_h3_dataward_predictions_in_noise_coordinate(self):
+        model = _DatawardRoleFlowModel()
+        distiller = AnyFlowDistiller(
+            teacher_model=model,
+            noise_scheduler=None,
+            config={"model_type": "lora", "stage": "onpolicy", "rollout_step_counts": [2]},
+        )
+        batch = _prepared_batch()
+        batch["timesteps"] = torch.tensor([0.0, 0.5])
+
+        with patch("torch.randn_like", return_value=torch.zeros_like(batch["latents"])):
+            with distiller._adapter_role("student"):
+                result = distiller._training_rollout(batch, step_count=2)
+
+        self.assertTrue(torch.allclose(result, torch.full_like(result, -7.0)))
+        self.assertEqual(model.component.active_adapter, "default")
+
+    def test_onpolicy_generator_loss_backpropagates_only_to_student_adapter(self):
+        model = _FlowModel()
+        distiller = AnyFlowDistiller(
+            teacher_model=model,
+            noise_scheduler=None,
+            config={"model_type": "lora", "stage": "onpolicy", "rollout_step_counts": [2]},
+        )
+        model.component.adapter_params["anyflow_discriminator"].data.fill_(1.0)
+        batch = _prepared_batch()
+
+        loss, logs = distiller._onpolicy_generator_loss(batch)
+        loss.backward()
+
+        self.assertGreater(float(loss.detach()), 0.0)
+        self.assertIsNotNone(model.component.adapter_params["default"].grad)
+        self.assertIsNone(model.component.adapter_params["anyflow_discriminator"].grad)
+        self.assertEqual(logs["anyflow_rollout_steps"], 2.0)
+        self.assertEqual(model.component.active_adapter, "default")
+
+    def test_onpolicy_discriminator_step_updates_only_discriminator_adapter(self):
+        model = _FlowModel()
+        distiller = AnyFlowDistiller(
+            teacher_model=model,
+            noise_scheduler=None,
+            config={
+                "model_type": "lora",
+                "stage": "onpolicy",
+                "rollout_step_counts": [1],
+                "discriminator_lr": 0.1,
+            },
+        )
+        batch = _prepared_batch()
+        student_before = model.component.adapter_params["default"].detach().clone()
+        discriminator_before = model.component.adapter_params["anyflow_discriminator"].detach().clone()
+
+        distiller.discriminator_step(batch)
+
+        self.assertTrue(torch.equal(model.component.adapter_params["default"], student_before))
+        self.assertFalse(torch.equal(model.component.adapter_params["anyflow_discriminator"], discriminator_before))
+        self.assertEqual(model.component.active_adapter, "default")
+
+    def test_onpolicy_discriminator_gradients_are_averaged_across_ddp_ranks(self):
+        model = _FlowModel()
+        distiller = AnyFlowDistiller(
+            teacher_model=model,
+            noise_scheduler=None,
+            config={"model_type": "lora", "stage": "onpolicy", "rollout_step_counts": [1]},
+        )
+        parameter = distiller._discriminator_parameters[0]
+        parameter.grad = torch.full_like(parameter, 3.0)
+
+        def sum_across_two_ranks(gradient, **kwargs):
+            self.assertEqual(kwargs["op"], torch.distributed.ReduceOp.SUM)
+            gradient.mul_(2.0)
+
+        with (
+            patch("torch.distributed.is_available", return_value=True),
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.get_world_size", return_value=2),
+            patch("torch.distributed.all_reduce", side_effect=sum_across_two_ranks) as all_reduce,
+        ):
+            distiller._sync_discriminator_gradients()
+
+        all_reduce.assert_called_once()
+        self.assertTrue(torch.equal(parameter.grad, torch.full_like(parameter, 3.0)))
+
+    def test_onpolicy_discriminator_checkpoint_round_trip(self):
+        model = _FlowModel()
+        distiller = AnyFlowDistiller(
+            teacher_model=model,
+            noise_scheduler=None,
+            config={"model_type": "lora", "stage": "onpolicy", "rollout_step_counts": [1]},
+        )
+        model.component.adapter_params["anyflow_discriminator"].data.fill_(3.0)
+
+        with tempfile.TemporaryDirectory() as directory:
+            distiller.on_save_checkpoint(12, directory)
+            model.component.adapter_params["anyflow_discriminator"].data.zero_()
+            distiller.on_load_checkpoint(directory)
+
+            self.assertTrue(torch.equal(model.component.adapter_params["anyflow_discriminator"], torch.tensor([3.0])))
+            self.assertTrue((Path(directory) / "anyflow_discriminator.safetensors").is_file())
+            self.assertTrue((Path(directory) / "anyflow_discriminator_optim.pt").is_file())
 
     def test_factory_creates_anyflow_distiller(self):
         model = _FlowModel()
@@ -253,13 +471,13 @@ class AnyFlowDistillerTests(unittest.TestCase):
             "anyflow",
             teacher_model=model,
             noise_scheduler=None,
-            config={"distillation_config": {"anyflow": {"target_mode": "linear", "r_timestep_sampler": "zero"}}},
+            config={"distillation_config": {"anyflow": {"stage": "forward"}}},
             model_type="lora",
             prediction_type="flow_matching",
         )
 
         self.assertIsInstance(distiller, AnyFlowDistiller)
-        self.assertEqual(distiller.config["target_mode"], "linear")
+        self.assertEqual(distiller.config["stage"], "forward")
         self.assertTrue(model.component.flowmap_enabled)
 
     def test_requires_flow_matching_model(self):
@@ -307,6 +525,15 @@ class AnyFlowDistillerTests(unittest.TestCase):
 
         self.assertTrue(torch.equal(r_timestep, torch.tensor([1.0])))
 
+    def test_validation_scheduler_advances_native_dataward_timestep(self):
+        scheduler = AnyFlowValidationScheduler(_DatawardValidationScheduler(), num_train_timesteps=1000)
+
+        first_endpoint = scheduler.r_timestep_for(torch.tensor([0.0]))
+        final_endpoint = scheduler.r_timestep_for(torch.tensor([0.5]))
+
+        self.assertTrue(torch.equal(first_endpoint, torch.tensor([0.5])))
+        self.assertTrue(torch.equal(final_endpoint, torch.tensor([1.0])))
+
     def test_validation_scheduler_wraps_t_parameter_component(self):
         scheduler = AnyFlowValidationScheduler(_ValidationScheduler())
         component = _TParameterComponent()
@@ -340,7 +567,7 @@ class AnyFlowDistillerTests(unittest.TestCase):
         distiller = AnyFlowDistiller(
             teacher_model=model,
             noise_scheduler=None,
-            config={"model_type": "lora", "target_mode": "linear"},
+            config={"model_type": "lora"},
         )
 
         scheduler = distiller.get_scheduler(model.pipeline.scheduler)
@@ -355,7 +582,7 @@ class AnyFlowDistillerTests(unittest.TestCase):
         distiller = AnyFlowDistiller(
             teacher_model=model,
             noise_scheduler=None,
-            config={"model_type": "lora", "target_mode": "linear"},
+            config={"model_type": "lora"},
         )
 
         scheduler = distiller.get_scheduler(model.pipeline.scheduler)

--- a/tests/test_distillation_cmd_args.py
+++ b/tests/test_distillation_cmd_args.py
@@ -65,19 +65,19 @@ class DistillationCmdArgsTests(unittest.TestCase):
     def test_distillation_config_json_string_is_parsed(self):
         args_list = _base_args() + [
             "--distillation_method=anyflow",
-            '--distillation_config={"anyflow":{"target_mode":"linear","teacher_rollout_steps":2}}',
+            '--distillation_config={"anyflow":{"stage":"onpolicy","rollout_step_counts":[2,4,8]}}',
         ]
 
         args = parse_cmdline_args(input_args=args_list, exit_on_error=True)
 
         self.assertEqual(
             args.distillation_config,
-            {"anyflow": {"target_mode": "linear", "teacher_rollout_steps": 2}},
+            {"anyflow": {"stage": "onpolicy", "rollout_step_counts": [2, 4, 8]}},
         )
 
     def test_distillation_config_file_is_loaded(self):
         with NamedTemporaryFile("w", suffix=".json") as handle:
-            handle.write('{"anyflow":{"target_mode":"linear","r_timestep_sampler":"zero"}}')
+            handle.write('{"anyflow":{"stage":"forward","diffusion_ratio":0.5}}')
             handle.flush()
 
             args = parse_cmdline_args(
@@ -87,19 +87,19 @@ class DistillationCmdArgsTests(unittest.TestCase):
 
         self.assertEqual(
             args.distillation_config,
-            {"anyflow": {"target_mode": "linear", "r_timestep_sampler": "zero"}},
+            {"anyflow": {"stage": "forward", "diffusion_ratio": 0.5}},
         )
 
     def test_mapping_to_cli_args_preserves_distillation_config_mapping(self):
         cli_args = mapping_to_cli_args(
             {
                 "distillation_method": "anyflow",
-                "distillation_config": {"anyflow": {"target_mode": "linear"}},
+                "distillation_config": {"anyflow": {"stage": "forward"}},
             }
         )
 
         self.assertIn("--distillation_method=anyflow", cli_args)
-        self.assertIn('--distillation_config={"anyflow": {"target_mode": "linear"}}', cli_args)
+        self.assertIn('--distillation_config={"anyflow": {"stage": "forward"}}', cli_args)
 
 
 if __name__ == "__main__":

--- a/tests/test_flux2_model.py
+++ b/tests/test_flux2_model.py
@@ -7,6 +7,37 @@ import torch
 from simpletuner.helpers.models.flux2.model import Flux2
 
 
+class _RecordingFlux2Transformer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.last_kwargs = None
+
+    def forward(
+        self,
+        hidden_states,
+        encoder_hidden_states=None,
+        timestep=None,
+        r_timestep=None,
+        img_ids=None,
+        txt_ids=None,
+        guidance=None,
+        return_dict=True,
+        **kwargs,
+    ):
+        del return_dict
+        self.last_kwargs = {
+            "hidden_states": hidden_states,
+            "encoder_hidden_states": encoder_hidden_states,
+            "timestep": timestep,
+            "r_timestep": r_timestep,
+            "img_ids": img_ids,
+            "txt_ids": txt_ids,
+            "guidance": guidance,
+            **kwargs,
+        }
+        return SimpleNamespace(sample=torch.zeros_like(hidden_states))
+
+
 class Flux2ModelTests(unittest.TestCase):
     def setUp(self):
         self.model = Flux2.__new__(Flux2)
@@ -76,6 +107,25 @@ class Flux2ModelTests(unittest.TestCase):
                 torch.tensor([[0.1, 0.9, 0.5, 0.7]], dtype=torch.float32),
             )
         )
+
+    def test_model_predict_forwards_anyflow_r_timestep(self):
+        transformer = _RecordingFlux2Transformer()
+        self.model.model = transformer
+        self.model.unwrap_model = MagicMock(side_effect=lambda model=None, **_: model)
+        r_timesteps = torch.tensor([0.25])
+
+        result = self.model.model_predict(
+            {
+                "noisy_latents": torch.randn(1, 128, 2, 2),
+                "latents": torch.randn(1, 128, 2, 2),
+                "timesteps": torch.tensor([250.0]),
+                "prompt_embeds": torch.randn(1, 3, 16),
+                Flux2.FLOWMAP_R_TIMESTEP_BATCH_KEY: r_timesteps,
+            }
+        )
+
+        self.assertIs(transformer.last_kwargs["r_timestep"], r_timesteps)
+        self.assertEqual(result["model_prediction"].shape, (1, 128, 2, 2))
 
     def test_model_predict_appends_clean_conditioning_timesteps(self):
         hidden_states_buffer = {}

--- a/tests/test_ltxvideo2_model.py
+++ b/tests/test_ltxvideo2_model.py
@@ -1,9 +1,57 @@
 import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import torch
 
-from simpletuner.helpers.models.ltxvideo2.model import _align_ltx2_connector_attention_mask, _pad_ltx2_audio_sequence_for_cp
+from simpletuner.helpers.models.ltxvideo2.model import (
+    LTXVideo2,
+    _align_ltx2_connector_attention_mask,
+    _pad_ltx2_audio_sequence_for_cp,
+)
 from simpletuner.helpers.models.ltxvideo2.transformer import LTX2AudioVideoAttnProcessor, LTX2PerturbedAttnProcessor
+
+
+class _FakeLTX2Connectors:
+    def __call__(self, encoder_hidden_states, additive_attention_mask, additive_mask=False):
+        del additive_attention_mask, additive_mask
+        batch_size = encoder_hidden_states.shape[0]
+        device = encoder_hidden_states.device
+        dtype = encoder_hidden_states.dtype
+        video_embeds = torch.zeros(batch_size, 2, 8, device=device, dtype=dtype)
+        audio_embeds = torch.zeros(batch_size, 3, 8, device=device, dtype=dtype)
+        attention_mask = torch.ones(batch_size, 3, device=device, dtype=torch.bool)
+        return video_embeds, audio_embeds, attention_mask
+
+
+class _RecordingLTX2Transformer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(patch_size=1, patch_size_t=1)
+        self.last_kwargs = None
+
+    def forward(
+        self,
+        hidden_states,
+        audio_hidden_states,
+        encoder_hidden_states,
+        audio_encoder_hidden_states,
+        timestep,
+        audio_timestep,
+        r_timestep=None,
+        **kwargs,
+    ):
+        self.last_kwargs = {
+            "hidden_states": hidden_states,
+            "audio_hidden_states": audio_hidden_states,
+            "encoder_hidden_states": encoder_hidden_states,
+            "audio_encoder_hidden_states": audio_encoder_hidden_states,
+            "timestep": timestep,
+            "audio_timestep": audio_timestep,
+            "r_timestep": r_timestep,
+            **kwargs,
+        }
+        return torch.zeros_like(hidden_states), torch.zeros_like(audio_hidden_states)
 
 
 class TestLTXVideo2ModelHelpers(unittest.TestCase):
@@ -50,6 +98,45 @@ class TestLTXVideo2ModelHelpers(unittest.TestCase):
             LTX2PerturbedAttnProcessor._flatten_attention_output,
             LTX2AudioVideoAttnProcessor._flatten_attention_output,
         )
+
+    def test_model_predict_forwards_anyflow_r_timestep(self):
+        model = LTXVideo2.__new__(LTXVideo2)
+        transformer = _RecordingLTX2Transformer()
+        model.model = transformer
+        model.config = SimpleNamespace(
+            controlnet=False,
+            weight_dtype=torch.float32,
+            framerate=None,
+            tread_config=None,
+            twinflow_enabled=False,
+            context_parallel_size=1,
+            context_parallel_comm_strategy="allgather",
+            ltx2_intrinsic_conditioning=None,
+        )
+        model.accelerator = SimpleNamespace(device=torch.device("cpu"))
+        model.connectors = _FakeLTX2Connectors()
+        model.crepa_regularizer = None
+        model.unwrap_model = MagicMock(side_effect=lambda model=None, **_: model)
+        model._load_connectors = MagicMock()
+        model._new_hidden_state_buffer = MagicMock(return_value={})
+        model._build_grounding_position_net_kwargs = MagicMock(return_value=None)
+        r_timesteps = torch.tensor([0.25])
+
+        result = LTXVideo2.model_predict(
+            model,
+            {
+                "noisy_latents": torch.randn(1, 128, 1, 2, 2),
+                "audio_latents": torch.randn(1, 8, 3, 4),
+                "audio_noisy_latents": torch.randn(1, 8, 3, 4),
+                "encoder_hidden_states": torch.randn(1, 4, 8),
+                "timesteps": torch.tensor([0.75]),
+                LTXVideo2.FLOWMAP_R_TIMESTEP_BATCH_KEY: r_timesteps,
+            },
+        )
+
+        self.assertIs(transformer.last_kwargs["r_timestep"], r_timesteps)
+        self.assertEqual(result["model_prediction"].shape, (1, 128, 1, 2, 2))
+        self.assertEqual(result["audio_prediction"].shape, (1, 8, 3, 4))
 
 
 if __name__ == "__main__":

--- a/tests/test_wan_model.py
+++ b/tests/test_wan_model.py
@@ -8,6 +8,29 @@ from simpletuner.helpers.models.common import PipelineTypes, VideoModelFoundatio
 from simpletuner.helpers.models.wan.model import Wan, add_first_frame_latent_conditioning
 
 
+class _RecordingWanTransformer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.last_kwargs = None
+
+    def forward(
+        self,
+        hidden_states,
+        encoder_hidden_states,
+        timestep,
+        r_timestep=None,
+        **kwargs,
+    ):
+        self.last_kwargs = {
+            "hidden_states": hidden_states,
+            "encoder_hidden_states": encoder_hidden_states,
+            "timestep": timestep,
+            "r_timestep": r_timestep,
+            **kwargs,
+        }
+        return (torch.zeros_like(hidden_states),)
+
+
 class WanModelTests(unittest.TestCase):
     def _animegen_config(self, flavour: str):
         return SimpleNamespace(
@@ -238,6 +261,37 @@ class WanModelTests(unittest.TestCase):
         self.assertTrue(torch.equal(conditioned[:, 20:, :1], clean_latents[:, :, :1]))
         self.assertTrue(torch.all(conditioned[:, 20:, 1:] == 0))
         warning.assert_not_called()
+
+    def test_model_predict_forwards_anyflow_r_timestep(self):
+        model = object.__new__(Wan)
+        transformer = _RecordingWanTransformer()
+        model.model = transformer
+        model.config = SimpleNamespace(
+            controlnet=False,
+            weight_dtype=torch.float32,
+            twinflow_enabled=False,
+            tread_config=None,
+        )
+        model.accelerator = SimpleNamespace(device=torch.device("cpu"))
+        model.crepa_regularizer = None
+        model.unwrap_model = MagicMock(side_effect=lambda model=None, **_: model)
+        model._new_hidden_state_buffer = MagicMock(return_value={})
+        model._build_grounding_position_net_kwargs = MagicMock(return_value=None)
+        model._apply_i2v_conditioning_to_kwargs = MagicMock()
+        r_timesteps = torch.tensor([0.25])
+
+        result = Wan.model_predict(
+            model,
+            {
+                "noisy_latents": torch.randn(1, 16, 1, 2, 2),
+                "encoder_hidden_states": torch.randn(1, 4, 8),
+                "timesteps": torch.tensor([0.75]),
+                Wan.FLOWMAP_R_TIMESTEP_BATCH_KEY: r_timesteps,
+            },
+        )
+
+        self.assertIs(transformer.last_kwargs["r_timestep"], r_timesteps)
+        self.assertEqual(result["model_prediction"].shape, (1, 16, 1, 2, 2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replace the removed SimpleTuner-specific online-teacher and linear targets with explicit NVIDIA-style AnyFlow stages. The forward stage now builds MeanFlow interval targets with the official interval mixture, scheduler shift, central-difference tangent correction, timestep weighting, and adaptive branch balancing. The on-policy stage adds the shared-base LoRA discriminator role, DMD generator loss, discriminator update, and checkpoint sidecars.

Update AnyFlow examples and documentation, including translated quickstarts and experimental docs, to use stage=forward/stage=onpolicy configuration instead of legacy target_mode settings.

Add focused regression coverage for the corrected objective, legacy option rejection, on-policy adapter separation, checkpoint save/load, H3 dataward timestep conversion in generic AnyFlow, and real Wan, Flux2, and LTXVideo2 model_predict forwarding of flowmap_r_timesteps into r_timestep.