### PR TITLE
Synchronize standalone context-parallel training batches

### DIFF
--- a/simpletuner/helpers/data_backend/runtime/context_parallel_sync.py
+++ b/simpletuner/helpers/data_backend/runtime/context_parallel_sync.py
@@ -296,7 +296,7 @@ class ContextParallelBatchSynchronizer:
         return sync_batch_for_context_parallel(batch, self.accelerator, self._cp_info)
 
     @contextmanager
-    def synchronized_rng(self, base_seed: int, step: int):
+    def synchronized_rng(self, base_seed: Optional[int], step: int):
         """Use one RNG stream for every model-parallel rank in a data replica."""
         self._ensure_initialized()
         if not self._cp_info[0]:
@@ -316,7 +316,8 @@ class ContextParallelBatchSynchronizer:
                 random.seed(replica_seed)
                 torch.default_generator.manual_seed(replica_seed)
                 for device_index in cuda_devices:
-                    torch.cuda.default_generators[device_index].manual_seed(replica_seed)
+                    with torch.cuda.device(device_index):
+                        torch.cuda.manual_seed(replica_seed)
                 yield
         finally:
             random.setstate(python_rng_state)

--- a/simpletuner/helpers/data_backend/runtime/context_parallel_sync.py
+++ b/simpletuner/helpers/data_backend/runtime/context_parallel_sync.py
@@ -20,6 +20,8 @@ The synchronization addresses two key issues:
 import logging
 import numbers
 import os
+import random
+from contextlib import contextmanager
 from typing import Any, Optional, Tuple
 
 import torch
