### PR TITLE
AnyFlow: negative prompt handling fixes

### DIFF
--- a/simpletuner/helpers/distillation/anyflow/distiller.py
+++ b/simpletuner/helpers/distillation/anyflow/distiller.py
@@ -74,8 +74,9 @@ class AnyFlowDistiller(DistillationBase):
 
     @classmethod
     def training_batch_requirements(cls, config: Dict[str, Any]) -> set[str]:
-        guidance_scale = float(config.get("fuse_guidance_scale", cls._DEFAULTS["fuse_guidance_scale"]))
-        return {"unconditional_text_embeddings"} if guidance_scale != 1.0 else set()
+        fuse_guidance = float(config.get("fuse_guidance_scale", cls._DEFAULTS["fuse_guidance_scale"]))
+        real_guidance = float(config.get("real_score_guidance_scale", cls._DEFAULTS["real_score_guidance_scale"]))
+        return {"unconditional_text_embeddings"} if fuse_guidance != 1.0 or real_guidance != 0.0 else set()
 
     def __init__(
         self,
@@ -743,6 +744,9 @@ class AnyFlowDistiller(DistillationBase):
         negative_tags = prepared_batch.get("negative_text_token_tags")
         if torch.is_tensor(negative_tags):
             unconditional_batch["text_token_tags"] = negative_tags
+        negative_mask = prepared_batch.get("negative_encoder_attention_mask")
+        if torch.is_tensor(negative_mask):
+            unconditional_batch["encoder_attention_mask"] = negative_mask
         unconditional_x0 = self._score_x0(unconditional_batch, noisy_latents, sigmas)
         return conditional_x0 + (conditional_x0 - unconditional_x0) * guidance
 

--- a/tests/helpers/distillation/test_anyflow_distiller.py
+++ b/tests/helpers/distillation/test_anyflow_distiller.py
@@ -259,9 +259,14 @@ class AnyFlowDistillerTests(unittest.TestCase):
             "anyflow",
             {"distillation_config": {"fuse_guidance_scale": 3.0}},
         )
+        real_guidance_only = DistillerFactory.training_batch_requirements(
+            "anyflow",
+            {"distillation_config": {"fuse_guidance_scale": 1.0, "real_score_guidance_scale": 0.5}},
+        )
 
         self.assertEqual(direct, {"unconditional_text_embeddings"})
         self.assertEqual(unwrapped, direct)
+        self.assertEqual(real_guidance_only, direct)
         self.assertEqual(nested, direct)
 
     def test_removed_legacy_target_modes_are_rejected(self):
@@ -588,6 +593,38 @@ class AnyFlowDistillerTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "cached unconditional text embeddings"):
             distiller._meanflow_loss(batch, {"model_prediction": torch.ones_like(batch["latents"])})
+
+    def test_real_score_guidance_uses_negative_tags_and_attention_mask(self):
+        model = _FlowModel()
+        distiller = AnyFlowDistiller(
+            teacher_model=model,
+            noise_scheduler=None,
+            config={"model_type": "lora", "real_score_guidance_scale": 0.5},
+        )
+        batch = _prepared_batch()
+        batch["encoder_hidden_states"] = torch.ones(2, 5, 1)
+        batch["negative_encoder_hidden_states"] = torch.zeros(2, 3, 1)
+        batch["text_token_tags"] = torch.ones(2, 5, dtype=torch.long)
+        batch["negative_text_token_tags"] = torch.full((2, 3), 2, dtype=torch.long)
+        batch["encoder_attention_mask"] = torch.ones(2, 5, dtype=torch.long)
+        batch["negative_encoder_attention_mask"] = torch.tensor([[1, 1, 0], [1, 0, 0]], dtype=torch.long)
+        conditional_x0 = torch.ones_like(batch["latents"])
+        unconditional_x0 = torch.zeros_like(batch["latents"])
+
+        with patch.object(distiller, "_score_x0", return_value=unconditional_x0) as score_x0:
+            result = distiller._apply_real_score_guidance(
+                batch,
+                batch["noisy_latents"],
+                batch["timesteps"],
+                conditional_x0,
+            )
+
+        score_x0.assert_called_once()
+        unconditional_batch = score_x0.call_args.args[0]
+        self.assertIs(unconditional_batch["encoder_hidden_states"], batch["negative_encoder_hidden_states"])
+        self.assertIs(unconditional_batch["text_token_tags"], batch["negative_text_token_tags"])
+        self.assertIs(unconditional_batch["encoder_attention_mask"], batch["negative_encoder_attention_mask"])
+        self.assertTrue(torch.equal(result, torch.full_like(conditional_x0, 1.5)))
 
     def test_onpolicy_initializes_separate_discriminator_adapter_and_optimizer(self):
         model = _FlowModel()


### PR DESCRIPTION
This pull request updates the AnyFlow distillation logic to better support "real score guidance" by improving how unconditional batches are constructed and ensuring correct data is used during guidance. It also strengthens test coverage to verify these behaviors.

**Distillation logic improvements:**

* Updated `AnyFlowDistiller.training_batch_requirements` to require `unconditional_text_embeddings` if either `fuse_guidance_scale` is not 1.0 or `real_score_guidance_scale` is not 0.0, ensuring the correct conditioning data is prepared for both guidance modes.
* Modified `_apply_real_score_guidance` to copy `negative_encoder_attention_mask` into the unconditional batch when present, ensuring the unconditional pass uses the correct attention mask for real score guidance.

**Test enhancements:**

* Added a test to verify that `training_batch_requirements` correctly reports the need for unconditional embeddings when only `real_score_guidance_scale` is set.
* Added a comprehensive test to ensure that, when real score guidance is used, the unconditional batch is constructed with the correct negative hidden states, tags, and attention mask, and that the guidance computation produces the expected result.