### PR TITLE
Run startup validation after checkpoint resume

### DIFF
--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -1867,7 +1867,7 @@ class Trainer:
             self.resume_and_prepare()
             self._exit_on_signal()
             self.init_trackers()
-            self._run_startup_validation()
+            self.run_startup_validation()
 
             # Start the training process
             self.train()
@@ -6315,12 +6315,18 @@ class Trainer:
 
         return should_validate
 
-    def _run_startup_validation(self) -> bool:
+    def run_startup_validation(self) -> bool:
         if not bool(getattr(self.config, "validation_on_startup", False)) or getattr(self, "validation", None) is None:
             return False
-        step = int(self.state.get("global_step", StateTracker.get_global_step()))
+        step = self.state.get("global_step")
+        if step is None:
+            step = StateTracker.get_global_step()
+        step = int(step or 0)
         logger.info("Running startup validation at restored global step %d.", step)
         return self._run_intermediary_validation(step, manual_validation_requested=True)
+
+    def _run_startup_validation(self) -> bool:
+        return self.run_startup_validation()
 
     def _create_torch_profiler(self):
         trace_dir = os.environ.get("SIMPLETUNER_TORCH_PROFILER_DIR")

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -1867,6 +1867,7 @@ class Trainer:
             self.resume_and_prepare()
             self._exit_on_signal()
             self.init_trackers()
+            self._run_startup_validation()
 
             # Start the training process
             self.train()
@@ -6313,6 +6314,13 @@ class Trainer:
             self.mark_optimizer_train()
 
         return should_validate
+
+    def _run_startup_validation(self) -> bool:
+        if not bool(getattr(self.config, "validation_on_startup", False)) or getattr(self, "validation", None) is None:
+            return False
+        step = int(self.state.get("global_step", StateTracker.get_global_step()))
+        logger.info("Running startup validation at restored global step %d.", step)
+        return self._run_intermediary_validation(step, manual_validation_requested=True)
 
     def _create_torch_profiler(self):
         trace_dir = os.environ.get("SIMPLETUNER_TORCH_PROFILER_DIR")

--- a/simpletuner/train.py
+++ b/simpletuner/train.py
@@ -82,6 +82,7 @@ def _run_training(trainer: Trainer) -> None:
     trainer.resume_and_prepare()
 
     trainer.init_trackers()
+    trainer._run_startup_validation()
     trainer.train()
 
 

--- a/simpletuner/train.py
+++ b/simpletuner/train.py
@@ -82,7 +82,7 @@ def _run_training(trainer: Trainer) -> None:
     trainer.resume_and_prepare()
 
     trainer.init_trackers()
-    trainer._run_startup_validation()
+    trainer.run_startup_validation()
     trainer.train()
 
 

--- a/tests/test_train_cleanup.py
+++ b/tests/test_train_cleanup.py
@@ -92,7 +92,7 @@ class _FakeTrainer:
     def init_trackers(self, *_, **__):
         return None
 
-    def _run_startup_validation(self, *_, **__):
+    def run_startup_validation(self, *_, **__):
         self.startup_validation_called = True
 
     def train(self, *_, **__):

--- a/tests/test_train_cleanup.py
+++ b/tests/test_train_cleanup.py
@@ -21,6 +21,7 @@ class _FakeTrainer:
 
     def __init__(self, *args, **kwargs):
         self.cleanup_called = False
+        self.startup_validation_called = False
         self.bf = _DummyFetcher()
         self.config = MagicMock()
         _FakeTrainer.instances.append(self)
@@ -91,6 +92,9 @@ class _FakeTrainer:
     def init_trackers(self, *_, **__):
         return None
 
+    def _run_startup_validation(self, *_, **__):
+        self.startup_validation_called = True
+
     def train(self, *_, **__):
         # Simulate a runtime failure after initial setup
         raise RuntimeError("simulated training failure")
@@ -117,6 +121,10 @@ class TrainEntryCleanupTest(unittest.TestCase):
         self.assertTrue(
             trainer.cleanup_called,
             "train.py did not invoke trainer.cleanup() after a training failure",
+        )
+        self.assertTrue(
+            trainer.startup_validation_called,
+            "train.py did not dispatch startup validation before training",
         )
 
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -825,7 +825,7 @@ class TestTrainer(unittest.TestCase):
         trainer._run_intermediary_validation = MagicMock(return_value=True)
 
         with patch("simpletuner.helpers.training.trainer.logger.info") as log_info:
