### PR TITLE
AnyFlow: improve reproducibility of results

### DIFF
--- a/documentation/experimental/ANYFLOW.es.md
+++ b/documentation/experimental/ANYFLOW.es.md
@@ -90,6 +90,10 @@ MiniMax-H3 ya contiene destilación CFG, por lo que sus ejecuciones on-policy no
 `real_score_guidance_scale=0`. Los modelos que requieren una pasada CFG externa para el score real deben cachear
 embeddings de texto negativos y pueden configurar la escala explícitamente.
 
+Cuando `--seed` está definido, AnyFlow samplea intervalos MeanFlow, schedules de rollout, latentes de rollout, ruido DMD
+y sigmas DMD desde un generador Torch aislado por dispositivo. Esto mantiene estables las muestras AnyFlow cuando código
+de entrenamiento no relacionado consume el RNG global de Torch. No vuelve bit-estable el backward de attention en CUDA.
+
 ## Configuración compartida
 
 - `stage`: `forward` u `onpolicy`. Predeterminado: `forward`.

--- a/documentation/experimental/ANYFLOW.hi.md
+++ b/documentation/experimental/ANYFLOW.hi.md
@@ -88,6 +88,10 @@ no-grad student rollout चलाता है, logit-normal shifted time sample
 MiniMax-H3 में पहले से CFG distillation है, इसलिए इसके on-policy runs में आम तौर पर `real_score_guidance_scale=0` रखा जाना चाहिए।
 जिन models को external real-score CFG pass चाहिए, उन्हें negative text embeddings cache करने होंगे और scale explicitly set किया जा सकता है।
 
+जब `--seed` set होता है, AnyFlow MeanFlow intervals, rollout schedules, rollout latents, DMD noise, और DMD sigmas को
+per-device isolated Torch generator से sample करता है। इससे unrelated training code के global Torch RNG consume करने पर
+भी AnyFlow samples stable रहते हैं। यह CUDA attention backward को bit-stable नहीं बनाता।
+
 ## Shared Configuration
 
 - `stage`: `forward` या `onpolicy`। Default: `forward`।

--- a/documentation/experimental/ANYFLOW.ja.md
+++ b/documentation/experimental/ANYFLOW.ja.md
@@ -88,6 +88,10 @@ adapter と optimizer は、各 SimpleTuner checkpoint の横に `anyflow_discri
 MiniMax-H3 はすでに CFG distillation を含むため、on-policy run では通常 `real_score_guidance_scale=0` のままにします。
 外部 real-score CFG pass が必要なモデルでは negative text embeddings を cache し、scale を明示的に設定できます。
 
+`--seed` が設定されている場合、AnyFlow は MeanFlow interval、rollout schedule、rollout latent、DMD noise、DMD
+sigma を device ごとに隔離された Torch generator から sample します。これにより、無関係な training code が global
+Torch RNG を消費しても AnyFlow sample は安定します。CUDA attention backward を bit-stable にするものではありません。
+
 ## 共通設定
 
 - `stage`: `forward` または `onpolicy`。デフォルト: `forward`。

--- a/documentation/experimental/ANYFLOW.md
+++ b/documentation/experimental/ANYFLOW.md
@@ -99,6 +99,10 @@ MiniMax-H3 already contains CFG distillation, so its on-policy runs should norma
 `real_score_guidance_scale=0`. Models that require an external real-score CFG pass must cache negative text embeddings
 and can set the scale explicitly.
 
+When `--seed` is set, AnyFlow samples MeanFlow intervals, rollout schedules, rollout latents, DMD noise, and DMD sigmas
+from an isolated per-device Torch generator. This keeps AnyFlow samples stable when unrelated training code consumes the
+global Torch RNG. It does not make CUDA attention backward bit-stable.
+
 ## Shared Configuration
 
 - `stage`: `forward` or `onpolicy`. Default: `forward`.

--- a/documentation/experimental/ANYFLOW.pt-BR.md
+++ b/documentation/experimental/ANYFLOW.pt-BR.md
@@ -89,6 +89,11 @@ MiniMax-H3 já contém destilação CFG, então suas execuções on-policy norma
 `real_score_guidance_scale=0`. Modelos que exigem uma passada CFG externa para o score real precisam cachear embeddings
 de texto negativos e podem configurar a escala explicitamente.
 
+Quando `--seed` está definido, o AnyFlow amostra intervalos MeanFlow, schedules de rollout, latentes de rollout, ruído
+DMD e sigmas DMD a partir de um gerador Torch isolado por dispositivo. Isso mantém as amostras AnyFlow estáveis quando
+código de treinamento não relacionado consome o RNG global do Torch. Isso não torna o backward de attention em CUDA
+bit-estável.
+
 ## Configuração compartilhada
 
 - `stage`: `forward` ou `onpolicy`. Padrão: `forward`.

--- a/documentation/experimental/ANYFLOW.zh.md
+++ b/documentation/experimental/ANYFLOW.zh.md
@@ -86,6 +86,10 @@ checkpoint 保存为 `anyflow_discriminator.safetensors` 和 `anyflow_discrimina
 MiniMax-H3 已经包含 CFG distillation，因此它的 on-policy 运行通常应保持 `real_score_guidance_scale=0`。需要外部 real-score
 CFG pass 的模型必须缓存 negative text embeddings，并可以显式设置该 scale。
 
