### PR TITLE
add --init_lora_step to specify the last global_step the initial LoRA weights came from

### DIFF
--- a/documentation/OPTIONS.es.md
+++ b/documentation/OPTIONS.es.md
@@ -1719,10 +1719,11 @@ Mapeo de opciones upstream (LayerSync → SimpleTuner):
 
 - **Qué**: Continúa la contabilidad del paso global desde el adaptador de solo modelo cargado mediante `--init_lora`.
 - **Cuándo**: Úsalo solo cuando el checkpoint completo del entrenador no esté disponible pero hayan sobrevivido sus pesos LoRA.
+- **Inferencia automática**: Si se omite esta opción, SimpleTuner usa los metadatos `global_step` de un archivo safetensors local indicado por `--init_lora`, cuando estén presentes. Un valor explícito, incluido `0`, reemplaza los metadatos.
 - **Requisitos**: Debe ser no negativo y menor que `--max_train_steps`; requiere `--init_lora` y no puede combinarse con `--resume_from_checkpoint`.
 - **Estado**: La cadencia de checkpoints y validación continúa desde este paso, pero el optimizador, el muestreador y el estado RNG comienzan de nuevo. Los schedules de learning rate `constant` y `constant_with_warmup` se restauran al paso correspondiente.
 
-### `--init_lora_ema_path`
+### `--init_lora_ema`
 
 - **Qué**: Carga el estado nativo `ema_model.pt` de SimpleTuner asociado con `--init_lora`.
 - **Requisitos**: Requiere `--init_lora` y `--use_ema=true`.
@@ -1855,7 +1856,7 @@ usage: train.py [-h] --model_family
                 [--peft_lora_target_modules PEFT_LORA_TARGET_MODULES]
                 [--singlora_ramp_up_steps SINGLORA_RAMP_UP_STEPS]
                 [--init_lora INIT_LORA] [--init_lora_step INIT_LORA_STEP]
-                [--init_lora_ema_path INIT_LORA_EMA_PATH]
+                [--init_lora_ema INIT_LORA_EMA]
                 [--lycoris_config LYCORIS_CONFIG]
                 [--init_lokr_norm INIT_LOKR_NORM]
                 [--flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit,tiny,nano,controlnet,all+ffs+embedder,all+ffs+embedder+controlnet}]
@@ -2246,7 +2247,7 @@ options:
   --init_lora_step INIT_LORA_STEP
                         Continue global-step accounting from a model-only LoRA
                         checkpoint without optimizer state
-  --init_lora_ema_path INIT_LORA_EMA_PATH
+  --init_lora_ema INIT_LORA_EMA
                         Load a raw SimpleTuner EMA state alongside init_lora
   --lycoris_config LYCORIS_CONFIG
                         Path to LyCORIS configuration JSON file

--- a/documentation/OPTIONS.es.md
+++ b/documentation/OPTIONS.es.md
@@ -1715,6 +1715,19 @@ Mapeo de opciones upstream (LayerSync → SimpleTuner):
 
 > ℹ️ Los modelos transformer como PixArt, SD3 o Hunyuan usan los nombres de subcarpeta `transformer` y `transformer_ema`.
 
+### `--init_lora_step`
+
+- **Qué**: Continúa la contabilidad del paso global desde el adaptador de solo modelo cargado mediante `--init_lora`.
+- **Cuándo**: Úsalo solo cuando el checkpoint completo del entrenador no esté disponible pero hayan sobrevivido sus pesos LoRA.
+- **Requisitos**: Debe ser no negativo y menor que `--max_train_steps`; requiere `--init_lora` y no puede combinarse con `--resume_from_checkpoint`.
+- **Estado**: La cadencia de checkpoints y validación continúa desde este paso, pero el optimizador, el muestreador y el estado RNG comienzan de nuevo. Los schedules de learning rate `constant` y `constant_with_warmup` se restauran al paso correspondiente.
+
+### `--init_lora_ema_path`
+
+- **Qué**: Carga el estado nativo `ema_model.pt` de SimpleTuner asociado con `--init_lora`.
+- **Requisitos**: Requiere `--init_lora` y `--use_ema=true`.
+- **Nota**: Espera el estado EMA nativo guardado con el checkpoint, no un archivo safetensors LoRA EMA exportado.
+
 ### `--delete_invalid_checkpoints`
 
 - **Qué**: Elimina checkpoints locales que no puedan cargarse al reanudar.
@@ -1841,7 +1854,9 @@ usage: train.py [-h] --model_family
                 [--peft_lora_mode {standard,singlora}]
                 [--peft_lora_target_modules PEFT_LORA_TARGET_MODULES]
                 [--singlora_ramp_up_steps SINGLORA_RAMP_UP_STEPS]
-                [--init_lora INIT_LORA] [--lycoris_config LYCORIS_CONFIG]
+                [--init_lora INIT_LORA] [--init_lora_step INIT_LORA_STEP]
+                [--init_lora_ema_path INIT_LORA_EMA_PATH]
+                [--lycoris_config LYCORIS_CONFIG]
                 [--init_lokr_norm INIT_LOKR_NORM]
                 [--flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit,tiny,nano,controlnet,all+ffs+embedder,all+ffs+embedder+controlnet}]
                 [--use_dora [USE_DORA]]
@@ -2228,6 +2243,11 @@ options:
   --init_lora INIT_LORA
                         Specify an existing LoRA or LyCORIS safetensors file
                         to initialize the adapter
+  --init_lora_step INIT_LORA_STEP
+                        Continue global-step accounting from a model-only LoRA
+                        checkpoint without optimizer state
+  --init_lora_ema_path INIT_LORA_EMA_PATH
+                        Load a raw SimpleTuner EMA state alongside init_lora
   --lycoris_config LYCORIS_CONFIG
                         Path to LyCORIS configuration JSON file
   --init_lokr_norm INIT_LOKR_NORM

--- a/documentation/OPTIONS.hi.md
+++ b/documentation/OPTIONS.hi.md
@@ -1713,6 +1713,19 @@ Upstream option mapping (LayerSync → SimpleTuner):
 
 > ℹ️ PixArt, SD3, या Hunyuan जैसे transformer मॉडल `transformer` और `transformer_ema` subfolder नाम उपयोग करते हैं।
 
+### `--init_lora_step`
+
+- **What**: `--init_lora` से load किए गए model-only adapter के global-step accounting को जारी रखें।
+- **When**: इसका उपयोग केवल तभी करें जब full trainer checkpoint उपलब्ध न हो, लेकिन LoRA weights उपलब्ध हों।
+- **Requirements**: मान non-negative और `--max_train_steps` से छोटा होना चाहिए; `--init_lora` आवश्यक है और इसे `--resume_from_checkpoint` के साथ उपयोग नहीं किया जा सकता।
+- **State**: Checkpoint और validation cadence इस step से जारी रहते हैं, लेकिन optimizer, sampler और RNG state नए सिरे से शुरू होते हैं। `constant` और `constant_with_warmup` learning-rate schedules संबंधित step पर restore होते हैं।
+
+### `--init_lora_ema_path`
+
+- **What**: `--init_lora` से संबंधित raw SimpleTuner `ema_model.pt` state load करें।
+- **Requirements**: `--init_lora` और `--use_ema=true` दोनों आवश्यक हैं।
+- **Note**: यह checkpoint के साथ save किए गए raw EMA state की अपेक्षा करता है, exported EMA LoRA safetensors file की नहीं।
+
 ### `--delete_invalid_checkpoints`
 
 - **What**: resume करते समय जो local checkpoints load नहीं हो सकते उन्हें delete करें।
@@ -1839,7 +1852,9 @@ usage: train.py [-h] --model_family
                 [--peft_lora_mode {standard,singlora}]
                 [--peft_lora_target_modules PEFT_LORA_TARGET_MODULES]
                 [--singlora_ramp_up_steps SINGLORA_RAMP_UP_STEPS]
