### PR TITLE
minimax h3: negative prompting fixes for validation

### DIFF
--- a/simpletuner/helpers/configuration/cli_utils.py
+++ b/simpletuner/helpers/configuration/cli_utils.py
@@ -273,6 +273,8 @@ def mapping_to_cli_args(
 
         value_str = str(value).strip()
         if not value_str:
+            if isinstance(value, str) and field is not None and getattr(field, "allow_empty", False):
+                cli_args.append(_format_key_value(key, ""))
             continue
 
         cli_args.append(_format_key_value(key, value_str))

--- a/simpletuner/helpers/models/minimaxh3/before_denoise.py
+++ b/simpletuner/helpers/models/minimaxh3/before_denoise.py
@@ -89,6 +89,36 @@ def _layout_outputs() -> list[OutputParam]:
             type_hint=int,
             description="How many leading audio rows are reference rows rather than generated rows.",
         ),
+        OutputParam(
+            "negative_layout",
+            type_hint=MiniMaxH3PackedSequence,
+            description="Optional negative-branch packed layout for real CFG.",
+        ),
+        OutputParam(
+            "negative_position_ids",
+            type_hint=torch.Tensor,
+            description="Optional negative-branch rotary coordinates.",
+        ),
+        OutputParam(
+            "negative_token_tags",
+            type_hint=torch.Tensor,
+            description="Optional negative-branch modality tags.",
+        ),
+        OutputParam(
+            "negative_video_indices",
+            type_hint=torch.Tensor,
+            description="Optional negative-branch video row positions.",
+        ),
+        OutputParam(
+            "negative_audio_indices",
+            type_hint=torch.Tensor,
+            description="Optional negative-branch audio row positions.",
+        ),
+        OutputParam(
+            "negative_text_indices",
+            type_hint=torch.Tensor,
+            description="Optional negative-branch text row positions.",
+        ),
     ]
 
 
@@ -110,6 +140,18 @@ def _set_layout_state(block_state, layout: MiniMaxH3PackedSequence, device: torc
     if not prefix:
         block_state.num_condition_video_rows = layout.num_condition_video_rows
         block_state.num_condition_audio_rows = layout.num_condition_audio_rows
+
+
+def _clear_negative_layout_state(block_state) -> None:
+    for name in (
+        "layout",
+        "position_ids",
+        "token_tags",
+        "video_indices",
+        "audio_indices",
+        "text_indices",
+    ):
+        setattr(block_state, f"negative_{name}", None)
 
 
 class MiniMaxH3PrepareLayoutStep(ModularPipelineBlocks):
@@ -172,6 +214,8 @@ class MiniMaxH3PrepareLayoutStep(ModularPipelineBlocks):
                 block_state.keyframe_anchors,
             )
             _set_layout_state(block_state, negative_layout, components._execution_device, prefix="negative_")
+        else:
+            _clear_negative_layout_state(block_state)
 
         self.set_block_state(state, block_state)
         return components, state
@@ -237,6 +281,8 @@ class MiniMaxH3Ref2VAPrepareLayoutStep(ModularPipelineBlocks):
                 components.patch_size,
             )
             _set_layout_state(block_state, negative_layout, components._execution_device, prefix="negative_")
+        else:
+            _clear_negative_layout_state(block_state)
 
         self.set_block_state(state, block_state)
         return components, state

--- a/simpletuner/helpers/models/minimaxh3/denoise.py
+++ b/simpletuner/helpers/models/minimaxh3/denoise.py
@@ -364,7 +364,7 @@ def _predict_guided_velocity(
     video_velocity, audio_velocity = positive_video, positive_audio
 
     guidance_scale = _resolve_guidance_scale(block_state)
-    apply_cfg = guidance_scale > 1.0 and _within_cfg_window(block_state, i)
+    apply_cfg = guidance_scale != 1.0 and _within_cfg_window(block_state, i)
     if apply_cfg:
         negative_prompt_embeds = _validate_negative_branch(block_state)
         negative_video, negative_audio = _predict_velocity(

--- a/simpletuner/helpers/models/minimaxh3/model.py
+++ b/simpletuner/helpers/models/minimaxh3/model.py
@@ -709,19 +709,12 @@ class MiniMaxH3(VideoModelFoundation):
         if max_text_length is None:
             max_text_length = MINIMAX_H3_DEFAULT_MAX_TEXT_LENGTH
         prompt_contexts = getattr(self, "_current_prompt_contexts", None)
-        allow_contextless_validation = bool(getattr(self, "_current_prompt_is_validation", False))
         if self.requires_text_embed_image_context():
             if not prompt_contexts or len(prompt_contexts) != len(prompts):
-                if not allow_contextless_validation:
-                    raise ValueError("MiniMax-H3 FL2VA text encoding requires image context for each caption.")
                 prompt_contexts = [{} for _ in prompts]
                 prompt_images = [None] * len(prompts)
             else:
-                prompt_images = self._prepare_prompt_image_batch(
-                    prompt_contexts,
-                    len(prompts),
-                    allow_contextless_validation=allow_contextless_validation,
-                )
+                prompt_images = self._prepare_prompt_image_batch(prompt_contexts, len(prompts))
         else:
             prompt_images = [None] * len(prompts)
         if prompt_contexts is None:
@@ -771,16 +764,14 @@ class MiniMaxH3(VideoModelFoundation):
         self,
         prompt_contexts: list[dict],
         batch_size: int,
-        *,
-        allow_contextless_validation: bool = False,
     ) -> list[list[Image.Image] | None]:
         if not prompt_contexts or len(prompt_contexts) != batch_size:
-            raise ValueError("MiniMax-H3 FL2VA text encoding requires one image context per caption.")
+            raise ValueError("MiniMax-H3 text encoding requires one context record per caption.")
         image_batch = []
         for index, context in enumerate(prompt_contexts):
             image = self._extract_prompt_image_from_context(context)
             if image is None:
-                if allow_contextless_validation and not self._prompt_context_declares_image(context):
+                if not self._prompt_context_declares_image(context):
                     image_batch.append(None)
                     continue
                 raise ValueError(f"Failed to resolve MiniMax-H3 text conditioning image for caption index {index}.")
@@ -795,10 +786,7 @@ class MiniMaxH3(VideoModelFoundation):
             context.get(key) is not None
             for key in (
                 "conditioning_pixel_values",
-                "image_path",
                 "image_paths",
-                "data_backend_id",
-                "data_backend_ids",
             )
         )
 