+设置 `--seed` 时，AnyFlow 会从按设备隔离的 Torch generator 中采样 MeanFlow 区间、rollout schedule、rollout latent、DMD
+noise 和 DMD sigma。这样即使无关训练代码消耗了全局 Torch RNG，AnyFlow 样本也会保持稳定。这不会让 CUDA attention
+backward 达到 bit-stable。
+
 ## 共享配置
 
 - `stage`: `forward` 或 `onpolicy`。默认：`forward`。

--- a/simpletuner/helpers/distillation/anyflow/distiller.py
+++ b/simpletuner/helpers/distillation/anyflow/distiller.py
@@ -111,6 +111,8 @@ class AnyFlowDistiller(DistillationBase):
         self._delta_initial_parameters = {
             name: parameter.detach().float().cpu().clone() for name, parameter in self._trainable_delta_parameters()
         }
+        self._rng_seed = self._resolve_rng_seed()
+        self._rng_generators: Dict[str, torch.Generator] = {}
 
         self._student_adapter_name: Optional[str] = None
         self._discriminator_adapter_name: Optional[str] = None
@@ -253,6 +255,92 @@ class AnyFlowDistiller(DistillationBase):
     # ------------------------------------------------------------------
     # Configuration and adapter roles
     # ------------------------------------------------------------------