-                [--init_lora INIT_LORA] [--lycoris_config LYCORIS_CONFIG]
+                [--init_lora INIT_LORA] [--init_lora_step INIT_LORA_STEP]
+                [--init_lora_ema_path INIT_LORA_EMA_PATH]
+                [--lycoris_config LYCORIS_CONFIG]
                 [--init_lokr_norm INIT_LOKR_NORM]
                 [--flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit,tiny,nano,controlnet,all+ffs+embedder,all+ffs+embedder+controlnet}]
                 [--use_dora [USE_DORA]]
@@ -2226,6 +2241,11 @@ options:
   --init_lora INIT_LORA
                         Specify an existing LoRA or LyCORIS safetensors file
                         to initialize the adapter
+  --init_lora_step INIT_LORA_STEP
+                        Continue global-step accounting from a model-only LoRA
+                        checkpoint without optimizer state
+  --init_lora_ema_path INIT_LORA_EMA_PATH
+                        Load a raw SimpleTuner EMA state alongside init_lora
   --lycoris_config LYCORIS_CONFIG
                         Path to LyCORIS configuration JSON file
   --init_lokr_norm INIT_LOKR_NORM

--- a/documentation/OPTIONS.hi.md
+++ b/documentation/OPTIONS.hi.md
@@ -1717,10 +1717,11 @@ Upstream option mapping (LayerSync → SimpleTuner):
 
 - **What**: `--init_lora` से load किए गए model-only adapter के global-step accounting को जारी रखें।
 - **When**: इसका उपयोग केवल तभी करें जब full trainer checkpoint उपलब्ध न हो, लेकिन LoRA weights उपलब्ध हों।
+- **Automatic inference**: यह option न देने पर, local `--init_lora` safetensors file में `global_step` metadata मौजूद हो तो SimpleTuner उसका उपयोग करता है। `0` सहित कोई explicit value metadata को override करती है।
 - **Requirements**: मान non-negative और `--max_train_steps` से छोटा होना चाहिए; `--init_lora` आवश्यक है और इसे `--resume_from_checkpoint` के साथ उपयोग नहीं किया जा सकता।
 - **State**: Checkpoint और validation cadence इस step से जारी रहते हैं, लेकिन optimizer, sampler और RNG state नए सिरे से शुरू होते हैं। `constant` और `constant_with_warmup` learning-rate schedules संबंधित step पर restore होते हैं।
 
-### `--init_lora_ema_path`
+### `--init_lora_ema`
 
 - **What**: `--init_lora` से संबंधित raw SimpleTuner `ema_model.pt` state load करें।
 - **Requirements**: `--init_lora` और `--use_ema=true` दोनों आवश्यक हैं।
@@ -1853,7 +1854,7 @@ usage: train.py [-h] --model_family
                 [--peft_lora_target_modules PEFT_LORA_TARGET_MODULES]
                 [--singlora_ramp_up_steps SINGLORA_RAMP_UP_STEPS]
                 [--init_lora INIT_LORA] [--init_lora_step INIT_LORA_STEP]
-                [--init_lora_ema_path INIT_LORA_EMA_PATH]
+                [--init_lora_ema INIT_LORA_EMA]
                 [--lycoris_config LYCORIS_CONFIG]
                 [--init_lokr_norm INIT_LOKR_NORM]
                 [--flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit,tiny,nano,controlnet,all+ffs+embedder,all+ffs+embedder+controlnet}]
@@ -2244,7 +2245,7 @@ options:
   --init_lora_step INIT_LORA_STEP
                         Continue global-step accounting from a model-only LoRA
                         checkpoint without optimizer state
-  --init_lora_ema_path INIT_LORA_EMA_PATH
+  --init_lora_ema INIT_LORA_EMA
                         Load a raw SimpleTuner EMA state alongside init_lora
   --lycoris_config LYCORIS_CONFIG
                         Path to LyCORIS configuration JSON file

--- a/documentation/OPTIONS.ja.md
+++ b/documentation/OPTIONS.ja.md
@@ -1720,10 +1720,11 @@ LayerSync は同一 Transformer 内の「学生」レイヤーを、より強い
 
 - **内容**: `--init_lora` で読み込んだモデル重みのみの adapter から、global step の計数を継続します。
 - **使用時**: 完全な trainer checkpoint は利用できないが、LoRA 重みが残っている場合にのみ使用します。
+- **自動推論**: このオプションを省略すると、ローカルの `--init_lora` safetensors file に `global_step` metadata がある場合、SimpleTuner はその値を使用します。`0` を含む明示的な値は metadata を上書きします。
 - **要件**: 0 以上かつ `--max_train_steps` 未満である必要があります。`--init_lora` が必須で、`--resume_from_checkpoint` とは併用できません。
 - **状態**: checkpoint と validation の間隔はこの step から継続しますが、optimizer、sampler、RNG state は新規に開始します。`constant` と `constant_with_warmup` の learning-rate schedule は対応する step に復元されます。
 
-### `--init_lora_ema_path`
+### `--init_lora_ema`
 
 - **内容**: `--init_lora` に対応する SimpleTuner の raw `ema_model.pt` state を読み込みます。
 - **要件**: `--init_lora` と `--use_ema=true` の両方が必要です。
@@ -1856,7 +1857,7 @@ usage: train.py [-h] --model_family
                 [--peft_lora_target_modules PEFT_LORA_TARGET_MODULES]
                 [--singlora_ramp_up_steps SINGLORA_RAMP_UP_STEPS]
                 [--init_lora INIT_LORA] [--init_lora_step INIT_LORA_STEP]
-                [--init_lora_ema_path INIT_LORA_EMA_PATH]
+                [--init_lora_ema INIT_LORA_EMA]
                 [--lycoris_config LYCORIS_CONFIG]
                 [--init_lokr_norm INIT_LOKR_NORM]
                 [--flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit,tiny,nano,controlnet,all+ffs+embedder,all+ffs+embedder+controlnet}]
@@ -2246,7 +2247,7 @@ options:
   --init_lora_step INIT_LORA_STEP
                         Continue global-step accounting from a model-only LoRA
                         checkpoint without optimizer state
-  --init_lora_ema_path INIT_LORA_EMA_PATH
+  --init_lora_ema INIT_LORA_EMA
                         Load a raw SimpleTuner EMA state alongside init_lora
   --lycoris_config LYCORIS_CONFIG
                         Path to LyCORIS configuration JSON file

--- a/documentation/OPTIONS.ja.md
+++ b/documentation/OPTIONS.ja.md
@@ -1716,6 +1716,19 @@ LayerSync は同一 Transformer 内の「学生」レイヤーを、より強い
 
 > ℹ️ PixArt、SD3、Hunyuan などの Transformer モデルは `transformer` と `transformer_ema` のサブフォルダ名を使用します。
 
+### `--init_lora_step`
+
+- **内容**: `--init_lora` で読み込んだモデル重みのみの adapter から、global step の計数を継続します。
+- **使用時**: 完全な trainer checkpoint は利用できないが、LoRA 重みが残っている場合にのみ使用します。
+- **要件**: 0 以上かつ `--max_train_steps` 未満である必要があります。`--init_lora` が必須で、`--resume_from_checkpoint` とは併用できません。
+- **状態**: checkpoint と validation の間隔はこの step から継続しますが、optimizer、sampler、RNG state は新規に開始します。`constant` と `constant_with_warmup` の learning-rate schedule は対応する step に復元されます。
+
+### `--init_lora_ema_path`
+
+- **内容**: `--init_lora` に対応する SimpleTuner の raw `ema_model.pt` state を読み込みます。
+- **要件**: `--init_lora` と `--use_ema=true` の両方が必要です。
+- **注記**: exported EMA LoRA safetensors file ではなく、checkpoint と共に保存された raw EMA state を指定します。
+
 ### `--delete_invalid_checkpoints`
 
 - **内容**: 再開時に読み込めないローカルチェックポイントを削除します。
