### PR TITLE
Treat empty validation benchmark folders as absent

### DIFF
--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -2335,9 +2335,9 @@ class Validation:
         """
         Determines whether the base model benchmark outputs already exist.
         """
-        base_model_benchmark = self._benchmark_path()
+        base_model_benchmark = self._benchmark_path(benchmark=benchmark)
 
-        return os.path.exists(base_model_benchmark) and bool(os.listdir(base_model_benchmark))
+        return os.path.isdir(base_model_benchmark) and bool(os.listdir(base_model_benchmark))
 
     def _benchmark_path(self, benchmark: str = "base_model"):
         # does the benchmark directory exist?

--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -2337,7 +2337,7 @@ class Validation:
         """
         base_model_benchmark = self._benchmark_path()
 
-        return os.path.exists(base_model_benchmark)
+        return os.path.exists(base_model_benchmark) and bool(os.listdir(base_model_benchmark))
 
     def _benchmark_path(self, benchmark: str = "base_model"):
         # does the benchmark directory exist?

--- a/tests/test_validation_benchmark.py
+++ b/tests/test_validation_benchmark.py
@@ -24,6 +24,31 @@ class ValidationBenchmarkTests(unittest.TestCase):
 
             self.assertTrue(validation.benchmark_exists())
 
+    def test_benchmark_exists_uses_requested_benchmark_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            validation = Validation.__new__(Validation)
+            validation.config = SimpleNamespace(output_dir=tmpdir)
+            base_model_dir = validation._benchmark_path("base_model")
+            custom_dir = validation._benchmark_path("custom")
+            os.makedirs(base_model_dir)
+            os.makedirs(custom_dir)
+            with open(os.path.join(custom_dir, "sample.png"), "wb") as handle:
+                handle.write(b"placeholder")
+
+            self.assertFalse(validation.benchmark_exists("base_model"))
+            self.assertTrue(validation.benchmark_exists("custom"))
+
+    def test_benchmark_exists_treats_file_as_absent(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            validation = Validation.__new__(Validation)
+            validation.config = SimpleNamespace(output_dir=tmpdir)
+            benchmarks_dir = os.path.join(tmpdir, "benchmarks")
+            os.makedirs(benchmarks_dir)
+            with open(os.path.join(benchmarks_dir, "base_model"), "wb") as handle:
+                handle.write(b"placeholder")
+
+            self.assertFalse(validation.benchmark_exists())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_validation_benchmark.py
+++ b/tests/test_validation_benchmark.py
@@ -1,0 +1,29 @@
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+from simpletuner.helpers.training.validation import Validation
+
+
+class ValidationBenchmarkTests(unittest.TestCase):
+    def test_benchmark_exists_requires_existing_outputs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            validation = Validation.__new__(Validation)
+            validation.config = SimpleNamespace(output_dir=tmpdir)
+
+            self.assertFalse(validation.benchmark_exists())
+
+            benchmark_dir = validation._benchmark_path()
+            self.assertTrue(os.path.isdir(os.path.join(tmpdir, "benchmarks")))
+            os.makedirs(benchmark_dir)
+            self.assertFalse(validation.benchmark_exists())
+
+            with open(os.path.join(benchmark_dir, "sample.png"), "wb") as handle:
+                handle.write(b"placeholder")
+
+            self.assertTrue(validation.benchmark_exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
- Makes validation benchmark reuse require a non-empty benchmark output folder.
- Prevents an empty benchmark directory from suppressing benchmark generation or stitching behavior.
- Adds focused coverage for missing, empty, and populated benchmark folders.

Validation:
- `.venv/bin/python -m unittest -v -f tests.test_validation_benchmark tests.test_validation_scheduler_cache`
- Branch diff and commit-message identity scan passed.