@@ -817,8 +805,9 @@ class MiniMaxH3(VideoModelFoundation):
             else:
                 data_backend_id = context.get("data_backend_id")
         else:
-            image_path = context.get("image_path")
-            data_backend_id = context.get("data_backend_id")
+            # `image_path` alone identifies the target sample in ordinary T2V
+            # backends. Only plural paths or direct pixels denote reference context.
+            return None
         if not image_path or not data_backend_id:
             return None
         backend_entry = StateTracker.get_data_backend(data_backend_id)
@@ -875,7 +864,7 @@ class MiniMaxH3(VideoModelFoundation):
 
     def convert_negative_text_embed_for_pipeline(self, text_embedding: dict) -> dict:
         guidance_scale = float(getattr(self.config, "validation_guidance_real", 1.0) or 1.0)
-        if guidance_scale <= 1.0:
+        if guidance_scale == 1.0:
             return {}
         result = {
             "negative_prompt_embeds": text_embedding["prompt_embeds"],
@@ -1072,7 +1061,7 @@ class MiniMaxH3(VideoModelFoundation):
         return True
 
     def uses_validation_negative_prompt(self) -> bool:
-        return float(getattr(self.config, "validation_guidance_real", 1.0) or 1.0) > 1.0
+        return float(getattr(self.config, "validation_guidance_real", 1.0) or 1.0) != 1.0
 
     def validation_negative_prompt_requires_prompt_context(self) -> bool:
         return True
@@ -1085,7 +1074,7 @@ class MiniMaxH3(VideoModelFoundation):
         guidance_scale_real = pipeline_kwargs.pop("guidance_scale_real", None)
         if guidance_scale_real is None:
             guidance_scale_real = getattr(self.config, "validation_guidance_real", None)
-        if guidance_scale_real is not None and float(guidance_scale_real) > 1.0:
+        if guidance_scale_real is not None and float(guidance_scale_real) != 1.0:
             pipeline_kwargs["guidance_scale"] = float(guidance_scale_real)
             if isinstance(getattr(self.config, "validation_no_cfg_until_timestep", None), int):
                 pipeline_kwargs.setdefault(

--- a/simpletuner/helpers/multiaspect/sampler.py
+++ b/simpletuner/helpers/multiaspect/sampler.py
@@ -569,6 +569,48 @@ class MultiAspectSampler(torch.utils.data.Sampler):
             f"Bucket {bucket} is empty or doesn't have enough samples for a full batch. Removing from bucket list. {len(self.buckets)} remain."
         )
 
+    @staticmethod
+    def _positive_int(value):
+        try:
+            value = int(value)
+        except (TypeError, ValueError):
+            return None
+        return value if value > 0 else None
+
+    def _configured_max_samples(self, data_backend_config):
+        configured_max_samples = self._positive_int(data_backend_config.get("max_num_samples"))
+        if configured_max_samples is not None:
+            return configured_max_samples
+        return self._positive_int(getattr(self.metadata_backend, "max_num_samples", None))
+
+    def _bucket_report_total(self, stage: str):
+        bucket_report = getattr(self.metadata_backend, "bucket_report", None)
+        bucket_summaries = getattr(bucket_report, "bucket_summaries", None)
+        if not isinstance(bucket_summaries, dict):
+            return None
+        summary = bucket_summaries.get(stage)
+        if not isinstance(summary, dict):
+            return None
+        return self._positive_int(summary.get("total_samples"))
+
+    def _model_card_sample_count(self, data_backend_config):
+        configured_max_samples = self._configured_max_samples(data_backend_config)
+        report_total = self._bucket_report_total("post_refresh")
+        if report_total is not None:
+            total_sample_count = report_total
+            approximate = False
+        else:
+            total_sample_count = sum(len(indices) for indices in self.metadata_backend.aspect_ratio_bucket_indices.values())
+            effective_dp_size, _dp_rank, _cp_size = get_cp_aware_dp_info(self.accelerator)
+            approximate = effective_dp_size > 1
+            if approximate:
+                total_sample_count *= effective_dp_size
+
+        if configured_max_samples is not None:
+            total_sample_count = min(total_sample_count, configured_max_samples)
+            approximate = False
+        return f"~{total_sample_count}" if approximate else total_sample_count
+
     def log_state(self, show_rank: bool = True, alt_stats: bool = False):
         # self.debug_log(
         #     f'Active Buckets: {", ".join(self.convert_to_human_readable(float(b), self.metadata_backend.aspect_ratio_bucket_indices[b], self.resolution) for b in self.buckets)}'
@@ -580,18 +622,7 @@ class MultiAspectSampler(torch.utils.data.Sampler):
             # Return an overview instead of a snapshot.
             # Eg. return totals, and not "as it is now"
             data_backend_config = StateTracker.get_data_backend_config(self.id)
-            total_image_count = len(self.metadata_backend.seen_images) + len(self._get_unseen_images())
-            configured_max_samples = data_backend_config.get("max_num_samples")
-            try:
-                configured_max_samples = int(configured_max_samples)
-            except (TypeError, ValueError):
-                configured_max_samples = None
-            if configured_max_samples is not None and configured_max_samples > 0:
-                total_image_count = min(total_image_count * self.accelerator.num_processes, configured_max_samples)
-            elif self.accelerator.num_processes > 1:
-                # We don't know the direct count without more work, so we'll estimate it here for multi-GPU training.
-                total_image_count *= self.accelerator.num_processes
-                total_image_count = f"~{total_image_count}"
+            total_image_count = self._model_card_sample_count(data_backend_config)
             printed_state = [f"- Repeats: {data_backend_config.get('repeats', 0)}"]
             printed_state.append(f"- Total number of {self.sample_type_strs}: {total_image_count}")
             printed_state.append(f"- Total number of aspect buckets: {len(self.buckets)}")

--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -826,10 +826,10 @@ def _validation_negative_prompt_record(
         metadata = (
             _validation_reference_prompt_metadata(validation_input_image) if validation_input_image is not None else {}
         )
-        if not metadata:
-            raise ValueError("Validation negative prompt encoding requires image context for this model.")
         if positive_prompt is not None:
             metadata["positive_prompt"] = positive_prompt
+        if not metadata:
+            raise ValueError("Validation negative prompt encoding requires prompt or image context for this model.")
         return {
             "prompt": negative_prompt,
             "key": _validation_negative_text_cache_key(args, shortname, negative_prompt),
@@ -851,6 +851,7 @@ def prepare_validation_prompt_list(args, embed_cache, model):
         [PromptLibraryEntry(prompt="")] if not StateTracker.get_args().validation_disable_unconditional else []
     )
     validation_shortnames = ["unconditional"] if not StateTracker.get_args().validation_disable_unconditional else []
+    validation_prompt_inputs: dict[str, Any] = {}
     if model_uses_text_cache and not hasattr(embed_cache, "model_type"):
         raise ValueError(
             f"The default text embed cache backend was not found. You must specify 'default: true' on your text embed data backend via {StateTracker.get_args().data_backend_config}."
@@ -941,6 +942,8 @@ def prepare_validation_prompt_list(args, embed_cache, model):
                         embed_cache.compute_embeddings_for_prompts([prompt_record], load_from_cache=False)
                 sample_prompts.append(PromptLibraryEntry(prompt=validation_prompt))
                 sample_shortnames.append(shortname)
+                if reference_images:
+                    validation_prompt_inputs[shortname] = reference_images
             if sample_prompts:
                 validation_prompts.extend(sample_prompts)
                 validation_shortnames.extend(sample_shortnames)
@@ -1036,18 +1039,37 @@ def prepare_validation_prompt_list(args, embed_cache, model):
     # Compute negative embed for validation prompts, if any are set, so that it's stored before we unload the text encoder.
     if validation_prompts and precompute_text_embeddings:
         negative_prompt = StateTracker.get_args().validation_negative_prompt
+        needs_context = model.validation_negative_prompt_requires_prompt_context()
         if (
             negative_prompt is not None
             and str(negative_prompt).strip().lower() != "none"
-            and negative_prompt != ""
+            and (negative_prompt != "" or needs_context)
             and model.uses_validation_negative_prompt()
         ):
             if getattr(args, "model_family", None) == "ideogram":
                 logger.info(f"Precomputing the negative prompt embed for validations: {negative_prompt}")
                 model.log_model_devices()
                 embed_cache.encode_validation_negative_prompt(negative_prompt)
-            elif model.validation_negative_prompt_requires_prompt_context():
-                logger.info("Deferring validation negative prompt encoding; this model needs per-sample prompt context.")
+            elif needs_context:
+                logger.info("Precomputing context-dependent negative prompt embeds for validations.")
+                model.log_model_devices()
+                for entry, shortname in zip(validation_prompts, validation_shortnames):
+                    if shortname == "unconditional":
+                        continue
+                    negative_prompt_record = _validation_negative_prompt_record(
+                        args,
+                        model,
+                        negative_prompt,
+                        shortname,
+                        validation_prompt_inputs.get(shortname),
+                        positive_prompt=entry.prompt,
+                    )
+                    embed_cache.compute_embeddings_for_prompts(
+                        [negative_prompt_record],
+                        is_validation=True,
+                        load_from_cache=False,
+                        is_negative_prompt=True,
+                    )
             elif model.should_precompute_validation_negative_prompt():
                 logger.info(f"Precomputing the negative prompt embed for validations: {negative_prompt}")
                 model.log_model_devices()

--- a/simpletuner/inference.py
+++ b/simpletuner/inference.py
@@ -138,7 +138,10 @@ class CheckpointInferenceRuntime:
         )
         StateTracker.set_default_text_embed_cache(self.embed_cache)
         self.embed_cache.discover_all_files()
-        if trainer.model.uses_validation_negative_prompt():
+        if (
+            trainer.model.uses_validation_negative_prompt()
+            and not trainer.model.validation_negative_prompt_requires_prompt_context()
+        ):
             negative_prompt = trainer.config.validation_negative_prompt or ""
             if trainer.config.model_family == "ideogram":
                 self.embed_cache.encode_validation_negative_prompt(negative_prompt)

--- a/tests/test_allow_empty_fields.py
+++ b/tests/test_allow_empty_fields.py
@@ -16,6 +16,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from simpletuner.helpers.configuration.cli_utils import mapping_to_cli_args
 from simpletuner.simpletuner_sdk.server.services.configs_service import ConfigsService
 from simpletuner.simpletuner_sdk.server.services.field_service import FieldService
 from simpletuner.simpletuner_sdk.server.services.training_service import build_config_bundle
@@ -23,6 +24,11 @@ from simpletuner.simpletuner_sdk.server.services.training_service import build_c
 
 class TestAllowEmptyFields(unittest.TestCase):
     """Test allow_empty field handling through the full stack."""
+
+    def test_empty_string_preserved_when_mapping_to_cli_args(self):
+        result = mapping_to_cli_args({"validation_negative_prompt": ""})
+
+        self.assertIn("--validation_negative_prompt=", result)
 
     def test_empty_string_preserved_in_form_submission(self):
         """Test that empty strings are preserved during form normalization."""

--- a/tests/test_minimaxh3.py
+++ b/tests/test_minimaxh3.py
@@ -15,7 +15,7 @@ from simpletuner.helpers.models.common import PipelineTypes, TextEmbedCacheKey
 from simpletuner.helpers.models.ideogram.quantized_loading import Fp8Linear
 from simpletuner.helpers.models.minimaxh3.activations import MiniMaxH3FeedForward
 from simpletuner.helpers.models.minimaxh3.autoencoder import AutoencoderKLMiniMaxH3
-from simpletuner.helpers.models.minimaxh3.before_denoise import MiniMaxH3SetTimestepsStep
+from simpletuner.helpers.models.minimaxh3.before_denoise import MiniMaxH3PrepareLayoutStep, MiniMaxH3SetTimestepsStep
 from simpletuner.helpers.models.minimaxh3.before_encoder import MiniMaxH3SetupStep
 from simpletuner.helpers.models.minimaxh3.denoise import _denoiser_inputs, _predict_guided_velocity
 from simpletuner.helpers.models.minimaxh3.encoders import MiniMaxH3TextEncoderStep
@@ -826,11 +826,34 @@ class MiniMaxH3Tests(unittest.TestCase):
         self.assertEqual(encoded["prompt_embeds"].shape, (1, 3, 4))
         self.assertIsNone(encode_prompt.call_args.kwargs["images"])
 
-    def test_nonvalidation_prompt_still_requires_image_context(self):
+    def test_t2v_training_prompt_ignores_source_video_as_image_context(self):
         model = MiniMaxH3.__new__(MiniMaxH3)
         model.accelerator = SimpleNamespace(device=torch.device("cpu"))
         model.config = SimpleNamespace(weight_dtype=torch.float32)
-        model._current_prompt_contexts = [{}]
+        model._current_prompt_contexts = [
+            {
+                "image_path": "/dataset/target.mp4",
+                "data_backend_id": "openvid",
+            }
+        ]
+        model._text_encoder_components = lambda: SimpleNamespace(transformer=SimpleNamespace(dtype=torch.float32))
+
+        with patch(
+            "simpletuner.helpers.models.minimaxh3.model.MiniMaxH3TextEncoderStep.encode_prompt",
+            return_value=(
+                torch.zeros(1, 3, 4),
+                torch.tensor([1, 1, 1], dtype=torch.long),
+            ),
+        ) as encode_prompt:
+            model._encode_prompts(["caption"])
+
+        self.assertIsNone(encode_prompt.call_args.kwargs["images"])
+
+    def test_declared_reference_context_still_requires_resolvable_image(self):
+        model = MiniMaxH3.__new__(MiniMaxH3)
+        model.accelerator = SimpleNamespace(device=torch.device("cpu"))
+        model.config = SimpleNamespace(weight_dtype=torch.float32)
+        model._current_prompt_contexts = [{"image_paths": ["/missing/reference.png"]}]
         model._text_encoder_components = lambda: SimpleNamespace(transformer=SimpleNamespace(dtype=torch.float32))
 
         with self.assertRaisesRegex(ValueError, "Failed to resolve MiniMax-H3 text conditioning image"):
@@ -2017,6 +2040,59 @@ class MiniMaxH3Tests(unittest.TestCase):
         )
         self.assertEqual(transformer.calls[2]["skip_layers"], [1])
 
+    def test_prepare_layout_persists_negative_branch_outputs(self):
+        output_names = {output.name for output in MiniMaxH3PrepareLayoutStep().intermediate_outputs}
+
+        self.assertTrue(
+            {
+                "negative_layout",
+                "negative_position_ids",
+                "negative_token_tags",
+                "negative_video_indices",
+                "negative_audio_indices",
+                "negative_text_indices",
+            }.issubset(output_names)
+        )
+
+    def test_prepare_layout_sets_absent_negative_branch_outputs_to_none(self):
+        step = MiniMaxH3PrepareLayoutStep()
+        block_state = SimpleNamespace(
+            text_token_tags=torch.full((3,), MINIMAX_H3_TEXT_TAG, dtype=torch.long),
+            negative_text_token_tags=None,
+            num_latent_frames=1,
+            latent_height=2,
+            latent_width=2,
+            num_audio_latents=0,
+            keyframe_anchors=(),
+        )
+        step.get_block_state = Mock(return_value=block_state)
+        step.set_block_state = Mock()
+        components = SimpleNamespace(patch_size=(1, 2, 2), _execution_device=torch.device("cpu"))
+
+        step(components, object())
+
+        for name in (
+            "negative_layout",
+            "negative_position_ids",
+            "negative_token_tags",
+            "negative_video_indices",
+            "negative_audio_indices",
+            "negative_text_indices",
+        ):
+            self.assertIsNone(getattr(block_state, name))
+
+    def test_guided_velocity_supports_deguidance(self):
+        transformer = FakeH3Transformer()
+        block_state = tiny_block_state_for_guidance()
+        block_state.guidance_scale = 1.0 / 3.0
+        block_state.skip_guidance_layers = []
+
+        video, audio = _predict_guided_velocity(transformer, block_state, i=0, num_steps=1)
+
+        self.assertTrue(torch.allclose(video, torch.full_like(video, 4.0 / 3.0)))
+        self.assertTrue(torch.allclose(audio, torch.full_like(audio, 34.0 / 3.0)))
+        self.assertEqual([call["text_rows"] for call in transformer.calls], [5, 3])
+
     def test_convert_negative_text_embed_for_pipeline_enables_real_cfg(self):
         wrapper = MiniMaxH3.__new__(MiniMaxH3)
         wrapper.config = SimpleNamespace(validation_guidance_real=4.0, validation_no_cfg_until_timestep=2)
@@ -2041,6 +2117,9 @@ class MiniMaxH3Tests(unittest.TestCase):
         wrapper.config.validation_guidance_real = 2.0
         self.assertTrue(wrapper.uses_validation_negative_prompt())
         self.assertFalse(wrapper.should_precompute_validation_negative_prompt())
+
+        wrapper.config.validation_guidance_real = 1.0 / 3.0
+        self.assertTrue(wrapper.uses_validation_negative_prompt())
 
     def test_validation_negative_prompt_record_uses_image_context_key(self):
         wrapper = MiniMaxH3.__new__(MiniMaxH3)
@@ -2069,10 +2148,26 @@ class MiniMaxH3Tests(unittest.TestCase):
         wrapper.config = SimpleNamespace(validation_guidance_real=2.0)
         args = SimpleNamespace(model_family="minimax_h3")
 
-        with self.assertRaisesRegex(ValueError, "requires image context"):
+        with self.assertRaisesRegex(ValueError, "requires prompt or image context"):
             _validation_negative_prompt_record(args, wrapper, "bad blur", "sample-a", None)
 
-    def test_validation_negative_prompt_precompute_is_skipped_for_h3(self):
+    def test_validation_negative_prompt_record_accepts_t2v_prompt_context(self):
+        wrapper = MiniMaxH3.__new__(MiniMaxH3)
+        wrapper.config = SimpleNamespace(validation_guidance_real=2.0)
+        args = SimpleNamespace(model_family="minimax_h3")
+
+        record = _validation_negative_prompt_record(
+            args,
+            wrapper,
+            "",
+            "sample-a",
+            None,
+            positive_prompt="visible prompt",
+        )
+
+        self.assertEqual(record["metadata"], {"positive_prompt": "visible prompt"})
+
+    def test_validation_negative_prompt_is_precomputed_for_h3(self):
         class DummyEmbedCache:
             model_type = "minimax_h3"
             text_cache_ondemand = False
@@ -2093,7 +2188,7 @@ class MiniMaxH3Tests(unittest.TestCase):
             validation_prompt_library=False,
             user_prompt_library=None,
             validation_prompt="visible prompt",
-            validation_negative_prompt="bad blur",
+            validation_negative_prompt="",
             validation_disable_unconditional=True,
             data_backend_config="config.json",
         )