@@ -1842,7 +1855,9 @@ usage: train.py [-h] --model_family
                 [--peft_lora_mode {standard,singlora}]
                 [--peft_lora_target_modules PEFT_LORA_TARGET_MODULES]
                 [--singlora_ramp_up_steps SINGLORA_RAMP_UP_STEPS]
-                [--init_lora INIT_LORA] [--lycoris_config LYCORIS_CONFIG]
+                [--init_lora INIT_LORA] [--init_lora_step INIT_LORA_STEP]
+                [--init_lora_ema_path INIT_LORA_EMA_PATH]
+                [--lycoris_config LYCORIS_CONFIG]
                 [--init_lokr_norm INIT_LOKR_NORM]
                 [--flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit,tiny,nano,controlnet,all+ffs+embedder,all+ffs+embedder+controlnet}]
                 [--use_dora [USE_DORA]]
@@ -2228,6 +2243,11 @@ options:
   --init_lora INIT_LORA
                         Specify an existing LoRA or LyCORIS safetensors file
                         to initialize the adapter
+  --init_lora_step INIT_LORA_STEP
+                        Continue global-step accounting from a model-only LoRA
+                        checkpoint without optimizer state
+  --init_lora_ema_path INIT_LORA_EMA_PATH
+                        Load a raw SimpleTuner EMA state alongside init_lora
   --lycoris_config LYCORIS_CONFIG
                         Path to LyCORIS configuration JSON file
   --init_lokr_norm INIT_LOKR_NORM

--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -1723,10 +1723,11 @@ Upstream option mapping (LayerSync → SimpleTuner):
 
 - **What**: Continue global-step accounting from the model-only adapter loaded by `--init_lora`.
 - **When**: Use this only when the full trainer checkpoint is unavailable but its LoRA weights survived.
+- **Automatic inference**: When this option is omitted, SimpleTuner uses the `global_step` metadata from a local `--init_lora` safetensors file when present. An explicit value, including `0`, overrides the metadata.
 - **Requirements**: Must be non-negative and smaller than `--max_train_steps`; requires `--init_lora` and cannot be combined with `--resume_from_checkpoint`.
 - **State**: Checkpoint and validation cadence continue from this step, but optimizer, sampler, and RNG state start fresh. `constant` and `constant_with_warmup` learning-rate schedules are restored to the corresponding step.
 
-### `--init_lora_ema_path`
+### `--init_lora_ema`
 
 - **What**: Load the raw SimpleTuner `ema_model.pt` state associated with `--init_lora`.
 - **Requirements**: Requires both `--init_lora` and `--use_ema=true`.
@@ -1859,7 +1860,7 @@ usage: train.py [-h] --model_family
                 [--peft_lora_target_modules PEFT_LORA_TARGET_MODULES]
                 [--singlora_ramp_up_steps SINGLORA_RAMP_UP_STEPS]
                 [--init_lora INIT_LORA] [--init_lora_step INIT_LORA_STEP]
-                [--init_lora_ema_path INIT_LORA_EMA_PATH]
+                [--init_lora_ema INIT_LORA_EMA]
                 [--lycoris_config LYCORIS_CONFIG]
                 [--init_lokr_norm INIT_LOKR_NORM]
                 [--flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit,tiny,nano,controlnet,all+ffs+embedder,all+ffs+embedder+controlnet}]
@@ -2250,7 +2251,7 @@ options:
   --init_lora_step INIT_LORA_STEP
                         Continue global-step accounting from a model-only LoRA
                         checkpoint without optimizer state
-  --init_lora_ema_path INIT_LORA_EMA_PATH
+  --init_lora_ema INIT_LORA_EMA
                         Load a raw SimpleTuner EMA state alongside init_lora
   --lycoris_config LYCORIS_CONFIG
                         Path to LyCORIS configuration JSON file

--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -1719,6 +1719,19 @@ Upstream option mapping (LayerSync → SimpleTuner):
 
 > ℹ️ Transformer models such as PixArt, SD3, or Hunyuan, use the `transformer` and `transformer_ema` subfolder names.
 
+### `--init_lora_step`
+
+- **What**: Continue global-step accounting from the model-only adapter loaded by `--init_lora`.
+- **When**: Use this only when the full trainer checkpoint is unavailable but its LoRA weights survived.
+- **Requirements**: Must be non-negative and smaller than `--max_train_steps`; requires `--init_lora` and cannot be combined with `--resume_from_checkpoint`.
+- **State**: Checkpoint and validation cadence continue from this step, but optimizer, sampler, and RNG state start fresh. `constant` and `constant_with_warmup` learning-rate schedules are restored to the corresponding step.
+
+### `--init_lora_ema_path`
+
+- **What**: Load the raw SimpleTuner `ema_model.pt` state associated with `--init_lora`.
+- **Requirements**: Requires both `--init_lora` and `--use_ema=true`.
+- **Note**: This expects the raw EMA state saved with the checkpoint, not an exported EMA LoRA safetensors file.
+
 ### `--delete_invalid_checkpoints`
 
 - **What**: Delete local checkpoints that cannot be loaded while resuming.
@@ -1845,7 +1858,9 @@ usage: train.py [-h] --model_family
                 [--peft_lora_mode {standard,singlora}]
                 [--peft_lora_target_modules PEFT_LORA_TARGET_MODULES]
                 [--singlora_ramp_up_steps SINGLORA_RAMP_UP_STEPS]
-                [--init_lora INIT_LORA] [--lycoris_config LYCORIS_CONFIG]
+                [--init_lora INIT_LORA] [--init_lora_step INIT_LORA_STEP]
+                [--init_lora_ema_path INIT_LORA_EMA_PATH]
+                [--lycoris_config LYCORIS_CONFIG]
                 [--init_lokr_norm INIT_LOKR_NORM]
                 [--flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit,tiny,nano,controlnet,all+ffs+embedder,all+ffs+embedder+controlnet}]
                 [--use_dora [USE_DORA]]
@@ -2232,6 +2247,11 @@ options:
   --init_lora INIT_LORA
                         Specify an existing LoRA or LyCORIS safetensors file
                         to initialize the adapter
+  --init_lora_step INIT_LORA_STEP
+                        Continue global-step accounting from a model-only LoRA
+                        checkpoint without optimizer state
+  --init_lora_ema_path INIT_LORA_EMA_PATH
+                        Load a raw SimpleTuner EMA state alongside init_lora
   --lycoris_config LYCORIS_CONFIG
                         Path to LyCORIS configuration JSON file
   --init_lokr_norm INIT_LOKR_NORM

--- a/documentation/OPTIONS.pt-BR.md
+++ b/documentation/OPTIONS.pt-BR.md
@@ -1711,6 +1711,19 @@ Mapeamento de opcoes upstream (LayerSync → SimpleTuner):
 
 > ℹ️ Modelos transformer como PixArt, SD3 ou Hunyuan usam os subdiretorios `transformer` e `transformer_ema`.
 
+### `--init_lora_step`
+
+- **O que**: Continua a contagem do passo global a partir do adapter somente de modelo carregado por `--init_lora`.
+- **Quando**: Use somente quando o checkpoint completo do trainer nao estiver disponivel, mas os pesos LoRA tiverem sobrevivido.
+- **Requisitos**: Deve ser nao negativo e menor que `--max_train_steps`; exige `--init_lora` e nao pode ser combinado com `--resume_from_checkpoint`.
+- **Estado**: A cadencia de checkpoints e validacao continua a partir desse passo, mas os estados do optimizer, sampler e RNG recomecam. Os schedules de learning rate `constant` e `constant_with_warmup` sao restaurados para o passo correspondente.
+
+### `--init_lora_ema_path`
+
+- **O que**: Carrega o estado raw `ema_model.pt` do SimpleTuner associado a `--init_lora`.
+- **Requisitos**: Exige `--init_lora` e `--use_ema=true`.
+- **Nota**: Espera o estado EMA raw salvo com o checkpoint, nao um arquivo safetensors LoRA EMA exportado.
+
 ### `--delete_invalid_checkpoints`
 
 - **O que**: Remove checkpoints locais que nao podem ser carregados ao retomar.
