### PR TITLE
Refactor ComfyUI LoRA conversion through model hooks

### DIFF
--- a/simpletuner/helpers/models/auraflow/model.py
+++ b/simpletuner/helpers/models/auraflow/model.py
@@ -36,6 +36,7 @@ class Auraflow(ImageModelFoundation):
     ENABLED_IN_WIZARD = True
     PREDICTION_TYPE = PredictionTypes.FLOW_MATCHING
     MODEL_TYPE = ModelTypes.TRANSFORMER
+    COMFYUI_LORA_PRESERVE_COMPONENT_PREFIXES = {"transformer"}
     ATTENTION_KWARG_NAME = "attention_kwargs"
     AUTOENCODER_CLASS = AutoencoderKL
     LATENT_CHANNEL_COUNT = 4

--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -56,7 +56,6 @@ from simpletuner.helpers.training.lora_format import (
     collect_lora_alphas,
     convert_comfyui_to_diffusers,
     convert_diffusers_to_comfyui,
-    convert_diffusers_to_comfyui_sd_lora,
     detect_state_dict_format,
     normalize_lora_format,
     peft_lora_config_kwargs_from_state_dict,
@@ -492,6 +491,7 @@ class ModelFoundation(ABC):
     DDP_FIND_UNUSED_PARAMETERS = False
     DEFAULT_AUDIO_CHANNELS = 1
     DEFAULT_LORA_EXCLUDE_TARGETS = None  # regex, not list
+    COMFYUI_LORA_PRESERVE_COMPONENT_PREFIXES = None
 
     # Acceleration backend support - models declare what they DON'T support
     UNSUPPORTED_BACKENDS: set = set()  # Empty = supports all backends
@@ -1887,7 +1887,10 @@ class ModelFoundation(ABC):
                 active_format = PEFTLoRAFormat.COMFYUI
         alpha_map = {}
         if active_format == PEFTLoRAFormat.COMFYUI:
-            lora_state_dict, comfy_alphas = convert_comfyui_to_diffusers(lora_state_dict, target_prefix=key_to_replace)
+            lora_state_dict, comfy_alphas = self._convert_lora_state_dict_from_comfyui(
+                lora_state_dict,
+                target_prefix=key_to_replace,
+            )
             alpha_map.update(_normalise_alpha_map(comfy_alphas))
         if network_alphas:
             alpha_map.update(_normalise_alpha_map(network_alphas))
@@ -1924,6 +1927,11 @@ class ModelFoundation(ABC):
         if incompatible_keys is not None:
             unexpected_keys = getattr(incompatible_keys, "unexpected_keys", None)
             if unexpected_keys:
+                if len(unexpected_keys) == len(denoiser_sd):
+                    raise ValueError(
+                        "LoRA checkpoint loading rejected every denoiser tensor. "
+                        "The checkpoint naming or adapter configuration is incompatible with the model."
+                    )
                 logger.warning(f"LoRA loading found unexpected keys not in the denoiser model: {unexpected_keys}")
 
         if getattr(self.config, "train_text_encoder", False):
@@ -1948,6 +1956,27 @@ class ModelFoundation(ABC):
                 )
 
         logger.info("Finished loading LoRA weights successfully.")