@@ -2115,14 +2210,18 @@ class MiniMaxH3Tests(unittest.TestCase):
             [entry.prompt for entry in metadata["validation_prompts"]],
             ["visible prompt"],
         )
-        wrapper.log_model_devices.assert_not_called()
+        wrapper.log_model_devices.assert_called_once_with()
         embed_cache.encode_validation_negative_prompt.assert_not_called()
         negative_calls = [
             call
             for call in embed_cache.compute_embeddings_for_prompts.call_args_list
             if call.kwargs.get("is_negative_prompt")
         ]
-        self.assertEqual(negative_calls, [])
+        self.assertEqual(len(negative_calls), 1)
+        negative_record = negative_calls[0].args[0][0]
+        self.assertEqual(negative_record["prompt"], "")
+        self.assertEqual(negative_record["metadata"], {"positive_prompt": "visible prompt"})
+        self.assertFalse(negative_calls[0].kwargs["load_from_cache"])
 
     def test_comfy_lora_conversion_maps_h3_names_and_splits_qkv(self):
         qkv_down = torch.randn(4, 16)

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -69,7 +69,10 @@ class TestMultiAspectSampler(unittest.TestCase):
         sampler.id = "video-dataset"
         sampler.metadata_backend = SimpleNamespace(seen_images={str(i): True for i in range(1000)})
         sampler._get_unseen_images = MagicMock(return_value=[None] * 3997)