@@ -1837,7 +1850,9 @@ usage: train.py [-h] --model_family
                 [--peft_lora_mode {standard,singlora}]
                 [--peft_lora_target_modules PEFT_LORA_TARGET_MODULES]
                 [--singlora_ramp_up_steps SINGLORA_RAMP_UP_STEPS]
-                [--init_lora INIT_LORA] [--lycoris_config LYCORIS_CONFIG]
+                [--init_lora INIT_LORA] [--init_lora_step INIT_LORA_STEP]
+                [--init_lora_ema_path INIT_LORA_EMA_PATH]
+                [--lycoris_config LYCORIS_CONFIG]
                 [--init_lokr_norm INIT_LOKR_NORM]
                 [--flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit,tiny,nano,controlnet,all+ffs+embedder,all+ffs+embedder+controlnet}]
                 [--use_dora [USE_DORA]]
@@ -2223,6 +2238,11 @@ options:
   --init_lora INIT_LORA
                         Specify an existing LoRA or LyCORIS safetensors file
                         to initialize the adapter
+  --init_lora_step INIT_LORA_STEP
+                        Continue global-step accounting from a model-only LoRA
+                        checkpoint without optimizer state
+  --init_lora_ema_path INIT_LORA_EMA_PATH
+                        Load a raw SimpleTuner EMA state alongside init_lora
   --lycoris_config LYCORIS_CONFIG
                         Path to LyCORIS configuration JSON file
   --init_lokr_norm INIT_LOKR_NORM

--- a/documentation/OPTIONS.pt-BR.md
+++ b/documentation/OPTIONS.pt-BR.md
@@ -1715,10 +1715,11 @@ Mapeamento de opcoes upstream (LayerSync → SimpleTuner):
 
 - **O que**: Continua a contagem do passo global a partir do adapter somente de modelo carregado por `--init_lora`.
 - **Quando**: Use somente quando o checkpoint completo do trainer nao estiver disponivel, mas os pesos LoRA tiverem sobrevivido.
+- **Inferencia automatica**: Quando esta opcao e omitida, o SimpleTuner usa o metadata `global_step` de um arquivo safetensors local fornecido por `--init_lora`, quando presente. Um valor explicito, incluindo `0`, substitui o metadata.
 - **Requisitos**: Deve ser nao negativo e menor que `--max_train_steps`; exige `--init_lora` e nao pode ser combinado com `--resume_from_checkpoint`.
 - **Estado**: A cadencia de checkpoints e validacao continua a partir desse passo, mas os estados do optimizer, sampler e RNG recomecam. Os schedules de learning rate `constant` e `constant_with_warmup` sao restaurados para o passo correspondente.
 
-### `--init_lora_ema_path`
+### `--init_lora_ema`
 
 - **O que**: Carrega o estado raw `ema_model.pt` do SimpleTuner associado a `--init_lora`.
 - **Requisitos**: Exige `--init_lora` e `--use_ema=true`.
@@ -1851,7 +1852,7 @@ usage: train.py [-h] --model_family
                 [--peft_lora_target_modules PEFT_LORA_TARGET_MODULES]
                 [--singlora_ramp_up_steps SINGLORA_RAMP_UP_STEPS]
                 [--init_lora INIT_LORA] [--init_lora_step INIT_LORA_STEP]
-                [--init_lora_ema_path INIT_LORA_EMA_PATH]
+                [--init_lora_ema INIT_LORA_EMA]
                 [--lycoris_config LYCORIS_CONFIG]
                 [--init_lokr_norm INIT_LOKR_NORM]
                 [--flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit,tiny,nano,controlnet,all+ffs+embedder,all+ffs+embedder+controlnet}]
@@ -2241,7 +2242,7 @@ options:
   --init_lora_step INIT_LORA_STEP
                         Continue global-step accounting from a model-only LoRA
                         checkpoint without optimizer state
-  --init_lora_ema_path INIT_LORA_EMA_PATH
+  --init_lora_ema INIT_LORA_EMA
                         Load a raw SimpleTuner EMA state alongside init_lora
   --lycoris_config LYCORIS_CONFIG
                         Path to LyCORIS configuration JSON file

--- a/documentation/OPTIONS.zh.md
+++ b/documentation/OPTIONS.zh.md
@@ -1718,6 +1718,19 @@ LayerSync 通过在同一 Transformer 内让“学生”层对齐更强的“教
 
 > ℹ️ PixArt、SD3、Hunyuan 等 Transformer 模型使用 `transformer` 与 `transformer_ema` 子目录名称。
 
+### `--init_lora_step`
+
+- **内容**：从 `--init_lora` 加载的纯模型 adapter 继续全局步数计数。
+- **使用时机**：仅在完整 trainer checkpoint 不可用、但 LoRA 权重仍然保留时使用。
+- **要求**：必须为非负数且小于 `--max_train_steps`；需要 `--init_lora`，且不能与 `--resume_from_checkpoint` 同时使用。
+- **状态**：checkpoint 与 validation 的节奏从该步数继续，但 optimizer、sampler 和 RNG state 会重新开始。`constant` 与 `constant_with_warmup` learning-rate schedule 会恢复到对应步数。
+
+### `--init_lora_ema_path`
+
+- **内容**：加载与 `--init_lora` 对应的 SimpleTuner 原始 `ema_model.pt` state。
+- **要求**：需要 `--init_lora` 和 `--use_ema=true`。
+- **注意**：这里需要的是 checkpoint 保存的原始 EMA state，而不是导出的 EMA LoRA safetensors 文件。
+
 ### `--delete_invalid_checkpoints`
 
 - **内容**：恢复时删除无法加载的本地检查点。
@@ -1844,7 +1857,9 @@ usage: train.py [-h] --model_family
                 [--peft_lora_mode {standard,singlora}]
                 [--peft_lora_target_modules PEFT_LORA_TARGET_MODULES]
                 [--singlora_ramp_up_steps SINGLORA_RAMP_UP_STEPS]
-                [--init_lora INIT_LORA] [--lycoris_config LYCORIS_CONFIG]
+                [--init_lora INIT_LORA] [--init_lora_step INIT_LORA_STEP]
+                [--init_lora_ema_path INIT_LORA_EMA_PATH]
+                [--lycoris_config LYCORIS_CONFIG]
                 [--init_lokr_norm INIT_LOKR_NORM]
                 [--flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit,tiny,nano,controlnet,all+ffs+embedder,all+ffs+embedder+controlnet}]
                 [--use_dora [USE_DORA]]
@@ -2230,6 +2245,11 @@ options:
   --init_lora INIT_LORA
                         Specify an existing LoRA or LyCORIS safetensors file
                         to initialize the adapter
+  --init_lora_step INIT_LORA_STEP
+                        Continue global-step accounting from a model-only LoRA
+                        checkpoint without optimizer state
+  --init_lora_ema_path INIT_LORA_EMA_PATH
+                        Load a raw SimpleTuner EMA state alongside init_lora
   --lycoris_config LYCORIS_CONFIG
                         Path to LyCORIS configuration JSON file
   --init_lokr_norm INIT_LOKR_NORM