@@ -162,6 +164,14 @@ def sync_batch_for_context_parallel(
         if not data_enabled:
             return batch
 
+        parallelism_config = getattr(accelerator, "parallelism_config", None)
+        dp_shard_size = _normalize_parallel_size(getattr(parallelism_config, "dp_shard_size", 1), "dp_shard_size")
+        if dp_shard_size == 1:
+            leader_global_rank = data_rank * data_group_size
+            batch_list = [batch if data_local_rank == 0 else None]
+            dist.broadcast_object_list(batch_list, src=leader_global_rank, group=cp_group)
+            return batch_list[0]
+
         replica_batch = None
         for replica_rank in range(data_parallel_size):
             leader_global_rank = replica_rank * data_group_size
@@ -284,6 +294,32 @@ class ContextParallelBatchSynchronizer:
         """
         self._ensure_initialized()
         return sync_batch_for_context_parallel(batch, self.accelerator, self._cp_info)
+
+    @contextmanager
+    def synchronized_rng(self, base_seed: int, step: int):
+        """Use one RNG stream for every model-parallel rank in a data replica."""
+        self._ensure_initialized()
+        if not self._cp_info[0]:
+            yield
+            return
+
+        _, data_rank, _, _, data_parallel_size = get_model_replica_data_info(self.accelerator, self._cp_info)
+        replica_seed = (int(base_seed or 0) + int(step) * data_parallel_size + data_rank) % (2**63 - 1)
+        python_rng_state = random.getstate()
+        device = getattr(self.accelerator, "device", torch.device("cpu"))
+        cuda_devices = []
+        if isinstance(device, torch.device) and device.type == "cuda":
+            cuda_devices = [device.index if device.index is not None else torch.cuda.current_device()]
+
+        try:
+            with torch.random.fork_rng(devices=cuda_devices):
+                random.seed(replica_seed)
+                torch.default_generator.manual_seed(replica_seed)
+                for device_index in cuda_devices:
+                    torch.cuda.default_generators[device_index].manual_seed(replica_seed)
+                yield
+        finally:
+            random.setstate(python_rng_state)
 
     def fetch_batch(self, iterator_fn, step: int, *iterator_args) -> Any:
         """

--- a/simpletuner/helpers/training/context_parallel.py
+++ b/simpletuner/helpers/training/context_parallel.py
@@ -88,6 +88,13 @@ def build_context_parallel_topology(config: Any, world_size: int, cp_size: int, 
     )
 
 
+def scale_standalone_context_parallel_loss(loss: torch.Tensor, topology: ContextParallelTopology | None) -> torch.Tensor:
+    """Compensate for DDP averaging CP-partitioned gradients over the full world."""
+    if topology is None or topology.cp_size <= 1 or topology.dp_shard_size != 1:
+        return loss
+    return loss * topology.cp_size
+
+
 def _accelerator_state(accelerator: Any) -> Any:
     state = getattr(accelerator, "state", None)
     if state is None:

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -5729,7 +5729,8 @@ class Trainer:
         loss, _loss_logs, _diffusion_loss, _aux_loss_logs, _distill_logs = self._compute_model_prediction_loss(
             dict(prepared_batch)
         )
-        self.accelerator.backward(scale_standalone_context_parallel_loss(loss, self._context_parallel_topology))
+        context_parallel_topology = getattr(self, "_context_parallel_topology", None)
+        self.accelerator.backward(scale_standalone_context_parallel_loss(loss, context_parallel_topology))
         if torch.cuda.is_available():
             torch.cuda.synchronize()
         elapsed = time.perf_counter() - start_time

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -6467,7 +6467,7 @@ class Trainer:
                 # This ensures all ranks in a CP group receive the same batch before the
                 # model's _cp_plan splits it along the sequence dimension.
                 raw_batch = cp_batch_synchronizer.fetch_batch(iterator_fn, step, *iterator_args)
-                with cp_batch_synchronizer.synchronized_rng(self.config.seed, step):
+                with cp_batch_synchronizer.synchronized_rng(getattr(self.config, "seed", None), step):
                     prepared_batch = self.prepare_batch(raw_batch)
                 training_logger.debug(f"Iterator: {iterator_fn}")
                 if self.config.lr_scheduler == "cosine_with_restarts":

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -189,6 +189,7 @@ from simpletuner.helpers.training.context_parallel import (
     normalize_context_parallel_size,
     normalize_context_parallel_strategy,
     resolve_context_parallel_world_size,
+    scale_standalone_context_parallel_loss,
 )
 
 try:
@@ -5728,7 +5729,7 @@ class Trainer:
         loss, _loss_logs, _diffusion_loss, _aux_loss_logs, _distill_logs = self._compute_model_prediction_loss(
             dict(prepared_batch)
         )
-        self.accelerator.backward(loss)
+        self.accelerator.backward(scale_standalone_context_parallel_loss(loss, self._context_parallel_topology))
         if torch.cuda.is_available():
             torch.cuda.synchronize()
         elapsed = time.perf_counter() - start_time
@@ -6465,7 +6466,8 @@ class Trainer:
                 # This ensures all ranks in a CP group receive the same batch before the
                 # model's _cp_plan splits it along the sequence dimension.
                 raw_batch = cp_batch_synchronizer.fetch_batch(iterator_fn, step, *iterator_args)
-                prepared_batch = self.prepare_batch(raw_batch)
+                with cp_batch_synchronizer.synchronized_rng(self.config.seed, step):
+                    prepared_batch = self.prepare_batch(raw_batch)
                 training_logger.debug(f"Iterator: {iterator_fn}")
                 if self.config.lr_scheduler == "cosine_with_restarts":
                     self.extra_lr_scheduler_kwargs["step"] = self.state["global_step"]
@@ -6635,7 +6637,8 @@ class Trainer:
                         training_logger.debug("Backwards pass.")
                         if self._ramtorch_sync_enabled():
                             torch.cuda.synchronize()
-                        self.accelerator.backward(loss)
+                        backward_loss = scale_standalone_context_parallel_loss(loss, self._context_parallel_topology)
+                        self.accelerator.backward(backward_loss)
                         if self._ramtorch_sync_enabled():
                             torch.cuda.synchronize()
 

--- a/tests/test_context_parallel_runtime.py
+++ b/tests/test_context_parallel_runtime.py
@@ -10,6 +10,7 @@ from simpletuner.helpers.training.context_parallel import (
     configure_cp_only_accelerator,
     normalize_context_parallel_size,
     normalize_context_parallel_strategy,
+    scale_standalone_context_parallel_loss,
 )
 
 
@@ -66,6 +67,18 @@ class ContextParallelTopologyTests(unittest.TestCase):
             normalize_context_parallel_size("nope")
         with self.assertRaises(ValueError):
             normalize_context_parallel_strategy("ring")
+
+    def test_standalone_context_parallel_scales_loss_before_world_ddp_average(self):
+        loss = torch.tensor(2.0)
+        topology = ContextParallelTopology(cp_size=2, dp_replicate_size=4, dp_shard_size=1, strategy="alltoall")
+
+        self.assertEqual(scale_standalone_context_parallel_loss(loss, topology).item(), 4.0)
+
+    def test_fsdp_context_parallel_does_not_scale_loss(self):
+        loss = torch.tensor(2.0)
+        topology = ContextParallelTopology(cp_size=2, dp_replicate_size=1, dp_shard_size=4, strategy="alltoall")
+
+        self.assertIs(scale_standalone_context_parallel_loss(loss, topology), loss)
 
 
 class ContextParallelAcceleratorAttachTests(unittest.TestCase):

--- a/tests/test_runtime_components.py
+++ b/tests/test_runtime_components.py
@@ -928,6 +928,26 @@ class TestContextParallelBatchSynchronizer(unittest.TestCase):
         self.assertTrue(torch.equal(draws[0][0], draws[1][0]))
         self.assertEqual(draws[0][1], draws[1][1])
 
+    def test_synchronized_rng_accepts_missing_base_seed(self):
+        from simpletuner.helpers.data_backend.runtime.context_parallel_sync import ContextParallelBatchSynchronizer
+
+        parallelism_config = MagicMock(cp_size=2, cp_enabled=True, dp_replicate_size=1, dp_shard_size=1)
+        mesh = MagicMock()
+        mesh.get_group.return_value = MagicMock()
+        mesh.get_local_rank.return_value = 0
+        accelerator = MagicMock(
+            parallelism_config=parallelism_config,
+            torch_device_mesh=mesh,
+            num_processes=2,
+            process_index=0,
+            device=torch.device("cpu"),
+        )
+
+        synchronizer = ContextParallelBatchSynchronizer(accelerator)
+
+        with synchronizer.synchronized_rng(base_seed=None, step=7):
+            self.assertIsInstance(torch.rand(1), torch.Tensor)
+
     def test_synchronized_rng_differs_between_data_replicas(self):
         from simpletuner.helpers.data_backend.runtime.context_parallel_sync import ContextParallelBatchSynchronizer
 

--- a/tests/test_runtime_components.py
+++ b/tests/test_runtime_components.py
@@ -7,11 +7,14 @@ system during training.
 """
 
 import queue
+import random
 import threading
 import time
 import unittest
 from typing import Any, Dict
 from unittest.mock import MagicMock, Mock, patch
+
+import torch
 
 from simpletuner.helpers.data_backend.runtime import BatchFetcher
 from simpletuner.helpers.data_backend.runtime import dataloader_iterator as dataloader_module
@@ -830,6 +833,37 @@ class TestContextParallelBatchSynchronizer(unittest.TestCase):
             mock_iterator.assert_not_called()
             self.assertEqual(result, {"broadcasted": True})
 
+    def test_standalone_cp_broadcasts_only_within_its_replica_group(self):
+        from simpletuner.helpers.data_backend.runtime.context_parallel_sync import ContextParallelBatchSynchronizer
+
+        parallelism_config = MagicMock()
+        parallelism_config.cp_size = 2
+        parallelism_config.cp_enabled = True
+        parallelism_config.dp_replicate_size = 4
+        parallelism_config.dp_shard_size = 1
+
+        cp_group = MagicMock()
+        mesh = MagicMock()
+        mesh.get_group.return_value = cp_group
+        mesh.get_local_rank.return_value = 0
+
+        accelerator = MagicMock()
+        accelerator.parallelism_config = parallelism_config
+        accelerator.torch_device_mesh = mesh
+        accelerator.num_processes = 8
+        accelerator.process_index = 6
+
+        synchronizer = ContextParallelBatchSynchronizer(accelerator)
+        iterator = MagicMock(return_value={"replica": 3})
+        with patch("simpletuner.helpers.data_backend.runtime.context_parallel_sync.dist") as mock_dist:
+            result = synchronizer.fetch_batch(iterator, 10)
+
+        self.assertEqual(result, {"replica": 3})
+        mock_dist.broadcast_object_list.assert_called_once()
+        _, kwargs = mock_dist.broadcast_object_list.call_args
+        self.assertEqual(kwargs["src"], 6)
+        self.assertIs(kwargs["group"], cp_group)
+
     def test_fetch_batch_fsdp_shard_rank_skips_iterator(self):
         """FSDP shard ranks are model-parallel ranks, not independent samplers."""
         from simpletuner.helpers.data_backend.runtime.context_parallel_sync import ContextParallelBatchSynchronizer
@@ -864,6 +898,63 @@ class TestContextParallelBatchSynchronizer(unittest.TestCase):
 
         mock_iterator.assert_not_called()
         self.assertEqual(result, {"broadcasted": True})
+
+    def test_synchronized_rng_matches_within_data_replica(self):
+        from simpletuner.helpers.data_backend.runtime.context_parallel_sync import ContextParallelBatchSynchronizer
+
+        def accelerator_for_rank(rank):
+            parallelism_config = MagicMock()
+            parallelism_config.cp_size = 2
+            parallelism_config.cp_enabled = True
+            parallelism_config.dp_replicate_size = 2
+            parallelism_config.dp_shard_size = 1
+            mesh = MagicMock()
+            mesh.get_group.return_value = MagicMock()
+            mesh.get_local_rank.return_value = rank % 2
+            accelerator = MagicMock()
+            accelerator.parallelism_config = parallelism_config
+            accelerator.torch_device_mesh = mesh
+            accelerator.num_processes = 4
+            accelerator.process_index = rank
+            accelerator.device = torch.device("cpu")
+            return accelerator
+
+        draws = []
+        for rank in (0, 1):
+            synchronizer = ContextParallelBatchSynchronizer(accelerator_for_rank(rank))
+            with synchronizer.synchronized_rng(base_seed=42, step=7):
+                draws.append((torch.rand(4), random.random()))
+
+        self.assertTrue(torch.equal(draws[0][0], draws[1][0]))
+        self.assertEqual(draws[0][1], draws[1][1])
+
+    def test_synchronized_rng_differs_between_data_replicas(self):
+        from simpletuner.helpers.data_backend.runtime.context_parallel_sync import ContextParallelBatchSynchronizer
+
+        def accelerator_for_rank(rank):
+            parallelism_config = MagicMock()
+            parallelism_config.cp_size = 2
+            parallelism_config.cp_enabled = True
+            parallelism_config.dp_replicate_size = 2
+            parallelism_config.dp_shard_size = 1
+            mesh = MagicMock()
+            mesh.get_group.return_value = MagicMock()
+            mesh.get_local_rank.return_value = rank % 2
+            accelerator = MagicMock()
+            accelerator.parallelism_config = parallelism_config
+            accelerator.torch_device_mesh = mesh
+            accelerator.num_processes = 4
+            accelerator.process_index = rank
+            accelerator.device = torch.device("cpu")
+            return accelerator
+
+        draws = []
+        for rank in (0, 2):
+            synchronizer = ContextParallelBatchSynchronizer(accelerator_for_rank(rank))
+            with synchronizer.synchronized_rng(base_seed=42, step=7):
+                draws.append(torch.rand(4))
+
+        self.assertFalse(torch.equal(draws[0], draws[1]))
 
 
 class TestContextParallelDataParallelInfo(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Synchronizes batch sampling across standalone context-parallel replica groups so CP ranks train on the same source sample before sequence splitting.
- Keeps activation-offload prefetch autotune usable when no explicit CP topology object is attached.
- Allows CP batch RNG synchronization when the config does not provide an explicit seed.

## Validation
- `.venv/bin/python -m unittest -v -f tests.test_context_parallel_runtime tests.test_runtime_components tests.test_gradient_checkpointing_backend.TestGradientCheckpointingBackend.test_trainer_prefetch_autotune_uses_model_predict_and_discards_gradients tests.test_trainer.TestTrainer.test_accumulate_unpacks_training_models_for_fsdp2`
- branch diff and commit message privacy scan passed