+
+    def _convert_lora_state_dict_from_comfyui(
+        self,
+        weights: dict,
+        *,
+        target_prefix: str,
+    ) -> tuple[dict, dict]:
+        return convert_comfyui_to_diffusers(weights, target_prefix=target_prefix)
+
+    def _convert_lora_state_dict_to_comfyui(
+        self,
+        weights: dict,
+        *,
+        adapter_metadata: Optional[dict] = None,
+        component_adapter_metadata: Optional[dict] = None,
+    ) -> dict:
+        return convert_diffusers_to_comfyui(
+            weights,
+            adapter_metadata=adapter_metadata,
+            preserve_component_prefixes=self.COMFYUI_LORA_PRESERVE_COMPONENT_PREFIXES,
+        )
 
     def save_lora_weights(self, *args, **kwargs):
         """
@@ -1978,22 +2007,6 @@ class ModelFoundation(ABC):
             import safetensors.torch
             from diffusers.loaders.lora_base import LORA_ADAPTER_METADATA_KEY
 
-            comfy_preserve_prefix_families = {
-                "flux",
-                "flux2",
-                "lumina2",
-                "sd3",
-                "auraflow",
-                "pixart_sigma",
-                "hidream",
-            }
-            preserve_component_prefixes = (
-                {"transformer"} if self.config.model_family in comfy_preserve_prefix_families else None
-            )
-
-            # Use model-specific converters where available
-            model_family = self.config.model_family
-
             def comfyui_save_function(weights, filename):
                 metadata = {"format": "pt"}
                 if adapter_metadata:
@@ -2002,23 +2015,11 @@ class ModelFoundation(ABC):
                     except Exception:
                         pass
 
-                if model_family == "flux2":
-                    from simpletuner.helpers.models.flux2.pipeline import _convert_diffusers_flux2_lora_to_comfyui
-
-                    converted = _convert_diffusers_flux2_lora_to_comfyui(weights, adapter_metadata=adapter_metadata)
-                elif model_family in {"sd1x", "sdxl"}:
-                    converted = convert_diffusers_to_comfyui_sd_lora(
-                        weights,
-                        adapter_metadata=adapter_metadata,
-                        component_adapter_metadata=component_adapter_metadata,
-                        sdxl=(model_family == "sdxl"),
-                    )
-                else:
-                    converted = convert_diffusers_to_comfyui(
-                        weights,
-                        adapter_metadata=adapter_metadata,
-                        preserve_component_prefixes=preserve_component_prefixes,
-                    )
+                converted = self._convert_lora_state_dict_to_comfyui(
+                    weights,
+                    adapter_metadata=adapter_metadata,
+                    component_adapter_metadata=component_adapter_metadata,
+                )
                 safetensors.torch.save_file(converted, filename, metadata=metadata)
 
             kwargs["save_function"] = comfyui_save_function

--- a/simpletuner/helpers/models/flux/model.py
+++ b/simpletuner/helpers/models/flux/model.py
@@ -54,6 +54,7 @@ class Flux(ImageModelFoundation):
     PREDICTION_TYPE = PredictionTypes.FLOW_MATCHING
     MODEL_TYPE = ModelTypes.TRANSFORMER
     AUTO_LORA_FORMAT_DETECTION = True
+    COMFYUI_LORA_PRESERVE_COMPONENT_PREFIXES = {"transformer"}
     # Flux Dev uses dynamic shifting (use_dynamic_shifting: true in scheduler config).
     # Schnell has use_dynamic_shifting: false, so the flag here just prevents static override.
     USES_DYNAMIC_SHIFT = True

--- a/simpletuner/helpers/models/flux2/model.py
+++ b/simpletuner/helpers/models/flux2/model.py
@@ -88,6 +88,7 @@ class Flux2(ImageModelFoundation):
     MODEL_TYPE = ModelTypes.TRANSFORMER
     AUTO_LORA_FORMAT_DETECTION = True
     NATIVE_COMFYUI_LORA_SUPPORT = True  # Flux2 has native ComfyUI LoRA support, no conversion needed
+    COMFYUI_LORA_PRESERVE_COMPONENT_PREFIXES = {"transformer"}
     AUTOENCODER_CLASS = AutoencoderKLFlux2
     LATENT_CHANNEL_COUNT = 128  # 32 VAE channels × 4 (2×2 pixel shuffle) = 128 transformer channels
     VAE_SCALE_FACTOR = 16  # 8x spatial + 2x pixel shuffle
@@ -114,6 +115,18 @@ class Flux2(ImageModelFoundation):
         "attn.to_qkv_mlp_proj",
         # "attn.to_out",
     ]
+
+    def _convert_lora_state_dict_to_comfyui(
+        self,
+        weights: dict,
+        *,
+        adapter_metadata=None,
+        component_adapter_metadata=None,
+    ) -> dict:
+        from simpletuner.helpers.models.flux2.pipeline import _convert_diffusers_flux2_lora_to_comfyui
+
+        return _convert_diffusers_flux2_lora_to_comfyui(weights, adapter_metadata=adapter_metadata)
+
     SLIDER_LORA_TARGET = [
         # Restrict to image/self-stream attention; avoid add_* context projections
         "attn.to_q",

--- a/simpletuner/helpers/models/hidream/model.py
+++ b/simpletuner/helpers/models/hidream/model.py
@@ -48,6 +48,7 @@ class HiDream(ImageModelFoundation):
     ENABLED_IN_WIZARD = True
     PREDICTION_TYPE = PredictionTypes.FLOW_MATCHING
     MODEL_TYPE = ModelTypes.TRANSFORMER
+    COMFYUI_LORA_PRESERVE_COMPONENT_PREFIXES = {"transformer"}
     AUTOENCODER_CLASS = AutoencoderKL
     LATENT_CHANNEL_COUNT = 16
     MAXIMUM_CANVAS_SIZE = 1024**2  # H*W cannot exceed this value.

--- a/simpletuner/helpers/models/lumina2/model.py
+++ b/simpletuner/helpers/models/lumina2/model.py
@@ -33,6 +33,7 @@ class Lumina2(ImageModelFoundation):
     ENABLED_IN_WIZARD = True
     PREDICTION_TYPE = PredictionTypes.FLOW_MATCHING
     MODEL_TYPE = ModelTypes.TRANSFORMER
+    COMFYUI_LORA_PRESERVE_COMPONENT_PREFIXES = {"transformer"}
     AUTO_LORA_FORMAT_DETECTION = True
     AUTOENCODER_CLASS = AutoencoderKL
     LATENT_CHANNEL_COUNT = 16

--- a/simpletuner/helpers/models/pixart/model.py
+++ b/simpletuner/helpers/models/pixart/model.py
@@ -48,6 +48,7 @@ class PixartSigma(ImageModelFoundation):
     ENABLED_IN_WIZARD = True
     PREDICTION_TYPE = PredictionTypes.EPSILON
     MODEL_TYPE = ModelTypes.TRANSFORMER
+    COMFYUI_LORA_PRESERVE_COMPONENT_PREFIXES = {"transformer"}
     ATTENTION_KWARG_NAME = "cross_attention_kwargs"
     AUTOENCODER_CLASS = AutoencoderKL
     LATENT_CHANNEL_COUNT = 4

--- a/simpletuner/helpers/models/sd1x/model.py
+++ b/simpletuner/helpers/models/sd1x/model.py
@@ -48,6 +48,22 @@ class StableDiffusion1(ImageModelFoundation):
     # Only training the Attention blocks by default seems to help more with SD3.
     DEFAULT_LYCORIS_TARGET = ["Attention"]
 
+    def _convert_lora_state_dict_to_comfyui(
+        self,
+        weights: dict,
+        *,
+        adapter_metadata=None,
+        component_adapter_metadata=None,
+    ) -> dict:
+        from simpletuner.helpers.training.lora_format import convert_diffusers_to_comfyui_sd_lora
+
+        return convert_diffusers_to_comfyui_sd_lora(
+            weights,
+            adapter_metadata=adapter_metadata,
+            component_adapter_metadata=component_adapter_metadata,
+            sdxl=False,
+        )
+
     MODEL_CLASS = UNet2DConditionModel
     MODEL_SUBFOLDER = "unet"
     PIPELINE_CLASSES = {

--- a/simpletuner/helpers/models/sd3/model.py
+++ b/simpletuner/helpers/models/sd3/model.py
@@ -110,6 +110,7 @@ class SD3(ImageModelFoundation):
     ENABLED_IN_WIZARD = True
     PREDICTION_TYPE = PredictionTypes.FLOW_MATCHING
     MODEL_TYPE = ModelTypes.TRANSFORMER
+    COMFYUI_LORA_PRESERVE_COMPONENT_PREFIXES = {"transformer"}
     AUTOENCODER_CLASS = AutoencoderKL
     LATENT_CHANNEL_COUNT = 16
     VALIDATION_PREVIEW_SPEC = ImageTAESpec(repo_id="madebyollin/taesd3")

--- a/simpletuner/helpers/models/sdxl/model.py
+++ b/simpletuner/helpers/models/sdxl/model.py
@@ -58,6 +58,22 @@ class SDXL(ImageModelFoundation):
     # Only training the Attention blocks by default seems to help more with SD3.
     DEFAULT_LYCORIS_TARGET = ["Attention"]
 
+    def _convert_lora_state_dict_to_comfyui(
+        self,
+        weights: dict,
+        *,
+        adapter_metadata=None,
+        component_adapter_metadata=None,
+    ) -> dict:
+        from simpletuner.helpers.training.lora_format import convert_diffusers_to_comfyui_sd_lora
+
+        return convert_diffusers_to_comfyui_sd_lora(
+            weights,
+            adapter_metadata=adapter_metadata,
+            component_adapter_metadata=component_adapter_metadata,
+            sdxl=True,
+        )
+
     MODEL_CLASS = UNet2DConditionModel
     MODEL_SUBFOLDER = "unet"
     PIPELINE_CLASSES = {

--- a/tests/test_lora_metadata.py
+++ b/tests/test_lora_metadata.py
@@ -11,6 +11,7 @@ from safetensors import safe_open
 from safetensors.torch import save_file
 
 from simpletuner.helpers.models.common import ModelFoundation, ModelTypes, PipelineTypes
+from simpletuner.helpers.models.sdxl.model import SDXL
 from simpletuner.helpers.training.save_hooks import (
     MODEL_SPEC_VERSION,
     SaveHookManager,
@@ -165,6 +166,8 @@ class _DummySDXLSavePipeline:
 
 class _DummySaveModel:
     PIPELINE_CLASSES = {PipelineTypes.TEXT2IMG: _DummySavePipeline, PipelineTypes.CONTROLNET: _DummySavePipeline}
+    COMFYUI_LORA_PRESERVE_COMPONENT_PREFIXES = None
+    _convert_lora_state_dict_to_comfyui = ModelFoundation._convert_lora_state_dict_to_comfyui
 
     def __init__(self, model_family, lora_format="comfyui", controlnet=False):
         self.config = SimpleNamespace(model_family=model_family, lora_format=lora_format, controlnet=controlnet)
@@ -172,6 +175,7 @@ class _DummySaveModel:
 
 class _DummySDXLSaveModel(_DummySaveModel):
     PIPELINE_CLASSES = {PipelineTypes.TEXT2IMG: _DummySDXLSavePipeline, PipelineTypes.CONTROLNET: _DummySDXLSavePipeline}
+    _convert_lora_state_dict_to_comfyui = SDXL._convert_lora_state_dict_to_comfyui
 
 
 class _DummyArtifactModel(_DummyModel):

--- a/tests/test_lora_metadata.py
+++ b/tests/test_lora_metadata.py
@@ -192,6 +192,33 @@ class _DummyArtifactModel(_DummyModel):
         self.save_lora_weights = lambda *args, **kwargs: ModelFoundation.save_lora_weights(self, *args, **kwargs)
 
 
+class _DummyLoadPipeline:
+    @staticmethod
+    def lora_state_dict(_input_dir):
+        return {"transformer.bad_adapter.lora_A.weight": torch.ones(1, 1)}
+
+
+class _DummyLoadModel:
+    PIPELINE_CLASSES = {PipelineTypes.TEXT2IMG: _DummyLoadPipeline}
+    MODEL_TYPE = SimpleNamespace(value="transformer")
+    CONTROLNET_LORA_STATE_DICT_PREFIX = "controlnet"
+    AUTO_LORA_FORMAT_DETECTION = False
+    _collect_wrapped_component_classes = ModelFoundation._collect_wrapped_component_classes
+    _convert_lora_state_dict_from_comfyui = ModelFoundation._convert_lora_state_dict_from_comfyui
+
+    def __init__(self):
+        self.model = torch.nn.Linear(1, 1)
+        self.controlnet = None
+        self.text_encoders = []
+        self.config = SimpleNamespace(controlnet=False, lora_format="diffusers", train_text_encoder=False)
+
+    def unwrap_model(self, model):
+        return model
+
+    def _apply_alpha_scaling(self, *_args, **_kwargs):
+        return None
+
+
 _ema_stub = SimpleNamespace(
     store=lambda *args, **kwargs: None, copy_to=lambda *args, **kwargs: None, restore=lambda *args, **kwargs: None
 )
@@ -541,6 +568,19 @@ class SaveHookMetadataTests(unittest.TestCase):
         self.assertEqual(len(written), len(lora_state))
         for key in written:
             self.assertTrue(key.endswith((".lora_A.weight", ".lora_B.weight")), key)
+
+    def test_load_lora_rejects_when_every_denoiser_tensor_is_unexpected(self):
+        model = _DummyLoadModel()
+
+        with (
+            patch("diffusers.utils.convert_unet_state_dict_to_peft", side_effect=lambda state_dict: state_dict),
+            patch(
+                "peft.utils.set_peft_model_state_dict",
+                return_value=SimpleNamespace(unexpected_keys=["bad_adapter.lora_A.weight"]),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "rejected every denoiser tensor"):
+                ModelFoundation.load_lora_weights(model, [model.model], "unused")
 
     def test_save_hook_peft_output_loads_through_diffusers_with_model_prefix(self):
         from diffusers.loaders.peft import PeftAdapterMixin


### PR DESCRIPTION
## Summary
- Moves ComfyUI LoRA import/export conversion behind model hooks instead of common model-family conditionals.
- Preserves existing transformer prefix behavior and SD/SDXL/Kohya conversion behavior through model overrides.
- Raises when denoiser LoRA loading rejects every tensor as unexpected.

## Validation
- `.venv/bin/python -m unittest -v -f tests.test_lora_metadata`
- branch diff and commit message privacy scan passed