-        sampler.accelerator = SimpleNamespace(num_processes=8)
+        sampler.metadata_backend.aspect_ratio_bucket_indices = {"1.0": [None] * 600}
+        sampler.metadata_backend.max_num_samples = 4096
+        sampler.metadata_backend.bucket_report = None
+        sampler.accelerator = SimpleNamespace(num_processes=8, process_index=0)
         sampler.logger = MagicMock()
         sampler.sample_type_strs = "videos"
         sampler.buckets = ["0.75", "1.0", "1.25", "1.5", "1.75"]
@@ -80,7 +83,7 @@ class TestMultiAspectSampler(unittest.TestCase):
             patch.object(
                 StateTracker,
                 "get_data_backend_config",
-                return_value={"max_num_samples": 4096, "video": {"num_frames": 39}},
+                return_value={"max_num_samples": "not-an-int", "video": {"num_frames": 39}},
             ),
             patch.object(StateTracker, "get_dataset_schedule", return_value={"reached": True}),
         ):
@@ -90,6 +93,91 @@ class TestMultiAspectSampler(unittest.TestCase):
         self.assertIn("- Target frame count: 39", overview)
         self.assertIn("- FPS: unknown", overview)
         self.assertNotIn("~39976", overview)
+        self.assertNotIn("~4800", overview)
+
+    def test_model_card_overview_uses_bucket_count_not_seen_progress(self):
+        sampler = object.__new__(MultiAspectSampler)
+        sampler.id = "video-dataset"
+        sampler.metadata_backend = SimpleNamespace(
+            aspect_ratio_bucket_indices={"1.0": [None] * 65536},
+            bucket_report=None,
+            max_num_samples=None,
+            seen_images={str(i): True for i in range(5740)},
+        )
+        sampler._get_unseen_images = MagicMock(return_value=[None] * 65536)
+        sampler.accelerator = SimpleNamespace(num_processes=4, process_index=0)
+        sampler.logger = MagicMock()
+        sampler.sample_type_strs = "videos"
+        sampler.buckets = ["1.0"]
+        sampler.is_regularisation_data = False
+        sampler.conditioning_type = None
+
+        with (
+            patch.object(StateTracker, "get_data_backend_config", return_value={"video": {"num_frames": 39}}),
+            patch.object(StateTracker, "get_dataset_schedule", return_value={"reached": True}),
+            patch("simpletuner.helpers.multiaspect.sampler.get_cp_aware_dp_info", return_value=(1, 0, 4)),
+        ):
+            overview = sampler.log_state(show_rank=False, alt_stats=True)
+
+        self.assertIn("- Total number of videos: 65536", overview)
+        self.assertNotIn("285096", overview)
+        self.assertNotIn("~", overview)
+
+    def test_model_card_overview_scales_data_parallel_bucket_shard_without_seen_progress(self):
+        sampler = object.__new__(MultiAspectSampler)
+        sampler.id = "video-dataset"
+        sampler.metadata_backend = SimpleNamespace(
+            aspect_ratio_bucket_indices={"1.0": [None] * 8192},
+            bucket_report=None,
+            max_num_samples=None,
+            seen_images={str(i): True for i in range(250)},
+        )
+        sampler._get_unseen_images = MagicMock(return_value=[None] * 7942)
+        sampler.accelerator = SimpleNamespace(num_processes=8, process_index=0)
+        sampler.logger = MagicMock()
+        sampler.sample_type_strs = "videos"
+        sampler.buckets = ["1.0"]
+        sampler.is_regularisation_data = False
+        sampler.conditioning_type = None
+
+        with (
+            patch.object(StateTracker, "get_data_backend_config", return_value={}),
+            patch.object(StateTracker, "get_dataset_schedule", return_value={"reached": True}),
+            patch("simpletuner.helpers.multiaspect.sampler.get_cp_aware_dp_info", return_value=(8, 0, 1)),
+        ):
+            overview = sampler.log_state(show_rank=False, alt_stats=True)
+
+        self.assertIn("- Total number of videos: ~65536", overview)
+        self.assertNotIn("67536", overview)
+
+    def test_model_card_overview_prefers_exact_bucket_report_total(self):
+        sampler = object.__new__(MultiAspectSampler)
+        sampler.id = "image-dataset"
+        sampler.metadata_backend = SimpleNamespace(
+            aspect_ratio_bucket_indices={"1.0": [None] * 16},
+            bucket_report=SimpleNamespace(bucket_summaries={"post_refresh": {"total_samples": 123}}),
+            max_num_samples=None,
+            seen_images={str(i): True for i in range(7)},
+        )
+        sampler._get_unseen_images = MagicMock(return_value=[None] * 16)
+        sampler.accelerator = SimpleNamespace(num_processes=8, process_index=0)
+        sampler.logger = MagicMock()
+        sampler.sample_type_strs = "images"
+        sampler.buckets = ["1.0"]
+        sampler.is_regularisation_data = False
+        sampler.conditioning_type = None
+        sampler.resolution = 512
+        sampler.resolution_type = "pixel"
+
+        with (
+            patch.object(StateTracker, "get_data_backend_config", return_value={}),
+            patch.object(StateTracker, "get_dataset_schedule", return_value={"reached": True}),
+            patch("simpletuner.helpers.multiaspect.sampler.get_cp_aware_dp_info", return_value=(8, 0, 1)),
+        ):
+            overview = sampler.log_state(show_rank=False, alt_stats=True)
+
+        self.assertIn("- Total number of images: 123", overview)
+        self.assertNotIn("~128", overview)
 
     def test_save_state(self):
         with patch.object(self.sampler.state_manager, "save_state") as mock_save_state:


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes across the codebase, primarily focused on better handling of negative prompt logic, prompt context requirements, sample counting/reporting, and support for empty string CLI arguments. It also adds new outputs and state management for negative-branch layouts in the MiniMax-H3 model pipeline, and improves test coverage for CLI argument mapping.