-            result = trainer._run_startup_validation()
+            result = trainer.run_startup_validation()
 
         self.assertTrue(result)
         log_info.assert_called_once_with("Running startup validation at restored global step %d.", 500)
@@ -837,10 +837,23 @@ class TestTrainer(unittest.TestCase):
         trainer.state = {"global_step": 500}
         trainer._run_intermediary_validation = MagicMock()
 
-        result = trainer._run_startup_validation()
+        result = trainer.run_startup_validation()
 
         self.assertFalse(result)
         trainer._run_intermediary_validation.assert_not_called()
+
+    def test_run_startup_validation_uses_lazy_global_step_fallback(self):
+        trainer = object.__new__(Trainer)
+        trainer.config = SimpleNamespace(validation_on_startup=True)
+        trainer.validation = MagicMock()
+        trainer.state = {"global_step": None}
+        trainer._run_intermediary_validation = MagicMock(return_value=True)
+
+        with patch("simpletuner.helpers.training.trainer.StateTracker.get_global_step", return_value=None):
+            result = trainer.run_startup_validation()
+
+        self.assertTrue(result)
+        trainer._run_intermediary_validation.assert_called_once_with(0, manual_validation_requested=True)
 
     @patch("simpletuner.helpers.training.trainer.load_config")
     @patch("simpletuner.helpers.training.trainer.safety_check")
@@ -1285,9 +1298,7 @@ class TestTrainer(unittest.TestCase):
         logs = {}
         trainer._update_grad_metrics(logs, clone_norm_value=True)
         self.assertIn("grad_absmax", logs)
-        self.assertEqual(
-            logs["grad_absmax"], float(trainer.grad_norm.clone().detach())
-        )
+        self.assertEqual(logs["grad_absmax"], float(trainer.grad_norm.clone().detach()))
 
     def test_update_grad_metrics_clones_norm_value_when_requested(self):
         trainer = self._build_trainer_for_grad_logging(
@@ -1349,9 +1360,7 @@ class TestTrainer(unittest.TestCase):
         )
         metrics = trainer._compose_training_progress_metrics(epoch=1)
         self.assertIn("grad_absmax", metrics)
-        self.assertEqual(
-            metrics["grad_absmax"], float(trainer.grad_norm.clone().detach())
-        )
+        self.assertEqual(metrics["grad_absmax"], float(trainer.grad_norm.clone().detach()))
         self.assertNotIn("grad_norm", metrics)
 
     def test_compose_training_progress_metrics_excludes_grad_with_deepspeed(self):

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -817,6 +817,31 @@ class TestTrainer(unittest.TestCase):
             epoch_end=True,
         )
 
+    def test_run_startup_validation_uses_restored_global_step(self):
+        trainer = object.__new__(Trainer)
+        trainer.config = SimpleNamespace(validation_on_startup=True)
+        trainer.validation = MagicMock()
+        trainer.state = {"global_step": 500}
+        trainer._run_intermediary_validation = MagicMock(return_value=True)
+
+        with patch("simpletuner.helpers.training.trainer.logger.info") as log_info:
+            result = trainer._run_startup_validation()
+
+        self.assertTrue(result)
+        log_info.assert_called_once_with("Running startup validation at restored global step %d.", 500)
+        trainer._run_intermediary_validation.assert_called_once_with(500, manual_validation_requested=True)
+
+    def test_run_startup_validation_is_disabled_by_default(self):
+        trainer = object.__new__(Trainer)
+        trainer.config = SimpleNamespace()
+        trainer.state = {"global_step": 500}
+        trainer._run_intermediary_validation = MagicMock()
+
+        result = trainer._run_startup_validation()
+
+        self.assertFalse(result)
+        trainer._run_intermediary_validation.assert_not_called()
+
     @patch("simpletuner.helpers.training.trainer.load_config")
     @patch("simpletuner.helpers.training.trainer.safety_check")
     @patch("simpletuner.helpers.training.state_tracker.StateTracker")


### PR DESCRIPTION
## Summary
- Runs startup validation after `resume_and_prepare()` so resumed jobs validate with restored state.
- Shares the startup-validation dispatch through a Trainer helper that uses the restored global step.
- Covers enabled, disabled, and entrypoint call-order behavior in unittests.

## Validation
- `.venv/bin/python -m unittest -v -f tests.test_train_cleanup tests.test_trainer.TestTrainer.test_run_startup_validation_uses_restored_global_step tests.test_trainer.TestTrainer.test_run_startup_validation_is_disabled_by_default`
- branch diff and commit message privacy scan passed
