### PR TITLE
Add rank-local training diagnostics hooks

### DIFF
--- a/simpletuner/train.py
+++ b/simpletuner/train.py
@@ -62,6 +62,14 @@ def _configure_faulthandler() -> None:
     import faulthandler
     import signal
 
+    timeout_seconds_raw = environ.get("SIMPLETUNER_FAULTHANDLER_TIMEOUT_SECONDS", "0")
+    try:
+        timeout_seconds = int(timeout_seconds_raw)
+    except ValueError as exc:
+        raise ValueError(
+            "SIMPLETUNER_FAULTHANDLER_TIMEOUT_SECONDS must be an integer; " f"received {timeout_seconds_raw!r}."
+        ) from exc
+
     global _faulthandler_stream
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
@@ -70,7 +78,6 @@ def _configure_faulthandler() -> None:
     faulthandler.enable(file=_faulthandler_stream, all_threads=True)
     if hasattr(signal, "SIGUSR1"):
         faulthandler.register(signal.SIGUSR1, file=_faulthandler_stream, all_threads=True)
-    timeout_seconds = int(environ.get("SIMPLETUNER_FAULTHANDLER_TIMEOUT_SECONDS", "0"))
     if timeout_seconds > 0:
         faulthandler.dump_traceback_later(
             timeout_seconds,

--- a/simpletuner/train.py
+++ b/simpletuner/train.py
@@ -5,6 +5,20 @@ import logging
 from os import environ
 from pathlib import Path
 
+
+def _configure_rank_local_inductor_cache() -> None:
+    cache_root = environ.get("SIMPLETUNER_RANK_LOCAL_INDUCTOR_CACHE_ROOT")
+    if not cache_root:
+        return
+
+    rank = environ.get("LOCAL_RANK", environ.get("RANK", "unknown"))
+    cache_dir = Path(cache_root) / f"rank-{rank}"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    environ["TORCHINDUCTOR_CACHE_DIR"] = str(cache_dir)
+
+
+_configure_rank_local_inductor_cache()
+
 # Import WebhookLogger setup FIRST before creating any loggers
 from simpletuner.helpers.logging import get_logger
 
@@ -37,6 +51,33 @@ if hasattr(log_format, "configure_third_party_loggers"):
     log_format.configure_third_party_loggers()
 
 logger = get_logger("SimpleTuner")
+_faulthandler_stream = None
+
+
+def _configure_faulthandler() -> None:
+    output_dir = environ.get("SIMPLETUNER_FAULTHANDLER_DIR")
+    if not output_dir:
+        return
+
+    import faulthandler
+    import signal
+
+    global _faulthandler_stream
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    rank = environ.get("RANK", environ.get("LOCAL_RANK", "unknown"))
+    _faulthandler_stream = (output_path / f"rank-{rank}.log").open("a", buffering=1)
+    faulthandler.enable(file=_faulthandler_stream, all_threads=True)
+    if hasattr(signal, "SIGUSR1"):
+        faulthandler.register(signal.SIGUSR1, file=_faulthandler_stream, all_threads=True)
+    timeout_seconds = int(environ.get("SIMPLETUNER_FAULTHANDLER_TIMEOUT_SECONDS", "0"))
+    if timeout_seconds > 0:
+        faulthandler.dump_traceback_later(
+            timeout_seconds,
+            repeat=True,
+            file=_faulthandler_stream,
+            exit=False,
+        )
 
 
 def _run_training(trainer: Trainer) -> None:
@@ -205,6 +246,7 @@ def _configure_last_ditch_webhook():
 
 
 if __name__ == "__main__":
+    _configure_faulthandler()
     trainer = None
 
     def _cleanup_trainer():

--- a/tests/test_train_cleanup.py
+++ b/tests/test_train_cleanup.py
@@ -1,5 +1,8 @@
+import os
 import runpy
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 try:
@@ -100,6 +103,61 @@ class _FakeTrainer:
 
 
 class TrainEntryCleanupTest(unittest.TestCase):
+    def test_rank_local_inductor_cache_uses_local_rank(self):
+        import simpletuner.train as train_module
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with patch.dict(
+                os.environ,
+                {
+                    "SIMPLETUNER_RANK_LOCAL_INDUCTOR_CACHE_ROOT": tmp_dir,
+                    "LOCAL_RANK": "2",
+                },
+                clear=False,
+            ):
+                os.environ.pop("TORCHINDUCTOR_CACHE_DIR", None)
+
+                train_module._configure_rank_local_inductor_cache()
+
+                expected_cache_dir = Path(tmp_dir) / "rank-2"
+                self.assertEqual(os.environ["TORCHINDUCTOR_CACHE_DIR"], str(expected_cache_dir))
+                self.assertTrue(expected_cache_dir.is_dir())
+
+    def test_faulthandler_uses_rank_local_output_and_timeout(self):
+        import simpletuner.train as train_module
+
+        previous_stream = train_module._faulthandler_stream
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "SIMPLETUNER_FAULTHANDLER_DIR": tmp_dir,
+                        "SIMPLETUNER_FAULTHANDLER_TIMEOUT_SECONDS": "11",
+                        "RANK": "3",
+                    },
+                    clear=False,
+                ),
+                patch("faulthandler.enable") as mock_enable,
+                patch("faulthandler.register") as mock_register,
+                patch("faulthandler.dump_traceback_later") as mock_dump_traceback_later,
+            ):
+                try:
+                    train_module._faulthandler_stream = None
+                    train_module._configure_faulthandler()
+
+                    output_file = Path(tmp_dir) / "rank-3.log"
+                    self.assertTrue(output_file.exists())
+                    self.assertEqual(train_module._faulthandler_stream.name, str(output_file))
+                    mock_enable.assert_called_once()
+                    mock_register.assert_called_once()
+                    mock_dump_traceback_later.assert_called_once()
+                    self.assertEqual(mock_dump_traceback_later.call_args.args[0], 11)
+                finally:
+                    if train_module._faulthandler_stream is not None:
+                        train_module._faulthandler_stream.close()
+                    train_module._faulthandler_stream = previous_stream
+
     def test_train_main_invokes_cleanup_on_failure(self):
         """Train entrypoint should call trainer.cleanup when a failure occurs."""
         _FakeTrainer.instances.clear()

