### PR TITLE
Respect active model dropout cache policy in collate

### DIFF
--- a/simpletuner/helpers/training/collate.py
+++ b/simpletuner/helpers/training/collate.py
@@ -336,7 +336,7 @@ def compute_single_embedding(prompt_entry, text_embed_cache, model=None):
         # Grab the default text embed backend for null caption.
         text_embed_cache = StateTracker.get_default_text_embed_cache()
         # Use sentinel key for filename-based caches to match encode_dropout_caption()
-        cache_model = model or getattr(text_embed_cache, "model", None)
+        cache_model = model if model is not None else getattr(text_embed_cache, "model", None)
         use_dropout_sentinel = getattr(cache_model, "use_text_cache_dropout_sentinel", lambda: True)()
         if text_embed_cache._requires_path_based_keys and use_dropout_sentinel:
             prompt_entry["key"] = "__caption_dropout__"

--- a/simpletuner/helpers/training/collate.py
+++ b/simpletuner/helpers/training/collate.py
@@ -327,7 +327,7 @@ def compute_latents(filepaths, data_backend_id: str, model):
     return latents
 
 
-def compute_single_embedding(prompt_entry, text_embed_cache):
+def compute_single_embedding(prompt_entry, text_embed_cache, model=None):
     """Worker function to compute embedding for a single caption."""
     if not isinstance(prompt_entry, dict):
         prompt_entry = {"prompt": prompt_entry, "key": prompt_entry, "metadata": {}}
@@ -336,7 +336,8 @@ def compute_single_embedding(prompt_entry, text_embed_cache):
         # Grab the default text embed backend for null caption.
         text_embed_cache = StateTracker.get_default_text_embed_cache()
         # Use sentinel key for filename-based caches to match encode_dropout_caption()
-        use_dropout_sentinel = getattr(text_embed_cache.model, "use_text_cache_dropout_sentinel", lambda: True)()
+        cache_model = model or getattr(text_embed_cache, "model", None)
+        use_dropout_sentinel = getattr(cache_model, "use_text_cache_dropout_sentinel", lambda: True)()
         if text_embed_cache._requires_path_based_keys and use_dropout_sentinel:
             prompt_entry["key"] = "__caption_dropout__"
         debug_log(
@@ -376,7 +377,7 @@ def compute_prompt_embeddings(prompt_entries, text_embed_cache, model):
         default_cache, "text_cache_ondemand", False
     )
     if getattr(text_embed_cache, "text_cache_ondemand", False) or empty_prompt_uses_ondemand:
-        text_encoder_output = [compute_single_embedding(entry, text_embed_cache) for entry in normalized_entries]
+        text_encoder_output = [compute_single_embedding(entry, text_embed_cache, model) for entry in normalized_entries]
     else:
         with ThreadPoolExecutor() as executor:
             text_encoder_output = list(
@@ -384,6 +385,7 @@ def compute_prompt_embeddings(prompt_entries, text_embed_cache, model):
                     compute_single_embedding,
                     normalized_entries,
                     [text_embed_cache] * len(normalized_entries),
+                    [model] * len(normalized_entries),
                 )
             )
     prompt_embeds, pooled_prompt_embeds, attn_masks, time_ids = [], [], [], []

--- a/tests/test_collate.py
+++ b/tests/test_collate.py
@@ -13,6 +13,7 @@ from simpletuner.helpers.training.collate import (
     collate_fn,
     compute_latents,
     compute_prompt_embeddings,
+    compute_single_embedding,
     describe_missing_conditioning_pairs,
 )
 from simpletuner.helpers.training.state_tracker import StateTracker
@@ -238,6 +239,22 @@ class CollateFunctionTests(unittest.TestCase):
         executor.assert_not_called()
         self.assertEqual(compute_one.call_count, 2)
         self.assertEqual(result["prompt_embeds"].shape, torch.Size([2, 1, 1]))
+
+    def test_empty_prompt_uses_active_model_dropout_cache_policy(self):
+        dataset_cache = MagicMock()
+        default_cache = MagicMock()
+        default_cache._requires_path_based_keys = True
+        default_cache.model = SimpleNamespace()
+        default_cache.compute_prompt_embeddings_with_model.return_value = {"prompt_embeds": torch.ones(1, 1, 1)}
+        model = MagicMock()
+        model.use_text_cache_dropout_sentinel.return_value = False
+        prompt_entry = {"prompt": "", "key": "dataset:sample.mp4", "metadata": {"context": "sample"}}
+
+        with patch.object(StateTracker, "get_default_text_embed_cache", return_value=default_cache):
+            compute_single_embedding(prompt_entry, dataset_cache, model)
+
+        self.assertEqual(prompt_entry["key"], "dataset:sample.mp4")
+        default_cache.compute_prompt_embeddings_with_model.assert_called_once_with(prompt_records=[prompt_entry])
 
     def test_collate_fn_stacks_conditioning_image_embeds(self):
         conditioning_tensor = torch.ones(2, 4)

--- a/tests/test_collate.py
+++ b/tests/test_collate.py
@@ -241,13 +241,19 @@ class CollateFunctionTests(unittest.TestCase):
         self.assertEqual(result["prompt_embeds"].shape, torch.Size([2, 1, 1]))
 
     def test_empty_prompt_uses_active_model_dropout_cache_policy(self):
+        class FalseyModel:
+            def __bool__(self):
+                return False
+
+            def use_text_cache_dropout_sentinel(self):
+                return False
+
         dataset_cache = MagicMock()
         default_cache = MagicMock()
         default_cache._requires_path_based_keys = True
         default_cache.model = SimpleNamespace()
         default_cache.compute_prompt_embeddings_with_model.return_value = {"prompt_embeds": torch.ones(1, 1, 1)}
-        model = MagicMock()
-        model.use_text_cache_dropout_sentinel.return_value = False
+        model = FalseyModel()
         prompt_entry = {"prompt": "", "key": "dataset:sample.mp4", "metadata": {"context": "sample"}}
 
         with patch.object(StateTracker, "get_default_text_embed_cache", return_value=default_cache):


### PR DESCRIPTION
## Summary
- Passes the active model into single-prompt embedding computation from the collate path.
- Uses the active model when deciding whether empty prompts should use the dropout sentinel key.
- Adds collate coverage for preserving dataset keys when the active model disables the sentinel.

## Validation
- `.venv/bin/python -m unittest -v -f tests.test_collate`
- branch diff and commit message privacy scan passed
