### PR TITLE
distillation should disable lora_dropout unless force-enabled by user; add --skip_text_encoder for never loading text enc once enabled

### DIFF
--- a/documentation/experimental/ANYFLOW.md
+++ b/documentation/experimental/ANYFLOW.md
@@ -48,8 +48,30 @@ For each global batch, the forward stage:
 7. Balances each non-diffusion sample against the global diffusion-branch loss mean.
 
 Guidance fusion requires cached unconditional text embeddings. SimpleTuner loads the caption-dropout embedding for
-each sample and uses the same image context for models such as MiniMax-H3. Set `fuse_guidance_scale=1.0` only when the
-student should retain external CFG instead of learning AnyFlow's guidance-distilled conditional field.
+each sample and uses the same image context. Set `fuse_guidance_scale=1.0` when the student should retain external CFG
+or the base model's conditional path already contains guidance distillation.
+
+### Guidance-Distilled Base Models
+
+MiniMax-H3's conditional prediction already contains its distilled guidance field and does not have a calibrated
+unconditional branch for AnyFlow to fuse. Its forward-stage configuration should therefore use:
+
+```json
+{
+  "fuse_guidance_scale": 1.0,
+  "diffusion_target": "base_prediction"
+}
+```
+
+`fuse_guidance_scale=1.0` disables the unconditional pass, but by itself it leaves the `r=t` branch targeting the raw
+sample velocity. That branch can train a guidance-distilled base away from its useful conditional field. With
+`diffusion_target=base_prediction`, SimpleTuner instead evaluates the same noisy latent at `r=t` with the adapter
+disabled and uses that frozen-base prediction only for diffusion samples. Consistency and arbitrary intervals retain
+the AnyFlow tangent target.
+
+The frozen-base/raw-flow residual supplies the adaptive-weighting reference when the anchored diffusion loss starts at
+zero. This prevents adaptive weighting from zeroing every interval loss at adapter initialization. No second
+transformer is allocated, but the frozen-base evaluation adds one no-grad forward per training step.
 
 ## On-Policy Stage
 
@@ -112,6 +134,8 @@ global Torch RNG. It does not make CUDA attention backward bit-stable.
 - `fuse_guidance_scale`: guidance scale distilled into the conditional student prediction. Default: `3.0`.
 - `meanflow_weight_type`: `beta08` or `uniform`. Default: `beta08`.
 - `meanflow_adaptive_weighting`: balance non-diffusion samples against the diffusion branch. Default: `true`.
+- `diffusion_target`: `flow` for NVIDIA's raw-flow objective or `base_prediction` for an already guidance-distilled
+  conditional field. Default: `flow`. `base_prediction` requires adapter training and `fuse_guidance_scale=1.0`.
 - `gate_value`: FlowMap delta-timestep embedding blend. Default: `0.25`.
 - `deltatime_type`: `r` or `t-r`. Default: `r`.
 - `loss_weight`: forward MeanFlow loss multiplier. Default: `1.0`.
@@ -119,6 +143,10 @@ global Torch RNG. It does not make CUDA attention backward bit-stable.
 ## Limits
 
 - AnyFlow requires a flow-matching model with model-specific FlowMap interval conditioning.
+- AnyFlow adapter training requires `lora_dropout=0`. Independent dropout masks in the two finite-difference forwards
+  are divided by the small central-difference interval and corrupt the derivative target. SimpleTuner overrides the
+  general LoRA default for distillation unless the user explicitly forces a different value, and AnyFlow rejects a
+  nonzero value during model preparation.
 - On-policy training currently requires standard PEFT LoRA. Sharing the base avoids allocating generator, real-score,
   and discriminator copies of a large transformer on every DDP rank.
 - Joint MiniMax-H3 audio-video training is rejected. Video uses schedule shift 12 while audio uses shift 3; native

--- a/simpletuner/diagnostics/h3_objective_geometry.py
+++ b/simpletuner/diagnostics/h3_objective_geometry.py
@@ -7,6 +7,7 @@ import random
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from types import MethodType
 from typing import Any, Iterable
 
 import numpy as np
@@ -390,7 +391,17 @@ def _first_raw_batch():
     return raw_batch
 
 
-def initialize_trainer(config: dict[str, Any]):
+def _forbid_text_encoder_load(model, *args, **kwargs):
+    del model, args, kwargs
+    raise RuntimeError("H3 objective geometry attempted to load the text encoder while --skip-text-encoder is active.")
+
+
+def _forbid_text_encoding(model, *args, **kwargs):
+    del model, args, kwargs
+    raise RuntimeError("H3 objective geometry missed the prepared text embedding cache.")
+
+
+def initialize_trainer(config: dict[str, Any], *, skip_text_encoder: bool = False):
     from simpletuner.helpers.training.attention_backend import AttentionBackendController, AttentionPhase
     from simpletuner.helpers.training.trainer import Trainer
 
