### PR TITLE
Fix Hub training metadata commit message

### DIFF
--- a/simpletuner/helpers/publishing/huggingface.py
+++ b/simpletuner/helpers/publishing/huggingface.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from pathlib import Path
@@ -80,15 +81,69 @@ class HubManager:
         else:
             return f"\nVAE: {self.config.pretrained_vae_model_name_or_path}"
 
+    def _resolved_prediction_type(self) -> str | None:
+        configured = getattr(self.config, "prediction_type", None)
+        if configured:
+            return str(getattr(configured, "value", configured))
+        model_prediction_type = getattr(self.model, "PREDICTION_TYPE", None)
+        if model_prediction_type is None:
+            return None
+        return str(getattr(model_prediction_type, "value", model_prediction_type))
+
+    def _training_batch_string(self) -> str:
+        batch_size = self.config.train_batch_size
+        gradient_accumulation_steps = int(getattr(self.config, "gradient_accumulation_steps", 1) or 1)
+        if gradient_accumulation_steps > 1:
+            return (
+                f"\nLearning rate {self.config.learning_rate}, batch size {batch_size}, "
+                f"and {gradient_accumulation_steps} gradient accumulation steps."
+            )
+        return f"\nLearning rate {self.config.learning_rate} and batch size {batch_size}."
+
+    def _prediction_schedule_string(self) -> str:
+        prediction_type = self._resolved_prediction_type()
+        if prediction_type in {"epsilon", "v_prediction"}:
+            return (
+                f"\nTrained with {prediction_type} prediction type and "
+                f"rescaled_betas_zero_snr={self.config.rescale_betas_zero_snr}"
+                f"\nUsing '{self.config.training_scheduler_timestep_spacing}' timestep spacing."
+            )
+        if prediction_type == "flow_matching":
+            return "\nTraining objective: flow matching."
+        if prediction_type:
+            return f"\nTraining objective: {prediction_type}."
+        return ""
+
+    def _distillation_string(self) -> str:
+        distillation_method = getattr(self.config, "distillation_method", None)
+        if distillation_method is None:
+            return ""
+        distillation_method = str(getattr(distillation_method, "value", distillation_method))
+        if distillation_method.lower() in {"", "none", "null"}:
+            return ""
+
+        lines = [f"Distillation method: {distillation_method}."]
+        distillation_config = getattr(self.config, "distillation_config", None)
+        if distillation_config:
+            lines.append(
+                "Distillation config: "
+                + json.dumps(
+                    distillation_config,
+                    sort_keys=True,
+                    default=str,
+                )
+            )
+        return "\n" + "\n".join(lines)
+
     def _commit_message(self, global_step: int = None, epoch: int = None):
         resolved_epoch = (epoch - 1) if epoch is not None else (StateTracker.get_epoch() - 1)
         resolved_step = global_step if global_step is not None else StateTracker.get_global_step()
         return (
             f"Trained for {resolved_epoch} epochs and {resolved_step} steps."
             f"\nTrained with datasets {self.collected_data_backend_str}"
-            f"\nLearning rate {self.config.learning_rate}, batch size {self.config.train_batch_size}, and {self.config.gradient_accumulation_steps} gradient accumulation steps."
-            f"\nTrained with {self.config.prediction_type} prediction type and rescaled_betas_zero_snr={self.config.rescale_betas_zero_snr}"
-            f"\nUsing '{self.config.training_scheduler_timestep_spacing}' timestep spacing."
+            f"{self._training_batch_string()}"
+            f"{self._prediction_schedule_string()}"
+            f"{self._distillation_string()}"
             f"\nBase model: {self.config.pretrained_model_name_or_path}"
             f"{self._vae_string()}"
         )

--- a/simpletuner/helpers/publishing/huggingface.py
+++ b/simpletuner/helpers/publishing/huggingface.py
@@ -105,7 +105,7 @@ class HubManager:
         if prediction_type in {"epsilon", "v_prediction"}:
             return (
                 f"\nTrained with {prediction_type} prediction type and "
-                f"rescaled_betas_zero_snr={self.config.rescale_betas_zero_snr}"
+                f"rescale_betas_zero_snr={self.config.rescale_betas_zero_snr}"
                 f"\nUsing '{self.config.training_scheduler_timestep_spacing}' timestep spacing."
             )
         if prediction_type == "flow_matching":
@@ -135,7 +135,7 @@ class HubManager:
             )
         return "\n" + "\n".join(lines)
 