**Negative prompt handling and prompt context requirements:**

* Refined the logic for when negative prompt embeddings are used: negative prompts are now applied whenever the guidance scale is not exactly 1.0 (previously only when >1.0), affecting both model configuration and runtime behavior (`model.py`, `denoise.py`). [[1]](diffhunk://#diff-30ffe091aab82bdafdba22d7ab2f6464e77ac8052186d12395f4e2be9dd9859bL367-R367) [[2]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fL878-R867) [[3]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fL1075-R1064) [[4]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fL1088-R1077)
* Improved the logic for encoding prompts and handling prompt contexts, ensuring that image context requirements are enforced more strictly and consistently, and simplifying related code paths (`model.py`, `validation.py`, `inference.py`). [[1]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fL712-R717) [[2]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fL774-R774) [[3]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fL798-L801) [[4]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fL820-R810) [[5]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09L829-R832) [[6]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09R1042-R1072) [[7]](diffhunk://#diff-3dcec3f148d3d819d52e4782409ead7a16fa6535f02b4df43fa26d1ccbea03e8L141-R144)
* Enhanced the validation prompt preparation to precompute and cache context-dependent negative prompt embeddings for each validation prompt when required, instead of deferring or skipping them (`validation.py`). [[1]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09R854) [[2]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09R945-R946) [[3]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09R1042-R1072)

**MiniMax-H3 negative-branch layout support:**

* Added new output parameters and state management for negative-branch layouts, including packed sequences and various index tensors, and ensured proper state clearing when not in use (`before_denoise.py`). [[1]](diffhunk://#diff-133ff4fc96964f924037ae27a5eb4b3be8a0d365ca33c2ed8a1a5d3f816aad45R92-R121) [[2]](diffhunk://#diff-133ff4fc96964f924037ae27a5eb4b3be8a0d365ca33c2ed8a1a5d3f816aad45R145-R156) [[3]](diffhunk://#diff-133ff4fc96964f924037ae27a5eb4b3be8a0d365ca33c2ed8a1a5d3f816aad45R217-R218) [[4]](diffhunk://#diff-133ff4fc96964f924037ae27a5eb4b3be8a0d365ca33c2ed8a1a5d3f816aad45R284-R285)

**Sample counting and reporting improvements:**

* Refactored sample counting logic in the multi-aspect sampler to provide more accurate and robust reporting, especially for distributed/multi-GPU training scenarios, and centralized logic for determining configured sample limits (`sampler.py`). [[1]](diffhunk://#diff-75840b55abd559f646fd0c6246dc61b884be967b92ea2950f6f036266cd647a2R572-R613) [[2]](diffhunk://#diff-75840b55abd559f646fd0c6246dc61b884be967b92ea2950f6f036266cd647a2L583-R625)

**CLI argument and test improvements:**

* Enhanced the `mapping_to_cli_args` utility to support fields that explicitly allow empty strings, and added a corresponding unit test to ensure this behavior is preserved (`cli_utils.py`, `test_allow_empty_fields.py`). [[1]](diffhunk://#diff-31579b1d6cf8d0179cb7ba18af403cb2a245c7820f42a78bb4cde60a74204f35R276-R277) [[2]](diffhunk://#diff-8a769246117f71a189d86b3d5da23fc51e6e9477c2441ac81086e0a7d2c58dd4R19) [[3]](diffhunk://#diff-8a769246117f71a189d86b3d5da23fc51e6e9477c2441ac81086e0a7d2c58dd4R28-R32)

---

**Negative prompt and prompt context logic:**
- Refined negative prompt application to use guidance scale ≠ 1.0 and improved context-dependent negative prompt embedding precomputation and enforcement. [[1]](diffhunk://#diff-30ffe091aab82bdafdba22d7ab2f6464e77ac8052186d12395f4e2be9dd9859bL367-R367) [[2]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fL878-R867) [[3]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fL1075-R1064) [[4]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fL1088-R1077) [[5]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fL712-R717) [[6]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fL774-R774) [[7]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fL798-L801) [[8]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fL820-R810) [[9]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09L829-R832) [[10]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09R854) [[11]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09R945-R946) [[12]](diffhunk://#diff-a9d2f29d2f51332df9278b5ae38e00c8d7098f60c9e085723e5bc1fbba0b8b09R1042-R1072) [[13]](diffhunk://#diff-3dcec3f148d3d819d52e4782409ead7a16fa6535f02b4df43fa26d1ccbea03e8L141-R144)

**MiniMax-H3 negative-branch layout support:**
- Added negative-branch layout outputs and state management, including clearing logic when not used, for improved CFG support. [[1]](diffhunk://#diff-133ff4fc96964f924037ae27a5eb4b3be8a0d365ca33c2ed8a1a5d3f816aad45R92-R121) [[2]](diffhunk://#diff-133ff4fc96964f924037ae27a5eb4b3be8a0d365ca33c2ed8a1a5d3f816aad45R145-R156) [[3]](diffhunk://#diff-133ff4fc96964f924037ae27a5eb4b3be8a0d365ca33c2ed8a1a5d3f816aad45R217-R218) [[4]](diffhunk://#diff-133ff4fc96964f924037ae27a5eb4b3be8a0d365ca33c2ed8a1a5d3f816aad45R284-R285)

**Sample counting/reporting:**
- Improved sample counting and reporting in the multi-aspect sampler, handling distributed training and configuration limits more robustly. [[1]](diffhunk://#diff-75840b55abd559f646fd0c6246dc61b884be967b92ea2950f6f036266cd647a2R572-R613) [[2]](diffhunk://#diff-75840b55abd559f646fd0c6246dc61b884be967b92ea2950f6f036266cd647a2L583-R625)

**CLI argument handling and tests:**
- Updated `mapping_to_cli_args` to support explicit empty string fields and added a test for this behavior. [[1]](diffhunk://#diff-31579b1d6cf8d0179cb7ba18af403cb2a245c7820f42a78bb4cde60a74204f35R276-R277) [[2]](diffhunk://#diff-8a769246117f71a189d86b3d5da23fc51e6e9477c2441ac81086e0a7d2c58dd4R19) [[3]](diffhunk://#diff-8a769246117f71a189d86b3d5da23fc51e6e9477c2441ac81086e0a7d2c58dd4R28-R32)