### PR TITLE
Preserve validation context in text embed cache

### DIFF
--- a/simpletuner/helpers/caching/text_embeds.py
+++ b/simpletuner/helpers/caching/text_embeds.py
@@ -260,11 +260,15 @@ class TextEmbeddingCache(WebhookMixin):
         pending_records: List[PromptCacheRecord],
         pending_filenames: List[str],
         is_negative_prompt: bool = False,
+        is_validation: bool = False,
     ) -> None:
         prompts = [record.get("prompt") for record in pending_records]
         prompt_contexts = [record.get("metadata") or {} for record in pending_records]
-        text_encoder_output = self.model.encode_text_batch(
-            prompts, is_negative_prompt=is_negative_prompt, prompt_contexts=prompt_contexts
+        text_encoder_output = self._encode_text_batch(
+            prompts,
+            is_negative_prompt=is_negative_prompt,
+            prompt_contexts=prompt_contexts,
+            is_validation=is_validation,
         )
         if not isinstance(text_encoder_output, dict):
             raise TypeError(f"encode_text_batch returned {type(text_encoder_output)}; expected a dict.")
@@ -287,6 +291,32 @@ class TextEmbeddingCache(WebhookMixin):
                 filename,
                 self._slice_batch_output_for_cache(text_encoder_output, index, batch_size),
             )
+
+    def _encode_text_batch(
+        self,
+        prompts: list,
+        *,
+        is_negative_prompt: bool,
+        prompt_contexts: Optional[List[dict]],
+        is_validation: bool,
+    ):
+        had_validation_marker = hasattr(self.model, "_current_prompt_is_validation")
+        previous_validation_marker = getattr(self.model, "_current_prompt_is_validation", None)
+        self.model._current_prompt_is_validation = bool(is_validation)
+        try:
+            return self.model.encode_text_batch(
+                prompts,
+                is_negative_prompt=is_negative_prompt,
+                prompt_contexts=prompt_contexts,
+            )
+        finally:
+            if had_validation_marker:
+                self.model._current_prompt_is_validation = previous_validation_marker
+            else:
+                try:
+                    delattr(self.model, "_current_prompt_is_validation")
+                except AttributeError:
+                    pass
 
     def discover_all_files(self):
         """Identify all files in the data backend."""
@@ -515,7 +545,7 @@ class TextEmbeddingCache(WebhookMixin):
         should_encode = not load_from_cache
         if requires_context and uncached_records and should_encode:
             contextless_records = [record for record in raw_records if not record.get("metadata")]
-            if contextless_records:
+            if contextless_records and not is_validation:
                 logger.warning(
                     f"{self.rank_info}(id={self.id}) Prompt records require image context but metadata "
                     f"was missing for {len(contextless_records)} entries. "
@@ -526,6 +556,10 @@ class TextEmbeddingCache(WebhookMixin):
                 raw_records = [record for record in raw_records if record.get("metadata")]
                 if not raw_records:
                     return None
+            elif contextless_records:
+                self.debug_log(
+                    "Encoding contextless validation prompt(s) for a model that normally requires image metadata."
+                )
 
         output = None
         if self.model is not None:
@@ -657,6 +691,7 @@ class TextEmbeddingCache(WebhookMixin):
                             pending_records,
                             pending_filenames,
                             is_negative_prompt=is_negative_prompt,
+                            is_validation=is_validation,
                         )
                         pending_records = []
                         pending_filenames = []
@@ -666,8 +701,11 @@ class TextEmbeddingCache(WebhookMixin):
                     encoder_device = self.text_encoders[0].device if self.text_encoders else "model"
                     self.debug_log(f"Encoding filename {filename} :: device {encoder_device} :: prompt {prompt}")
                     prompt_contexts = [record.get("metadata") or {}]
