### PR TITLE
Restore constant-with-warmup LR on resume

### DIFF
--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -4721,7 +4721,7 @@ class Trainer:
             logger.info(f"Loading DCM checkpoint states..")
             self.distiller.on_load_checkpoint(checkpoint_dir)
         try:
-            if "constant" == self.config.lr_scheduler and not self.config.is_schedulefree:
+            if self.config.lr_scheduler in ("constant", "constant_with_warmup") and not self.config.is_schedulefree:
                 for g in self.optimizer.param_groups:
                     if "lr" in g:
                         g["lr"] = self.config.learning_rate

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -4649,9 +4649,12 @@ class Trainer:
         delete_invalid_checkpoints = bool(delete_invalid_value)
         resume_latest = resume_value == "latest"
         deleted_checkpoint_names: set[str] = set()
-        configured_param_group_lrs = []
+        optimizer_param_groups = []
         if getattr(self, "optimizer", None) is not None:
-            configured_param_group_lrs = [group.get("lr") for group in getattr(self.optimizer, "param_groups", [])]
+            raw_param_groups = getattr(self.optimizer, "param_groups", None)
+            if isinstance(raw_param_groups, list):
+                optimizer_param_groups = raw_param_groups
+        configured_param_group_lrs = [group.get("lr") for group in optimizer_param_groups]
 
         while True:
             checkpoint_dir = None
@@ -4725,7 +4728,7 @@ class Trainer:
             self.distiller.on_load_checkpoint(checkpoint_dir)
         try:
             if self.config.lr_scheduler in ("constant", "constant_with_warmup") and not self.config.is_schedulefree:
-                for group_index, group in enumerate(self.optimizer.param_groups):
+                for group_index, group in enumerate(optimizer_param_groups):
                     if "lr" not in group:
                         continue
                     if group_index < len(configured_param_group_lrs) and configured_param_group_lrs[group_index] is not None:

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -4649,6 +4649,9 @@ class Trainer:
         delete_invalid_checkpoints = bool(delete_invalid_value)
         resume_latest = resume_value == "latest"
         deleted_checkpoint_names: set[str] = set()
+        configured_param_group_lrs = []
+        if getattr(self, "optimizer", None) is not None:
+            configured_param_group_lrs = [group.get("lr") for group in getattr(self.optimizer, "param_groups", [])]
 
         while True:
             checkpoint_dir = None
@@ -4722,12 +4725,16 @@ class Trainer:
             self.distiller.on_load_checkpoint(checkpoint_dir)
         try:
             if self.config.lr_scheduler in ("constant", "constant_with_warmup") and not self.config.is_schedulefree:
-                for g in self.optimizer.param_groups:
-                    if "lr" in g:
-                        g["lr"] = self.config.learning_rate
+                for group_index, group in enumerate(self.optimizer.param_groups):
+                    if "lr" not in group:
+                        continue
+                    if group_index < len(configured_param_group_lrs) and configured_param_group_lrs[group_index] is not None:
+                        group["lr"] = configured_param_group_lrs[group_index]
                 for k, v in lr_scheduler.state_dict().items():
                     if k in ("base_lrs", "_last_lr"):