--- a/documentation/OPTIONS.zh.md
+++ b/documentation/OPTIONS.zh.md
@@ -1722,10 +1722,11 @@ LayerSync 通过在同一 Transformer 内让“学生”层对齐更强的“教
 
 - **内容**：从 `--init_lora` 加载的纯模型 adapter 继续全局步数计数。
 - **使用时机**：仅在完整 trainer checkpoint 不可用、但 LoRA 权重仍然保留时使用。
+- **自动推断**：省略此选项时，如果本地 `--init_lora` safetensors 文件包含 `global_step` metadata，SimpleTuner 会使用该值。显式值（包括 `0`）会覆盖 metadata。
 - **要求**：必须为非负数且小于 `--max_train_steps`；需要 `--init_lora`，且不能与 `--resume_from_checkpoint` 同时使用。
 - **状态**：checkpoint 与 validation 的节奏从该步数继续，但 optimizer、sampler 和 RNG state 会重新开始。`constant` 与 `constant_with_warmup` learning-rate schedule 会恢复到对应步数。
 
-### `--init_lora_ema_path`
+### `--init_lora_ema`
 
 - **内容**：加载与 `--init_lora` 对应的 SimpleTuner 原始 `ema_model.pt` state。
 - **要求**：需要 `--init_lora` 和 `--use_ema=true`。
@@ -1858,7 +1859,7 @@ usage: train.py [-h] --model_family
                 [--peft_lora_target_modules PEFT_LORA_TARGET_MODULES]
                 [--singlora_ramp_up_steps SINGLORA_RAMP_UP_STEPS]
                 [--init_lora INIT_LORA] [--init_lora_step INIT_LORA_STEP]
-                [--init_lora_ema_path INIT_LORA_EMA_PATH]
+                [--init_lora_ema INIT_LORA_EMA]
                 [--lycoris_config LYCORIS_CONFIG]
                 [--init_lokr_norm INIT_LOKR_NORM]
                 [--flux_lora_target {mmdit,context,context+ffs,all,all+ffs,ai-toolkit,tiny,nano,controlnet,all+ffs+embedder,all+ffs+embedder+controlnet}]
@@ -2248,7 +2249,7 @@ options:
   --init_lora_step INIT_LORA_STEP
                         Continue global-step accounting from a model-only LoRA
                         checkpoint without optimizer state
-  --init_lora_ema_path INIT_LORA_EMA_PATH
+  --init_lora_ema INIT_LORA_EMA
                         Load a raw SimpleTuner EMA state alongside init_lora
   --lycoris_config LYCORIS_CONFIG
                         Path to LyCORIS configuration JSON file

--- a/simpletuner/helpers/training/save_hooks.py
+++ b/simpletuner/helpers/training/save_hooks.py
@@ -613,7 +613,10 @@ class SaveHookManager:
         return metadata
 
     def _build_modelspec_metadata(self, checkpoint_dir: str | None = None) -> dict[str, str]:
-        metadata = {"modelspec.sai_model_spec": MODEL_SPEC_VERSION}
+        metadata = {
+            "modelspec.sai_model_spec": MODEL_SPEC_VERSION,
+            "global_step": str(int(StateTracker.get_global_step() or 0)),
+        }
 
         architecture = self._derive_modelspec_architecture()
         if architecture:

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -2235,6 +2235,29 @@ class Trainer:
             self._hub_upload_executor.shutdown(wait=True)
             self._hub_upload_executor = None
 
+    def _initial_lora_step(self) -> int:
+        raw_step = getattr(self.config, "init_lora_step", 0)
+        if isinstance(raw_step, unittest_mock.Mock):
+            raw_step = 0
+        try:
+            initial_step = int(raw_step or 0)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"init_lora_step must be a non-negative integer, received {raw_step!r}.") from exc
+
+        if initial_step < 0 or (isinstance(raw_step, float) and not raw_step.is_integer()):
+            raise ValueError(f"init_lora_step must be a non-negative integer, received {raw_step!r}.")
+        if initial_step == 0:
+            return 0
+        if not getattr(self.config, "init_lora", None):
+            raise ValueError("init_lora_step requires init_lora.")
+        if getattr(self.config, "resume_from_checkpoint", None):
+            raise ValueError("init_lora_step cannot be combined with resume_from_checkpoint.")
+
+        max_train_steps = getattr(self.config, "max_train_steps", None)
+        if max_train_steps not in (None, 0) and initial_step >= int(max_train_steps):
+            raise ValueError(f"init_lora_step ({initial_step}) must be smaller than max_train_steps ({max_train_steps}).")
+        return initial_step
+
     def _misc_init(self):
         """things that do not really need an order."""
         torch.set_num_threads(self.config.torch_num_threads)
@@ -2248,8 +2271,9 @@ class Trainer:
         #  takes into account the number of gradient_accumulation_steps. If we use 1 gradient_accumulation_step,
         #  then global_step and step will be the same throughout training. However, if we use
         #  2 gradient_accumulation_steps, then global_step will be twice as large as step, and so on.
-        self.state["global_step"] = 0
-        self.state["global_resume_step"] = 0
+        initial_lora_step = self._initial_lora_step()
+        self.state["global_step"] = initial_lora_step
+        self.state["global_resume_step"] = initial_lora_step
         self.state["first_epoch"] = 1
         self.state["args"] = self.config.__dict__
         self.timesteps_buffer = []
@@ -2266,6 +2290,7 @@ class Trainer:
         self.extra_lr_scheduler_kwargs = {}
         self.iteration_tracker = IterationTracker()
         StateTracker.set_global_step(self.state["global_step"])
+        StateTracker.set_global_resume_step(self.state["global_resume_step"])
         self._init_publishing_manager()
         self.config.use_deepspeed_optimizer, self.config.use_deepspeed_scheduler = prepare_model_for_deepspeed(
             self.accelerator, self.config
@@ -4098,6 +4123,25 @@ class Trainer:
         _init_lyrics_scheduler()
         return lr_scheduler
 
+    def _load_initial_lora_ema_state(self) -> None:
+        init_ema_path = getattr(self.config, "init_lora_ema_path", None)
+        if isinstance(init_ema_path, unittest_mock.Mock):
+            init_ema_path = None
+        if not init_ema_path:
+            return
+        if not getattr(self.config, "init_lora", None):
+            raise ValueError("init_lora_ema_path requires init_lora.")
+        if not getattr(self.config, "use_ema", False):
+            raise ValueError("init_lora_ema_path requires use_ema=true.")
+        if not os.path.isfile(init_ema_path):
+            raise FileNotFoundError(f"Initial LoRA EMA state does not exist: {init_ema_path}")
+        if self.ema_model is None:
+            return
+
+        self.ema_model.load_state_dict(init_ema_path)
+        if self.accelerator.is_main_process:
+            logger.info(f"Loaded initial LoRA EMA state from {init_ema_path}")
+
     def init_ema_model(self):
         # Create EMA for the model.
         self.ema_model = None
@@ -4151,8 +4195,12 @@ class Trainer:
                 warmup_steps=getattr(self.config, "ema_warmup_steps", 0),
                 foreach=not self.config.ema_foreach_disable,
             )
+            self._load_initial_lora_ema_state()
             if should_log:
                 logger.info(f"EMA model creation completed with {self.ema_model.parameter_count():,} parameters")
+
+        if not instantiate_on_rank:
+            self._load_initial_lora_ema_state()
 
         self.accelerator.wait_for_everyone()
         # same about running on all processes to ensure alignment.
@@ -4726,7 +4774,26 @@ class Trainer:
         self.state["global_resume_step"] = self.state["global_step"] = StateTracker.get_global_step()
         StateTracker.set_global_resume_step(self.state["global_resume_step"])
         if not self.config.resume_from_checkpoint:
