### PR TITLE
add missing sample label in stitched validation outputs

### DIFF
--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -2262,6 +2262,13 @@ class Validation:
 
         return None
 
+    def _validation_step_label(self):
+        return f"step {StateTracker.get_global_step()}"
+
+    def _ema_comparison_labels(self, display_has_checkpoint_label: bool):
+        checkpoint_label = None if display_has_checkpoint_label else self._validation_step_label()
+        return [checkpoint_label, "EMA"]
+
     def stitch_benchmark_image(
         self,
         validation_image_result,
@@ -4887,14 +4894,18 @@ class Validation:
 
                     if has_input_stitching and not will_add_benchmark:
                         # Only input stitching, no benchmark
+                        step_label = self._validation_step_label()
                         display_validation_results = [
                             self.stitch_validation_input_image(
                                 validation_image_result=img,
                                 validation_input_image=validation_input_image_for_resolution,
-                                labels=(["input", f"step {StateTracker.get_global_step()}"]),
+                                labels=(["input", step_label]),
                             )
                             for img in display_validation_results
                         ]
+                        display_has_checkpoint_label = True
+                    else:
+                        display_has_checkpoint_label = False
 
                     # Apply controlnet stitching if needed (using original results)
                     if any([self.config.controlnet, self.config.control]):
@@ -4906,13 +4917,14 @@ class Validation:
 
                     # Apply benchmark stitching if we determined we have a benchmark
                     if will_add_benchmark:
+                        step_label = self._validation_step_label()
                         if has_input_stitching:
                             # Three-way stitch: input | output | benchmark
                             for idx, original_img in enumerate(original_validation_image_results):
                                 labels_to_use = [
                                     "input",
                                     "base model",
-                                    f"step {StateTracker.get_global_step()}",
+                                    step_label,
                                 ]
 
                                 display_validation_results[idx] = self.stitch_three_images(
@@ -4929,9 +4941,10 @@ class Validation:
                                     benchmark_image=benchmark_image,
                                     labels=[
                                         "base model",
-                                        f"step {StateTracker.get_global_step()}",
+                                        step_label,
                                     ],
                                 )
+                        display_has_checkpoint_label = True
 
                     # Handle EMA comparison stitching
                     if self.config.use_ema and self.config.ema_validation == "comparison" and ema_image_results is not None:
@@ -4945,7 +4958,7 @@ class Validation:
                             ema_stitched = self.stitch_benchmark_image(
                                 validation_image_result=ema_img,
                                 benchmark_image=display_img,
-                                labels=[None, "EMA"],
+                                labels=self._ema_comparison_labels(display_has_checkpoint_label),
                             )
                             ema_display_results.append(ema_stitched)
 

--- a/tests/helpers/test_validation_stitching.py
+++ b/tests/helpers/test_validation_stitching.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 from PIL import Image
 
@@ -37,6 +38,18 @@ class TestValidationStitching(unittest.TestCase):
 
         self.assertIsInstance(stitched, Image.Image)
         self.assertEqual(stitched.size, (10 + 12 + 5 + 8 + 5 + 6, 12))
+
+    @patch("simpletuner.helpers.training.validation.StateTracker.get_global_step", return_value=321)
+    def test_ema_comparison_labels_hot_weights_when_display_is_unlabelled(self, _global_step):
+        labels = self.validation._ema_comparison_labels(display_has_checkpoint_label=False)
+
+        self.assertEqual(labels, ["step 321", "EMA"])
+
+    @patch("simpletuner.helpers.training.validation.StateTracker.get_global_step", return_value=321)
+    def test_ema_comparison_keeps_existing_hot_weight_label(self, _global_step):
+        labels = self.validation._ema_comparison_labels(display_has_checkpoint_label=True)
+
+        self.assertEqual(labels, [None, "EMA"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request refactors how validation image labels are generated and handled in the training validation process, focusing on improving code reuse and clarity. It introduces helper methods for label generation, updates label assignment logic throughout the image stitching pipeline, and adds new tests to ensure correct label behavior, especially for EMA (Exponential Moving Average) comparison scenarios.

**Validation label generation improvements:**

* Added `_validation_step_label` and `_ema_comparison_labels` helper methods to encapsulate and centralize label creation logic in `validation.py`.

**Pipeline and stitching logic updates:**

* Refactored label assignment in the validation pipeline to use the new helper methods, reducing duplication and ensuring consistent labeling for validation steps and EMA comparisons. [[1]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09R4897-R4908) [[2]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09R4920-R4927) [[3]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09L4932-R4947) [[4]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09L4948-R4961)

**Testing enhancements:**

* Added unit tests for `_ema_comparison_labels` to verify correct label output depending on whether a checkpoint label is displayed, using mocking to control the global step.
* Imported `patch` from `unittest.mock` to support the new tests.