+    def _resolve_rng_seed(self) -> Optional[int]:
+        seed = self.config.get("seed")
+        if seed in (None, "", 0):
+            seed = getattr(getattr(self.teacher_model, "config", None), "seed", None)
+        if seed in (None, "", 0):
+            return None
+
+        seed = int(seed)
+        seed_for_each_device = self.config.get("seed_for_each_device")
+        if seed_for_each_device is None:
+            seed_for_each_device = getattr(getattr(self.teacher_model, "config", None), "seed_for_each_device", False)
+        if bool(seed_for_each_device):
+            accelerator = getattr(self.teacher_model, "accelerator", None)
+            seed += int(getattr(accelerator, "process_index", 0) or 0)
+        return seed
+
+    @staticmethod
+    def _canonical_rng_device(device: torch.device | str) -> torch.device:
+        torch_device = torch.device(device)
+        if torch_device.type == "cuda" and torch_device.index is None and torch.cuda.is_available():
+            return torch.device("cuda", torch.cuda.current_device())
+        return torch_device
+
+    def _rng_generator(self, device: torch.device | str) -> Optional[torch.Generator]:
+        if self._rng_seed is None:
+            return None
+
+        torch_device = self._canonical_rng_device(device)
+        key = str(torch_device)
+        generator = self._rng_generators.get(key)
+        if generator is None:
+            generator = torch.Generator(device=torch_device)
+            generator.manual_seed(self._rng_seed)
+            self._rng_generators[key] = generator
+        return generator
+
+    def _rand(
+        self,
+        size: Sequence[int] | torch.Size,
+        *,
+        device: torch.device | str,
+        dtype: Optional[torch.dtype] = None,
+    ) -> torch.Tensor:
+        torch_device = self._canonical_rng_device(device)
+        kwargs: Dict[str, Any] = {"device": torch_device}
+        if dtype is not None:
+            kwargs["dtype"] = dtype
+        generator = self._rng_generator(torch_device)
+        if generator is not None:
+            kwargs["generator"] = generator
+        return torch.rand(size, **kwargs)
+
+    def _randn(
+        self,
+        size: Sequence[int] | torch.Size,
+        *,
+        device: torch.device | str,
+        dtype: Optional[torch.dtype] = None,
+    ) -> torch.Tensor:
+        torch_device = self._canonical_rng_device(device)
+        kwargs: Dict[str, Any] = {"device": torch_device}
+        if dtype is not None:
+            kwargs["dtype"] = dtype
+        generator = self._rng_generator(torch_device)
+        if generator is not None:
+            kwargs["generator"] = generator
+        return torch.randn(size, **kwargs)
+
+    def _randn_like(self, tensor: torch.Tensor) -> torch.Tensor:
+        return self._randn(tuple(tensor.shape), device=tensor.device, dtype=tensor.dtype)
+
+    def _randint(
+        self,
+        high: int,
+        size: Sequence[int] | torch.Size,
+        *,
+        device: torch.device | str,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        torch_device = self._canonical_rng_device(device)
+        kwargs: Dict[str, Any] = {"device": torch_device, "dtype": dtype}
+        generator = self._rng_generator(torch_device)
+        if generator is not None:
+            kwargs["generator"] = generator
+        return torch.randint(high, size, **kwargs)
+
     @property
     def _device(self) -> torch.device:
         accelerator = getattr(self.teacher_model, "accelerator", None)
@@ -416,8 +504,8 @@ class AnyFlowDistiller(DistillationBase):
         latents = prepared_batch["latents"]
         batch_size = int(latents.shape[0])
         device = latents.device
-        first = torch.rand(batch_size, device=device, dtype=torch.float32)
-        second = torch.rand(batch_size, device=device, dtype=torch.float32)
+        first = self._rand((batch_size,), device=device, dtype=torch.float32)
+        second = self._rand((batch_size,), device=device, dtype=torch.float32)
         t_base = torch.maximum(first, second)
         r_base = torch.minimum(first, second)
 
@@ -551,7 +639,7 @@ class AnyFlowDistiller(DistillationBase):
             )
 
         sigma = self._sample_dmd_sigma(generated.shape[0], logit_normal=False, device=generated.device)
-        noise = torch.randn_like(generated)
+        noise = self._randn_like(generated)
         sigma_broadcast = self._broadcast_time(sigma, generated).to(generated.dtype)
         noisy = ((1.0 - sigma_broadcast) * generated + sigma_broadcast * noise).detach()
 
@@ -589,7 +677,7 @@ class AnyFlowDistiller(DistillationBase):
             ).detach()
 
         sigma = self._sample_dmd_sigma(generated.shape[0], logit_normal=True, device=generated.device)
-        noise = torch.randn_like(generated)
+        noise = self._randn_like(generated)
         sigma_broadcast = self._broadcast_time(sigma, generated).to(generated.dtype)
         noisy = (1.0 - sigma_broadcast) * generated + sigma_broadcast * noise
         prediction = self._predict_at_sigmas(dmd_batch, noisy, sigma, sigma)
@@ -606,7 +694,7 @@ class AnyFlowDistiller(DistillationBase):
         if grad_timestep < 0 or grad_timestep >= step_count:
             raise ValueError(f"AnyFlow grad_timestep must be in [0, {step_count}), got {grad_timestep}.")
 
-        latents = torch.randn_like(prepared_batch["latents"])
+        latents = self._randn_like(prepared_batch["latents"])
         base_sigmas = torch.linspace(1.0, 0.0, step_count + 1, device=latents.device, dtype=torch.float32)
         sigmas = self._apply_scheduler_shift(base_sigmas)
 