-            logger.info(f"Not resuming from checkpoint.")
+            initial_lora_step = self._initial_lora_step()
+            if initial_lora_step:
+                optimizer_param_groups = getattr(getattr(self, "optimizer", None), "param_groups", [])
+                configured_param_group_lrs = [group.get("initial_lr", group.get("lr")) for group in optimizer_param_groups]
+                self._restore_constant_scheduler_lr(
+                    lr_scheduler,
+                    optimizer_param_groups,
+                    configured_param_group_lrs,
+                    initial_lora_step,
+                )
+                self.config.total_steps_remaining_at_start -= initial_lora_step
+                if hasattr(self.model, "reset_flow_custom_timestep_cursor"):
+                    self.model.reset_flow_custom_timestep_cursor(initial_lora_step)
+                logger.warning(
+                    "Continuing from init_lora at global step %s with fresh optimizer, sampler, and RNG state. "
+                    "Use resume_from_checkpoint when full trainer state is available.",
+                    initial_lora_step,
+                )
+            else:
+                logger.info("Not resuming from checkpoint.")
             return lr_scheduler
         resume_value = str(self.config.resume_from_checkpoint)
         delete_invalid_value = getattr(self.config, "delete_invalid_checkpoints", False)

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -2235,10 +2235,29 @@ class Trainer:
             self._hub_upload_executor.shutdown(wait=True)
             self._hub_upload_executor = None
 
+    def _init_lora_metadata_global_step(self) -> str | None:
+        init_lora = getattr(self.config, "init_lora", None)
+        if not isinstance(init_lora, (str, os.PathLike)) or not os.path.isfile(init_lora):
+            return None
+
+        from safetensors import safe_open
+
+        try:
+            with safe_open(os.fspath(init_lora), framework="pt", device="cpu") as handle:
+                metadata = handle.metadata() or {}
+        except Exception as exc:
+            raise ValueError(f"Unable to inspect init_lora checkpoint metadata: {init_lora}") from exc
+        return metadata.get("global_step")
+
     def _initial_lora_step(self) -> int:
-        raw_step = getattr(self.config, "init_lora_step", 0)
+        raw_step = getattr(self.config, "init_lora_step", None)
         if isinstance(raw_step, unittest_mock.Mock):
-            raw_step = 0
+            raw_step = None
+        inferred_from_metadata = raw_step is None
+        if inferred_from_metadata:
+            raw_step = self._init_lora_metadata_global_step()
+        if raw_step is None:
+            return 0
         try:
             initial_step = int(raw_step or 0)
         except (TypeError, ValueError) as exc:
@@ -2256,7 +2275,54 @@ class Trainer:
         max_train_steps = getattr(self.config, "max_train_steps", None)
         if max_train_steps not in (None, 0) and initial_step >= int(max_train_steps):
             raise ValueError(f"init_lora_step ({initial_step}) must be smaller than max_train_steps ({max_train_steps}).")
+        if inferred_from_metadata:
+            self.config.init_lora_step = initial_step
+            logger.info("Using global step %s from init_lora safetensors metadata.", initial_step)
         return initial_step
+
+    def _restore_constant_scheduler_lr(
+        self,
+        lr_scheduler,
+        optimizer_param_groups: list[dict],
+        configured_param_group_lrs: list[float | None],
+        global_step: int,
+    ) -> None:
+        if (
+            lr_scheduler is None
+            or self.config.lr_scheduler not in ("constant", "constant_with_warmup")
+            or self.config.is_schedulefree
+        ):
+            return
+
+        scheduler_steps = global_step
+        if not getattr(lr_scheduler, "split_batches", False):
+            scheduler_steps *= self.accelerator.num_processes
+
+        warmup_steps = int(getattr(self.config, "lr_warmup_steps", 0) or 0) * self.accelerator.num_processes
+        lr_scale = 1.0
+        if self.config.lr_scheduler == "constant_with_warmup" and warmup_steps > 0:
+            lr_scale = min(float(scheduler_steps) / float(warmup_steps), 1.0)
+
+        restored_lrs = []
+        for group_index, group in enumerate(optimizer_param_groups):
+            configured_lr = configured_param_group_lrs[group_index]
+            if configured_lr is None:
+                restored_lrs.append(group.get("lr"))
+                continue
+            restored_lr = configured_lr * lr_scale
+            group["lr"] = restored_lr
+            restored_lrs.append(restored_lr)
+
+        scheduler_state = lr_scheduler.state_dict()
+        if "base_lrs" in scheduler_state:
+            scheduler_state["base_lrs"] = list(configured_param_group_lrs)
+        if "_last_lr" in scheduler_state:
+            scheduler_state["_last_lr"] = restored_lrs
+        if "last_epoch" in scheduler_state:
+            scheduler_state["last_epoch"] = scheduler_steps
+        if "_step_count" in scheduler_state:
+            scheduler_state["_step_count"] = scheduler_steps + 1
+        lr_scheduler.load_state_dict(scheduler_state)
 
     def _misc_init(self):
         """things that do not really need an order."""
@@ -4124,15 +4190,15 @@ class Trainer:
         return lr_scheduler
 
     def _load_initial_lora_ema_state(self) -> None:
-        init_ema_path = getattr(self.config, "init_lora_ema_path", None)
+        init_ema_path = getattr(self.config, "init_lora_ema", None)
         if isinstance(init_ema_path, unittest_mock.Mock):
             init_ema_path = None
         if not init_ema_path:
             return
         if not getattr(self.config, "init_lora", None):
-            raise ValueError("init_lora_ema_path requires init_lora.")
+            raise ValueError("init_lora_ema requires init_lora.")
         if not getattr(self.config, "use_ema", False):
-            raise ValueError("init_lora_ema_path requires use_ema=true.")
+            raise ValueError("init_lora_ema requires use_ema=true.")
         if not os.path.isfile(init_ema_path):
             raise FileNotFoundError(f"Initial LoRA EMA state does not exist: {init_ema_path}")
         if self.ema_model is None:

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/lora.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/lora.py
@@ -257,7 +257,7 @@ def register_lora_fields(registry: "FieldRegistry") -> None:
             tab="model",
             section="lora_config",
             subsection="advanced",
-            default_value=0,
+            default_value=None,
             validation_rules=[
                 ValidationRule(ValidationRuleType.MIN, value=0, message="Initial LoRA training step must be non-negative")
             ],
@@ -265,7 +265,10 @@ def register_lora_fields(registry: "FieldRegistry") -> None:
                 FieldDependency(field="model_type", value="lora"),
             ],
             help_text="Continue global-step accounting from a model-only LoRA checkpoint without optimizer state",
-            tooltip="Use only when a full trainer checkpoint is unavailable. Optimizer, sampler, and RNG state start fresh.",
+            tooltip=(
+                "When omitted, use global_step metadata from a local init_lora safetensors file. "
+                "Optimizer, sampler, and RNG state start fresh."
+            ),
             documentation="OPTIONS.md#--init_lora_step",
             importance=ImportanceLevel.ADVANCED,
             order=9,
@@ -274,8 +277,8 @@ def register_lora_fields(registry: "FieldRegistry") -> None:
 
     registry._add_field(
         ConfigField(
-            name="init_lora_ema_path",
-            arg_name="--init_lora_ema_path",
+            name="init_lora_ema",
+            arg_name="--init_lora_ema",
             ui_label="Initial LoRA EMA State",
             field_type=FieldType.TEXT,
             tab="model",
@@ -288,7 +291,7 @@ def register_lora_fields(registry: "FieldRegistry") -> None:
             ],
             help_text="Load a raw SimpleTuner EMA state alongside init_lora",
             tooltip="Use the ema_model.pt saved with the same model-only LoRA checkpoint.",
-            documentation="OPTIONS.md#--init_lora_ema_path",
+            documentation="OPTIONS.md#--init_lora_ema",
             importance=ImportanceLevel.ADVANCED,
             order=10,
         )

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/lora.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/lora.py
@@ -248,6 +248,52 @@ def register_lora_fields(registry: "FieldRegistry") -> None:
         )
     )
 
