### PR TITLE
Allow process group timeout overrides from the environment

### DIFF
--- a/simpletuner/helpers/configuration/cmd_args.py
+++ b/simpletuner/helpers/configuration/cmd_args.py
@@ -1050,7 +1050,14 @@ def parse_cmdline_args(input_args=None, exit_on_error: bool = False):
     args.logging_dir = os.path.join(args.output_dir, args.logging_dir)
     args.accelerator_project_config = ProjectConfiguration(project_dir=args.output_dir, logging_dir=args.logging_dir)
     # Create the custom configuration
-    process_group_timeout = int(os.environ.get("SIMPLETUNER_PROCESS_GROUP_TIMEOUT_SECONDS", "5400"))
+    process_group_timeout_raw = os.environ.get("SIMPLETUNER_PROCESS_GROUP_TIMEOUT_SECONDS", "5400")
+    try:
+        process_group_timeout = int(process_group_timeout_raw)
+    except ValueError as exc:
+        raise ValueError(
+            "SIMPLETUNER_PROCESS_GROUP_TIMEOUT_SECONDS must be a positive integer; "
+            f"received {process_group_timeout_raw!r}."
+        ) from exc
     if process_group_timeout < 1:
         raise ValueError("SIMPLETUNER_PROCESS_GROUP_TIMEOUT_SECONDS must be a positive integer.")
     args.process_group_kwargs = InitProcessGroupKwargs(timeout=timedelta(seconds=process_group_timeout))

--- a/simpletuner/helpers/configuration/cmd_args.py
+++ b/simpletuner/helpers/configuration/cmd_args.py
@@ -1050,7 +1050,10 @@ def parse_cmdline_args(input_args=None, exit_on_error: bool = False):
     args.logging_dir = os.path.join(args.output_dir, args.logging_dir)
     args.accelerator_project_config = ProjectConfiguration(project_dir=args.output_dir, logging_dir=args.logging_dir)
     # Create the custom configuration
-    args.process_group_kwargs = InitProcessGroupKwargs(timeout=timedelta(seconds=5400))  # 1.5 hours
+    process_group_timeout = int(os.environ.get("SIMPLETUNER_PROCESS_GROUP_TIMEOUT_SECONDS", "5400"))
+    if process_group_timeout < 1:
+        raise ValueError("SIMPLETUNER_PROCESS_GROUP_TIMEOUT_SECONDS must be a positive integer.")
+    args.process_group_kwargs = InitProcessGroupKwargs(timeout=timedelta(seconds=process_group_timeout))
 
     # Enable TF32 for faster training on Ampere GPUs,
     # cf https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-devices

--- a/tests/test_fsdp_cmd_args.py
+++ b/tests/test_fsdp_cmd_args.py
@@ -154,16 +154,18 @@ class TestFSDPCmdArgs(unittest.TestCase):
         tmp_dir = tempfile.mkdtemp()
         self.addCleanup(lambda: shutil.rmtree(tmp_dir, ignore_errors=True))
 
-        args = parse_cmdline_args(
-            input_args=[
-                "--model_family=sdxl",
-                "--model_type=full",
-                f"--output_dir={tmp_dir}",
-                "--optimizer=adamw_bf16",
-                "--data_backend_config=dummy",
-            ],
-            exit_on_error=False,
-        )
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SIMPLETUNER_PROCESS_GROUP_TIMEOUT_SECONDS", None)
+            args = parse_cmdline_args(
+                input_args=[
+                    "--model_family=sdxl",
+                    "--model_type=full",
+                    f"--output_dir={tmp_dir}",
+                    "--optimizer=adamw_bf16",
+                    "--data_backend_config=dummy",
+                ],
+                exit_on_error=False,
+            )
 
         self.assertEqual(args.process_group_kwargs.timeout.total_seconds(), 5400)
 
@@ -191,6 +193,23 @@ class TestFSDPCmdArgs(unittest.TestCase):
 
         with patch.dict(os.environ, {"SIMPLETUNER_PROCESS_GROUP_TIMEOUT_SECONDS": "0"}, clear=False):
             with self.assertRaisesRegex(ValueError, "positive integer"):
