### PR TITLE
MultiGPU (DDP): support FP8 RamTorch and Musubi block swap

### DIFF
--- a/simpletuner/helpers/musubi_block_swap.py
+++ b/simpletuner/helpers/musubi_block_swap.py
@@ -169,7 +169,7 @@ def _move_module_without_swapping_quantized_params(module: nn.Module, device: to
 
 
 def prepare_musubi_model_for_ddp(module: nn.Module, device: torch.device) -> tuple[int, int]:
-    """Keep trainable state local while excluding streamed frozen state from DDP."""
+    """Move trainable params to the rank device and exclude frozen params plus buffers from DDP."""
     target_device = torch.device(device)
     moved_trainable = 0
     for param in module.parameters():

--- a/simpletuner/helpers/musubi_block_swap.py
+++ b/simpletuner/helpers/musubi_block_swap.py
@@ -4,7 +4,11 @@ from typing import Iterable, List, Optional
 import torch
 import torch.nn as nn
 
-__all__ = ["MusubiBlockSwapManager", "apply_musubi_pretrained_defaults"]
+__all__ = [
+    "MusubiBlockSwapManager",
+    "apply_musubi_pretrained_defaults",
+    "prepare_musubi_model_for_ddp",
+]
 
 
 def _module_on_device(module: nn.Module, device: torch.device) -> bool:
@@ -162,6 +166,26 @@ def _move_module_without_swapping_quantized_params(module: nn.Module, device: to
             _move_sdnq_tensor_to_device(buffer, device)
         elif not _same_device(buffer.device, device):
             module._buffers[key] = buffer.to(device, non_blocking=True)
+
+
+def prepare_musubi_model_for_ddp(module: nn.Module, device: torch.device) -> tuple[int, int]:
+    """Keep trainable state local while excluding streamed frozen state from DDP."""
+    target_device = torch.device(device)
+    moved_trainable = 0
+    for param in module.parameters():
+        if not param.requires_grad or _same_device(param.device, target_device):
+            continue
+        param.data = param.data.to(target_device, non_blocking=True)
+        if param.grad is not None:
+            param.grad = param.grad.to(target_device, non_blocking=True)
+        moved_trainable += 1
+
+    ignored_names = {name for name, param in module.named_parameters() if not param.requires_grad}
+    ignored_names.update(name for name, _buffer in module.named_buffers())
+    existing = set(getattr(module, "_ddp_params_and_buffers_to_ignore", set()))
+    newly_ignored = ignored_names - existing
+    module._ddp_params_and_buffers_to_ignore = existing | ignored_names
+    return moved_trainable, len(newly_ignored)
 
 
 class MusubiBlockSwapManager:

--- a/simpletuner/helpers/ramtorch_extensions.py
+++ b/simpletuner/helpers/ramtorch_extensions.py
@@ -18,6 +18,7 @@ import torch.nn.functional as F
 from torch.profiler import record_function
 
 from simpletuner.helpers.ramtorch import profiling as ramtorch_profile
+from simpletuner.helpers.ramtorch.modules.linear import CPUBouncingLinear
 
 # Per-device state for async transfers (shared with ramtorch)
 _DEVICE_STATE = {}
@@ -235,6 +236,101 @@ def _next_transfer_stream(state, device):
     selected = int(state.get("transfer_stream_clk", 0)) % len(streams)
     state["transfer_stream_clk"] = selected + 1
     return streams[selected]
+
+
+class _FrozenFp8BouncingLinearFn(torch.autograd.Function):
+    """Stream a frozen scaled-FP8 weight without retaining it for backward."""
+
+    @staticmethod
+    def forward(ctx, x, weight_cpu, weight_scale_cpu, bias_cpu, module):
+        weight, weight_scale, bias = _transfer_forward_tensors(
+            module,
+            weight_cpu,
+            weight_scale_cpu,
+            bias_cpu,
+        )
+        compute_dtype = x.dtype
+        weight = weight.to(compute_dtype) * weight_scale.to(compute_dtype).unsqueeze(1)
+        bias = bias.to(compute_dtype) if bias is not None else None
+
+        ctx.module = module
+        ctx.save_for_backward(weight_cpu, weight_scale_cpu)
+        return F.linear(x, weight, bias)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        weight_cpu, weight_scale_cpu = ctx.saved_tensors
+        weight, weight_scale = _transfer_forward_tensors(
+            ctx.module,
+            weight_cpu,
+            weight_scale_cpu,
+        )
+        compute_dtype = grad_output.dtype
+        weight = weight.to(compute_dtype) * weight_scale.to(compute_dtype).unsqueeze(1)
+        grad_input = grad_output.matmul(weight)
+        return grad_input, None, None, None, None
+
+
+class CPUBouncingFp8Linear(CPUBouncingLinear):
+    """RamTorch linear for frozen FP8 weights with a per-output-row scale."""
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        *,
+        weight: torch.Tensor,
+        weight_scale: torch.Tensor,
+        bias: torch.Tensor | None,
+        device,
+        compute_dtype: torch.dtype | None = None,
+    ) -> None:
+        nn.Module.__init__(self)
+        self.in_features = in_features
+        self.out_features = out_features
+        self.device = device
+        self.compute_dtype = compute_dtype
+        self.is_ramtorch = True
+
+        weight = _to_cpu_pinned(weight.detach().to("cpu"))
+        weight_scale = _to_cpu_pinned(weight_scale.detach().to("cpu", dtype=torch.float32))
+        self.register_buffer("weight", weight)
+        self.register_buffer("weight_scale", weight_scale)
+        if bias is not None:
+            self.register_buffer("bias", _to_cpu_pinned(bias.detach().to("cpu")))
+        else:
+            self.bias = None
+
+        self.weight.is_ramtorch = True
+        self.weight_scale.is_ramtorch = True
+        if self.bias is not None:
+            self.bias.is_ramtorch = True
+
+    def _apply(self, fn):
+        # Scaled FP8 storage must remain FP8/FP32 on CPU. Only the ephemeral
+        # dequantized weight follows the activation dtype on the target device.
+        return self
+
+    def cuda(self, device=None):
+        return self
+
+    def cpu(self):
+        return self
+
+    def forward(self, x):
+        return _FrozenFp8BouncingLinearFn.apply(
+            x,
+            self.weight,
+            self.weight_scale,
+            self.bias,
+            self,
+        )
+
+    def prefetch_forward(self) -> bool:
+        return _prefetch_forward_tensors(self, self.weight, self.weight_scale, self.bias)
+
+    def ramtorch_forward_bytes(self) -> int:
+        return ramtorch_profile.tensor_bytes((self.weight, self.weight_scale, self.bias))
 
 
 class CPUBouncingEmbedding(nn.Module):

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -53,6 +53,7 @@ from simpletuner.helpers.data_backend.runtime.schedule import normalize_start_ep
 from simpletuner.helpers.distillation.registry import DistillationRegistry
 from simpletuner.helpers.distillation.requirements import EMPTY_PROFILE, DistillerRequirementProfile
 from simpletuner.helpers.models.registry import ModelRegistry
+from simpletuner.helpers.musubi_block_swap import prepare_musubi_model_for_ddp
 from simpletuner.helpers.publishing import PublishingManager
 from simpletuner.helpers.publishing.huggingface import HubManager
 from simpletuner.helpers.publishing.providers.s3 import S3PublishingProvider
@@ -935,11 +936,14 @@ class Trainer:
                 kwargs_handlers=accelerator_custom_config,
             )
 