-                        v[0] = self.config.learning_rate
+                        for group_index, configured_lr in enumerate(configured_param_group_lrs):
+                            if configured_lr is not None and group_index < len(v):
+                                v[group_index] = configured_lr
         except Exception as e:
             event = notification_event(
                 message="Could not update learning rate scheduler LR value.",

--- a/tests/test_resume_lr_scheduler.py
+++ b/tests/test_resume_lr_scheduler.py
@@ -36,14 +36,18 @@ class ResumeLRSchedulerTests(unittest.TestCase):
             trainer.accelerator.load_state = Mock()
             trainer.accelerator.wait_for_everyone = Mock()
             trainer.state = {"global_step": 0, "first_epoch": 1, "current_epoch": 1}
-            trainer.optimizer = Mock(param_groups=[{"lr": 0.25}])
+            trainer.optimizer = Mock(param_groups=[{"lr": 0.001}, {"lr": 0.0002}])
             trainer.distiller = None
             trainer.job_id = "test-job"
             trainer._emit_event = Mock()
             trainer.checkpoint_manager = CheckpointManager(tmpdir)
-            scheduler_state = {"base_lrs": [0.25], "_last_lr": [0.25]}
+            scheduler_state = {"base_lrs": [0.25, 0.25], "_last_lr": [0.25, 0.25]}
             lr_scheduler = Mock()
             lr_scheduler.state_dict.return_value = scheduler_state
+            trainer.accelerator.load_state.side_effect = lambda _checkpoint: trainer.optimizer.param_groups.__setitem__(
+                slice(None),
+                [{"lr": 0.25}, {"lr": 0.25}],
+            )
 
             with (
                 patch("simpletuner.helpers.training.state_tracker.StateTracker.get_data_backends", return_value={}),
@@ -56,8 +60,9 @@ class ResumeLRSchedulerTests(unittest.TestCase):
                 trainer.init_resume_checkpoint(lr_scheduler=lr_scheduler)
 
             self.assertEqual(trainer.optimizer.param_groups[0]["lr"], 0.001)
-            self.assertEqual(scheduler_state["base_lrs"], [0.001])
-            self.assertEqual(scheduler_state["_last_lr"], [0.001])
+            self.assertEqual(trainer.optimizer.param_groups[1]["lr"], 0.0002)
+            self.assertEqual(scheduler_state["base_lrs"], [0.001, 0.0002])
+            self.assertEqual(scheduler_state["_last_lr"], [0.001, 0.0002])
             trainer.accelerator.load_state.assert_called_once_with(str(checkpoint_dir))
             mock_attention_backend.assert_called_once_with(str(checkpoint_dir))
 

--- a/tests/test_resume_lr_scheduler.py
+++ b/tests/test_resume_lr_scheduler.py
@@ -1,0 +1,66 @@
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from simpletuner.helpers.training.trainer import Trainer
+from simpletuner.helpers.utils.checkpoint_manager import CheckpointManager
+
+
+class ResumeLRSchedulerTests(unittest.TestCase):
+    @patch("simpletuner.helpers.training.trainer.AttentionBackendController.on_load_checkpoint")
+    def test_constant_with_warmup_resume_restores_configured_lr(self, mock_attention_backend):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            checkpoint_dir = Path(tmpdir, "checkpoint-100")
+            checkpoint_dir.mkdir()
+            trainer = object.__new__(Trainer)
+            trainer.model = SimpleNamespace(reset_flow_custom_timestep_cursor=Mock())
+            trainer.config = SimpleNamespace(
+                output_dir=tmpdir,
+                resume_from_checkpoint=str(checkpoint_dir),
+                total_steps_remaining_at_start=100,
+                global_resume_step=1,
+                num_train_epochs=1,
+                max_train_steps=100,
+                musubi_blocks_to_swap=0,
+                lr_scheduler="constant_with_warmup",
+                learning_rate=0.001,
+                is_schedulefree=False,
+                overrode_max_train_steps=False,
+                strict_epoch_limit=True,
+                optimizer="adamw",
+                delete_invalid_checkpoints=False,
+            )
+            trainer.accelerator = Mock(num_processes=1)
+            trainer.accelerator.load_state = Mock()
+            trainer.accelerator.wait_for_everyone = Mock()
+            trainer.state = {"global_step": 0, "first_epoch": 1, "current_epoch": 1}
+            trainer.optimizer = Mock(param_groups=[{"lr": 0.25}])
+            trainer.distiller = None
+            trainer.job_id = "test-job"
+            trainer._emit_event = Mock()
+            trainer.checkpoint_manager = CheckpointManager(tmpdir)
+            scheduler_state = {"base_lrs": [0.25], "_last_lr": [0.25]}
+            lr_scheduler = Mock()
+            lr_scheduler.state_dict.return_value = scheduler_state
+
+            with (
+                patch("simpletuner.helpers.training.state_tracker.StateTracker.get_data_backends", return_value={}),
+                patch("simpletuner.helpers.training.state_tracker.StateTracker.get_global_step", return_value=100),
+                patch("simpletuner.helpers.training.state_tracker.StateTracker.set_global_resume_step"),
+                patch("simpletuner.helpers.training.state_tracker.StateTracker.get_training_state", return_value={}),
+                patch("simpletuner.helpers.training.state_tracker.StateTracker.get_epoch", return_value=1),
+                patch("simpletuner.helpers.training.state_tracker.StateTracker.set_epoch"),
+            ):
+                trainer.init_resume_checkpoint(lr_scheduler=lr_scheduler)
+
+            self.assertEqual(trainer.optimizer.param_groups[0]["lr"], 0.001)
+            self.assertEqual(scheduler_state["base_lrs"], [0.001])
+            self.assertEqual(scheduler_state["_last_lr"], [0.001])
+            trainer.accelerator.load_state.assert_called_once_with(str(checkpoint_dir))
+            mock_attention_backend.assert_called_once_with(str(checkpoint_dir))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Restores configured learning rate on resume for `constant_with_warmup`, matching the existing `constant` behavior.
- Updates optimizer param groups and scheduler `base_lrs` / `_last_lr` after checkpoint load.
- Adds a standalone resume LR regression test.

## Validation
- `.venv/bin/python -m unittest -v -f tests.test_resume_lr_scheduler tests.test_trainer.TestTrainer.test_init_resume_checkpoint`
- branch diff and commit message privacy scan passed
