### PR TITLE
Configure SDNQ compile mode before import

### DIFF
--- a/simpletuner/helpers/configuration/cmd_args.py
+++ b/simpletuner/helpers/configuration/cmd_args.py
@@ -29,6 +29,7 @@ from simpletuner.helpers.training.attention_backend import (
 from simpletuner.helpers.training.multi_process import should_log
 from simpletuner.helpers.training.optimizer_param import is_optimizer_deprecated, is_optimizer_grad_fp32
 from simpletuner.helpers.training.quantisation import MANUAL_QUANTIZATION_PRESETS, PIPELINE_QUANTIZATION_PRESETS
+from simpletuner.helpers.training.sdnq_compile import configure_sdnq_compile_mode
 from simpletuner.helpers.training.state_tracker import StateTracker
 from simpletuner.simpletuner_sdk.server.services.field_registry.types import (
     ConfigField,
@@ -805,6 +806,8 @@ def parse_cmdline_args(input_args=None, exit_on_error: bool = False):
                 setattr(args, option_name, parsed)
             else:
                 raise ValueError(f"{option_name} must be a JSON object or a path to a JSON object.")
+
+    configure_sdnq_compile_mode(getattr(args, "sdnq_compile_mode", "auto"))
 
     manual_quant_precisions = set(MANUAL_QUANTIZATION_PRESETS)
     pipeline_quant_precisions = set(PIPELINE_QUANTIZATION_PRESETS)

--- a/simpletuner/helpers/models/krea2/quantized_loading.py
+++ b/simpletuner/helpers/models/krea2/quantized_loading.py
@@ -128,6 +128,9 @@ def _materialize_krea2_meta_buffers(model: nn.Module) -> None:
 
 
 def _load_sdnq_training_symbols():
+    from simpletuner.helpers.training.sdnq_compile import configure_sdnq_compile_mode
+
+    configure_sdnq_compile_mode()
     try:
         from sdnq.dequantizer import SDNQDequantizer
         from sdnq.layers import get_sdnq_wrapper_class

--- a/simpletuner/helpers/models/z_image/quantized_loading.py
+++ b/simpletuner/helpers/models/z_image/quantized_loading.py
@@ -117,6 +117,9 @@ def _materialize_zimage_meta_buffers(model: nn.Module) -> None:
 
 
 def _load_sdnq_training_symbols():
+    from simpletuner.helpers.training.sdnq_compile import configure_sdnq_compile_mode
+
+    configure_sdnq_compile_mode()
     try:
         from sdnq.dequantizer import SDNQDequantizer
         from sdnq.layers import get_sdnq_wrapper_class

--- a/simpletuner/helpers/training/quantisation/__init__.py
+++ b/simpletuner/helpers/training/quantisation/__init__.py
@@ -1042,8 +1042,8 @@ def _sdnq_model(
     if weights_dtype is None:
         raise ValueError(f"Invalid SDNQ precision level: {model_precision}")
 
+    configure_sdnq_compile_mode()
     args = StateTracker.get_args()
-    configure_sdnq_compile_mode(getattr(args, "sdnq_compile_mode", "auto"))
 
     try:
         # Silence sdnq startup logs

--- a/simpletuner/helpers/training/quantisation/__init__.py
+++ b/simpletuner/helpers/training/quantisation/__init__.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import sys
 from contextlib import nullcontext
 from functools import partial
 from inspect import Parameter, signature
@@ -10,6 +9,7 @@ import torch
 
 from simpletuner.helpers.training.multi_process import should_log
 from simpletuner.helpers.training.quantisation.fp8_native import mark_fp8_native_ddp_ignore_params
+from simpletuner.helpers.training.sdnq_compile import configure_sdnq_compile_mode
 from simpletuner.helpers.training.state_tracker import StateTracker
 
 logger = logging.getLogger(__name__)
@@ -1043,16 +1043,7 @@ def _sdnq_model(
         raise ValueError(f"Invalid SDNQ precision level: {model_precision}")
 
     args = StateTracker.get_args()
-    sdnq_compile_mode = getattr(args, "sdnq_compile_mode", "auto")
-    if sdnq_compile_mode not in (None, "auto"):
-        if "sdnq.common" in sys.modules:
-            logger.warning(
-                "SDNQ was already imported before --sdnq_compile_mode=%s could be applied. "
-                "Set SDNQ_USE_TORCH_COMPILE before process startup to force this mode.",
-                sdnq_compile_mode,
-            )
-        else:
-            os.environ["SDNQ_USE_TORCH_COMPILE"] = "1" if sdnq_compile_mode == "compile" else "0"
+    configure_sdnq_compile_mode(getattr(args, "sdnq_compile_mode", "auto"))
 
     try:
         # Silence sdnq startup logs

--- a/simpletuner/helpers/training/sdnq_compile.py
+++ b/simpletuner/helpers/training/sdnq_compile.py
@@ -9,6 +9,18 @@ _IMPORT_WARNING_EMITTED = False
 _CONFIGURED_MODE: str | None = None
 
 
+def _get_sdnq_compile_mode_from_args(args: Any) -> Any:
+    if args is None:
+        return "auto"
+    try:
+        args_dict = vars(args)
+    except TypeError:
+        return getattr(args, "sdnq_compile_mode", "auto")
+    if isinstance(args_dict, dict) and "sdnq_compile_mode" not in args_dict:
+        return "auto"
+    return getattr(args, "sdnq_compile_mode", "auto")
+
+
 def configure_sdnq_compile_mode(sdnq_compile_mode: Any = None) -> None:
     global _CONFIGURED_MODE, _IMPORT_WARNING_EMITTED
 
@@ -16,7 +28,7 @@ def configure_sdnq_compile_mode(sdnq_compile_mode: Any = None) -> None:
         from simpletuner.helpers.training.state_tracker import StateTracker
 
         args = StateTracker.get_args()
-        sdnq_compile_mode = getattr(args, "sdnq_compile_mode", "auto") if args is not None else "auto"
+        sdnq_compile_mode = _get_sdnq_compile_mode_from_args(args)
 
     if sdnq_compile_mode is None:
         return

--- a/simpletuner/helpers/training/sdnq_compile.py
+++ b/simpletuner/helpers/training/sdnq_compile.py
@@ -1,0 +1,44 @@
+import logging
+import os
+import sys
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_IMPORT_WARNING_EMITTED = False
+_CONFIGURED_MODE: str | None = None
+
+
+def configure_sdnq_compile_mode(sdnq_compile_mode: Any = None) -> None:
+    global _CONFIGURED_MODE, _IMPORT_WARNING_EMITTED
+
+    if sdnq_compile_mode is None:
+        from simpletuner.helpers.training.state_tracker import StateTracker
+
+        args = StateTracker.get_args()
+        sdnq_compile_mode = getattr(args, "sdnq_compile_mode", "auto") if args is not None else "auto"
+
+    if sdnq_compile_mode is None:
+        return
+
+    mode = str(sdnq_compile_mode).strip().lower()
+    if mode in ("", "auto", "none"):
+        return
+    if mode not in {"compile", "eager"}:
+        raise ValueError("--sdnq_compile_mode must be one of: auto, compile, eager.")
+
+    expected_value = "1" if mode == "compile" else "0"
+    if "sdnq.common" in sys.modules:
+        if _CONFIGURED_MODE == mode or os.environ.get("SDNQ_USE_TORCH_COMPILE") == expected_value:
+            return
+        if not _IMPORT_WARNING_EMITTED:
+            logger.warning(
+                "SDNQ was already imported before --sdnq_compile_mode=%s could be applied. "
+                "Set SDNQ_USE_TORCH_COMPILE before process startup to force this mode.",
+                mode,
+            )
+            _IMPORT_WARNING_EMITTED = True
+        return
+
+    os.environ["SDNQ_USE_TORCH_COMPILE"] = expected_value
+    _CONFIGURED_MODE = mode

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -95,6 +95,7 @@ from simpletuner.helpers.training.quantisation import (
     mark_transformerengine_ddp_ignore_params,
 )
 from simpletuner.helpers.training.script_runner import run_hook_script
+from simpletuner.helpers.training.sdnq_compile import configure_sdnq_compile_mode
 from simpletuner.helpers.training.state_tracker import StateTracker
 from simpletuner.helpers.training.validation import Validation, prepare_validation_prompt_list
 from simpletuner.helpers.training.wrappers import unwrap_model
@@ -1100,6 +1101,7 @@ class Trainer:
 
         StateTracker.set_accelerator(self.accelerator)
         StateTracker.set_args(self.config)
+        configure_sdnq_compile_mode()
         StateTracker.set_weight_dtype(self.config.weight_dtype)
         self.set_model_family()
 

--- a/tests/test_quantization_config_parsing.py
+++ b/tests/test_quantization_config_parsing.py
@@ -23,6 +23,13 @@ class TestQuantizationConfigParsing(unittest.TestCase):
     def setUp(self):
         self.original_args = StateTracker.get_args()
         self.original_sdnq_compile = os.environ.get("SDNQ_USE_TORCH_COMPILE")
+        from simpletuner.helpers.training import sdnq_compile
+
+        self.sdnq_compile = sdnq_compile
+        self.original_configured_mode = sdnq_compile._CONFIGURED_MODE
+        self.original_import_warning_emitted = sdnq_compile._IMPORT_WARNING_EMITTED
+        sdnq_compile._CONFIGURED_MODE = None
+        sdnq_compile._IMPORT_WARNING_EMITTED = False
 
     def tearDown(self):
         StateTracker.set_args(self.original_args)
@@ -30,6 +37,8 @@ class TestQuantizationConfigParsing(unittest.TestCase):
             os.environ.pop("SDNQ_USE_TORCH_COMPILE", None)
         else:
             os.environ["SDNQ_USE_TORCH_COMPILE"] = self.original_sdnq_compile
+        self.sdnq_compile._CONFIGURED_MODE = self.original_configured_mode
+        self.sdnq_compile._IMPORT_WARNING_EMITTED = self.original_import_warning_emitted
 
     def test_pipeline_quantize_via_rejects_manual_precision(self):
         args_list = _base_args() + ["--quantize_via=pipeline", "--base_model_precision=int8-sdnq"]

--- a/tests/test_quantization_config_parsing.py
+++ b/tests/test_quantization_config_parsing.py
@@ -1,7 +1,12 @@
 import json
+import os
+import sys
 import unittest
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
 
 from simpletuner.helpers.configuration.cmd_args import parse_cmdline_args
+from simpletuner.helpers.training.state_tracker import StateTracker
 
 
 def _base_args():
@@ -15,6 +20,17 @@ def _base_args():
 
 
 class TestQuantizationConfigParsing(unittest.TestCase):
+    def setUp(self):
+        self.original_args = StateTracker.get_args()
+        self.original_sdnq_compile = os.environ.get("SDNQ_USE_TORCH_COMPILE")
+
+    def tearDown(self):
+        StateTracker.set_args(self.original_args)
+        if self.original_sdnq_compile is None:
+            os.environ.pop("SDNQ_USE_TORCH_COMPILE", None)
+        else:
+            os.environ["SDNQ_USE_TORCH_COMPILE"] = self.original_sdnq_compile
+
     def test_pipeline_quantize_via_rejects_manual_precision(self):
         args_list = _base_args() + ["--quantize_via=pipeline", "--base_model_precision=int8-sdnq"]
         with self.assertRaises(ValueError):
@@ -71,3 +87,78 @@ class TestQuantizationConfigParsing(unittest.TestCase):
         self.assertEqual(args.sdnq_modules_to_not_convert, ["proj_out", "norm_out"])
         self.assertEqual(args.sdnq_modules_dtype_dict, {"minimum_6bit": ["x_embedder"]})
         self.assertEqual(args.sdnq_modules_quant_config, {"attn": {"group_size": -1}})
+
+    def test_sdnq_compile_mode_sets_env_before_import(self):
+        from simpletuner.helpers.training.sdnq_compile import configure_sdnq_compile_mode
+
+        StateTracker.set_args(SimpleNamespace(sdnq_compile_mode="eager"))
+        os.environ.pop("SDNQ_USE_TORCH_COMPILE", None)
+        with patch.dict("sys.modules", {"sdnq.common": None}, clear=False):
+            del sys.modules["sdnq.common"]
+            configure_sdnq_compile_mode()
+
+        self.assertEqual(os.environ["SDNQ_USE_TORCH_COMPILE"], "0")
+
+        StateTracker.set_args(SimpleNamespace(sdnq_compile_mode="compile"))
+        configure_sdnq_compile_mode()
+
+        self.assertEqual(os.environ["SDNQ_USE_TORCH_COMPILE"], "1")
+
+    def test_sdnq_compile_mode_does_not_warn_after_prior_configuration(self):
+        from simpletuner.helpers.training import sdnq_compile
+
+        os.environ.pop("SDNQ_USE_TORCH_COMPILE", None)
+        with patch.dict("sys.modules", {"sdnq.common": None}, clear=False):
+            del sys.modules["sdnq.common"]
+            sdnq_compile.configure_sdnq_compile_mode("compile")
+
+        with (
+            patch.dict("sys.modules", {"sdnq.common": ModuleType("sdnq.common")}, clear=False),
+            patch.object(sdnq_compile.logger, "warning") as warning,
+        ):
+            sdnq_compile.configure_sdnq_compile_mode("compile")
+
+        warning.assert_not_called()
+
+    def test_convrot_loader_applies_sdnq_compile_mode_before_import(self):
+        from simpletuner.helpers.models.z_image import quantized_loading
+
+        class Dummy:
+            pass
+
+        dequantizer_module = ModuleType("sdnq.dequantizer")
+        dequantizer_module.SDNQDequantizer = Dummy
+        layers_module = ModuleType("sdnq.layers")
+        layers_module.get_sdnq_wrapper_class = lambda module, forward: module
+        forward_module = ModuleType("sdnq.training.forward")
+        forward_module.get_forward_func = lambda *args, **kwargs: None
+        tensor_module = ModuleType("sdnq.training.tensor")
+        tensor_module.SDNQTensor = Dummy
+        training_module = ModuleType("sdnq.training")
+        sdnq_module = ModuleType("sdnq")
+
+        modules = {
+            "sdnq": sdnq_module,
+            "sdnq.dequantizer": dequantizer_module,
+            "sdnq.layers": layers_module,
+            "sdnq.training": training_module,
+            "sdnq.training.forward": forward_module,
+            "sdnq.training.tensor": tensor_module,
+        }
+        with (
+            patch.dict("sys.modules", modules),
+            patch("simpletuner.helpers.training.sdnq_compile.configure_sdnq_compile_mode") as configure,
+        ):
+            quantized_loading._load_sdnq_training_symbols()
+
+        configure.assert_called_once_with()
+
+    def test_sdnq_compile_mode_configures_during_parse(self):
+        os.environ.pop("SDNQ_USE_TORCH_COMPILE", None)
+        args = parse_cmdline_args(
+            input_args=_base_args() + ["--base_model_precision=int8-sdnq", "--sdnq_compile_mode=eager"],
+            exit_on_error=False,
+        )
+
+        self.assertEqual(args.sdnq_compile_mode, "eager")
+        self.assertEqual(os.environ["SDNQ_USE_TORCH_COMPILE"], "0")

--- a/tests/test_quantization_config_parsing.py
+++ b/tests/test_quantization_config_parsing.py
@@ -3,7 +3,7 @@ import os
 import sys
 import unittest
 from types import ModuleType, SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from simpletuner.helpers.configuration.cmd_args import parse_cmdline_args
 from simpletuner.helpers.training.state_tracker import StateTracker
@@ -103,6 +103,16 @@ class TestQuantizationConfigParsing(unittest.TestCase):
         configure_sdnq_compile_mode()
 
         self.assertEqual(os.environ["SDNQ_USE_TORCH_COMPILE"], "1")
+
+    def test_sdnq_compile_mode_defaults_when_config_lacks_attribute(self):
+        from simpletuner.helpers.training.sdnq_compile import configure_sdnq_compile_mode
+
+        StateTracker.set_args(Mock())
+        os.environ.pop("SDNQ_USE_TORCH_COMPILE", None)
+
+        configure_sdnq_compile_mode()
+
+        self.assertNotIn("SDNQ_USE_TORCH_COMPILE", os.environ)
 
     def test_sdnq_compile_mode_does_not_warn_after_prior_configuration(self):
         from simpletuner.helpers.training import sdnq_compile


### PR DESCRIPTION
Summary:
- Applies the SDNQ compile mode environment before SDNQ-backed model imports can occur.
- Defaults missing compile-mode config values to `auto` so trainer construction does not reject legacy test/config objects.
- Adds parser and trainer initialization coverage for the compile-mode contract.

Validation:
- `.venv/bin/python -m unittest -v -f tests.test_quantization_config_parsing tests.test_trainer.TestTrainer.test_misc_init`
- Branch diff and commit-message identity scan passed.