--- a/tests/test_train_cleanup.py
+++ b/tests/test_train_cleanup.py
@@ -1,5 +1,6 @@
 import os
 import runpy
+import signal
 import tempfile
 import unittest
 from pathlib import Path
@@ -150,13 +151,34 @@ class TrainEntryCleanupTest(unittest.TestCase):
                     self.assertTrue(output_file.exists())
                     self.assertEqual(train_module._faulthandler_stream.name, str(output_file))
                     mock_enable.assert_called_once()
-                    mock_register.assert_called_once()
+                    if hasattr(signal, "SIGUSR1"):
+                        mock_register.assert_called_once()
+                    else:
+                        mock_register.assert_not_called()
                     mock_dump_traceback_later.assert_called_once()
                     self.assertEqual(mock_dump_traceback_later.call_args.args[0], 11)
                 finally:
                     if train_module._faulthandler_stream is not None:
                         train_module._faulthandler_stream.close()
                     train_module._faulthandler_stream = previous_stream
+
+    def test_faulthandler_rejects_invalid_timeout(self):
+        import simpletuner.train as train_module
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with patch.dict(
+                os.environ,
+                {
+                    "SIMPLETUNER_FAULTHANDLER_DIR": tmp_dir,
+                    "SIMPLETUNER_FAULTHANDLER_TIMEOUT_SECONDS": "abc",
+                },
+                clear=False,
+            ):
+                with self.assertRaisesRegex(ValueError, "SIMPLETUNER_FAULTHANDLER_TIMEOUT_SECONDS.*'abc'"):
+                    train_module._configure_faulthandler()
+                if train_module._faulthandler_stream is not None:
+                    train_module._faulthandler_stream.close()
+                    train_module._faulthandler_stream = None
 
     def test_train_main_invokes_cleanup_on_failure(self):
         """Train entrypoint should call trainer.cleanup when a failure occurs."""


### PR DESCRIPTION
## Summary
- Adds opt-in rank-local TorchInductor cache directories for distributed training jobs.
- Adds opt-in rank-local faulthandler output and repeated traceback dumps for stalled workers.
- Covers both diagnostics helpers in the train-entry unittest suite.

## Validation
- `.venv/bin/python -m unittest -v -f tests.test_train_cleanup`
- branch diff and commit message privacy scan passed