-    def _commit_message(self, global_step: int = None, epoch: int = None):
+    def _commit_message(self, global_step: int | None = None, epoch: int | None = None):
         resolved_epoch = (epoch - 1) if epoch is not None else (StateTracker.get_epoch() - 1)
         resolved_step = global_step if global_step is not None else StateTracker.get_global_step()
         return (

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -240,7 +240,7 @@ class TestMetadataFunctions(unittest.TestCase):
         self.assertIn('"stage": "forward"', message)
         self.assertNotIn("gradient accumulation", message)
         self.assertNotIn("None prediction type", message)
-        self.assertNotIn("rescaled_betas_zero_snr", message)
+        self.assertNotIn("rescale_betas_zero_snr", message)
         self.assertNotIn("timestep spacing", message)
 
     def test_hub_commit_message_keeps_diffusion_schedule_fields_for_epsilon_models(self):
@@ -268,7 +268,7 @@ class TestMetadataFunctions(unittest.TestCase):
             message,
         )
         self.assertIn(
-            "Trained with epsilon prediction type and rescaled_betas_zero_snr=True",
+            "Trained with epsilon prediction type and rescale_betas_zero_snr=True",
             message,
         )
         self.assertIn("Using 'trailing' timestep spacing.", message)

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -5,6 +5,7 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from simpletuner.helpers.publishing.huggingface import HubManager
 from simpletuner.helpers.publishing.metadata import *
 from simpletuner.helpers.publishing.metadata import (
     _guidance_rescale,
@@ -202,6 +203,76 @@ class TestMetadataFunctions(unittest.TestCase):
         self.args.model_card_note = ""
         output = model_card_note(self.args)
         self.assertEqual(output.strip(), "")
+
+    def test_hub_commit_message_omits_diffusion_schedule_fields_for_flow_matching(self):
+        hub_manager = object.__new__(HubManager)
+        hub_manager.collected_data_backend_str = "['alt-embed-cache', 'h3-drift0-anyflow-openvid-39f-480']"
+        hub_manager.model = SimpleNamespace(PREDICTION_TYPE=SimpleNamespace(value="flow_matching"))
+        hub_manager.config = SimpleNamespace(
+            learning_rate=6e-5,
+            train_batch_size=1,
+            gradient_accumulation_steps=1,
+            prediction_type=None,
+            rescale_betas_zero_snr=False,
+            training_scheduler_timestep_spacing="trailing",
+            distillation_method="h3_drift",
+            distillation_config={
+                "h3_drift": {
+                    "loss_weight": 0.5,
+                    "inner_distillation_method": "anyflow",
+                    "inner_distillation_config": {"stage": "forward"},
+                }
+            },
+            pretrained_model_name_or_path="MiniMaxAI/MiniMax-H3",
+            pretrained_vae_model_name_or_path=(
+                "https://huggingface.co/Kijai/MiniMax-H3-experimental/resolve/main/"
+                "minimax_h3_video_vae_int8_convrot.safetensors"
+            ),
+            model_type="lora",
+        )
+
+        message = hub_manager._commit_message(global_step=1000, epoch=2)
+
+        self.assertIn("Learning rate 6e-05 and batch size 1.", message)
+        self.assertIn("Training objective: flow matching.", message)
+        self.assertIn("Distillation method: h3_drift.", message)
+        self.assertIn('"inner_distillation_method": "anyflow"', message)
+        self.assertIn('"stage": "forward"', message)
+        self.assertNotIn("gradient accumulation", message)
+        self.assertNotIn("None prediction type", message)
+        self.assertNotIn("rescaled_betas_zero_snr", message)
+        self.assertNotIn("timestep spacing", message)
+
+    def test_hub_commit_message_keeps_diffusion_schedule_fields_for_epsilon_models(self):
+        hub_manager = object.__new__(HubManager)
+        hub_manager.collected_data_backend_str = "['dataset']"
+        hub_manager.model = SimpleNamespace(PREDICTION_TYPE=SimpleNamespace(value="epsilon"))
+        hub_manager.config = SimpleNamespace(
+            learning_rate=1e-4,
+            train_batch_size=2,
+            gradient_accumulation_steps=4,
+            prediction_type="epsilon",
+            rescale_betas_zero_snr=True,
+            training_scheduler_timestep_spacing="trailing",
+            distillation_method=None,
+            distillation_config=None,
+            pretrained_model_name_or_path="base-model",
+            pretrained_vae_model_name_or_path="base-vae",
+            model_type="lora",
+        )
+
+        message = hub_manager._commit_message(global_step=20, epoch=2)
+
+        self.assertIn(
+            "Learning rate 0.0001, batch size 2, and 4 gradient accumulation steps.",
+            message,
+        )
+        self.assertIn(
+            "Trained with epsilon prediction type and rescaled_betas_zero_snr=True",
+            message,
+        )
+        self.assertIn("Using 'trailing' timestep spacing.", message)
+        self.assertNotIn("Distillation method:", message)
 
     def test_save_model_card(self):
         # Mocking StateTracker methods


### PR DESCRIPTION
This pull request refactors the commit message generation in `HubManager` to provide clearer, more context-aware summaries of training configurations, and adds comprehensive tests to ensure correct behavior for different training objectives. The changes improve both the maintainability and accuracy of published training metadata.

**Enhancements to commit message generation:**

- Refactored `_commit_message` in `HubManager` to delegate construction of batch, prediction schedule, and distillation information to new helper methods, making the message more modular and omitting irrelevant fields for specific prediction types.
- Added `_resolved_prediction_type`, `_training_batch_string`, `_prediction_schedule_string`, and `_distillation_string` helper methods to encapsulate logic for reporting training configuration details.

**Testing improvements:**

- Added tests for `HubManager._commit_message` to verify that only relevant fields are included for different prediction types (e.g., omitting diffusion schedule fields for flow matching, including them for epsilon) in `test_model_card.py`.
- Ensured that distillation method and config details are correctly serialized and included in the commit message when applicable.

**Other changes:**

- Added missing import for `HubManager` in `test_model_card.py`.
- Added missing import for `json` in `huggingface.py` to support serialization of distillation config.