@@ -398,10 +409,16 @@ def initialize_trainer(config: dict[str, Any]):
     trainer.init_noise_schedule()
     trainer.init_seed()
     trainer.init_huggingface_hub()
-    trainer.init_preprocessing_models()
+    if skip_text_encoder:
+        trainer.init_vae()
+        trainer.model.load_text_encoder = MethodType(_forbid_text_encoder_load, trainer.model)
+        trainer.model.encode_text_batch = MethodType(_forbid_text_encoding, trainer.model)
+    else:
+        trainer.init_preprocessing_models()
     trainer.init_precision(preprocessing_models_only=True)
     trainer.init_data_backend()
-    trainer.init_unload_text_encoder()
+    if not skip_text_encoder:
+        trainer.init_unload_text_encoder()
     trainer.init_unload_vae()
     trainer.init_load_base_model()
     trainer.init_delete_model_caches()
@@ -606,7 +623,9 @@ def _write_plots(
 def run_diagnostic(args: argparse.Namespace) -> None:
     args.output_dir.mkdir(parents=True, exist_ok=True)
     config = _diagnostic_config(args.config, args.output_dir)
-    trainer = initialize_trainer(config)
+    if args.skip_text_encoder:
+        config["validation_disable"] = True
+    trainer = initialize_trainer(config, skip_text_encoder=args.skip_text_encoder)
     try:
         _seed_everything(args.seed)
         raw_batch = _first_raw_batch()
@@ -703,6 +722,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--max-vector-elements", type=int, default=65536)
+    parser.add_argument(
+        "--skip-text-encoder",
+        action="store_true",
+        help="Require prepared text embeddings and never load or invoke the text encoder.",
+    )
     return parser
 
 

--- a/simpletuner/helpers/distillation/anyflow/distiller.py
+++ b/simpletuner/helpers/distillation/anyflow/distiller.py
@@ -42,6 +42,7 @@ class AnyFlowDistiller(DistillationBase):
         "meanflow_weight_type": "beta08",
         "meanflow_adaptive_weighting": True,
         "meanflow_non_diffusion_max_sigma": 1.0,
+        "diffusion_target": "flow",
         "cotrain_forward": True,
         "rollout_step_counts": (2, 4, 8, 16, 50),
         "dmd_weight": 1.0,
@@ -159,12 +160,17 @@ class AnyFlowDistiller(DistillationBase):
         batch["anyflow_timestep_interval"] = (batch["timesteps"].to(r_timesteps.dtype) - r_timesteps).abs()
 
         base_target = self._base_flow_target(batch, model=model)
+        meanflow_base_target = self._meanflow_base_target(
+            prepared_batch=batch,
+            t_sigmas=t_sigmas,
+            base_target=base_target,
+        )
         target = self._meanflow_target(
             prepared_batch=batch,
             model=model,
             t_sigmas=t_sigmas,
             r_sigmas=r_sigmas,
-            base_target=base_target,
+            base_target=meanflow_base_target,
         ).detach()
         batch["target"] = target
         batch["flow_target"] = target
@@ -398,9 +404,18 @@ class AnyFlowDistiller(DistillationBase):
             raise ValueError("AnyFlow meanflow_non_diffusion_max_sigma must be in (0.0, 1.0].")
         self.config["meanflow_non_diffusion_max_sigma"] = non_diffusion_max_sigma
 
+        diffusion_target = str(self.config["diffusion_target"]).strip().lower()
+        if diffusion_target not in {"flow", "base_prediction"}:
+            raise ValueError("AnyFlow diffusion_target must be one of: flow, base_prediction.")
+        if diffusion_target == "base_prediction" and not self.low_rank_distillation:
+            raise ValueError("AnyFlow diffusion_target=base_prediction currently requires adapter distillation.")
+        self.config["diffusion_target"] = diffusion_target
+
         guidance_scale = float(self.config["fuse_guidance_scale"])
         if guidance_scale <= 0.0:
             raise ValueError("AnyFlow fuse_guidance_scale must be greater than zero.")
+        if diffusion_target == "base_prediction" and guidance_scale != 1.0:
+            raise ValueError("AnyFlow diffusion_target=base_prediction requires fuse_guidance_scale=1.0.")
         self.config["fuse_guidance_scale"] = guidance_scale
 
         weight_type = str(self.config["meanflow_weight_type"]).strip().lower()
@@ -513,6 +528,53 @@ class AnyFlowDistiller(DistillationBase):
     # ------------------------------------------------------------------
     # NVIDIA forward MeanFlow stage
     # ------------------------------------------------------------------
+    @contextmanager
+    def _frozen_base_adapter(self) -> Iterator[None]:
+        if self.config["stage"] == "onpolicy":
+            with self._adapter_role("real"):
+                yield
+            return
+
+        component = self._flowmap_component
+        was_training = component.training
+        try:
+            self.toggle_adapter(enable=False)
+            component.eval()
+            yield
+        finally:
+            self.toggle_adapter(enable=True)
+            component.train(was_training)
+
+    def _meanflow_base_target(
+        self,
+        *,
+        prepared_batch: Dict[str, Any],
+        t_sigmas: torch.Tensor,
+        base_target: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.config["diffusion_target"] == "flow":
+            return base_target
+
+        with self._frozen_base_adapter(), torch.no_grad():
+            base_prediction = self._predict_at_sigmas(
+                prepared_batch,
+                prepared_batch["noisy_latents"],
+                t_sigmas,
+                t_sigmas,
+            ).detach()
+
+        base_prediction = base_prediction.to(device=base_target.device, dtype=base_target.dtype)
+        cosine, norm_ratio = self._chunked_per_sample_geometry(base_prediction, base_target)
+        prepared_batch["_anyflow_base_prediction_flow_cosine"] = cosine
+        prepared_batch["_anyflow_base_prediction_flow_norm_ratio"] = norm_ratio
+        prepared_batch["_anyflow_base_prediction_flow_mse"] = (
+            (base_prediction.float() - base_target.float()).square().flatten(1).mean(dim=1).detach()
+        )
+
+        diffusion_mask = prepared_batch["anyflow_diffusion_mask"].to(device=base_target.device, dtype=torch.bool)
+        diffusion_mask = self._broadcast_time(diffusion_mask, base_target)
+        return torch.where(diffusion_mask, base_prediction, base_target)
+
     def _prepare_meanflow_pair(self, prepared_batch: Dict[str, Any], model) -> tuple[torch.Tensor, torch.Tensor]:
         latents = prepared_batch["latents"]
         batch_size = int(latents.shape[0])
@@ -607,7 +669,8 @@ class AnyFlowDistiller(DistillationBase):
         prediction = self._fuse_guidance_prediction(prepared_batch, prediction)
         per_sample = (prediction.float() - target.float()).square().flatten(1).mean(dim=1)
         t_sigmas = self._scalar_sigmas(prepared_batch).to(device=per_sample.device, dtype=per_sample.dtype)
-        per_sample = per_sample * self._meanflow_timestep_weight(t_sigmas)
+        timestep_weight = self._meanflow_timestep_weight(t_sigmas)
+        per_sample = per_sample * timestep_weight
         prepared_batch["_anyflow_pre_adaptive_loss"] = per_sample.detach()
         adaptive_scale = torch.ones_like(per_sample)
 
@@ -618,6 +681,21 @@ class AnyFlowDistiller(DistillationBase):
             global_diffusion_mask = self._gather_detached(diffusion_mask)
             if bool(global_diffusion_mask.any()):
                 diffusion_mean = global_loss[global_diffusion_mask].mean()
+                base_prediction_flow_mse = prepared_batch.get("_anyflow_base_prediction_flow_mse")
+                if torch.is_tensor(base_prediction_flow_mse):
+                    adaptive_reference = (
+                        base_prediction_flow_mse.to(
+                            device=per_sample.device,
+                            dtype=per_sample.dtype,
+                        )
+                        * timestep_weight
+                    )
+                    prepared_batch["_anyflow_adaptive_reference_loss"] = adaptive_reference.detach()
+                    global_adaptive_reference = self._gather_detached(adaptive_reference)
+                    diffusion_mean = torch.maximum(
+                        diffusion_mean,
+                        global_adaptive_reference[global_diffusion_mask].mean(),
+                    )
                 non_diffusion_mask = ~diffusion_mask
                 if bool(non_diffusion_mask.any()):
                     scale = diffusion_mean / (per_sample.detach()[non_diffusion_mask] + 1e-5)
@@ -877,12 +955,16 @@ class AnyFlowDistiller(DistillationBase):
             "anyflow_interval": float(global_intervals.mean()),
             "anyflow_fuse_guidance_scale": float(self.config["fuse_guidance_scale"]),
             "anyflow_meanflow_non_diffusion_max_sigma": float(self.config["meanflow_non_diffusion_max_sigma"]),
+            "anyflow_diffusion_target_is_base_prediction": float(self.config["diffusion_target"] == "base_prediction"),
         }
         metric_tensors = {
             "t_sigma": prepared_batch.get("anyflow_t_sigmas"),
             "r_sigma": prepared_batch.get("anyflow_r_sigmas"),
             "target_base_cosine": prepared_batch.get("_anyflow_target_base_cosine"),
             "target_base_norm_ratio": prepared_batch.get("_anyflow_target_base_norm_ratio"),
+            "base_prediction_flow_cosine": prepared_batch.get("_anyflow_base_prediction_flow_cosine"),
+            "base_prediction_flow_norm_ratio": prepared_batch.get("_anyflow_base_prediction_flow_norm_ratio"),
+            "adaptive_reference_loss": prepared_batch.get("_anyflow_adaptive_reference_loss"),
             "pre_adaptive_loss": prepared_batch.get("_anyflow_pre_adaptive_loss"),
             "adaptive_scale": prepared_batch.get("_anyflow_adaptive_scale"),
             "post_adaptive_loss": prepared_batch.get("_anyflow_post_adaptive_loss"),

--- a/simpletuner/helpers/distillation/anyflow/distiller.py
+++ b/simpletuner/helpers/distillation/anyflow/distiller.py
@@ -60,6 +60,18 @@ class AnyFlowDistiller(DistillationBase):
 
     @classmethod
     def prepare_model_for_adapter(cls, model, config: Dict[str, Any]) -> None:
+        model_config = getattr(model, "config", None)
+        if isinstance(model_config, dict):
+            lora_dropout = model_config.get("lora_dropout", 0.0)
+        else:
+            lora_dropout = getattr(model_config, "lora_dropout", 0.0)
+        lora_dropout = float(lora_dropout or 0.0)
+        if lora_dropout != 0.0:
+            raise ValueError(
+                "AnyFlow requires lora_dropout=0.0. Independent dropout masks in the finite-difference forwards "
+                "corrupt the derivative target."
+            )
+
         component = cls._get_trained_component(model)
         enable_flowmap = getattr(component, "enable_flowmap_time_conditioning", None)
         if not callable(enable_flowmap):

--- a/simpletuner/helpers/distillation/common.py
+++ b/simpletuner/helpers/distillation/common.py
@@ -121,6 +121,15 @@ class DistillationBase:
         del config
         return set()
 
+    @classmethod
+    def adapter_dropout_override(cls) -> float | None:
+        """LoRA dropout the method's reference implementation trains with, or None to leave user config untouched.
+
+        Every currently supported reference (AnyFlow, DMD2, DCM, LCM-LoRA, Diffusion-DPO) trains adapters without
+        dropout; methods whose reference differs should override this.
+        """
+        return 0.0
+
     def toggle_adapter(self, enable=False):
         """
         Toggle the adapter on/off when using the same model for teacher and student.

--- a/simpletuner/helpers/distillation/factory.py
+++ b/simpletuner/helpers/distillation/factory.py
@@ -68,6 +68,20 @@ class DistillerFactory:
         distiller_cls.prepare_model_for_adapter(model, DistillerFactory._method_config(method, config))
 
     @staticmethod
+    def adapter_dropout_override(method: Union[str, DistillationMethod, None]) -> Optional[float]:
+        """Return the LoRA dropout a configured distillation method requires, or None."""
+        if isinstance(method, str):
+            if method.strip().lower() in {"", "none", "false", "0"}:
+                return None
+            method = DistillationMethod.from_string(method)
+        if method is None:
+            return None
+        distiller_cls = DistillationRegistry.get(method.value)
+        if distiller_cls is None:
+            return None
+        return distiller_cls.adapter_dropout_override()
+
+    @staticmethod
     def training_batch_requirements(
         method: Union[str, DistillationMethod, None],
         config: Dict[str, Any],

--- a/simpletuner/helpers/models/minimaxh3/model.py
+++ b/simpletuner/helpers/models/minimaxh3/model.py
@@ -231,13 +231,15 @@ class MiniMaxH3(VideoModelFoundation):
             return targets
 
         anyflow_config = self._anyflow_distillation_config()
+        train_time_embedder = bool(anyflow_config.get("train_time_embedder", True))
         train_delta_embedder = bool(anyflow_config.get("train_delta_embedder", True))
         targets.extend(["ff.net.0.proj", "ff.net.2"])
         if bool(anyflow_config.get("lora_target_adaln", False)):
             targets.append("adaln_proj.linear")
         transformer = self.unwrap_model(self.model) if getattr(self, "model", None) is not None else None
         if transformer is not None and getattr(transformer, "time_embedder", None) is not None:
-            targets.extend(["time_embedder.linear_1", "time_embedder.linear_2"])
+            if train_time_embedder:
+                targets.extend(["time_embedder.linear_1", "time_embedder.linear_2"])
             if train_delta_embedder:
                 targets.extend(["delta_time_embedder.linear_1", "delta_time_embedder.linear_2"])
         return list(dict.fromkeys(targets))

--- a/simpletuner/helpers/training/default_settings/safety_check.py
+++ b/simpletuner/helpers/training/default_settings/safety_check.py
@@ -21,6 +21,33 @@ from simpletuner.helpers.training.error_handling import validate_deepspeed_compa
 
 
 def safety_check(args, accelerator):
+    if getattr(args, "distillation_method", None):
+        from simpletuner.helpers.distillation.factory import DistillerFactory
+
+        dropout_override = DistillerFactory.adapter_dropout_override(args.distillation_method)
+        current_dropout = getattr(args, "lora_dropout", 0.0)
+        if dropout_override is not None and current_dropout != dropout_override:
+            force_enabled = os.environ.get("SIMPLETUNER_LORA_DROPOUT_FORCE_ENABLED", "").strip().lower() in (
+                "1",
+                "true",
+                "yes",
+                "on",
+            )
+            if force_enabled:
+                logger.warning(
+                    f"Keeping --lora_dropout={current_dropout} for {args.distillation_method} distillation because "
+                    "SIMPLETUNER_LORA_DROPOUT_FORCE_ENABLED is set; the reference implementation trains with "
+                    f"lora_dropout={dropout_override}."
+                )
+            else:
+                logger.warning(
+                    f"{args.distillation_method} distillation reference implementations train adapters with "
+                    f"lora_dropout={dropout_override}; overriding --lora_dropout={current_dropout}. Set "
+                    "SIMPLETUNER_LORA_DROPOUT_FORCE_ENABLED=1 to keep the configured value. Adapter dropout also "
+                    "injects amplified noise into finite-difference distillation targets."
+                )
+                args.lora_dropout = dropout_override
+
     if accelerator is not None and accelerator.num_processes > 1:
         # mulit-gpu safety checks & warnings
         if args.model_type == "lora" and args.lora_type == "standard":

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -4719,6 +4719,44 @@ class Trainer:
             f"missing checkpoint completion guard {CHECKPOINT_GUARD_FILENAME}",
         )
 
+    def _restore_constant_scheduler_lr(
+        self,
+        lr_scheduler,
+        optimizer_param_groups: list[dict[str, Any]],
+        configured_base_lrs: list[float | None],
+        global_step: int,
+    ) -> None:
+        if self.config.lr_scheduler not in ("constant", "constant_with_warmup") or self.config.is_schedulefree:
+            return
+
+        process_multiplier = 1 if getattr(lr_scheduler, "split_batches", False) else self.accelerator.num_processes
+        scheduler_step = int(global_step) * max(1, int(process_multiplier))
+        warmup_steps = 0
+        if self.config.lr_scheduler == "constant_with_warmup":
+            warmup_steps = int(getattr(self.config, "lr_warmup_steps", 0)) * max(1, int(process_multiplier))
+        warmup_scale = min(1.0, scheduler_step / max(1, warmup_steps)) if warmup_steps > 0 else 1.0
+
+        restored_lrs = [float(base_lr) * warmup_scale if base_lr is not None else None for base_lr in configured_base_lrs]
+        scheduler_state = lr_scheduler.state_dict()
+        scheduler_state["base_lrs"] = list(configured_base_lrs)
+        scheduler_state["_last_lr"] = list(restored_lrs)
+        if "last_epoch" in scheduler_state:
+            scheduler_state["last_epoch"] = scheduler_step
+        if "_step_count" in scheduler_state:
+            scheduler_state["_step_count"] = scheduler_step + 1
+        lr_scheduler.load_state_dict(scheduler_state)
+
+        for group_index, group in enumerate(optimizer_param_groups):
+            if group_index >= len(restored_lrs) or restored_lrs[group_index] is None:
+                continue
+            group["initial_lr"] = configured_base_lrs[group_index]
+            group["lr"] = restored_lrs[group_index]
+
+        logger.info(
+            f"Restored {self.config.lr_scheduler} scheduler at global step {global_step} "
+            f"(scheduler step {scheduler_step}) with learning rates {restored_lrs}."
+        )
+
     def init_resume_checkpoint(self, lr_scheduler):
         # Potentially load in the weights and states from a previous save
         self.config.total_steps_remaining_at_start = self.config.max_train_steps
@@ -4740,7 +4778,7 @@ class Trainer:
             raw_param_groups = getattr(self.optimizer, "param_groups", None)
             if isinstance(raw_param_groups, list):
                 optimizer_param_groups = raw_param_groups
-        configured_param_group_lrs = [group.get("lr") for group in optimizer_param_groups]
+        configured_param_group_lrs = [group.get("initial_lr", group.get("lr")) for group in optimizer_param_groups]
 
         while True:
             checkpoint_dir = None
@@ -4812,29 +4850,6 @@ class Trainer:
         if getattr(self, "distiller", None) is not None:
             logger.info(f"Loading DCM checkpoint states..")
             self.distiller.on_load_checkpoint(checkpoint_dir)
-        try:
-            if self.config.lr_scheduler in ("constant", "constant_with_warmup") and not self.config.is_schedulefree:
-                for group_index, group in enumerate(optimizer_param_groups):
-                    if "lr" not in group:
-                        continue
-                    if group_index < len(configured_param_group_lrs) and configured_param_group_lrs[group_index] is not None:
-                        group["lr"] = configured_param_group_lrs[group_index]
-                for k, v in lr_scheduler.state_dict().items():
-                    if k in ("base_lrs", "_last_lr"):
-                        for group_index, configured_lr in enumerate(configured_param_group_lrs):
-                            if configured_lr is not None and group_index < len(v):
-                                v[group_index] = configured_lr
-        except Exception as e:
-            event = notification_event(
-                message="Could not update learning rate scheduler LR value.",
-                severity="warning",
-                job_id=self.job_id,
-            )
-            self._emit_event(event)
-            logger.error(
-                f"Could not update lr_scheduler {self.config.lr_scheduler} learning rate to {self.config.learning_rate} upon resume: {e}"
-            )
-
         event = lifecycle_stage_event(
             key="init_resume_checkpoint",
             label="Resume Checkpoint",
@@ -4854,6 +4869,23 @@ class Trainer:
                 )
         self.state["global_resume_step"] = self.state["global_step"] = StateTracker.get_global_step()
         StateTracker.set_global_resume_step(self.state["global_resume_step"])
+        try:
+            self._restore_constant_scheduler_lr(
+                lr_scheduler,
+                optimizer_param_groups,
+                configured_param_group_lrs,
+                self.state["global_resume_step"],
+            )
+        except Exception as e:
+            event = notification_event(
+                message="Could not update learning rate scheduler LR value.",
+                severity="warning",
+                job_id=self.job_id,
+            )
+            self._emit_event(event)
+            logger.error(
+                f"Could not update lr_scheduler {self.config.lr_scheduler} learning rate to {self.config.learning_rate} upon resume: {e}"
+            )
         if hasattr(self.model, "load_flow_custom_timestep_state"):
             self.model.load_flow_custom_timestep_state(
                 checkpoint_dir,

--- a/tests/helpers/distillation/test_anyflow_distiller.py
+++ b/tests/helpers/distillation/test_anyflow_distiller.py
@@ -416,6 +416,82 @@ class AnyFlowDistillerTests(unittest.TestCase):
         self.assertEqual(len(model.teacher_timesteps), 2)
         self.assertTrue(model.component.adapter_enabled)
 
+    def test_meanflow_can_anchor_only_diffusion_samples_to_frozen_base_prediction(self):
+        model = _FlowModel()
+        distiller = AnyFlowDistiller(
+            teacher_model=model,
+            noise_scheduler=None,
+            config={
+                "model_type": "lora",
+                "diffusion_ratio": 0.5,
+                "consistency_ratio": 0.5,
+                "diffusion_target": "base_prediction",
+                "fuse_guidance_scale": 1.0,
+            },
+        )
+        draws = [
+            torch.tensor([0.8, 0.7]),
+            torch.tensor([0.2, 0.4]),
+        ]
+
+        with patch("torch.rand", side_effect=draws):
+            batch = distiller.prepare_batch(_prepared_batch(), model=model, state={})
+
+        expected = torch.ones_like(batch["target"])
+        expected[0] = 2.0
+        self.assertTrue(torch.equal(batch["target"], expected))
+        self.assertEqual(model.teacher_adapter_states, [False, True, True])
+        self.assertTrue(model.component.adapter_enabled)
+        self.assertTrue(model.component.training)
+        self.assertTrue(torch.equal(batch["_anyflow_base_prediction_flow_norm_ratio"], torch.full((2,), 2.0)))
+
+    def test_meanflow_diffusion_target_is_validated(self):
+        with self.assertRaisesRegex(ValueError, "diffusion_target"):
+            AnyFlowDistiller(
+                teacher_model=_FlowModel(),
+                noise_scheduler=None,
+                config={"model_type": "lora", "diffusion_target": "unknown"},
+            )
+
+        with self.assertRaisesRegex(ValueError, "requires fuse_guidance_scale=1.0"):
+            AnyFlowDistiller(
+                teacher_model=_FlowModel(),
+                noise_scheduler=None,
+                config={"model_type": "lora", "diffusion_target": "base_prediction"},
+            )
+
+    def test_frozen_base_target_uses_base_flow_residual_for_adaptive_weighting(self):
+        model = _FlowModel()
+        distiller = AnyFlowDistiller(
+            teacher_model=model,
+            noise_scheduler=None,
+            config={
+                "model_type": "lora",
+                "diffusion_ratio": 0.5,
+                "consistency_ratio": 0.5,
+                "diffusion_target": "base_prediction",
+                "meanflow_weight_type": "uniform",
+                "fuse_guidance_scale": 1.0,
+            },
+        )
+        draws = [
+            torch.tensor([0.8, 0.7]),
+            torch.tensor([0.2, 0.4]),
+        ]
+
+        with patch("torch.rand", side_effect=draws):
+            batch = distiller.prepare_batch(_prepared_batch(), model=model, state={})
+
+        prediction = batch["target"].clone()
+        prediction[1] += 2.0
+        loss = distiller._meanflow_loss(batch, {"model_prediction": prediction})
+
+        self.assertAlmostEqual(float(batch["_anyflow_pre_adaptive_loss"][0]), 0.0)
+        self.assertAlmostEqual(float(batch["_anyflow_adaptive_reference_loss"][0]), 1.0)
+        self.assertAlmostEqual(float(batch["_anyflow_adaptive_scale"][1]), 0.25, places=5)
+        self.assertAlmostEqual(float(batch["_anyflow_post_adaptive_loss"][1]), 1.0, places=5)
+        self.assertAlmostEqual(float(loss), 0.5, places=5)
+
     def test_seeded_meanflow_pair_uses_isolated_rng_stream(self):
         torch.manual_seed(1234)
         expected_next = torch.rand(4)

--- a/tests/helpers/distillation/test_anyflow_distiller.py
+++ b/tests/helpers/distillation/test_anyflow_distiller.py
@@ -239,6 +239,13 @@ class AnyFlowDistillerTests(unittest.TestCase):
         self.assertEqual(model.component.flowmap_gate_value, 0.4)
         self.assertEqual(model.component.flowmap_deltatime_type, "t-r")
 
+    def test_adapter_preparation_rejects_lora_dropout(self):
+        model = _FlowModel()
+        model.config.lora_dropout = 0.1
+
+        with self.assertRaisesRegex(ValueError, "lora_dropout=0.0"):
+            AnyFlowDistiller.prepare_model_for_adapter(model, {})
+
     def test_factory_reports_guidance_conditioning_for_method_config_shapes(self):
         direct = DistillerFactory.training_batch_requirements(
             "anyflow",

--- a/tests/test_minimaxh3.py
+++ b/tests/test_minimaxh3.py
@@ -1264,6 +1264,33 @@ class MiniMaxH3Tests(unittest.TestCase):
         self.assertIn("delta_time_embedder.linear_1", targets)
         self.assertIsNone(wrapper.get_lora_save_layers())
 
+    def test_anyflow_lora_targets_can_freeze_time_embedders(self):
+        wrapper = MiniMaxH3.__new__(MiniMaxH3)
+        wrapper.config = SimpleNamespace(
+            distillation_method="anyflow",
+            distillation_config={
+                "anyflow": {
+                    "train_time_embedder": False,
+                    "train_delta_embedder": False,
+                }
+            },
+            lora_type="standard",
+            peft_lora_target_modules=None,
+            slider_lora_target=False,
+            controlnet=False,
+        )
+        wrapper.model = tiny_h3_transformer()
+        wrapper.model.enable_flowmap_time_conditioning()
+        wrapper.accelerator = SimpleNamespace(unwrap_model=lambda model, keep_fp32_wrapper=True: model)
+
+        targets = wrapper.get_lora_target_layers()
+
+        self.assertIn("ff.net.0.proj", targets)
+        self.assertIn("ff.net.2", targets)
+        self.assertNotIn("time_embedder.linear_1", targets)
+        self.assertNotIn("delta_time_embedder.linear_1", targets)
+        self.assertIsNone(wrapper.get_lora_save_layers())
+
     def test_anyflow_curve_checkpoint_saves_delta_table_with_adapter(self):
         from peft import LoraConfig
         from peft.utils import get_peft_model_state_dict

--- a/tests/test_resume_lr_scheduler.py
+++ b/tests/test_resume_lr_scheduler.py
@@ -66,6 +66,72 @@ class ResumeLRSchedulerTests(unittest.TestCase):
             trainer.accelerator.load_state.assert_called_once_with(str(checkpoint_dir))
             mock_attention_backend.assert_called_once_with(str(checkpoint_dir))
 
+    @patch("simpletuner.helpers.training.trainer.AttentionBackendController.on_load_checkpoint")
+    def test_constant_with_warmup_resume_rebases_progress_for_new_world_size(self, mock_attention_backend):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            checkpoint_dir = Path(tmpdir, "checkpoint-200")
+            checkpoint_dir.mkdir()
+            trainer = object.__new__(Trainer)
+            trainer.model = SimpleNamespace(reset_flow_custom_timestep_cursor=Mock())
+            trainer.config = SimpleNamespace(
+                output_dir=tmpdir,
+                resume_from_checkpoint=str(checkpoint_dir),
+                total_steps_remaining_at_start=25000,
+                global_resume_step=1,
+                num_train_epochs=1,
+                max_train_steps=25000,
+                musubi_blocks_to_swap=0,
+                lr_scheduler="constant_with_warmup",
+                lr_warmup_steps=1000,
+                learning_rate=5e-5,
+                is_schedulefree=False,
+                overrode_max_train_steps=False,
+                strict_epoch_limit=True,
+                optimizer="adamw",
+                delete_invalid_checkpoints=False,
+            )
+            trainer.accelerator = Mock(num_processes=8)
+            trainer.accelerator.load_state = Mock()
+            trainer.accelerator.wait_for_everyone = Mock()
+            trainer.state = {"global_step": 0, "first_epoch": 1, "current_epoch": 1}
+            trainer.optimizer = Mock(param_groups=[{"lr": 0.0, "initial_lr": 5e-5}])
+            trainer.distiller = None
+            trainer.job_id = "test-job"
+            trainer._emit_event = Mock()
+            trainer.checkpoint_manager = CheckpointManager(tmpdir)
+            scheduler_state = {
+                "base_lrs": [5e-5],
+                "last_epoch": 800,
+                "_step_count": 801,
+                "_last_lr": [1e-5],
+            }
+            lr_scheduler = Mock(split_batches=False)
+            lr_scheduler.state_dict.return_value = scheduler_state
+            trainer.accelerator.load_state.side_effect = lambda _checkpoint: trainer.optimizer.param_groups.__setitem__(
+                slice(None),
+                [{"lr": 1e-5, "initial_lr": 5e-5}],
+            )
+
+            with (
+                patch("simpletuner.helpers.training.state_tracker.StateTracker.get_data_backends", return_value={}),
+                patch("simpletuner.helpers.training.state_tracker.StateTracker.get_global_step", return_value=200),
+                patch("simpletuner.helpers.training.state_tracker.StateTracker.set_global_resume_step"),
+                patch("simpletuner.helpers.training.state_tracker.StateTracker.get_training_state", return_value={}),
+                patch("simpletuner.helpers.training.state_tracker.StateTracker.get_epoch", return_value=1),
+                patch("simpletuner.helpers.training.state_tracker.StateTracker.set_epoch"),
+            ):
+                trainer.init_resume_checkpoint(lr_scheduler=lr_scheduler)
+
+            self.assertEqual(trainer.optimizer.param_groups[0]["lr"], 1e-5)
+            self.assertEqual(trainer.optimizer.param_groups[0]["initial_lr"], 5e-5)
+            self.assertEqual(scheduler_state["base_lrs"], [5e-5])
+            self.assertEqual(scheduler_state["last_epoch"], 1600)
+            self.assertEqual(scheduler_state["_step_count"], 1601)
+            self.assertEqual(scheduler_state["_last_lr"], [1e-5])
+            lr_scheduler.load_state_dict.assert_called_once_with(scheduler_state)
+            trainer.accelerator.load_state.assert_called_once_with(str(checkpoint_dir))
+            mock_attention_backend.assert_called_once_with(str(checkpoint_dir))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request introduces improvements to the handling of LoRA dropout in distillation methods and adds a new option for skipping the text encoder in the H3 objective geometry diagnostic. The most important changes are summarized below:

**Distillation and LoRA Dropout Handling:**

* Added a check in `AnyFlowDistiller.prepare_model_for_adapter` to enforce `lora_dropout=0.0`, raising an error if a nonzero value is set, as independent dropout masks corrupt the distillation target.
* Introduced an `adapter_dropout_override` method to distillation classes and the factory, allowing each method to specify the required LoRA dropout value. The safety check now warns and overrides the dropout value unless explicitly forced by an environment variable. [[1]](diffhunk://#diff-ef514fdba9033b25fbb59ad4181fc498c28a822694fed94712ae71d99337c481R124-R132) [[2]](diffhunk://#diff-e167edd9fbba7ea08d0d8001ae881dd32b0f584ffe153ac501c27f4805cd3ccfR70-R83) [[3]](diffhunk://#diff-15773eb2e82cce02f3434907caa7233d460a3c7fe079a8f30802992e49705592R24-R50)
* Added a unit test to ensure that `AnyFlowDistiller` rejects nonzero LoRA dropout values.

**H3 Objective Geometry Diagnostic Improvements:**

* Added a `--skip-text-encoder` CLI flag and corresponding logic to prevent loading or invoking the text encoder during diagnostics, requiring precomputed text embeddings instead. Validation is also disabled when this flag is active. [[1]](diffhunk://#diff-296fc350765368695a0b7773da76613268e90442a319883ca0978fb9616e447dR10) [[2]](diffhunk://#diff-296fc350765368695a0b7773da76613268e90442a319883ca0978fb9616e447dL393-R420) [[3]](diffhunk://#diff-296fc350765368695a0b7773da76613268e90442a319883ca0978fb9616e447dL609-R628) [[4]](diffhunk://#diff-296fc350765368695a0b7773da76613268e90442a319883ca0978fb9616e447dR725-R729)