@@ -662,26 +750,22 @@ class AnyFlowDistiller(DistillationBase):
         steps = self.config["rollout_step_counts"]
         device = self._device
         if torch.distributed.is_available() and torch.distributed.is_initialized():
-            if torch.distributed.get_rank() == 0:
-                index = torch.randint(len(steps), (1,), device=device, dtype=torch.long)
-            else:
-                index = torch.zeros(1, device=device, dtype=torch.long)
+            index = self._randint(len(steps), (1,), device=device, dtype=torch.long)
             torch.distributed.broadcast(index, src=0)
             step_count = int(steps[int(index.item())])
-            if torch.distributed.get_rank() == 0:
-                grad_timestep = torch.randint(step_count, (1,), device=device, dtype=torch.long)
-            else:
-                grad_timestep = torch.zeros(1, device=device, dtype=torch.long)
+            grad_timestep = self._randint(step_count, (1,), device=device, dtype=torch.long)
             torch.distributed.broadcast(grad_timestep, src=0)
             return step_count, int(grad_timestep.item())
 
-        step_count = int(steps[int(torch.randint(len(steps), (1,)).item())])
-        grad_timestep = int(torch.randint(step_count, (1,)).item())
+        step_count = int(steps[int(self._randint(len(steps), (1,), device=device, dtype=torch.long).item())])
+        grad_timestep = int(self._randint(step_count, (1,), device=device, dtype=torch.long).item())
         return step_count, grad_timestep
 
     def _sample_dmd_sigma(self, batch_size: int, *, logit_normal: bool, device: torch.device) -> torch.Tensor:
         base = (
-            torch.sigmoid(torch.randn(batch_size, device=device)) if logit_normal else torch.rand(batch_size, device=device)
+            torch.sigmoid(self._randn((batch_size,), device=device))
+            if logit_normal
+            else self._rand((batch_size,), device=device)
         )
         sigma = self._apply_scheduler_shift(base)
         return sigma.clamp(

--- a/simpletuner/helpers/distillation/factory.py
+++ b/simpletuner/helpers/distillation/factory.py
@@ -182,6 +182,8 @@ class DistillerFactory:
                     "model_type": model_type,
                     "model_family": model_family,
                     "prediction_type": prediction_type,
+                    "seed": config.get("seed"),
+                    "seed_for_each_device": config.get("seed_for_each_device", False),
                 },
                 student_model=student_model,
             )
@@ -195,6 +197,8 @@ class DistillerFactory:
                     "model_type": model_type,
                     "model_family": model_family,
                     "prediction_type": prediction_type,
+                    "seed": config.get("seed"),
+                    "seed_for_each_device": config.get("seed_for_each_device", False),
                 },
                 student_model=student_model,
             )

--- a/simpletuner/helpers/distillation/h3_drift/distiller.py
+++ b/simpletuner/helpers/distillation/h3_drift/distiller.py
@@ -144,6 +144,8 @@ class H3DriftDistiller(DistillationBase):
             config={
                 "distillation_config": {method: inner_config},
                 "train_text_encoder": bool(self.config.get("train_text_encoder", False)),
+                "seed": self.config.get("seed"),
+                "seed_for_each_device": self.config.get("seed_for_each_device", False),
             },
             model_type=str(self.config.get("model_type") or "lora"),
             model_family=self.config.get("model_family"),

--- a/simpletuner/inference.py
+++ b/simpletuner/inference.py
@@ -109,6 +109,7 @@ class CheckpointInferenceRuntime:
         trainer.init_tread_model()
         trainer.init_precision()
         trainer.init_freeze_models()
+        trainer.init_distillation_adapter_modules()
         trainer.init_trainable_peft_adapter()
         trainer.init_ema_model()
         trainer.init_precision(ema_only=True)

--- a/tests/helpers/distillation/test_anyflow_distiller.py
+++ b/tests/helpers/distillation/test_anyflow_distiller.py
@@ -404,6 +404,22 @@ class AnyFlowDistillerTests(unittest.TestCase):
         self.assertEqual(len(model.teacher_timesteps), 2)
         self.assertTrue(model.component.adapter_enabled)
 