+            ddp_kwargs = {}
             find_unused_parameters = self._resolve_ddp_find_unused_parameters()
             if find_unused_parameters is not None:
-                accelerator_custom_config.append(
-                    DistributedDataParallelKwargs(find_unused_parameters=find_unused_parameters)
-                )
+                ddp_kwargs["find_unused_parameters"] = find_unused_parameters
+            if (getattr(self.config, "musubi_blocks_to_swap", 0) or 0) > 0:
+                ddp_kwargs["gradient_as_bucket_view"] = True
+            if ddp_kwargs:
+                accelerator_custom_config.append(DistributedDataParallelKwargs(**ddp_kwargs))
 
             if not will_create_dynamo_plugin and dynamo_backend_env != "no":
                 accelerator_kwargs["dynamo_backend"] = dynamo_backend_env
@@ -4258,6 +4262,16 @@ class Trainer:
         ramtorch_enabled = getattr(self.config, "ramtorch", False)
         group_offload_requested = bool(getattr(self.config, "enable_group_offload", False))
         skip_model_device_placement = musubi_block_swap_active or ramtorch_enabled or group_offload_requested
+        if musubi_block_swap_active and self.accelerator.distributed_type == DistributedType.MULTI_GPU:
+            self._move_model_with_block_swap(primary_model)
+            moved_trainable, ignored_frozen = prepare_musubi_model_for_ddp(primary_model, self.accelerator.device)
+            logger.info(
+                "Prepared Musubi block swap model for DDP: moved %s trainable parameters to %s and ignored %s "
+                "frozen parameters/buffers.",
+                moved_trainable,
+                self.accelerator.device,
+                ignored_frozen,
+            )
         if skip_model_device_placement:
             logger.info(
                 "Skipping automatic device placement for primary model during accelerator.prepare() "

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -373,6 +373,11 @@ class Trainer:
         except Exception:
             return False
 
+    @staticmethod
+    def _ramtorch_shared_parameters_enabled() -> bool:
+        value = os.environ.get("SIMPLETUNER_RAMTORCH_SHARED_PARAMETERS", "1").strip().lower()
+        return value not in {"0", "false", "no", "off"}
+
     def _distributed_collectives_ready(self) -> bool:
         try:
             num_processes = int(getattr(self.accelerator, "num_processes", 1) or 1)
@@ -4176,9 +4181,10 @@ class Trainer:
         attach_shared_ramtorch_parameters = None
         if self._ramtorch_distributed() and primary_model is not None:
             ramtorch_utils.ensure_available()
-            from simpletuner.helpers.ramtorch.utils import (
-                attach_shared_ramtorch_parameters as attach_shared_ramtorch_parameters,
-            )
+            if self._ramtorch_shared_parameters_enabled():
+                from simpletuner.helpers.ramtorch.utils import (
+                    attach_shared_ramtorch_parameters as attach_shared_ramtorch_parameters,
+                )
 
             moved = ramtorch_utils.move_embeddings_to_device(primary_model, self.accelerator.device)
             if moved:
@@ -4186,9 +4192,14 @@ class Trainer:
             ignored = ramtorch_utils.mark_ddp_ignore_params(primary_model)
             if ignored:
                 logger.info("Marking %s RamTorch parameters to ignore for DDP.", ignored)
-            attached = attach_shared_ramtorch_parameters(primary_model)
-            if attached:
-                logger.info("Attached %s shared RamTorch parameters across ranks.", attached)
+            if attach_shared_ramtorch_parameters is not None:
+                attached = attach_shared_ramtorch_parameters(primary_model)
+                if attached:
+                    logger.info("Attached %s shared RamTorch parameters across ranks.", attached)
+            else:
+                logger.warning(
+                    "RamTorch shared parameters are disabled; each rank will retain its own CPU copy of streamed weights."
+                )
         if primary_model is not None and "torchao" in str(getattr(self.config, "base_model_precision", "")):
             ignored = mark_torchao_ddp_ignore_params(primary_model)
             if ignored:

--- a/simpletuner/helpers/utils/ramtorch.py
+++ b/simpletuner/helpers/utils/ramtorch.py
@@ -108,6 +108,16 @@ def _is_replaceable_linear(module: nn.Module) -> bool:
     return _is_quanto_linear(module) and hasattr(module, "in_features") and hasattr(module, "out_features")
 
 
+def _is_scaled_fp8_linear(module: nn.Module) -> bool:
+    weight = getattr(module, "weight", None)
+    weight_scale = getattr(module, "weight_scale", None)
+    if not torch.is_tensor(weight) or not torch.is_tensor(weight_scale):
+        return False
+    if not str(weight.dtype).startswith("torch.float8_"):
+        return False
+    return weight.ndim == 2 and weight_scale.shape == (weight.shape[0],)
+
+
 def _move_peft_lora_adapters_to_device(peft_layer: Any, device: torch.device | None) -> None:
     if device is None or getattr(peft_layer, "disable_adapters", False):
         return
@@ -292,6 +302,23 @@ def replace_linear_layers_with_ramtorch(
 
         child_bias = getattr(child, "bias", None)
         child_weight = getattr(child, "weight")
+        if _is_scaled_fp8_linear(child):
+            from simpletuner.helpers.ramtorch_extensions import CPUBouncingFp8Linear
+
+            new_layer = CPUBouncingFp8Linear(
+                int(child.in_features),
+                int(child.out_features),
+                weight=child_weight,
+                weight_scale=child.weight_scale,
+                bias=child_bias,
+                device=resolved_device,
+                compute_dtype=getattr(child, "compute_dtype", None),
+            )
+            new_layer.train(child.training)
+            setattr(parent, child_name, new_layer)
+            replaced += 1
+            continue
+
         new_layer = ramtorch_linear(
             int(child.in_features),
             int(child.out_features),

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/advanced.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/advanced.py
@@ -1797,6 +1797,24 @@ def register_advanced_fields(registry: "FieldRegistry") -> None:
         )
     )
 
+    registry._add_field(
+        ConfigField(
+            name="find_unused_parameters",
+            arg_name="--find_unused_parameters",
+            ui_label="Find Unused DDP Parameters",
+            field_type=FieldType.CHECKBOX,
+            tab="hardware",
+            section="accelerate",
+            subsection="advanced",
+            default_value=None,
+            help_text="Enable DistributedDataParallel unused-parameter detection for conditional training graphs.",
+            tooltip="Leave unset for the model default. Enable when some trainable parameters do not participate in every backward pass.",
+            importance=ImportanceLevel.ADVANCED,
+            order=19,
+            platform_specific=["cuda"],
+        )
+    )
+
     # Training Num Processes
     registry._add_field(
         ConfigField(

--- a/tests/test_distillation_cmd_args.py
+++ b/tests/test_distillation_cmd_args.py
@@ -90,6 +90,21 @@ class DistillationCmdArgsTests(unittest.TestCase):
             {"anyflow": {"stage": "forward", "diffusion_ratio": 0.5}},
         )
 
+    def test_find_unused_parameters_accepts_explicit_boolean_values(self):
+        enabled = parse_cmdline_args(
+            input_args=_base_args() + ["--find_unused_parameters"],
+            exit_on_error=True,
+        )
+        disabled = parse_cmdline_args(
+            input_args=_base_args() + ["--find_unused_parameters=false"],
+            exit_on_error=True,
+        )
+        default = parse_cmdline_args(input_args=_base_args(), exit_on_error=True)
+
+        self.assertTrue(enabled.find_unused_parameters)
+        self.assertFalse(disabled.find_unused_parameters)
+        self.assertIsNone(default.find_unused_parameters)
+
     def test_mapping_to_cli_args_preserves_distillation_config_mapping(self):
         cli_args = mapping_to_cli_args(
             {

--- a/tests/test_musubi_block_swap.py
+++ b/tests/test_musubi_block_swap.py
@@ -5,10 +5,35 @@ from unittest.mock import patch
 import torch
 from torch import nn
 
-from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager, _module_on_device
+from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager, _module_on_device, prepare_musubi_model_for_ddp
 
 
 class MusubiBlockSwapTests(unittest.TestCase):
+    def test_prepare_for_ddp_ignores_only_frozen_state(self):
+        module = nn.Sequential(nn.Linear(4, 4), nn.Linear(4, 4))
+        module[0].weight.requires_grad_(False)
+        module[0].bias.requires_grad_(False)
+        module.register_buffer("frozen_scale", torch.ones(1))
+
+        moved, ignored = prepare_musubi_model_for_ddp(module, torch.device("cpu"))
+
+        self.assertEqual(moved, 0)
+        self.assertEqual(ignored, 3)
+        self.assertEqual(
+            module._ddp_params_and_buffers_to_ignore,
+            {"0.weight", "0.bias", "frozen_scale"},
+        )
+
+    def test_prepare_for_ddp_preserves_existing_ignore_names(self):
+        module = nn.Linear(4, 4)
+        module.weight.requires_grad_(False)
+        module._ddp_params_and_buffers_to_ignore = {"existing"}
+
+        _moved, ignored = prepare_musubi_model_for_ddp(module, torch.device("cpu"))
+
+        self.assertEqual(ignored, 1)
+        self.assertEqual(module._ddp_params_and_buffers_to_ignore, {"existing", "weight"})
+
     def _accelerator_device(self):
         if torch.cuda.is_available():
             return torch.device("cuda")

--- a/tests/test_ramtorch.py
+++ b/tests/test_ramtorch.py
@@ -175,6 +175,40 @@ class RamTorchUtilsTests(unittest.TestCase):
         self.assertIn("weight", dict(model[0].named_buffers(recurse=False)))
         self.assertTrue(getattr(model[0].weight, "is_ramtorch", False))
 
+    def test_replace_scaled_fp8_linear_preserves_scale_and_output(self):
+        from simpletuner.helpers.models.ideogram.quantized_loading import FP8_WEIGHT_DTYPE, Fp8Linear
+        from simpletuner.helpers.ramtorch_extensions import CPUBouncingFp8Linear
+
+        source = Fp8Linear(3, 2, bias=True, compute_dtype=torch.float32)
+        source.weight.copy_(torch.tensor([[1.0, -2.0, 0.5], [2.0, 1.0, -1.0]]).to(FP8_WEIGHT_DTYPE))
+        source.weight_scale.copy_(torch.tensor([0.25, 2.0]))
+        source.bias.copy_(torch.tensor([0.5, -0.25]))
+        model = nn.Sequential(source)
+        x = torch.tensor([[1.0, 2.0, -1.0]], requires_grad=True)
+        expected = source(x)
+        expected.sum().backward()
+        expected_grad = x.grad.detach().clone()
+
+        x.grad = None
+        with patch.object(
+            ramtorch_utils,
+            "ensure_available",
+            return_value=self._build_stub_imports(lambda mod, device=None: None),
+        ):
+            replaced = ramtorch_utils.replace_linear_layers_with_ramtorch(model, device="cpu")
+
+        self.assertEqual(replaced, 1)
+        self.assertIsInstance(model[0], CPUBouncingFp8Linear)
+        self.assertEqual(model[0].weight.dtype, FP8_WEIGHT_DTYPE)
+        self.assertEqual(model[0].weight_scale.dtype, torch.float32)
+        self.assertTrue(getattr(model[0].weight, "is_ramtorch", False))
+        self.assertTrue(getattr(model[0].weight_scale, "is_ramtorch", False))
+
+        actual = model(x)
+        actual.sum().backward()
+        torch.testing.assert_close(actual, expected)
+        torch.testing.assert_close(x.grad, expected_grad)
+
     def test_move_embeddings_to_device_skips_ramtorch_buffers(self):
         class _BufferModel(nn.Module):
             def __init__(self):

--- a/tests/test_ramtorch_distributed_config.py
+++ b/tests/test_ramtorch_distributed_config.py
@@ -1,0 +1,27 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from simpletuner.helpers.training.trainer import Trainer
+
+
+class RamTorchDistributedConfigTests(unittest.TestCase):
+    def test_shared_parameters_default_to_enabled(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(Trainer._ramtorch_shared_parameters_enabled())
+
+    def test_shared_parameters_can_be_disabled(self):
+        for value in ("0", "false", "NO", "off"):
+            with (
+                self.subTest(value=value),
+                patch.dict(
+                    os.environ,
+                    {"SIMPLETUNER_RAMTORCH_SHARED_PARAMETERS": value},
+                    clear=True,
+                ),
+            ):
+                self.assertFalse(Trainer._ramtorch_shared_parameters_enabled())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
- Exposes DDP unused-parameter detection in the field registry/config mapping.
- Lets RamTorch stream scaled FP8 linear layers while preserving distributed ignore metadata for streamed/frozen parameters.
- Prepares Musubi block-swap models for DDP by marking swapped/frozen parameters consistently.

Validation:
- `.venv/bin/python -m unittest -v -f tests.test_distillation_cmd_args tests.test_ramtorch tests.test_ramtorch_distributed_config tests.test_musubi_block_swap`
- Branch diff and commit-message identity scan passed.
