### PR TITLE
Stabilize Webshart video metadata and validation logging (TensorBoard)

### DIFF
--- a/documentation/DATALOADER.es.md
+++ b/documentation/DATALOADER.es.md
@@ -681,8 +681,8 @@ Por ejemplo, con 4 GPUs, `train_batch_size=4` y `gradient_accumulation_steps=1`,
 Para ajustar automáticamente `repeats` cuando tu dataset es más pequeño que el tamaño efectivo de batch, usa el flag `--allow_dataset_oversubscription` (documentado en [OPTIONS.md](OPTIONS.md#--allow_dataset_oversubscription)).
 
 Cuando está habilitado, SimpleTuner:
-- Calcula los repeats mínimos necesarios para el entrenamiento
-- Aumenta automáticamente `repeats` para cumplir el requisito
+- Calcula los repeats mínimos necesarios para cada bucket de aspecto insuficiente
+- Rellena solo esos buckets para cumplir el tamaño efectivo de batch
 - Registra una advertencia mostrando el ajuste
 - **Respeta valores de repeats configurados manualmente** - si configuras `repeats` explícitamente en tu configuración de dataset, se omitirá el ajuste automático
 
@@ -1324,7 +1324,7 @@ Los datasets Webshart cargan shards tar estilo WebDataset mediante el paquete `w
 - `source` es obligatorio y apunta a una fuente que Webshart pueda descubrir.
 - `metadata` es opcional y puede apuntar a metadatos separados con captions. Para repositorios Hugging Face de metadata como `webshart/conceptual-captions-12m-webdataset-metadata`, pasa el repo id; Webshart sigue el layout de subcarpetas del source, como `data/`.
 - `metadata_backend` debe ser `webshart`; `caption_strategy` debe ser `webshart` o `instanceprompt`.
-- `webshart.cache_dir` almacena la metadata de SimpleTuner y las caches de Webshart.
+- `webshart.cache_dir` almacena la metadata de SimpleTuner y las caches de Webshart. `shard_cache_gb` y `parallel_downloads` se pasan a la cache de shards de Webshart; define `shard_cache_gb` como `0` para desactivar la cache de shards completos y mantener lecturas por rango indexadas.
 
 Requiere un build de Webshart con `TarDataLoader.list_shard_sample_aspect_buckets()`.
 

--- a/documentation/DATALOADER.hi.md
+++ b/documentation/DATALOADER.hi.md
@@ -681,8 +681,8 @@ effective_batch_size = train_batch_size × num_gpus × gradient_accumulation_ste
 यदि आपका dataset effective batch size से छोटा है और `repeats` स्वतः समायोजित करना चाहते हैं, तो `--allow_dataset_oversubscription` फ़्लैग का उपयोग करें ([OPTIONS.md](OPTIONS.md#--allow_dataset_oversubscription) में दस्तावेज़ित)।
 
 सक्षम होने पर, SimpleTuner:
-- training के लिए न्यूनतम repeats की गणना करेगा
-- आवश्यकता पूरी करने के लिए `repeats` स्वतः बढ़ाएगा
+- हर undersized aspect bucket के लिए आवश्यक न्यूनतम repeats की गणना करेगा
+- effective batch size पूरा करने के लिए केवल उन्हीं buckets को pad करेगा
 - adjustment दिखाने के लिए warning लॉग करेगा
 - **manually‑set repeats का सम्मान करेगा** — यदि आपने dataset config में `repeats` स्पष्ट रूप से सेट किया है, तो auto adjustment skip होगा
 
@@ -1324,7 +1324,7 @@ Webshart datasets `webshart` package के जरिए WebDataset-style tar sh
 - `source` required है और Webshart-discoverable dataset source को point करता है।
 - `metadata` optional है और captions वाले separate metadata location को point कर सकता है। `webshart/conceptual-captions-12m-webdataset-metadata` जैसे Hugging Face metadata repos के लिए repo id दें; Webshart source shard के `data/` जैसे subfolder layout को follow करता है।
 - `metadata_backend` को `webshart` होना चाहिए; `caption_strategy` `webshart` या `instanceprompt` हो सकता है।
-- `webshart.cache_dir` SimpleTuner metadata और Webshart caches store करता है।
+- `webshart.cache_dir` SimpleTuner metadata और Webshart caches store करता है। `shard_cache_gb` और `parallel_downloads` Webshart shard cache को pass किए जाते हैं; whole-shard caching disable करने और indexed range reads बनाए रखने के लिए `shard_cache_gb` को `0` सेट करें।
 
 इसके लिए `TarDataLoader.list_shard_sample_aspect_buckets()` वाला Webshart build चाहिए।
 

--- a/documentation/DATALOADER.ja.md
+++ b/documentation/DATALOADER.ja.md
@@ -675,15 +675,14 @@ effective_batch_size = train_batch_size × num_gpus × gradient_accumulation_ste
 - サンプル数が不足しているアスペクトバケット
 - 各バケットに必要な最小 repeats
 - 推奨される解決策
-- 推奨される解決策
 
 ##### データセットの自動オーバーサブスクリプション
 
 データセットが実効バッチサイズより小さい場合に `repeats` を自動調整するには、`--allow_dataset_oversubscription` フラグを使用します（[OPTIONS.md](OPTIONS.md#--allow_dataset_oversubscription) 参照）。
 
 有効化すると、SimpleTuner は次を行います:
-- 学習に必要な最小 repeats を計算
-- 要件を満たすように `repeats` を自動的に増加
+- サンプル数が不足している aspect bucket ごとに必要な最小 repeats を計算
+- 実効バッチサイズを満たすため、その bucket だけをパディング
 - 調整内容を警告ログで出力
 - **手動設定された repeats を尊重** - データセット設定で明示的に `repeats` を設定している場合、自動調整はスキップされます
 
@@ -1326,7 +1325,7 @@ Webshart データセットは `webshart` パッケージで WebDataset 形式�
 - `source` は必須で、Webshart が discover できる dataset source を指定します。
 - `metadata` は任意で、captions を含む別 metadata location を指定できます。`webshart/conceptual-captions-12m-webdataset-metadata` のような Hugging Face metadata repo では repo id だけを渡します。Webshart は source shard の `data/` などのサブフォルダ構成に従います。
 - `metadata_backend` は `webshart`、`caption_strategy` は `webshart` または `instanceprompt` にします。
-- `webshart.cache_dir` は SimpleTuner metadata と Webshart caches を保存します。
+- `webshart.cache_dir` は SimpleTuner metadata と Webshart caches を保存します。`shard_cache_gb` と `parallel_downloads` は Webshart の shard cache に渡されます。`shard_cache_gb` を `0` にすると、shard 全体の cache を無効にし、index 付き range read を維持します。
 
 `TarDataLoader.list_shard_sample_aspect_buckets()` を提供する Webshart build が必要です。
 

--- a/documentation/DATALOADER.md
+++ b/documentation/DATALOADER.md
@@ -682,8 +682,8 @@ For example, with 4 GPUs, `train_batch_size=4`, and `gradient_accumulation_steps
 To automatically adjust `repeats` when your dataset is smaller than the effective batch size, use the `--allow_dataset_oversubscription` flag (documented in [OPTIONS.md](OPTIONS.md#--allow_dataset_oversubscription)).
 
 When enabled, SimpleTuner will:
-- Calculate the minimum repeats needed for training
-- Automatically increase `repeats` to meet the requirement
+- Calculate the minimum repeats needed for each undersized aspect bucket
+- Pad only those buckets to meet the effective batch size
 - Log a warning showing the adjustment
 - **Respect manually-set repeats values** - if you explicitly configure `repeats` in your dataset config, the automatic adjustment will be skipped
 

--- a/documentation/DATALOADER.pt-BR.md
+++ b/documentation/DATALOADER.pt-BR.md
@@ -681,8 +681,8 @@ Por exemplo, com 4 GPUs, `train_batch_size=4` e `gradient_accumulation_steps=1`,
 Para ajustar automaticamente `repeats` quando seu dataset é menor que o tamanho efetivo do batch, use a flag `--allow_dataset_oversubscription` (documentada em [OPTIONS.md](OPTIONS.md#--allow_dataset_oversubscription)).
 
 Quando habilitado, o SimpleTuner irá:
-- Calcular o mínimo de repeats necessário para o treinamento
-- Aumentar automaticamente `repeats` para atender ao requisito
+- Calcular o mínimo de repeats necessário para cada bucket de aspecto insuficiente
+- Preencher apenas esses buckets para atender ao tamanho efetivo do batch
 - Registrar um aviso mostrando o ajuste
 - **Respeitar valores de repeats definidos manualmente** - se você configurar explicitamente `repeats` no seu config de dataset, o ajuste automático será ignorado
 
@@ -1324,7 +1324,7 @@ Datasets Webshart carregam shards tar no estilo WebDataset pelo pacote `webshart
 - `source` é obrigatório e aponta para uma fonte que o Webshart consiga descobrir.
 - `metadata` é opcional e pode apontar para metadados separados com captions. Para repos Hugging Face de metadata como `webshart/conceptual-captions-12m-webdataset-metadata`, passe o repo id; o Webshart segue o layout de subpastas do source, como `data/`.
 - `metadata_backend` deve ser `webshart`; `caption_strategy` deve ser `webshart` ou `instanceprompt`.
-- `webshart.cache_dir` armazena os metadados do SimpleTuner e os caches do Webshart.
+- `webshart.cache_dir` armazena os metadados do SimpleTuner e os caches do Webshart. `shard_cache_gb` e `parallel_downloads` são passados ao cache de shards do Webshart; defina `shard_cache_gb` como `0` para desativar o cache de shards completos e manter leituras por intervalo indexadas.
 
 Exige um build do Webshart com `TarDataLoader.list_shard_sample_aspect_buckets()`.
 

--- a/documentation/DATALOADER.zh.md
+++ b/documentation/DATALOADER.zh.md
@@ -675,15 +675,14 @@ effective_batch_size = train_batch_size × num_gpus × gradient_accumulation_ste
 - 样本不足的纵横比桶
 - 每个桶所需的最小 repeats
 - 建议的解决方案
-- 建议的解决方案
 
 ##### 自动数据集超订
 
 当数据集小于有效批大小时，可使用 `--allow_dataset_oversubscription` 标志自动调整 `repeats`（见 [OPTIONS.md](OPTIONS.md#--allow_dataset_oversubscription)）。
 
 启用后，SimpleTuner 将：
-- 计算训练所需的最小 repeats
-- 自动增加 `repeats` 以满足要求
+- 为每个样本不足的 aspect bucket 计算所需的最小 repeats
+- 只填充这些 bucket 以满足有效批大小
 - 记录一条警告日志说明调整
 - **尊重手动设置的 repeats** —— 若在数据集配置中显式设置了 `repeats`，则跳过自动调整
 
@@ -1326,7 +1325,7 @@ Webshart 数据集通过 `webshart` 包加载 WebDataset 风格的 tar shards。
 - `source` 必填，指向 Webshart 可 discover 的 dataset source。
 - `metadata` 可选，可指向包含 captions 的独立 metadata location。对于 `webshart/conceptual-captions-12m-webdataset-metadata` 这样的 Hugging Face metadata repo，传 repo id 即可；Webshart 会跟随 source shard 的 `data/` 等子目录布局。
 - `metadata_backend` 必须为 `webshart`；`caption_strategy` 应为 `webshart` 或 `instanceprompt`。
-- `webshart.cache_dir` 存储 SimpleTuner metadata 与 Webshart caches。
+- `webshart.cache_dir` 存储 SimpleTuner metadata 与 Webshart caches。`shard_cache_gb` 和 `parallel_downloads` 会传给 Webshart 的 shard cache；将 `shard_cache_gb` 设为 `0` 可禁用整 shard cache，并保留基于索引的 range reads。
 
 需要提供 `TarDataLoader.list_shard_sample_aspect_buckets()` 的 Webshart build。
 

--- a/simpletuner/helpers/data_backend/webshart.py
+++ b/simpletuner/helpers/data_backend/webshart.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import os
+import random
+import time
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
@@ -198,8 +200,37 @@ class WebshartDataBackend(BaseDataBackend):
 
     def _read_sample_bytes(self, identifier: Union[str, Path]) -> bytes:
         sample_ref = self.parse_sample_id(identifier)
-        entry = self.loader.load_sample(sample_ref.shard_idx, sample_ref.sample_idx)
-        return bytes(entry.data)
+        max_attempts = 6
+        for attempt in range(max_attempts):
+            try:
+                entry = self.loader.load_sample(sample_ref.shard_idx, sample_ref.sample_idx)
+                return bytes(entry.data)
+            except Exception as exc:
+                message = str(exc).lower()
+                retryable = any(
+                    marker in message
+                    for marker in (
+                        "rate limit",
+                        "http 429",
+                        "status code 429",
+                        "connection reset",
+                        "temporarily unavailable",
+                        "timed out",
+                        "timeout",
+                    )
+                )
+                if not retryable or attempt + 1 >= max_attempts:
+                    raise
+                delay = min(30.0, 2.0**attempt) + random.uniform(0.0, 1.0)
+                logger.warning(
+                    "Transient error reading Webshart sample %s; retrying in %.1fs (%d/%d): %s",
+                    identifier,
+                    delay,
+                    attempt + 1,
+                    max_attempts,
+                    exc,
+                )
+                time.sleep(delay)
 
     def read_sample_head_tail(
         self,

--- a/simpletuner/helpers/metadata/backends/base.py
+++ b/simpletuner/helpers/metadata/backends/base.py
@@ -781,7 +781,7 @@ class MetadataBackend:
         backend_config = StateTracker.get_data_backend_config(self.id) or {}
         configured_repeats = int(backend_config.get("repeats") or 0)
         user_set_repeats = configured_repeats > 0
-        auto_repeat_count = None
+        auto_repeat_counts = {}
 
         # Early validation: check if configuration is mathematically impossible
         buckets_that_will_fail = []
@@ -806,22 +806,19 @@ class MetadataBackend:
                 needed_repeats = ceil(effective_batch_size / images) - 1
                 min_repeats_needed[bucket_info["bucket"]] = needed_repeats
 
-            # The documented repeat setting applies to the whole backend, so
-            # use the maximum requirement and apply it consistently to every
-            # bucket rather than assigning a different repeat count per bucket.
             max_needed_repeats = max(min_repeats_needed.values())
             allow_oversubscription = StateTracker.get_args().allow_dataset_oversubscription
 
             # Check if dataset oversubscription is allowed
             if allow_oversubscription and not user_set_repeats:
-                # Automatically adjust repeats to make training possible
-                original_repeats = self.repeats
-                auto_repeat_count = max_needed_repeats
+                # Pad only undersized buckets. Applying the rarest bucket's repeat
+                # count backend-wide can multiply an otherwise large dataset.
+                auto_repeat_counts = min_repeats_needed
                 logger.warning(
-                    f"(id={self.id}) Dataset oversubscription enabled: automatically increasing repeats from {original_repeats} to {auto_repeat_count}\n"
+                    f"(id={self.id}) Dataset oversubscription enabled: automatically padding {len(auto_repeat_counts)} undersized bucket(s)\n"
                     f"  - This allows training with {total_samples} samples across {num_processes} GPUs\n"
                     f"  - Effective batch size: {effective_batch_size}\n"
-                    f"  - Logical repeat factor before per-bucket batch padding: {auto_repeat_count + 1}"
+                    f"  - Maximum per-bucket repeat factor: {max_needed_repeats + 1}"
                 )
                 # Validation passed with adjustment, continue
             else:
@@ -889,6 +886,7 @@ class MetadataBackend:
                 images = sorted(images, key=str)
                 random.Random(f"{shuffle_seed}:{self.id}:{bucket}").shuffle(images)
 
+            auto_repeat_count = auto_repeat_counts.get(bucket)
             if auto_repeat_count is not None:
                 logical_count = len(images) * (auto_repeat_count + 1)
                 scheduled_count = ceil(logical_count / effective_batch_size) * effective_batch_size

--- a/simpletuner/helpers/metadata/backends/webshart.py
+++ b/simpletuner/helpers/metadata/backends/webshart.py
@@ -412,10 +412,13 @@ class WebshartMetadataBackend(MetadataBackend):
             "skipped": {
                 "already_exists": 0,
                 "metadata_missing": 0,
+                "caption_missing": 0,
                 "too_small": 0,
                 "error": 0,
             },
         }
+        backend_config = StateTracker.get_data_backend_config(self.id) or {}
+        require_captions = str(backend_config.get("caption_strategy", "")).lower() == "webshart"
 
         if not ignore_existing_cache:
             self.reload_cache()
@@ -508,6 +511,9 @@ class WebshartMetadataBackend(MetadataBackend):
                                 statistics["skipped"]["metadata_missing"] += 1
                             continue
                         bucket_key, sample_metadata = prepared
+                        if require_captions and not sample_metadata.get("captions"):
+                            statistics["skipped"]["caption_missing"] += 1
+                            continue
                         aspect_ratio_bucket_updates.setdefault(bucket_key, []).append(sample_path)
                         metadata_updates[sample_path] = sample_metadata
                         if sample_metadata.get("captions"):

--- a/simpletuner/helpers/multiaspect/sampler.py
+++ b/simpletuner/helpers/multiaspect/sampler.py
@@ -583,12 +583,19 @@ class MultiAspectSampler(torch.utils.data.Sampler):
         if alt_stats:
             # Return an overview instead of a snapshot.
             # Eg. return totals, and not "as it is now"
+            data_backend_config = StateTracker.get_data_backend_config(self.id)
             total_image_count = len(self.metadata_backend.seen_images) + len(self._get_unseen_images())
-            if self.accelerator.num_processes > 1:
+            configured_max_samples = data_backend_config.get("max_num_samples")
+            try:
+                configured_max_samples = int(configured_max_samples)
+            except (TypeError, ValueError):
+                configured_max_samples = None
+            if configured_max_samples is not None and configured_max_samples > 0:
+                total_image_count = min(total_image_count * self.accelerator.num_processes, configured_max_samples)
+            elif self.accelerator.num_processes > 1:
                 # We don't know the direct count without more work, so we'll estimate it here for multi-GPU training.
                 total_image_count *= self.accelerator.num_processes
                 total_image_count = f"~{total_image_count}"
-            data_backend_config = StateTracker.get_data_backend_config(self.id)
             printed_state = [f"- Repeats: {data_backend_config.get('repeats', 0)}"]
             printed_state.append(f"- Total number of {self.sample_type_strs}: {total_image_count}")
             printed_state.append(f"- Total number of aspect buckets: {len(self.buckets)}")
@@ -617,8 +624,13 @@ class MultiAspectSampler(torch.utils.data.Sampler):
                     f"- Crop aspect: {'None' if not data_backend_config.get('crop') else data_backend_config.get('crop_aspect')}"
                 )
             elif self.sample_type_strs == "videos":
-                printed_state.append(f"- Target frame count: {data_backend_config.get('frames_per_video')}")
-                printed_state.append(f"- FPS: {data_backend_config.get('fps')}")
+                video_config = data_backend_config.get("video") or {}
+                target_frame_count = data_backend_config.get("frames_per_video") or video_config.get("num_frames")
+                fps = data_backend_config.get("fps") or video_config.get("fps")
+                printed_state.append(
+                    f"- Target frame count: {target_frame_count if target_frame_count is not None else 'unknown'}"
+                )
+                printed_state.append(f"- FPS: {fps if fps is not None else 'unknown'}")
             elif self.sample_type_strs == "audio":
                 sample_rate = data_backend_config.get("sample_rate") or data_backend_config.get("audio_sample_rate")
                 target_len = data_backend_config.get("sample_size") or data_backend_config.get("audio_samples")

--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -4989,7 +4989,7 @@ class Validation:
                         sample_rate=sample_rate,
                     )
         elif isinstance(self.model, VideoModelFoundation):
-            validation_images_utils.log_images_to_trackers(
+            validation_video.log_videos_to_trackers(
                 self.accelerator,
                 validation_images,
                 self.validation_resolutions,

--- a/simpletuner/helpers/training/validation_video.py
+++ b/simpletuner/helpers/training/validation_video.py
@@ -1,8 +1,10 @@
 import base64
+import importlib.util
 import logging
 import os
 import shutil
 import subprocess
+from functools import lru_cache
 from io import BytesIO
 
 import numpy as np
@@ -269,6 +271,15 @@ def _tensorboard_video(media):
     return tensor
 
 
+@lru_cache(maxsize=1)
+def _tensorboard_video_supported() -> bool:
+    """TensorBoard's video writer requires the legacy moviepy.editor module."""
+    try:
+        return importlib.util.find_spec("moviepy.editor") is not None
+    except (ImportError, ModuleNotFoundError, ValueError):
+        return False
+
+
 def _wandb_video(media):
     video = _video_to_thwc_array(media)
     if video is None:
@@ -308,15 +319,21 @@ def log_videos_to_trackers(accelerator, validation_images, validation_resolution
         elif tracker.name == "tensorboard":
             tracker = accelerator.get_tracker("tensorboard")
             image_logs = {}
+            video_supported = _tensorboard_video_supported()
             for shortname, media_list in validation_images.items():
                 for idx, media in enumerate(media_list):
                     res_label = validation_resolutions[idx] if idx < len(validation_resolutions) else "unknown"
                     tag = f"{shortname} - {res_label}"
-                    video = _tensorboard_video(media)
-                    if video is not None:
-                        tracker.writer.add_video(tag, video, global_step=global_step, fps=fps)
-                        continue
+                    if video_supported:
+                        video = _tensorboard_video(media)
+                        if video is not None:
+                            tracker.writer.add_video(tag, video, global_step=global_step, fps=fps)
+                            continue
                     image = _image_to_chw_batch(media)
+                    if image is None and not video_supported:
+                        first_frame = _first_frame_image(media)
+                        if first_frame is not None:
+                            image = _image_to_chw_batch(first_frame)
                     if image is not None:
                         image_logs[tag] = image
             if image_logs:

--- a/simpletuner/helpers/training/validation_video.py
+++ b/simpletuner/helpers/training/validation_video.py
@@ -5,7 +5,11 @@ import shutil
 import subprocess
 from io import BytesIO
 
+import numpy as np
+import torch
+import wandb
 from diffusers.utils.export_utils import export_to_video
+from PIL import Image
 
 from simpletuner.helpers.multiaspect.image import MultiaspectImage
 from simpletuner.helpers.training import validation_audio
@@ -167,6 +171,178 @@ def save_videos(
         validation_img_idx += 1
 
     return video_paths
+
+
+def _frame_to_rgb_array(frame):
+    if isinstance(frame, Image.Image):
+        return np.array(frame.convert("RGB"))
+    if torch.is_tensor(frame):
+        frame = frame.detach().cpu()
+        if frame.ndim == 3 and frame.shape[0] in (1, 3, 4):
+            frame = frame.permute(1, 2, 0)
+        frame = frame.numpy()
+    array = np.asarray(frame)
+    if array.ndim == 2:
+        array = array[..., np.newaxis]
+    if array.ndim != 3:
+        raise ValueError(f"Expected a video frame with 2 or 3 dimensions, got shape {array.shape}.")
+    if array.shape[-1] == 1:
+        array = np.repeat(array, 3, axis=-1)
+    elif array.shape[-1] == 4:
+        array = array[..., :3]
+    elif array.shape[-1] != 3:
+        raise ValueError(f"Expected RGB-like video frame data, got shape {array.shape}.")
+    return _normalise_array_to_uint8(array)
+
+
+def _normalise_array_to_uint8(array: np.ndarray) -> np.ndarray:
+    if np.issubdtype(array.dtype, np.integer):
+        return np.clip(array, 0, 255).astype(np.uint8)
+    array = array.astype(np.float32, copy=False)
+    if array.size and float(np.nanmin(array)) < 0.0:
+        array = (array + 1.0) / 2.0
+    if array.size and float(np.nanmax(array)) > 1.0:
+        array = array / 255.0
+    return np.clip(array * 255.0, 0, 255).astype(np.uint8)
+
+
+def _video_to_thwc_array(media):
+    if isinstance(media, Image.Image):
+        return None
+    if isinstance(media, list):
+        if not media:
+            return None
+        return np.stack([_frame_to_rgb_array(frame) for frame in media], axis=0)
+    if torch.is_tensor(media):
+        media = media.detach().cpu()
+        if media.ndim == 5:
+            if media.shape[-1] in (1, 3, 4):  # B, T, H, W, C
+                media = media[0]
+            elif media.shape[1] in (1, 3, 4):  # B, C, T, H, W
+                media = media[0].permute(1, 0, 2, 3)
+            elif media.shape[2] in (1, 3, 4):  # B, T, C, H, W
+                media = media[0]
+            else:
+                return None
+        media = media.numpy()
+    array = np.asarray(media)
+    if array.ndim == 5:
+        if array.shape[-1] in (1, 3, 4):  # B, T, H, W, C
+            array = array[0]
+        elif array.shape[1] in (1, 3, 4):  # B, C, T, H, W
+            array = np.moveaxis(array[0], 0, -1)
+        elif array.shape[2] in (1, 3, 4):  # B, T, C, H, W
+            array = np.moveaxis(array[0], 1, -1)
+        else:
+            return None
+    elif array.ndim == 4:
+        if array.shape[-1] in (1, 3, 4):  # T, H, W, C
+            pass
+        elif array.shape[1] in (1, 3, 4):  # T, C, H, W
+            array = np.moveaxis(array, 1, -1)
+        elif array.shape[0] in (1, 3, 4):  # C, T, H, W
+            array = np.moveaxis(array, 0, -1)
+        else:
+            return None
+    else:
+        return None
+    return np.stack([_frame_to_rgb_array(frame) for frame in array], axis=0)
+
+
+def _image_to_chw_batch(media):
+    if isinstance(media, list):
+        if not media:
+            return None
+        media = media[0]
+    try:
+        image = _frame_to_rgb_array(media)
+    except Exception:
+        return None
+    return np.moveaxis(image, -1, 0)[np.newaxis, ...]
+
+
+def _tensorboard_video(media):
+    video = _video_to_thwc_array(media)
+    if video is None:
+        return None
+    tensor = torch.from_numpy(video).permute(0, 3, 1, 2).unsqueeze(0).float() / 255.0
+    return tensor
+
+
+def _wandb_video(media):
+    video = _video_to_thwc_array(media)
+    if video is None:
+        return None
+    return np.moveaxis(video, -1, 1)
+
+
+def _first_frame_image(media):
+    video = _video_to_thwc_array(media)
+    if video is not None and len(video) > 0:
+        return Image.fromarray(video[0])
+    try:
+        return Image.fromarray(_frame_to_rgb_array(media))
+    except Exception:
+        return None
+
+
+def log_videos_to_trackers(accelerator, validation_images, validation_resolutions, config):
+    """
+    Log validation video media to trackers.
+
+    TensorBoard's image path expects NCHW and rejects 5D video tensors, so video
+    samples are sent through SummaryWriter.add_video as N,T,C,H,W.
+    """
+    fps = int(getattr(config, "framerate", None) or 16)
+    global_step = StateTracker.get_global_step()
+    for tracker in accelerator.trackers:
+        if tracker.name == "comet_ml":
+            experiment = accelerator.get_tracker("comet_ml").tracker
+            for shortname, media_list in validation_images.items():
+                for idx, media in enumerate(media_list):
+                    image = _first_frame_image(media)
+                    if image is None:
+                        continue
+                    res_label = str(validation_resolutions[idx]) if idx < len(validation_resolutions) else "unknown"
+                    experiment.log_image(image, name=f"{shortname} - {res_label} - frame 0")
+        elif tracker.name == "tensorboard":
+            tracker = accelerator.get_tracker("tensorboard")
+            image_logs = {}
+            for shortname, media_list in validation_images.items():
+                for idx, media in enumerate(media_list):
+                    res_label = validation_resolutions[idx] if idx < len(validation_resolutions) else "unknown"
+                    tag = f"{shortname} - {res_label}"
+                    video = _tensorboard_video(media)
+                    if video is not None:
+                        tracker.writer.add_video(tag, video, global_step=global_step, fps=fps)
+                        continue
+                    image = _image_to_chw_batch(media)
+                    if image is not None:
+                        image_logs[tag] = image
+            if image_logs:
+                tracker.log_images(image_logs, step=global_step)
+        elif tracker.name == "wandb":
+            resolution_list = []
+            for res in validation_resolutions:
+                if isinstance(res, tuple):
+                    resolution_list.append(f"{res[0]}x{res[1]}")
+                else:
+                    resolution_list.append(str(res))
+
+            logs = {}
+            for shortname, media_list in validation_images.items():
+                for idx, media in enumerate(media_list):
+                    res_label = resolution_list[idx] if idx < len(resolution_list) else "unknown"
+                    caption = f"{shortname} - {res_label}"
+                    video = _wandb_video(media)
+                    if video is not None:
+                        logs[caption] = wandb.Video(video, fps=fps, format="mp4", caption=caption)
+                    else:
+                        image = _first_frame_image(media)
+                        if image is not None:
+                            logs[caption] = wandb.Image(image, caption=caption)
+            if logs:
+                tracker.log(logs, step=global_step)
 
 
 def log_videos_to_webhook(validation_images, validation_video_paths, validation_shortname, validation_prompt, eval_scores):

--- a/tests/test_metadata_backend.py
+++ b/tests/test_metadata_backend.py
@@ -640,7 +640,7 @@ class TestAutomaticOversubscriptionLogicalSequence(unittest.TestCase):
             images + images + images[:14],
         )
 
-    def test_auto_repeat_count_is_backend_wide_across_buckets(self):
+    def test_auto_repeat_count_is_scoped_to_undersized_buckets(self):
         backend = self._backend([], dp_size=2, rank=0, batch_size=4)
         backend._aspect_ratio_bucket_indices = {
             "small": ["s0", "s1", "s2"],
@@ -651,7 +651,7 @@ class TestAutomaticOversubscriptionLogicalSequence(unittest.TestCase):
         self.assertEqual(backend.repeats, 0)
         self.assertEqual(
             {bucket: len(values) for bucket, values in backend.aspect_ratio_bucket_indices.items()},
-            {"small": 8, "large": 12},
+            {"small": 8, "large": 8},
         )
         self.assertEqual(
             backend.aspect_ratio_bucket_indices["small"],
@@ -659,7 +659,7 @@ class TestAutomaticOversubscriptionLogicalSequence(unittest.TestCase):
         )
         self.assertEqual(
             backend.aspect_ratio_bucket_indices["large"],
-            ["l0", "l1", "l2", "l3", "l4", "l5", "l6", "l0", "l1", "l2", "l3", "l4"],
+            ["l0", "l1", "l2", "l3", "l4", "l5", "l6", "l0"],
         )
 
     def test_manual_repeats_are_not_materialised(self):

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -64,6 +64,33 @@ class TestMultiAspectSampler(unittest.TestCase):
     def test_len(self):
         self.assertEqual(len(self.sampler), 2)
 
+    def test_model_card_video_overview_honors_sample_cap_and_nested_video_config(self):
+        sampler = object.__new__(MultiAspectSampler)
+        sampler.id = "video-dataset"
+        sampler.metadata_backend = SimpleNamespace(seen_images={str(i): True for i in range(1000)})
+        sampler._get_unseen_images = MagicMock(return_value=[None] * 3997)
+        sampler.accelerator = SimpleNamespace(num_processes=8)
+        sampler.logger = MagicMock()
+        sampler.sample_type_strs = "videos"
+        sampler.buckets = ["0.75", "1.0", "1.25", "1.5", "1.75"]
+        sampler.is_regularisation_data = False
+        sampler.conditioning_type = None
+
+        with (
+            patch.object(
+                StateTracker,
+                "get_data_backend_config",
+                return_value={"max_num_samples": 4096, "video": {"num_frames": 39}},
+            ),
+            patch.object(StateTracker, "get_dataset_schedule", return_value={"reached": True}),
+        ):
+            overview = sampler.log_state(show_rank=False, alt_stats=True)
+
+        self.assertIn("- Total number of videos: 4096", overview)
+        self.assertIn("- Target frame count: 39", overview)
+        self.assertIn("- FPS: unknown", overview)
+        self.assertNotIn("~39976", overview)
+
     def test_save_state(self):
         with patch.object(self.sampler.state_manager, "save_state") as mock_save_state:
             self.sampler.save_state(self.state_path)

--- a/tests/test_validation_video.py
+++ b/tests/test_validation_video.py
@@ -65,8 +65,9 @@ class TestValidationVideoTrackerLogging(unittest.TestCase):
         accelerator.get_tracker = MagicMock(return_value=tensorboard)
         return accelerator, tensorboard
 
+    @patch("simpletuner.helpers.training.validation_video._tensorboard_video_supported", return_value=True)
     @patch("simpletuner.helpers.training.validation_video.StateTracker.get_global_step", return_value=123)
-    def test_tensorboard_logs_5d_video_tensor_with_add_video(self, _global_step):
+    def test_tensorboard_logs_5d_video_tensor_with_add_video(self, _global_step, _video_supported):
         from simpletuner.helpers.training import validation_video
 
         accelerator, tensorboard = self._accelerator()
@@ -86,8 +87,9 @@ class TestValidationVideoTrackerLogging(unittest.TestCase):
         self.assertEqual(tensorboard.writer.add_video.call_args.kwargs, {"global_step": 123, "fps": 12})
         tensorboard.log_images.assert_not_called()
 
+    @patch("simpletuner.helpers.training.validation_video._tensorboard_video_supported", return_value=True)
     @patch("simpletuner.helpers.training.validation_video.StateTracker.get_global_step", return_value=123)
-    def test_tensorboard_logs_channel_last_5d_video_tensor_with_add_video(self, _global_step):
+    def test_tensorboard_logs_channel_last_5d_video_tensor_with_add_video(self, _global_step, _video_supported):
         from simpletuner.helpers.training import validation_video
 
         accelerator, tensorboard = self._accelerator()
@@ -102,6 +104,26 @@ class TestValidationVideoTrackerLogging(unittest.TestCase):
 
         logged_video = tensorboard.writer.add_video.call_args.args[1]
         self.assertEqual(logged_video.shape, torch.Size([1, 4, 3, 8, 8]))
+
+    @patch("simpletuner.helpers.training.validation_video._tensorboard_video_supported", return_value=False)
+    @patch("simpletuner.helpers.training.validation_video.StateTracker.get_global_step", return_value=123)
+    def test_tensorboard_falls_back_to_first_frame_without_moviepy(self, _global_step, _video_supported):
+        from simpletuner.helpers.training import validation_video
+
+        accelerator, tensorboard = self._accelerator()
+        video = torch.zeros(1, 4, 8, 8, 3)
+
+        validation_video.log_videos_to_trackers(
+            accelerator,
+            {"sample": [video]},
+            [(8, 8)],
+            SimpleNamespace(framerate=12),
+        )
+
+        tensorboard.writer.add_video.assert_not_called()
+        tensorboard.log_images.assert_called_once()
+        payload = tensorboard.log_images.call_args.args[0]
+        self.assertEqual(payload["sample - (8, 8)"].shape, (1, 3, 8, 8))
 
     @patch("simpletuner.helpers.training.validation_video.StateTracker.get_global_step", return_value=124)
     def test_tensorboard_falls_back_to_image_logging_for_static_image(self, _global_step):

--- a/tests/test_validation_video.py
+++ b/tests/test_validation_video.py
@@ -1,7 +1,10 @@
 import unittest
 from io import BytesIO
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
+
+import torch
+from PIL import Image
 
 
 class TestValidationVideoMux(unittest.TestCase):
@@ -49,6 +52,104 @@ class TestValidationVideoMux(unittest.TestCase):
             validation_video._mux_audio_into_video(video_path, MagicMock(), 16000)
 
         self.assertEqual(mock_run.call_args.args[0][0], "/venv/bin/imageio-ffmpeg")
+
+
+class TestValidationVideoTrackerLogging(unittest.TestCase):
+    def _accelerator(self):
+        tensorboard = SimpleNamespace(
+            name="tensorboard",
+            writer=SimpleNamespace(add_video=MagicMock()),
+            log_images=MagicMock(),
+        )
+        accelerator = SimpleNamespace(trackers=[SimpleNamespace(name="tensorboard")])
+        accelerator.get_tracker = MagicMock(return_value=tensorboard)
+        return accelerator, tensorboard
+
+    @patch("simpletuner.helpers.training.validation_video.StateTracker.get_global_step", return_value=123)
+    def test_tensorboard_logs_5d_video_tensor_with_add_video(self, _global_step):
+        from simpletuner.helpers.training import validation_video
+
+        accelerator, tensorboard = self._accelerator()
+        video = torch.zeros(1, 3, 4, 8, 8)
+
+        validation_video.log_videos_to_trackers(
+            accelerator,
+            {"sample": [video]},
+            [(8, 8)],
+            SimpleNamespace(framerate=12),
+        )
+
+        tensorboard.writer.add_video.assert_called_once()
+        tag, logged_video = tensorboard.writer.add_video.call_args.args[:2]
+        self.assertEqual(tag, "sample - (8, 8)")
+        self.assertEqual(logged_video.shape, torch.Size([1, 4, 3, 8, 8]))
+        self.assertEqual(tensorboard.writer.add_video.call_args.kwargs, {"global_step": 123, "fps": 12})
+        tensorboard.log_images.assert_not_called()
+
+    @patch("simpletuner.helpers.training.validation_video.StateTracker.get_global_step", return_value=123)
+    def test_tensorboard_logs_channel_last_5d_video_tensor_with_add_video(self, _global_step):
+        from simpletuner.helpers.training import validation_video
+
+        accelerator, tensorboard = self._accelerator()
+        video = torch.zeros(1, 4, 8, 8, 3)
+
+        validation_video.log_videos_to_trackers(
+            accelerator,
+            {"sample": [video]},
+            [(8, 8)],
+            SimpleNamespace(framerate=12),
+        )
+
+        logged_video = tensorboard.writer.add_video.call_args.args[1]
+        self.assertEqual(logged_video.shape, torch.Size([1, 4, 3, 8, 8]))
+
+    @patch("simpletuner.helpers.training.validation_video.StateTracker.get_global_step", return_value=124)
+    def test_tensorboard_falls_back_to_image_logging_for_static_image(self, _global_step):
+        from simpletuner.helpers.training import validation_video
+
+        accelerator, tensorboard = self._accelerator()
+        image = Image.new("RGB", (4, 5))
+
+        validation_video.log_videos_to_trackers(
+            accelerator,
+            {"sample": [image]},
+            [(4, 5)],
+            SimpleNamespace(framerate=None),
+        )
+
+        tensorboard.writer.add_video.assert_not_called()
+        tensorboard.log_images.assert_called_once()
+        payload = tensorboard.log_images.call_args.args[0]
+        self.assertEqual(payload["sample - (4, 5)"].shape, (1, 3, 5, 4))
+        self.assertEqual(tensorboard.log_images.call_args.kwargs, {"step": 124})
+
+    def test_validation_routes_video_models_to_video_tracker_logger(self):
+        from simpletuner.helpers.training import validation as validation_module
+
+        class FakeVideoModel:
+            def validation_audio_sample_rate(self):
+                return None
+
+        validation = validation_module.Validation.__new__(validation_module.Validation)
+        validation.model = FakeVideoModel()
+        validation.accelerator = MagicMock()
+        validation.validation_resolutions = [(8, 8)]
+        validation.config = SimpleNamespace()
+
+        with (
+            patch.object(validation_module, "VideoModelFoundation", FakeVideoModel),
+            patch.object(validation_module.validation_video, "log_videos_to_trackers") as log_videos,
+            patch.object(validation_module.validation_images_utils, "log_images_to_trackers") as log_images,
+        ):
+            validation._log_validations_to_trackers({"sample": [torch.zeros(1, 3, 2, 8, 8)]})
+
+        log_videos.assert_called_once_with(
+            validation.accelerator,
+            {"sample": [ANY]},
+            [(8, 8)],
+            validation.config,
+        )
+        log_images.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_webshart_backend.py
+++ b/tests/test_webshart_backend.py
@@ -185,5 +185,72 @@ class TestWebshartDataBackend(unittest.TestCase):
         backend.data_backend.read.assert_not_called()
 
 
+class TestWebshartMetadataCaptionFiltering(unittest.TestCase):
+    def _build_backend(self, entries):
+        backend = WebshartMetadataBackend.__new__(WebshartMetadataBackend)
+        backend.id = "test-backend"
+        backend.dataset_type = DatasetType.IMAGE
+        backend.max_num_samples = None
+        backend.metadata_update_interval = 3600
+        backend.aspect_ratio_bucket_indices = {}
+        backend.caption_cache = {}
+        backend.bucket_report = None
+        backend.data_backend = Mock(parallel_downloads=1)
+        backend.data_backend.get_shard_metadata = Mock(return_value={})
+        backend.reload_cache = Mock()
+        backend.load_image_metadata = Mock()
+        backend.save_cache = Mock()
+        backend.save_image_metadata = Mock()
+        backend._save_caption_cache = Mock()
+        backend._sync_image_files_with_buckets = Mock()
+        backend.set_metadata_by_filepath = Mock()
+        backend._all_shard_indices = Mock(return_value=[0])
+        backend._entries_for_shard = Mock(return_value=entries)
+        backend._sample_id_from_entry = Mock(side_effect=lambda shard_idx, entry: f"webshart://0/0/{entry['path']}")
+        backend._prepare_bucket_entry = Mock(
+            side_effect=lambda shard_metadata, entry, sample_path: (
+                {"captions": entry.get("captions")},
+                ("1.0", {"captions": entry.get("captions")}),
+                None,
+            )
+        )
+        return backend
+
+    def _entries(self):
+        return [
+            {"path": "captioned.webp", "captions": ["a caption"]},
+            {"path": "uncaptioned.webp", "captions": None},
+        ]
+
+    def test_webshart_caption_strategy_skips_caption_less_samples(self):
+        backend = self._build_backend(self._entries())
+        with patch(
+            "simpletuner.helpers.metadata.backends.webshart.StateTracker.get_data_backend_config",
+            return_value={"caption_strategy": "webshart"},
+        ):
+            backend.compute_aspect_ratio_bucket_indices()
+
+        self.assertEqual(
+            backend.aspect_ratio_bucket_indices,
+            {"1.0": ["webshart://0/0/captioned.webp"]},
+        )
+        self.assertEqual(backend.filtering_statistics["skipped"]["caption_missing"], 1)
+        self.assertEqual(backend.filtering_statistics["total_processed"], 1)
+
+    def test_other_caption_strategies_keep_caption_less_samples(self):
+        backend = self._build_backend(self._entries())
+        with patch(
+            "simpletuner.helpers.metadata.backends.webshart.StateTracker.get_data_backend_config",
+            return_value={"caption_strategy": "filename"},
+        ):
+            backend.compute_aspect_ratio_bucket_indices()
+
+        self.assertEqual(
+            backend.aspect_ratio_bucket_indices["1.0"],
+            ["webshart://0/0/captioned.webp", "webshart://0/0/uncaptioned.webp"],
+        )
+        self.assertEqual(backend.filtering_statistics["skipped"]["caption_missing"], 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_webshart_backend.py
+++ b/tests/test_webshart_backend.py
@@ -1,6 +1,7 @@
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import torch
@@ -11,6 +12,20 @@ from simpletuner.helpers.metadata.backends.webshart import WebshartMetadataBacke
 
 
 class TestWebshartDataBackend(unittest.TestCase):
+    @patch("simpletuner.helpers.data_backend.webshart.random.uniform", return_value=0.0)
+    @patch("simpletuner.helpers.data_backend.webshart.time.sleep")
+    def test_read_sample_bytes_retries_rate_limit(self, sleep, _uniform):
+        backend = WebshartDataBackend.__new__(WebshartDataBackend)
+        backend.loader = Mock(
+            load_sample=Mock(side_effect=[RuntimeError("Rate limit exceeded"), SimpleNamespace(data=b"sample")])
+        )
+
+        result = backend._read_sample_bytes("webshart://2/7/sample.mp4")
+
+        self.assertEqual(result, b"sample")
+        self.assertEqual(backend.loader.load_sample.call_count, 2)
+        sleep.assert_called_once_with(1.0)
+
     @patch("simpletuner.helpers.data_backend.webshart.requests.get")
     def test_read_sample_head_tail_uses_tar_member_ranges(self, requests_get):
         head_response = Mock(status_code=206, content=b"head")


### PR DESCRIPTION
Summary:
- Retries transient Webshart sample reads and skips caption-less Webshart samples when the Webshart caption strategy requires captions.
- Updates sampler model-card reporting for capped video datasets and synchronizes localized dataloader docs for shard-cache and oversubscription behavior.
- Routes video validation outputs through video-aware tracker logging, including TensorBoard 5D video tensors and first-frame fallback when video logging support is unavailable.

Validation:
- `.venv/bin/python -m unittest -v -f tests.test_webshart_backend tests.test_metadata_backend tests.test_sampler tests.test_validation_video tests.test_text_embeds tests.test_factory_edge_cases`
- Branch diff and commit-message identity scan passed.
