### PR TITLE
Constrain duplicated conditioning paths

### DIFF
--- a/simpletuner/helpers/metadata/utils/duplicator.py
+++ b/simpletuner/helpers/metadata/utils/duplicator.py
@@ -18,13 +18,17 @@ class DatasetDuplicator:
         target_dir_abs = os.path.abspath(target_dir)
         if os.path.isabs(path):
             path_abs = os.path.abspath(path)
-            if os.path.commonpath([path_abs, source_dir_abs]) == source_dir_abs:
+            try:
+                path_is_under_source = os.path.commonpath([path_abs, source_dir_abs]) == source_dir_abs
+            except ValueError:
+                path_is_under_source = False
+            if path_is_under_source:
                 rel_path = os.path.relpath(path_abs, source_dir_abs)
                 new_path = os.path.join(target_dir_abs, rel_path)
             else:
                 new_path = os.path.join(target_dir_abs, os.path.basename(path_abs))
         else:
-            new_path = os.path.join(target_dir, os.path.basename(path))
+            new_path = os.path.join(target_dir_abs, os.path.basename(path))
         if conditioning_data_type == "i2v_first_frame":
             new_path = os.path.splitext(new_path)[0] + ".png"
         return new_path

--- a/simpletuner/helpers/metadata/utils/duplicator.py
+++ b/simpletuner/helpers/metadata/utils/duplicator.py
@@ -13,6 +13,23 @@ else:
 
 class DatasetDuplicator:
     @staticmethod
+    def _translate_conditioning_path(path: str, source_dir: str, target_dir: str, conditioning_data_type: str | None) -> str:
+        source_dir_abs = os.path.abspath(source_dir)
+        target_dir_abs = os.path.abspath(target_dir)
+        if os.path.isabs(path):
+            path_abs = os.path.abspath(path)
+            if os.path.commonpath([path_abs, source_dir_abs]) == source_dir_abs:
+                rel_path = os.path.relpath(path_abs, source_dir_abs)
+                new_path = os.path.join(target_dir_abs, rel_path)
+            else:
+                new_path = os.path.join(target_dir_abs, os.path.basename(path_abs))
+        else:
+            new_path = os.path.join(target_dir, os.path.basename(path))
+        if conditioning_data_type == "i2v_first_frame":
+            new_path = os.path.splitext(new_path)[0] + ".png"
+        return new_path
+
+    @staticmethod
     def copy_metadata(source_backend, target_backend):
         """Copy metadata from source backend to target backend with path updates."""
         source_meta = source_backend.get("metadata_backend", None)
@@ -33,23 +50,18 @@ class DatasetDuplicator:
 
         if needs_path_update:
             logger.info(f"Copying metadata with path translation: '{source_dir}' -> '{target_dir}'")
-            source_dir_abs = os.path.abspath(source_dir)
-            target_dir_abs = os.path.abspath(target_dir)
 
             # Copy and update bucket indices
             target_meta.aspect_ratio_bucket_indices = {}
             for bucket, paths in source_meta.aspect_ratio_bucket_indices.items():
                 updated_paths = []
                 for path in paths:
-                    # Update the path to point to the target directory
-                    # Handle both absolute and relative paths
-                    if os.path.isabs(path):
-                        # For absolute paths, replace the directory
-                        rel_path = os.path.relpath(path, source_dir_abs)
-                        new_path = os.path.join(target_dir_abs, rel_path)
-                    else:
-                        # For relative paths, just prepend the new directory
-                        new_path = os.path.join(target_dir, os.path.basename(path))
+                    new_path = DatasetDuplicator._translate_conditioning_path(
+                        path,
+                        source_dir,
+                        target_dir,
+                        None,
+                    )
                     updated_paths.append(new_path)
                 target_meta.aspect_ratio_bucket_indices[bucket] = updated_paths
 
@@ -57,12 +69,12 @@ class DatasetDuplicator:
             if hasattr(source_meta, "image_metadata") and source_meta.image_metadata:
                 target_meta.image_metadata = {}
                 for path, metadata in source_meta.image_metadata.items():
-                    # Update paths in image metadata too
-                    if os.path.isabs(path):
-                        rel_path = os.path.relpath(path, source_dir_abs)
-                        new_path = os.path.join(target_dir_abs, rel_path)
-                    else:
-                        new_path = os.path.join(target_dir, os.path.basename(path))
+                    new_path = DatasetDuplicator._translate_conditioning_path(
+                        path,
+                        source_dir,
+                        target_dir,
+                        None,
+                    )
                     target_meta.image_metadata[new_path] = metadata
                 logger.debug(f"Copied {len(target_meta.image_metadata)} image_metadata entries")
             else:

--- a/tests/test_training_sample.py
+++ b/tests/test_training_sample.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -5,6 +7,7 @@ import numpy as np
 from PIL import Image
 
 from simpletuner.helpers.image_manipulation.training_sample import TrainingSample
+from simpletuner.helpers.metadata.utils.duplicator import DatasetDuplicator
 from simpletuner.helpers.training.state_tracker import StateTracker
 
 
@@ -83,6 +86,30 @@ class TestTrainingSample(unittest.TestCase):
         )
 
         self.assertEqual(sample.training_sample_path(source_backend_id), "17.jpg")
+
+    def test_conditioning_path_translation_does_not_escape_target_for_external_absolute_paths(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_dir = os.path.join(tmpdir, "source")
+            target_dir = os.path.join(tmpdir, "target")
+            inside_path = os.path.join(source_dir, "nested", "clip.mp4")
+            outside_path = os.path.join(tmpdir, "outside", "clip.mp4")
+
+            translated_inside = DatasetDuplicator._translate_conditioning_path(
+                inside_path,
+                source_dir,
+                target_dir,
+                "i2v_first_frame",
+            )
+            translated_outside = DatasetDuplicator._translate_conditioning_path(
+                outside_path,
+                source_dir,
+                target_dir,
+                "i2v_first_frame",
+            )
+
+        self.assertEqual(translated_inside, os.path.join(target_dir, "nested", "clip.png"))
+        self.assertEqual(translated_outside, os.path.join(target_dir, "clip.png"))
+        self.assertEqual(os.path.commonpath([target_dir, translated_outside]), target_dir)
 
     def test_image_downsample(self):
         """Test that downsampling is correctly applied before cropping."""

--- a/tests/test_training_sample.py
+++ b/tests/test_training_sample.py
@@ -93,6 +93,7 @@ class TestTrainingSample(unittest.TestCase):
             target_dir = os.path.join(tmpdir, "target")
             inside_path = os.path.join(source_dir, "nested", "clip.mp4")
             outside_path = os.path.join(tmpdir, "outside", "clip.mp4")
+            relative_path = os.path.join("relative", "clip.mp4")
 
             translated_inside = DatasetDuplicator._translate_conditioning_path(
                 inside_path,
@@ -106,10 +107,33 @@ class TestTrainingSample(unittest.TestCase):
                 target_dir,
                 "i2v_first_frame",
             )
+            translated_relative = DatasetDuplicator._translate_conditioning_path(
+                relative_path,
+                source_dir,
+                target_dir,
+                "i2v_first_frame",
+            )
 
         self.assertEqual(translated_inside, os.path.join(target_dir, "nested", "clip.png"))
         self.assertEqual(translated_outside, os.path.join(target_dir, "clip.png"))
+        self.assertEqual(translated_relative, os.path.join(target_dir, "clip.png"))
         self.assertEqual(os.path.commonpath([target_dir, translated_outside]), target_dir)
+
+    def test_conditioning_path_translation_handles_commonpath_root_mismatch(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_dir = os.path.join(tmpdir, "source")
+            target_dir = os.path.join(tmpdir, "target")
+            external_path = os.path.join(tmpdir, "outside", "clip.mp4")
+
+            with patch("simpletuner.helpers.metadata.utils.duplicator.os.path.commonpath", side_effect=ValueError):
+                translated = DatasetDuplicator._translate_conditioning_path(
+                    external_path,
+                    source_dir,
+                    target_dir,
+                    "i2v_first_frame",
+                )
+
+        self.assertEqual(translated, os.path.join(target_dir, "clip.png"))
 
     def test_image_downsample(self):
         """Test that downsampling is correctly applied before cropping."""


### PR DESCRIPTION
Summary:
- Prevents absolute conditioning metadata paths outside the source root from escaping the target root during metadata duplication.
- Reuses a single path translation helper for bucket entries and image metadata.
- Adds regression coverage for inside-root and outside-root absolute paths.

Validation:
- `.venv/bin/python -m unittest -v -f tests.test_training_sample`
- Branch diff and commit-message identity scan passed.