+    def test_seeded_meanflow_pair_uses_isolated_rng_stream(self):
+        torch.manual_seed(1234)
+        expected_next = torch.rand(4)
+        torch.manual_seed(1234)
+        model = _FlowModel()
+        distiller = AnyFlowDistiller(
+            teacher_model=model,
+            noise_scheduler=None,
+            config={"model_type": "lora", "seed": 987},
+        )
+
+        distiller.prepare_batch(_prepared_batch(), model=model, state={})
+        actual_next = torch.rand(4)
+
+        self.assertTrue(torch.equal(actual_next, expected_next))
+
     def test_meanflow_branch_assignment_uses_data_replica_rank_with_context_parallelism(self):
         model = _FlowModel()
         model.accelerator.num_processes = 8
@@ -596,7 +612,7 @@ class AnyFlowDistillerTests(unittest.TestCase):
         batch = _prepared_batch()
         batch["timesteps"] = torch.tensor([0.0, 0.5])
 
-        with patch("torch.randn_like", return_value=torch.zeros_like(batch["latents"])):
+        with patch.object(distiller, "_randn_like", return_value=torch.zeros_like(batch["latents"])):
             with distiller._adapter_role("student"):
                 result = distiller._training_rollout(batch, step_count=2, grad_timestep=1)
 
@@ -623,6 +639,38 @@ class AnyFlowDistillerTests(unittest.TestCase):
         self.assertEqual(logs["anyflow_rollout_steps"], 2.0)
         self.assertIn(logs["anyflow_rollout_grad_timestep"], (0.0, 1.0))
         self.assertEqual(model.component.active_adapter, "default")
+
+    def test_distributed_rollout_schedule_consumes_rank_local_draws_before_broadcast(self):
+        model = _FlowModel()
+        distiller = AnyFlowDistiller(
+            teacher_model=model,
+            noise_scheduler=None,
+            config={"model_type": "lora", "stage": "onpolicy", "rollout_step_counts": [2, 4, 8]},
+        )
+        broadcast_values = [0, 1]
+
+        def broadcast_from_rank_zero(tensor, src):
+            self.assertEqual(src, 0)
+            tensor.fill_(broadcast_values.pop(0))
+
+        with (
+            patch("torch.distributed.is_available", return_value=True),
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.broadcast", side_effect=broadcast_from_rank_zero) as broadcast,
+            patch.object(
+                distiller,
+                "_randint",
+                side_effect=[torch.tensor([2], dtype=torch.long), torch.tensor([0], dtype=torch.long)],
+            ) as randint,
+        ):
+            step_count, grad_timestep = distiller._distributed_rollout_schedule()
+
+        self.assertEqual(step_count, 2)
+        self.assertEqual(grad_timestep, 1)
+        self.assertEqual(broadcast.call_count, 2)
+        self.assertEqual(randint.call_count, 2)
+        self.assertEqual(randint.call_args_list[0].args, (3, (1,)))
+        self.assertEqual(randint.call_args_list[1].args, (2, (1,)))
 
     def test_onpolicy_discriminator_step_updates_only_discriminator_adapter(self):
         model = _FlowModel()
@@ -696,13 +744,14 @@ class AnyFlowDistillerTests(unittest.TestCase):
             "anyflow",
             teacher_model=model,
             noise_scheduler=None,
-            config={"distillation_config": {"anyflow": {"stage": "forward"}}},
+            config={"seed": 123, "distillation_config": {"anyflow": {"stage": "forward"}}},
             model_type="lora",
             prediction_type="flow_matching",
         )
 
         self.assertIsInstance(distiller, AnyFlowDistiller)
         self.assertEqual(distiller.config["stage"], "forward")
+        self.assertEqual(distiller._rng_seed, 123)
         self.assertTrue(model.component.flowmap_enabled)
 
     def test_requires_flow_matching_model(self):