-                    text_encoder_output = self.model.encode_text_batch(
-                        [prompt], is_negative_prompt=is_negative_prompt, prompt_contexts=prompt_contexts
+                    text_encoder_output = self._encode_text_batch(
+                        [prompt],
+                        is_negative_prompt=is_negative_prompt,
+                        prompt_contexts=prompt_contexts,
+                        is_validation=is_validation,
                     )
                     logger.debug(
                         f"Filename {filename} prompt embeds: {gather_dict_of_tensors_shapes(tensors=text_encoder_output)}, keys: {text_encoder_output.keys()}"
@@ -715,6 +753,7 @@ class TextEmbeddingCache(WebhookMixin):
                     pending_records,
                     pending_filenames,
                     is_negative_prompt=is_negative_prompt,
+                    is_validation=is_validation,
                 )
 
             while self.write_queue.qsize() > 0:
@@ -740,6 +779,10 @@ class TextEmbeddingCache(WebhookMixin):
             # If only one embedding, return it directly without concatenation
             if len(prompt_embeds_all) == 1:
                 return prompt_embeds_all[0]
+
+            transformed_encoder_output = self.model.collate_prompt_embeds(prompt_embeds_all)
+            if transformed_encoder_output:
+                return transformed_encoder_output
 
             # Concatenate multiple embeddings
             if prompt_embeds_all and "prompt_embeds" in prompt_embeds_all[0]:

--- a/tests/test_text_embeds.py
+++ b/tests/test_text_embeds.py
@@ -307,6 +307,78 @@ class TextEmbeddingCacheKeyTests(unittest.TestCase):
         self.assertEqual(cache.model.encode_text_batch.call_count, 2)
         self.assertEqual(cache.save_to_cache.call_count, 2)
 
+    @patch("simpletuner.helpers.caching.text_embeds.StateTracker.get_text_cache_files", return_value={})
+    def test_validation_encode_marks_model_context(self, _mock_cache_files):
+        cache = _make_cache(TextEmbedCacheKey.CAPTION)
+        cache.save_to_cache = MagicMock()
+
+        class ValidationAwareModel(_DummyModel):
+            TEXT_ENCODER_CONFIGURATION = {"text_encoder": {}}
+
+            def __init__(self):
+                super().__init__(TextEmbedCacheKey.CAPTION)
+                self.validation_markers = []
+
+            def encode_text_batch(self, prompts, is_negative_prompt=False, prompt_contexts=None):
+                self.validation_markers.append(getattr(self, "_current_prompt_is_validation", None))
+                return {
+                    "prompt_embeds": torch.ones(1, 2, 3),
+                    "attention_mask": torch.ones(1, 2, dtype=torch.bool),
+                }
+
+        cache.model = ValidationAwareModel()
+
+        cache.compute_embeddings_for_prompts(
+            [{"prompt": "a validation prompt", "key": "validation"}],
+            is_validation=True,
+            load_from_cache=False,
+        )
+
+        self.assertEqual(cache.model.validation_markers, [True])
+        self.assertFalse(hasattr(cache.model, "_current_prompt_is_validation"))
+
+    def test_multi_record_return_uses_model_collator_for_extra_tensors(self):
+        cache = _make_cache(TextEmbedCacheKey.CAPTION)
+
+        class CollatingModel(_DummyModel):
+            TEXT_ENCODER_CONFIGURATION = {"text_encoder": {}}
+
+            def __init__(self):
+                super().__init__(TextEmbedCacheKey.CAPTION)
+
+            def unpack_text_embeddings_from_cache(self, embeddings):
+                return embeddings
+
+            def collate_prompt_embeds(self, text_encoder_output):
+                return {
+                    "prompt_embeds": torch.cat([item["prompt_embeds"] for item in text_encoder_output], dim=0),
+                    "text_token_tags": torch.cat([item["text_token_tags"] for item in text_encoder_output], dim=0),
+                }
+
+        cache.model = CollatingModel()
+        cache.load_from_cache = MagicMock(
+            side_effect=[
+                {
+                    "prompt_embeds": torch.full((1, 2, 3), 1.0),
+                    "text_token_tags": torch.tensor([[1, 1]], dtype=torch.long),
+                },
+                {
+                    "prompt_embeds": torch.full((1, 2, 3), 2.0),
+                    "text_token_tags": torch.tensor([[2, 2]], dtype=torch.long),
+                },
+            ]
+        )
+
+        output = cache.compute_prompt_embeddings_with_model(
+            prompt_records=[
+                {"prompt": "first", "key": "first", "metadata": {}},
+                {"prompt": "second", "key": "second", "metadata": {}},
+            ],
+        )
+
+        self.assertEqual(output["prompt_embeds"].shape, torch.Size([2, 2, 3]))
+        self.assertEqual(output["text_token_tags"].tolist(), [[1, 1], [2, 2]])
+
     def test_batched_encode_saves_trimmed_per_caption_outputs(self):
         cache = _make_cache(TextEmbedCacheKey.CAPTION)
         saved = []


### PR DESCRIPTION
## Summary
- Preserves validation context when text embeddings are encoded through the cache path.
- Temporarily marks the model during validation prompt encoding and clears that state afterwards.
- Uses the model collator for multi-record cached outputs so auxiliary text tensors are preserved.

## Validation
- `.venv/bin/python -m unittest -v -f tests.test_text_embeds`
- branch diff and commit message privacy scan passed