+                parse_cmdline_args(
+                    input_args=[
+                        "--model_family=sdxl",
+                        "--model_type=full",
+                        f"--output_dir={tmp_dir}",
+                        "--optimizer=adamw_bf16",
+                        "--data_backend_config=dummy",
+                    ],
+                    exit_on_error=False,
+                )
+
+    def test_process_group_timeout_rejects_non_integer_override(self):
+        tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(tmp_dir, ignore_errors=True))
+
+        with patch.dict(os.environ, {"SIMPLETUNER_PROCESS_GROUP_TIMEOUT_SECONDS": "abc"}, clear=False):
+            with self.assertRaisesRegex(ValueError, "SIMPLETUNER_PROCESS_GROUP_TIMEOUT_SECONDS.*'abc'"):
                 parse_cmdline_args(
                     input_args=[
                         "--model_family=sdxl",

--- a/tests/test_fsdp_cmd_args.py
+++ b/tests/test_fsdp_cmd_args.py
@@ -1,9 +1,11 @@
+import os
 import shutil
 import sys
 import tempfile
 import types
 import unittest
 from importlib.machinery import ModuleSpec
+from unittest.mock import patch
 
 
 def _ensure_torchao_stub():
@@ -148,6 +150,58 @@ from simpletuner.helpers.configuration.cmd_args import parse_cmdline_args
 
 
 class TestFSDPCmdArgs(unittest.TestCase):
+    def test_process_group_timeout_defaults_to_ninety_minutes(self):
+        tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(tmp_dir, ignore_errors=True))
+
+        args = parse_cmdline_args(
+            input_args=[
+                "--model_family=sdxl",
+                "--model_type=full",
+                f"--output_dir={tmp_dir}",
+                "--optimizer=adamw_bf16",
+                "--data_backend_config=dummy",
+            ],
+            exit_on_error=False,
+        )
+
+        self.assertEqual(args.process_group_kwargs.timeout.total_seconds(), 5400)
+
+    def test_process_group_timeout_reads_environment_override(self):
+        tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(tmp_dir, ignore_errors=True))
+
+        with patch.dict(os.environ, {"SIMPLETUNER_PROCESS_GROUP_TIMEOUT_SECONDS": "7200"}, clear=False):
+            args = parse_cmdline_args(
+                input_args=[
+                    "--model_family=sdxl",
+                    "--model_type=full",
+                    f"--output_dir={tmp_dir}",
+                    "--optimizer=adamw_bf16",
+                    "--data_backend_config=dummy",
+                ],
+                exit_on_error=False,
+            )
+
+        self.assertEqual(args.process_group_kwargs.timeout.total_seconds(), 7200)
+
+    def test_process_group_timeout_rejects_non_positive_override(self):
+        tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(tmp_dir, ignore_errors=True))
+
+        with patch.dict(os.environ, {"SIMPLETUNER_PROCESS_GROUP_TIMEOUT_SECONDS": "0"}, clear=False):
+            with self.assertRaisesRegex(ValueError, "positive integer"):
+                parse_cmdline_args(
+                    input_args=[
+                        "--model_family=sdxl",
+                        "--model_type=full",
+                        f"--output_dir={tmp_dir}",
+                        "--optimizer=adamw_bf16",
+                        "--data_backend_config=dummy",
+                    ],
+                    exit_on_error=False,
+                )
+
     def test_fsdp_cli_normalization(self):
         tmp_dir = tempfile.mkdtemp()
         self.addCleanup(lambda: shutil.rmtree(tmp_dir, ignore_errors=True))


### PR DESCRIPTION
## Summary
- Lets distributed startup override the hard-coded process-group timeout with `SIMPLETUNER_PROCESS_GROUP_TIMEOUT_SECONDS`.
- Rejects non-positive timeout values during argument parsing.
- Adds parser coverage for default, overridden, and invalid timeout values.

## Validation
- `.venv/bin/python -m unittest -v -f tests.test_fsdp_cmd_args`
- branch diff and commit message privacy scan passed