+    registry._add_field(
+        ConfigField(
+            name="init_lora_step",
+            arg_name="--init_lora_step",
+            ui_label="Initial LoRA Training Step",
+            field_type=FieldType.NUMBER,
+            tab="model",
+            section="lora_config",
+            subsection="advanced",
+            default_value=0,
+            validation_rules=[
+                ValidationRule(ValidationRuleType.MIN, value=0, message="Initial LoRA training step must be non-negative")
+            ],
+            dependencies=[
+                FieldDependency(field="model_type", value="lora"),
+            ],
+            help_text="Continue global-step accounting from a model-only LoRA checkpoint without optimizer state",
+            tooltip="Use only when a full trainer checkpoint is unavailable. Optimizer, sampler, and RNG state start fresh.",
+            documentation="OPTIONS.md#--init_lora_step",
+            importance=ImportanceLevel.ADVANCED,
+            order=9,
+        )
+    )
+
+    registry._add_field(
+        ConfigField(
+            name="init_lora_ema_path",
+            arg_name="--init_lora_ema_path",
+            ui_label="Initial LoRA EMA State",
+            field_type=FieldType.TEXT,
+            tab="model",
+            section="lora_config",
+            subsection="advanced",
+            placeholder="path/to/ema_model.pt",
+            dependencies=[
+                FieldDependency(field="model_type", value="lora"),
+                FieldDependency(field="use_ema", value=True),
+            ],
+            help_text="Load a raw SimpleTuner EMA state alongside init_lora",
+            tooltip="Use the ema_model.pt saved with the same model-only LoRA checkpoint.",
+            documentation="OPTIONS.md#--init_lora_ema_path",
+            importance=ImportanceLevel.ADVANCED,
+            order=10,
+        )
+    )
+
     assistant_dependencies = [
         FieldDependency(field="model_type", value="lora"),
         FieldDependency(field="model_family", operator="in", values=["flux", "z_image", "ernie"]),

--- a/tests/test_lora_metadata.py
+++ b/tests/test_lora_metadata.py
@@ -699,7 +699,8 @@ class SaveHookMetadataTests(unittest.TestCase):
             lora_path = os.path.join(tmpdir, "pytorch_lora_weights.safetensors")
             save_file({"weight": torch.tensor([1.0])}, lora_path, metadata={"format": "pt"})
 
-            manager._apply_modelspec_metadata_to_lora(tmpdir)
+            with patch("simpletuner.helpers.training.save_hooks.StateTracker.get_global_step", return_value=321):
+                manager._apply_modelspec_metadata_to_lora(tmpdir)
 
             with safe_open(lora_path, framework="pt", device="cpu") as handle:
                 metadata = handle.metadata()
@@ -709,6 +710,7 @@ class SaveHookMetadataTests(unittest.TestCase):
         self.assertEqual(metadata.get("modelspec.architecture"), "sdxl-base-1.0/lora")
         self.assertEqual(metadata.get("modelspec.title"), "run-name")
         self.assertEqual(metadata.get("modelspec.resolution"), "1024x1024")
+        self.assertEqual(metadata.get("global_step"), "321")
 
     def test_models_spec_comment_runtime_templates_resolve_on_save(self):
         manager, _, _ = self._make_manager(
@@ -736,6 +738,7 @@ class SaveHookMetadataTests(unittest.TestCase):
             metadata.get("modelspec.comment"),
             "step=456 epoch=9 ts=2026-04-02T12:34:56+00:00",
         )
+        self.assertEqual(metadata.get("global_step"), "456")
 
 
 class FluxPipelineMetadataTests(unittest.TestCase):

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, call, patch
 
 import torch
+from safetensors.torch import save_file
 
 from simpletuner.helpers.publishing.huggingface import HubManager
 from simpletuner.helpers.publishing.providers.s3 import S3PublishingProvider
@@ -2277,6 +2278,47 @@ class TestTrainer(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "cannot be combined"):
             trainer._initial_lora_step()
 
+    def test_initial_lora_step_uses_safetensors_metadata_when_unspecified(self):
+        with tempfile.NamedTemporaryFile(suffix=".safetensors") as lora_file:
+            save_file({"weight": torch.ones(1)}, lora_file.name, metadata={"global_step": "1500"})
+            trainer = object.__new__(Trainer)
+            trainer.config = SimpleNamespace(
+                init_lora=lora_file.name,
+                init_lora_step=None,
+                resume_from_checkpoint=None,
+                max_train_steps=25000,
+            )
+
+            self.assertEqual(trainer._initial_lora_step(), 1500)
+            self.assertEqual(trainer.config.init_lora_step, 1500)
+
+    def test_initial_lora_step_explicit_zero_overrides_safetensors_metadata(self):
+        with tempfile.NamedTemporaryFile(suffix=".safetensors") as lora_file:
+            save_file({"weight": torch.ones(1)}, lora_file.name, metadata={"global_step": "1500"})
+            trainer = object.__new__(Trainer)
+            trainer.config = SimpleNamespace(
+                init_lora=lora_file.name,
+                init_lora_step=0,
+                resume_from_checkpoint=None,
+                max_train_steps=25000,
+            )
+
+            self.assertEqual(trainer._initial_lora_step(), 0)
+
+    def test_initial_lora_step_rejects_invalid_safetensors_metadata(self):
+        with tempfile.NamedTemporaryFile(suffix=".safetensors") as lora_file:
+            save_file({"weight": torch.ones(1)}, lora_file.name, metadata={"global_step": "not-a-step"})
+            trainer = object.__new__(Trainer)
+            trainer.config = SimpleNamespace(
+                init_lora=lora_file.name,
+                init_lora_step=None,
+                resume_from_checkpoint=None,
+                max_train_steps=25000,
+            )
+
+            with self.assertRaisesRegex(ValueError, "non-negative integer"):
+                trainer._initial_lora_step()
+
     def test_init_lora_step_continues_accounting_with_fresh_optimizer(self):
         trainer = object.__new__(Trainer)
         trainer.config = SimpleNamespace(
@@ -2317,12 +2359,38 @@ class TestTrainer(unittest.TestCase):
         self.assertEqual(scheduler_state["_step_count"], 12001)
         trainer.model.reset_flow_custom_timestep_cursor.assert_called_once_with(1500)
 
+    def test_init_lora_step_restores_constant_scheduler_inside_warmup(self):
+        trainer = object.__new__(Trainer)
+        trainer.config = SimpleNamespace(
+            lr_scheduler="constant_with_warmup",
+            lr_warmup_steps=1000,
+            is_schedulefree=False,
+        )
+        trainer.accelerator = Mock(num_processes=8)
+        optimizer_param_groups = [{"lr": 0.0, "initial_lr": 5e-5}]
+        scheduler_state = {
+            "base_lrs": [5e-5],
+            "last_epoch": 0,
+            "_step_count": 1,
+            "_last_lr": [0.0],
+        }
+        lr_scheduler = Mock(split_batches=False)
+        lr_scheduler.state_dict.return_value = scheduler_state
+
+        trainer._restore_constant_scheduler_lr(lr_scheduler, optimizer_param_groups, [5e-5], global_step=500)
+
+        self.assertEqual(optimizer_param_groups[0]["lr"], 2.5e-5)
+        self.assertEqual(scheduler_state["_last_lr"], [2.5e-5])
+        self.assertEqual(scheduler_state["last_epoch"], 4000)
+        self.assertEqual(scheduler_state["_step_count"], 4001)
+        lr_scheduler.load_state_dict.assert_called_once_with(scheduler_state)
+
     def test_load_initial_lora_ema_state(self):
         with tempfile.NamedTemporaryFile() as ema_file:
             trainer = object.__new__(Trainer)
             trainer.config = SimpleNamespace(
                 init_lora="adapter.safetensors",
-                init_lora_ema_path=ema_file.name,
+                init_lora_ema=ema_file.name,
                 use_ema=True,
             )
             trainer.accelerator = Mock(is_main_process=True)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -2265,6 +2265,73 @@ class TestTrainer(unittest.TestCase):
                 mock_logger.info.assert_called()
                 trainer.accelerator.load_state.assert_called_with("/path/to/output/checkpoint-200")
 
+    def test_initial_lora_step_rejects_full_checkpoint_resume(self):
+        trainer = object.__new__(Trainer)
+        trainer.config = SimpleNamespace(
+            init_lora="adapter.safetensors",
+            init_lora_step=1500,
+            resume_from_checkpoint="latest",
+            max_train_steps=25000,
+        )
+
+        with self.assertRaisesRegex(ValueError, "cannot be combined"):
+            trainer._initial_lora_step()
+
+    def test_init_lora_step_continues_accounting_with_fresh_optimizer(self):
+        trainer = object.__new__(Trainer)
+        trainer.config = SimpleNamespace(
+            init_lora="adapter.safetensors",
+            init_lora_step=1500,
+            resume_from_checkpoint=None,
+            max_train_steps=25000,
+            total_steps_remaining_at_start=0,
+            lr_scheduler="constant_with_warmup",
+            lr_warmup_steps=1000,
+            is_schedulefree=False,
+        )
+        trainer.state = {"global_step": 1500, "global_resume_step": 1500, "first_epoch": 1}
+        trainer.accelerator = Mock(num_processes=8)
+        trainer.optimizer = Mock(param_groups=[{"lr": 0.0, "initial_lr": 5e-5}])
+        trainer.model = Mock()
+        scheduler_state = {
+            "base_lrs": [5e-5],
+            "last_epoch": 0,
+            "_step_count": 1,
+            "_last_lr": [0.0],
+        }
+        lr_scheduler = Mock(split_batches=False)
+        lr_scheduler.state_dict.return_value = scheduler_state
+
+        with (
+            patch("simpletuner.helpers.training.state_tracker.StateTracker.get_global_step", return_value=1500),
+            patch("simpletuner.helpers.training.state_tracker.StateTracker.set_global_resume_step"),
+        ):
+            result = trainer.init_resume_checkpoint(lr_scheduler)
+
+        self.assertIs(result, lr_scheduler)
+        self.assertEqual(trainer.state["global_step"], 1500)
+        self.assertEqual(trainer.state["global_resume_step"], 1500)
+        self.assertEqual(trainer.config.total_steps_remaining_at_start, 23500)
+        self.assertEqual(trainer.optimizer.param_groups[0]["lr"], 5e-5)
+        self.assertEqual(scheduler_state["last_epoch"], 12000)
+        self.assertEqual(scheduler_state["_step_count"], 12001)
+        trainer.model.reset_flow_custom_timestep_cursor.assert_called_once_with(1500)
+
+    def test_load_initial_lora_ema_state(self):
+        with tempfile.NamedTemporaryFile() as ema_file:
+            trainer = object.__new__(Trainer)
+            trainer.config = SimpleNamespace(
+                init_lora="adapter.safetensors",
+                init_lora_ema_path=ema_file.name,
+                use_ema=True,
+            )
+            trainer.accelerator = Mock(is_main_process=True)
+            trainer.ema_model = Mock()
+
+            trainer._load_initial_lora_ema_state()
+
+            trainer.ema_model.load_state_dict.assert_called_once_with(ema_file.name)
+
     @patch("simpletuner.helpers.training.trainer.PublishingManager")
     @patch("simpletuner.helpers.training.trainer.AttentionBackendController.on_load_checkpoint")
     def test_init_resume_checkpoint_downloads_remote(self, mock_attention_backend, mock_manager):


### PR DESCRIPTION
This pull request adds two new options, `--init_lora_step` and `--init_lora_ema_path`, to the training workflow, allowing users to resume global step accounting and optionally load the EMA state when initializing from a model-only LoRA adapter. These changes are fully documented in all supported languages and are integrated into the trainer logic to ensure correct step tracking and validation.

**Trainer logic enhancements:**

* Added `_initial_lora_step` method to `simpletuner/helpers/training/trainer.py` to validate and compute the initial global step based on `init_lora_step`, enforcing constraints such as requiring `init_lora`, disallowing use with `resume_from_checkpoint`, and ensuring the step is within bounds.
* Updated `_misc_init` in `trainer.py` to initialize `global_step` and `global_resume_step` from `init_lora_step` and propagate these values to the `StateTracker`, ensuring correct resumption behavior. [[1]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27L2251-R2276) [[2]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R2293)

**Documentation updates (all languages):**

* Documented `--init_lora_step` and `--init_lora_ema_path` options, including their purpose, requirements, and usage notes, in English, Spanish, Japanese, Chinese, Hindi, and Portuguese documentation files. [[1]](diffhunk://#diff-45e063db3ebcffb55dde68f083e92399a74f4cefbb464e8cd36911971c50933fR1722-R1734) [[2]](diffhunk://#diff-3f0cd39e3a7f176d81408ae40dc4f8c6271347f75b1cee5cf71c4e701d7db561R1718-R1730) [[3]](diffhunk://#diff-fd629904ab3e1ecdd5b568c3ef6ac61e71e3d7741700e360820849938158a1d9R1719-R1731) [[4]](diffhunk://#diff-cddcc50c252e719be92644d65ea8542cc51d08f15e67d918bfae737904142b1fR1721-R1733) [[5]](diffhunk://#diff-39b5789a705b2e70400106934436b619d10413ca5e37bd7a2b5fa7aa0c0fb8cfR1716-R1728) [[6]](diffhunk://#diff-2c007ae9176f9f69b3ae16558be55b46d524f460a626f4e5c31e1e9a1d1b14b8R1714-R1726)
* Updated CLI usage examples and options listings in all documentation files to reflect the addition of the new arguments. [[1]](diffhunk://#diff-45e063db3ebcffb55dde68f083e92399a74f4cefbb464e8cd36911971c50933fL1848-R1863) [[2]](diffhunk://#diff-3f0cd39e3a7f176d81408ae40dc4f8c6271347f75b1cee5cf71c4e701d7db561L1844-R1859) [[3]](diffhunk://#diff-fd629904ab3e1ecdd5b568c3ef6ac61e71e3d7741700e360820849938158a1d9L1845-R1860) [[4]](diffhunk://#diff-cddcc50c252e719be92644d65ea8542cc51d08f15e67d918bfae737904142b1fL1847-R1862) [[5]](diffhunk://#diff-39b5789a705b2e70400106934436b619d10413ca5e37bd7a2b5fa7aa0c0fb8cfL1842-R1857) [[6]](diffhunk://#diff-2c007ae9176f9f69b3ae16558be55b46d524f460a626f4e5c31e1e9a1d1b14b8L1840-R1855) [[7]](diffhunk://#diff-45e063db3ebcffb55dde68f083e92399a74f4cefbb464e8cd36911971c50933fR2250-R2254) [[8]](diffhunk://#diff-3f0cd39e3a7f176d81408ae40dc4f8c6271347f75b1cee5cf71c4e701d7db561R2246-R2250) [[9]](diffhunk://#diff-fd629904ab3e1ecdd5b568c3ef6ac61e71e3d7741700e360820849938158a1d9R2246-R2250) [[10]](diffhunk://#diff-cddcc50c252e719be92644d65ea8542cc51d08f15e67d918bfae737904142b1fR2248-R2252) [[11]](diffhunk://#diff-39b5789a705b2e70400106934436b619d10413ca5e37bd7a2b5fa7aa0c0fb8cfR2244-R2248) [[12]](diffhunk://#diff-2c007ae9176f9f69b3ae16558be55b46d524f460a626f4e5c31e1e9a1d1b14b8R2241-R2245)