### PR TITLE
Preserve optimizer beta overrides from config strings

### DIFF
--- a/simpletuner/helpers/training/optimizer_param.py
+++ b/simpletuner/helpers/training/optimizer_param.py
@@ -902,9 +902,8 @@ def convert_arg_to_parameters(args):
                 out[param[0]] = float(param[1])
             else:
                 out[param[0]] = param[1]
-        return out
     if args.optimizer_beta1 is not None and args.optimizer_beta2 is not None:
-        # the user has supplied a beta1 and beta2 value
+        # Generic beta overrides remain useful alongside optimizer-specific settings.
         out["betas"] = tuple([args.optimizer_beta1, args.optimizer_beta2])
 
     return out

--- a/tests/test_optimizer_param.py
+++ b/tests/test_optimizer_param.py
@@ -1,0 +1,26 @@
+import unittest
+from types import SimpleNamespace
+
+from simpletuner.helpers.training.optimizer_param import convert_arg_to_parameters
+
+
+class OptimizerParamTests(unittest.TestCase):
+    def test_optimizer_config_preserves_generic_beta_overrides(self):
+        args = SimpleNamespace(
+            optimizer_config="weight_decay=0.0,eps=1e-8",
+            optimizer_beta1=0.9,
+            optimizer_beta2=0.95,
+        )
+
+        self.assertEqual(
+            convert_arg_to_parameters(args),
+            {
+                "weight_decay": 0.0,
+                "eps": 1e-8,
+                "betas": (0.9, 0.95),
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
- Keeps generic beta overrides when optimizer configuration is supplied as a string.
- Prevents config-string parsing from dropping explicit optimizer beta values before optimizer construction.
- Adds focused coverage for preserving the overrides.

Validation:
- `.venv/bin/python -m unittest -v -f tests.test_optimizer_param`
- Branch diff and commit-message identity scan passed.