--- a/tests/helpers/distillation/test_h3_drift_distiller.py
+++ b/tests/helpers/distillation/test_h3_drift_distiller.py
@@ -211,6 +211,7 @@ class H3DriftDistillerTests(unittest.TestCase):
             config={
                 "model_type": "lora",
                 "model_family": "minimaxh3",
+                "seed": 987,
                 "loss_weight": 0.5,
                 "sft_loss_weight": 0.25,
                 "inner_distillation_method": "anyflow",
@@ -241,6 +242,7 @@ class H3DriftDistillerTests(unittest.TestCase):
         loss, logs = distiller.compute_distill_loss(prepared, model_output, torch.tensor(4.0))
 
         self.assertTrue(model.component.flowmap_enabled)
+        self.assertEqual(distiller.inner_distiller._rng_seed, 987)
         self.assertTrue(torch.equal(prepared["target"], -torch.ones_like(latents)))
         self.assertTrue(
             torch.equal(
@@ -307,6 +309,7 @@ class H3DriftDistillerTests(unittest.TestCase):
         self.assertAlmostEqual(
             float(loss),
             logs["h3_drift_inner_total"] + logs["h3_drift_sft_loss"],
+            places=6,
         )
         self.assertEqual(logs["h3_drift_loss"], 0.0)
         self.assertEqual(logs["h3_drift_weighted_loss"], 0.0)

--- a/tests/test_checkpoint_inference_worker.py
+++ b/tests/test_checkpoint_inference_worker.py
@@ -24,6 +24,45 @@ class _WorkerConfig:
 
 
 class TestCheckpointInferenceWorker(unittest.TestCase):
+    def test_checkpoint_runtime_creates_distillation_modules_before_peft(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            trainer = MagicMock()
+            trainer.config = SimpleNamespace(
+                output_dir=temporary_directory,
+                model_family="minimaxh3",
+                validation_negative_prompt="",
+            )
+            trainer.model.text_encoders = []
+            trainer.model.tokenizers = []
+            trainer.model.uses_validation_negative_prompt.return_value = False
+            trainer.model.pipeline = object()
+            trainer.distiller = None
+
+            runtime = object.__new__(CheckpointInferenceRuntime)
+            runtime.checkpoint_name = "checkpoint-100"
+            runtime.session_dir = Path(temporary_directory) / "session"
+            runtime.job_id = "test-runtime"
+
+            with (
+                patch("simpletuner.inference.Trainer", return_value=trainer),
+                patch("simpletuner.inference.LocalDataBackend"),
+                patch("simpletuner.inference.TextEmbeddingCache") as embed_cache_class,
+                patch("simpletuner.inference.StateTracker"),
+                patch("simpletuner.inference.AttentionBackendController"),
+            ):
+                embed_cache_class.return_value.discover_all_files.return_value = None
+                runtime._load({}, lambda: False, False)
+
+            call_names = [call[0] for call in trainer.method_calls]
+            self.assertLess(
+                call_names.index("init_distillation_adapter_modules"),
+                call_names.index("init_trainable_peft_adapter"),
+            )
+            self.assertLess(
+                call_names.index("init_trainable_peft_adapter"),
+                call_names.index("init_distillation"),
+            )
+
     def test_flush_embed_cache_times_out_instead_of_blocking(self) -> None:
         runtime = object.__new__(CheckpointInferenceRuntime)
         thread = MagicMock()

--- a/tests/test_ideogram4_prompting.py
+++ b/tests/test_ideogram4_prompting.py
@@ -515,6 +515,9 @@ class Ideogram4PromptingTests(unittest.TestCase):
             def uses_validation_negative_prompt(self):
                 return True
 
+            def validation_negative_prompt_requires_prompt_context(self):
+                return False
+
             def should_precompute_validation_negative_prompt(self):
                 return True
 
@@ -557,6 +560,9 @@ class Ideogram4PromptingTests(unittest.TestCase):
 
             def uses_validation_negative_prompt(self):
                 return True
+
+            def validation_negative_prompt_requires_prompt_context(self):
+                return False
 
             def should_precompute_validation_negative_prompt(self):
                 return True
@@ -605,6 +611,9 @@ class Ideogram4PromptingTests(unittest.TestCase):
 
             def uses_validation_negative_prompt(self):
                 return True
+
+            def validation_negative_prompt_requires_prompt_context(self):
+                return False
 
             def should_precompute_validation_negative_prompt(self):
                 return True


### PR DESCRIPTION
This pull request introduces deterministic and stable sampling for AnyFlow distillation by implementing per-device isolated RNG streams, controlled by a user-settable `--seed`. This ensures reproducible results even when other code consumes the global Torch RNG. The changes include new helper methods for RNG management, updates to all sampling calls in the distiller, configuration propagation for seeds, and comprehensive tests for the new functionality.

**Core Functionality: Per-device Isolated RNG for AnyFlow**

- Added per-device isolated RNG streams in `AnyFlowDistiller`, controlled by a new `--seed` parameter, to ensure stable and reproducible sampling for MeanFlow intervals, rollout schedules, latents, DMD noise, and sigmas. Sampling now uses these isolated generators instead of the global RNG, preventing interference from unrelated training code. (F96f4db2L88R88, [[1]](diffhunk://#diff-3507172773668220890a8d1f09074e85390bc28a5622273f2b0ed83c28c214bfL419-R508) [[2]](diffhunk://#diff-3507172773668220890a8d1f09074e85390bc28a5622273f2b0ed83c28c214bfL554-R642) [[3]](diffhunk://#diff-3507172773668220890a8d1f09074e85390bc28a5622273f2b0ed83c28c214bfL592-R680) [[4]](diffhunk://#diff-3507172773668220890a8d1f09074e85390bc28a5622273f2b0ed83c28c214bfL609-R697) [[5]](diffhunk://#diff-3507172773668220890a8d1f09074e85390bc28a5622273f2b0ed83c28c214bfL665-R768)

- Propagated `seed` and `seed_for_each_device` configuration parameters throughout the distillation factory and H3 drift distiller, ensuring correct initialization and usage of isolated RNGs in all relevant contexts. [[1]](diffhunk://#diff-e167edd9fbba7ea08d0d8001ae881dd32b0f584ffe153ac501c27f4805cd3ccfR185-R186) [[2]](diffhunk://#diff-e167edd9fbba7ea08d0d8001ae881dd32b0f584ffe153ac501c27f4805cd3ccfR200-R201) [[3]](diffhunk://#diff-27f077f54a9a85bc3f31c1e1d2e30f147be4e824c15c6127fdba5c4d0d0ddc9dR147-R148)

**Testing and Validation**

- Added and updated unit tests in `test_anyflow_distiller.py` to verify that isolated RNG streams are used for sampling, that results are reproducible, and that distributed rollout schedules consume rank-local draws before broadcasting. [[1]](diffhunk://#diff-1923fea834eb577a48d00c5d8cbc8462fb56898164b3417f48d633cab003e35eR407-R422) [[2]](diffhunk://#diff-1923fea834eb577a48d00c5d8cbc8462fb56898164b3417f48d633cab003e35eL599-R615) [[3]](diffhunk://#diff-1923fea834eb577a48d00c5d8cbc8462fb56898164b3417f48d633cab003e35eR643-R674) [[4]](diffhunk://#diff-1923fea834eb577a48d00c5d8cbc8462fb56898164b3417f48d633cab003e35eL699-R754)

**Documentation**

- Updated AnyFlow documentation in all supported languages to describe the new deterministic sampling behavior and the effect of the `--seed` parameter. [[1]](diffhunk://#diff-879d5d693af285566fa80441ce09d8ba105f7801508758013d8c147c6410b5a2R102-R105) [[2]](diffhunk://#diff-96a501532836f84cbf0b2a05b8baf71a843fcb41b45e3adc64a45a1da7a08d33R93-R96) [[3]](diffhunk://#diff-daf1cfa01c831f6a029fa0ac9595d2e0fd55b0bbd2b8c1c1febe9383b6be3424R91-R94) [[4]](diffhunk://#diff-92b4b2c28140182c09dfc2a0a1c13044182a385e77168a63a62c2ab0cf183ce6R91-R94) [[5]](diffhunk://#diff-f41b17555e854cb4c29c993cc788ffbab3500d654682f0d48ea55d7bd2caf300R92-R96) [[6]](diffhunk://#diff-063fb34b1971dcd73c583a8ed03790994747fbe4080767e0ad503544b215ef9bR89-R92)

**Other**

- Ensured that distillation adapters are initialized before training in the inference pipeline for correctness.