### PR TITLE
anchor AnyFlow diffusion targets for guided bases

### DIFF
--- a/documentation/experimental/ANYFLOW.md
+++ b/documentation/experimental/ANYFLOW.md
@@ -48,8 +48,30 @@ For each global batch, the forward stage:
 7. Balances each non-diffusion sample against the global diffusion-branch loss mean.
 
 Guidance fusion requires cached unconditional text embeddings. SimpleTuner loads the caption-dropout embedding for
-each sample and uses the same image context for models such as MiniMax-H3. Set `fuse_guidance_scale=1.0` only when the
-student should retain external CFG instead of learning AnyFlow's guidance-distilled conditional field.
+each sample and uses the same image context. Set `fuse_guidance_scale=1.0` when the student should retain external CFG
+or the base model's conditional path already contains guidance distillation.
+
+### Guidance-Distilled Base Models
+
+MiniMax-H3's conditional prediction already contains its distilled guidance field and does not have a calibrated
+unconditional branch for AnyFlow to fuse. Its forward-stage configuration should therefore use:
+
+```json
+{
+  "fuse_guidance_scale": 1.0,
+  "diffusion_target": "base_prediction"
+}
+```
+
+`fuse_guidance_scale=1.0` disables the unconditional pass, but by itself it leaves the `r=t` branch targeting the raw
+sample velocity. That branch can train a guidance-distilled base away from its useful conditional field. With
+`diffusion_target=base_prediction`, SimpleTuner instead evaluates the same noisy latent at `r=t` with the adapter
+disabled and uses that frozen-base prediction only for diffusion samples. Consistency and arbitrary intervals retain
+the AnyFlow tangent target.
+
+The frozen-base/raw-flow residual supplies the adaptive-weighting reference when the anchored diffusion loss starts at
+zero. This prevents adaptive weighting from zeroing every interval loss at adapter initialization. No second
+transformer is allocated, but the frozen-base evaluation adds one no-grad forward per training step.
 
 ## On-Policy Stage
 
@@ -112,6 +134,8 @@ global Torch RNG. It does not make CUDA attention backward bit-stable.
 - `fuse_guidance_scale`: guidance scale distilled into the conditional student prediction. Default: `3.0`.
 - `meanflow_weight_type`: `beta08` or `uniform`. Default: `beta08`.
 - `meanflow_adaptive_weighting`: balance non-diffusion samples against the diffusion branch. Default: `true`.
+- `diffusion_target`: `flow` for NVIDIA's raw-flow objective or `base_prediction` for an already guidance-distilled
+  conditional field. Default: `flow`. `base_prediction` requires adapter training and `fuse_guidance_scale=1.0`.
 - `gate_value`: FlowMap delta-timestep embedding blend. Default: `0.25`.
 - `deltatime_type`: `r` or `t-r`. Default: `r`.
 - `loss_weight`: forward MeanFlow loss multiplier. Default: `1.0`.
@@ -119,6 +143,10 @@ global Torch RNG. It does not make CUDA attention backward bit-stable.
 ## Limits
 
 - AnyFlow requires a flow-matching model with model-specific FlowMap interval conditioning.
+- AnyFlow adapter training requires `lora_dropout=0`. Independent dropout masks in the two finite-difference forwards
+  are divided by the small central-difference interval and corrupt the derivative target. SimpleTuner overrides the
+  general LoRA default for distillation unless the user explicitly forces a different value, and AnyFlow rejects a
+  nonzero value during model preparation.
 - On-policy training currently requires standard PEFT LoRA. Sharing the base avoids allocating generator, real-score,
   and discriminator copies of a large transformer on every DDP rank.
 - Joint MiniMax-H3 audio-video training is rejected. Video uses schedule shift 12 while audio uses shift 3; native

--- a/simpletuner/helpers/distillation/anyflow/distiller.py
+++ b/simpletuner/helpers/distillation/anyflow/distiller.py
@@ -42,6 +42,7 @@ class AnyFlowDistiller(DistillationBase):
         "meanflow_weight_type": "beta08",
         "meanflow_adaptive_weighting": True,
         "meanflow_non_diffusion_max_sigma": 1.0,
+        "diffusion_target": "flow",
         "cotrain_forward": True,
         "rollout_step_counts": (2, 4, 8, 16, 50),
         "dmd_weight": 1.0,
@@ -147,12 +148,17 @@ class AnyFlowDistiller(DistillationBase):
         batch["anyflow_timestep_interval"] = (batch["timesteps"].to(r_timesteps.dtype) - r_timesteps).abs()
 
         base_target = self._base_flow_target(batch, model=model)
+        meanflow_base_target = self._meanflow_base_target(
+            prepared_batch=batch,
+            t_sigmas=t_sigmas,
+            base_target=base_target,
+        )
         target = self._meanflow_target(
             prepared_batch=batch,
             model=model,
             t_sigmas=t_sigmas,
             r_sigmas=r_sigmas,
-            base_target=base_target,
+            base_target=meanflow_base_target,
         ).detach()
         batch["target"] = target
         batch["flow_target"] = target
@@ -386,9 +392,18 @@ class AnyFlowDistiller(DistillationBase):
             raise ValueError("AnyFlow meanflow_non_diffusion_max_sigma must be in (0.0, 1.0].")
         self.config["meanflow_non_diffusion_max_sigma"] = non_diffusion_max_sigma
 
+        diffusion_target = str(self.config["diffusion_target"]).strip().lower()
+        if diffusion_target not in {"flow", "base_prediction"}:
+            raise ValueError("AnyFlow diffusion_target must be one of: flow, base_prediction.")
+        if diffusion_target == "base_prediction" and not self.low_rank_distillation:
+            raise ValueError("AnyFlow diffusion_target=base_prediction currently requires adapter distillation.")
+        self.config["diffusion_target"] = diffusion_target
+
         guidance_scale = float(self.config["fuse_guidance_scale"])
         if guidance_scale <= 0.0:
             raise ValueError("AnyFlow fuse_guidance_scale must be greater than zero.")
+        if diffusion_target == "base_prediction" and guidance_scale != 1.0:
+            raise ValueError("AnyFlow diffusion_target=base_prediction requires fuse_guidance_scale=1.0.")
         self.config["fuse_guidance_scale"] = guidance_scale
 
         weight_type = str(self.config["meanflow_weight_type"]).strip().lower()
@@ -501,6 +516,53 @@ class AnyFlowDistiller(DistillationBase):
     # ------------------------------------------------------------------
     # NVIDIA forward MeanFlow stage
     # ------------------------------------------------------------------
+    @contextmanager
+    def _frozen_base_adapter(self) -> Iterator[None]:
+        if self.config["stage"] == "onpolicy":
+            with self._adapter_role("real"):
+                yield
+            return
+
+        component = self._flowmap_component
+        was_training = component.training
+        try:
+            self.toggle_adapter(enable=False)
+            component.eval()
+            yield
+        finally:
+            self.toggle_adapter(enable=True)
+            component.train(was_training)
+
+    def _meanflow_base_target(
+        self,
+        *,
+        prepared_batch: Dict[str, Any],
+        t_sigmas: torch.Tensor,
+        base_target: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.config["diffusion_target"] == "flow":
+            return base_target
+
+        with self._frozen_base_adapter(), torch.no_grad():
+            base_prediction = self._predict_at_sigmas(
+                prepared_batch,
+                prepared_batch["noisy_latents"],
+                t_sigmas,
+                t_sigmas,
+            ).detach()
+
+        base_prediction = base_prediction.to(device=base_target.device, dtype=base_target.dtype)
+        cosine, norm_ratio = self._chunked_per_sample_geometry(base_prediction, base_target)
+        prepared_batch["_anyflow_base_prediction_flow_cosine"] = cosine
+        prepared_batch["_anyflow_base_prediction_flow_norm_ratio"] = norm_ratio
+        prepared_batch["_anyflow_base_prediction_flow_mse"] = (
+            (base_prediction.float() - base_target.float()).square().flatten(1).mean(dim=1).detach()
+        )
+
+        diffusion_mask = prepared_batch["anyflow_diffusion_mask"].to(device=base_target.device, dtype=torch.bool)
+        diffusion_mask = self._broadcast_time(diffusion_mask, base_target)
+        return torch.where(diffusion_mask, base_prediction, base_target)
+
     def _prepare_meanflow_pair(self, prepared_batch: Dict[str, Any], model) -> tuple[torch.Tensor, torch.Tensor]:
         latents = prepared_batch["latents"]
         batch_size = int(latents.shape[0])
@@ -595,7 +657,8 @@ class AnyFlowDistiller(DistillationBase):
         prediction = self._fuse_guidance_prediction(prepared_batch, prediction)
         per_sample = (prediction.float() - target.float()).square().flatten(1).mean(dim=1)
         t_sigmas = self._scalar_sigmas(prepared_batch).to(device=per_sample.device, dtype=per_sample.dtype)
-        per_sample = per_sample * self._meanflow_timestep_weight(t_sigmas)
+        timestep_weight = self._meanflow_timestep_weight(t_sigmas)
+        per_sample = per_sample * timestep_weight
         prepared_batch["_anyflow_pre_adaptive_loss"] = per_sample.detach()
         adaptive_scale = torch.ones_like(per_sample)
 
@@ -606,6 +669,21 @@ class AnyFlowDistiller(DistillationBase):
             global_diffusion_mask = self._gather_detached(diffusion_mask)
             if bool(global_diffusion_mask.any()):
                 diffusion_mean = global_loss[global_diffusion_mask].mean()
+                base_prediction_flow_mse = prepared_batch.get("_anyflow_base_prediction_flow_mse")
+                if torch.is_tensor(base_prediction_flow_mse):
+                    adaptive_reference = (
+                        base_prediction_flow_mse.to(
+                            device=per_sample.device,
+                            dtype=per_sample.dtype,
+                        )
+                        * timestep_weight
+                    )
+                    prepared_batch["_anyflow_adaptive_reference_loss"] = adaptive_reference.detach()
+                    global_adaptive_reference = self._gather_detached(adaptive_reference)
+                    diffusion_mean = torch.maximum(
+                        diffusion_mean,
+                        global_adaptive_reference[global_diffusion_mask].mean(),
+                    )
                 non_diffusion_mask = ~diffusion_mask
                 if bool(non_diffusion_mask.any()):
                     scale = diffusion_mean / (per_sample.detach()[non_diffusion_mask] + 1e-5)
@@ -865,12 +943,16 @@ class AnyFlowDistiller(DistillationBase):
             "anyflow_interval": float(global_intervals.mean()),
             "anyflow_fuse_guidance_scale": float(self.config["fuse_guidance_scale"]),
             "anyflow_meanflow_non_diffusion_max_sigma": float(self.config["meanflow_non_diffusion_max_sigma"]),
+            "anyflow_diffusion_target_is_base_prediction": float(self.config["diffusion_target"] == "base_prediction"),
         }
         metric_tensors = {
             "t_sigma": prepared_batch.get("anyflow_t_sigmas"),
             "r_sigma": prepared_batch.get("anyflow_r_sigmas"),
             "target_base_cosine": prepared_batch.get("_anyflow_target_base_cosine"),
             "target_base_norm_ratio": prepared_batch.get("_anyflow_target_base_norm_ratio"),
+            "base_prediction_flow_cosine": prepared_batch.get("_anyflow_base_prediction_flow_cosine"),
+            "base_prediction_flow_norm_ratio": prepared_batch.get("_anyflow_base_prediction_flow_norm_ratio"),
+            "adaptive_reference_loss": prepared_batch.get("_anyflow_adaptive_reference_loss"),
             "pre_adaptive_loss": prepared_batch.get("_anyflow_pre_adaptive_loss"),
             "adaptive_scale": prepared_batch.get("_anyflow_adaptive_scale"),
             "post_adaptive_loss": prepared_batch.get("_anyflow_post_adaptive_loss"),

--- a/simpletuner/helpers/models/minimaxh3/model.py
+++ b/simpletuner/helpers/models/minimaxh3/model.py
@@ -231,13 +231,15 @@ class MiniMaxH3(VideoModelFoundation):
             return targets
 
         anyflow_config = self._anyflow_distillation_config()
+        train_time_embedder = bool(anyflow_config.get("train_time_embedder", True))
         train_delta_embedder = bool(anyflow_config.get("train_delta_embedder", True))
         targets.extend(["ff.net.0.proj", "ff.net.2"])
         if bool(anyflow_config.get("lora_target_adaln", False)):
             targets.append("adaln_proj.linear")
         transformer = self.unwrap_model(self.model) if getattr(self, "model", None) is not None else None
         if transformer is not None and getattr(transformer, "time_embedder", None) is not None:
-            targets.extend(["time_embedder.linear_1", "time_embedder.linear_2"])
+            if train_time_embedder:
+                targets.extend(["time_embedder.linear_1", "time_embedder.linear_2"])
             if train_delta_embedder:
                 targets.extend(["delta_time_embedder.linear_1", "delta_time_embedder.linear_2"])
         return list(dict.fromkeys(targets))

--- a/tests/helpers/distillation/test_anyflow_distiller.py
+++ b/tests/helpers/distillation/test_anyflow_distiller.py
@@ -409,6 +409,82 @@ class AnyFlowDistillerTests(unittest.TestCase):
         self.assertEqual(len(model.teacher_timesteps), 2)
         self.assertTrue(model.component.adapter_enabled)
 
+    def test_meanflow_can_anchor_only_diffusion_samples_to_frozen_base_prediction(self):
+        model = _FlowModel()
+        distiller = AnyFlowDistiller(
+            teacher_model=model,
+            noise_scheduler=None,
+            config={
+                "model_type": "lora",
+                "diffusion_ratio": 0.5,
+                "consistency_ratio": 0.5,
+                "diffusion_target": "base_prediction",
+                "fuse_guidance_scale": 1.0,
+            },
+        )
+        draws = [
+            torch.tensor([0.8, 0.7]),
+            torch.tensor([0.2, 0.4]),
+        ]
+
+        with patch("torch.rand", side_effect=draws):
+            batch = distiller.prepare_batch(_prepared_batch(), model=model, state={})
+
+        expected = torch.ones_like(batch["target"])
+        expected[0] = 2.0
+        self.assertTrue(torch.equal(batch["target"], expected))
+        self.assertEqual(model.teacher_adapter_states, [False, True, True])
+        self.assertTrue(model.component.adapter_enabled)
+        self.assertTrue(model.component.training)
+        self.assertTrue(torch.equal(batch["_anyflow_base_prediction_flow_norm_ratio"], torch.full((2,), 2.0)))
+
+    def test_meanflow_diffusion_target_is_validated(self):
+        with self.assertRaisesRegex(ValueError, "diffusion_target"):
+            AnyFlowDistiller(
+                teacher_model=_FlowModel(),
+                noise_scheduler=None,
+                config={"model_type": "lora", "diffusion_target": "unknown"},
+            )
+
+        with self.assertRaisesRegex(ValueError, "requires fuse_guidance_scale=1.0"):
+            AnyFlowDistiller(
+                teacher_model=_FlowModel(),
+                noise_scheduler=None,
+                config={"model_type": "lora", "diffusion_target": "base_prediction"},
+            )
+
+    def test_frozen_base_target_uses_base_flow_residual_for_adaptive_weighting(self):
+        model = _FlowModel()
+        distiller = AnyFlowDistiller(
+            teacher_model=model,
+            noise_scheduler=None,
+            config={
+                "model_type": "lora",
+                "diffusion_ratio": 0.5,
+                "consistency_ratio": 0.5,
+                "diffusion_target": "base_prediction",
+                "meanflow_weight_type": "uniform",
+                "fuse_guidance_scale": 1.0,
+            },
+        )
+        draws = [
+            torch.tensor([0.8, 0.7]),
+            torch.tensor([0.2, 0.4]),
+        ]
+
+        with patch("torch.rand", side_effect=draws):
+            batch = distiller.prepare_batch(_prepared_batch(), model=model, state={})
+
+        prediction = batch["target"].clone()
+        prediction[1] += 2.0
+        loss = distiller._meanflow_loss(batch, {"model_prediction": prediction})
+
+        self.assertAlmostEqual(float(batch["_anyflow_pre_adaptive_loss"][0]), 0.0)
+        self.assertAlmostEqual(float(batch["_anyflow_adaptive_reference_loss"][0]), 1.0)
+        self.assertAlmostEqual(float(batch["_anyflow_adaptive_scale"][1]), 0.25, places=5)
+        self.assertAlmostEqual(float(batch["_anyflow_post_adaptive_loss"][1]), 1.0, places=5)
+        self.assertAlmostEqual(float(loss), 0.5, places=5)
+
     def test_seeded_meanflow_pair_uses_isolated_rng_stream(self):
         torch.manual_seed(1234)
         expected_next = torch.rand(4)

--- a/tests/test_minimaxh3.py
+++ b/tests/test_minimaxh3.py
@@ -1264,6 +1264,33 @@ class MiniMaxH3Tests(unittest.TestCase):
         self.assertIn("delta_time_embedder.linear_1", targets)
         self.assertIsNone(wrapper.get_lora_save_layers())
 
+    def test_anyflow_lora_targets_can_freeze_time_embedders(self):
+        wrapper = MiniMaxH3.__new__(MiniMaxH3)
+        wrapper.config = SimpleNamespace(
+            distillation_method="anyflow",
+            distillation_config={
+                "anyflow": {
+                    "train_time_embedder": False,
+                    "train_delta_embedder": False,
+                }
+            },
+            lora_type="standard",
+            peft_lora_target_modules=None,
+            slider_lora_target=False,
+            controlnet=False,
+        )
+        wrapper.model = tiny_h3_transformer()
+        wrapper.model.enable_flowmap_time_conditioning()
+        wrapper.accelerator = SimpleNamespace(unwrap_model=lambda model, keep_fp32_wrapper=True: model)
+
+        targets = wrapper.get_lora_target_layers()
+
+        self.assertIn("ff.net.0.proj", targets)
+        self.assertIn("ff.net.2", targets)
+        self.assertNotIn("time_embedder.linear_1", targets)
+        self.assertNotIn("delta_time_embedder.linear_1", targets)
+        self.assertIsNone(wrapper.get_lora_save_layers())
+
     def test_anyflow_curve_checkpoint_saves_delta_table_with_adapter(self):
         from peft import LoraConfig
         from peft.utils import get_peft_model_state_dict


### PR DESCRIPTION
This pull request introduces support for anchoring AnyFlow distillation to a frozen base model prediction, which is essential for models that have already learned guidance distillation (such as MiniMax-H3). It adds a new `diffusion_target` configuration, ensures correct handling and validation for this mode, and improves adaptive weighting for the new workflow. Additional changes include configuration and test updates, as well as the ability to control LoRA target layers for time embedders.

**AnyFlow Distillation Enhancements**

* Added a new `diffusion_target` configuration option (`"flow"` or `"base_prediction"`) to support anchoring diffusion samples to a frozen base prediction, with validation to ensure it is only used with adapter training and `fuse_guidance_scale=1.0`. This enables proper handling for guidance-distilled base models. [[1]](diffhunk://#diff-3507172773668220890a8d1f09074e85390bc28a5622273f2b0ed83c28c214bfR395-R406) [[2]](diffhunk://#diff-879d5d693af285566fa80441ce09d8ba105f7801508758013d8c147c6410b5a2L51-R74) [[3]](diffhunk://#diff-879d5d693af285566fa80441ce09d8ba105f7801508758013d8c147c6410b5a2R137-R149)
* Implemented the `_meanflow_base_target` method and `_frozen_base_adapter` context manager to compute the base prediction in a no-grad, adapter-disabled mode, and use it selectively for diffusion samples. [[1]](diffhunk://#diff-3507172773668220890a8d1f09074e85390bc28a5622273f2b0ed83c28c214bfR519-R565) [[2]](diffhunk://#diff-3507172773668220890a8d1f09074e85390bc28a5622273f2b0ed83c28c214bfR151-R161)
* Updated the adaptive weighting logic in `_meanflow_loss` to use the base prediction flow residual as a reference for diffusion samples, preventing adaptive weighting from zeroing interval losses at initialization. [[1]](diffhunk://#diff-3507172773668220890a8d1f09074e85390bc28a5622273f2b0ed83c28c214bfL598-R661) [[2]](diffhunk://#diff-3507172773668220890a8d1f09074e85390bc28a5622273f2b0ed83c28c214bfR672-R686)

**Configuration and Logging Improvements**

* Updated default and documentation to include the new `diffusion_target` option and clarified its usage for guidance-distilled models in `ANYFLOW.md`. [[1]](diffhunk://#diff-3507172773668220890a8d1f09074e85390bc28a5622273f2b0ed83c28c214bfR45) [[2]](diffhunk://#diff-879d5d693af285566fa80441ce09d8ba105f7801508758013d8c147c6410b5a2L51-R74) [[3]](diffhunk://#diff-879d5d693af285566fa80441ce09d8ba105f7801508758013d8c147c6410b5a2R137-R149)
* Enhanced logging and metrics to track whether `diffusion_target=base_prediction` is used and to log relevant per-sample statistics for the new workflow.

**LoRA Target Layer Control**

* Added support to freeze time and delta time embedders from LoRA targeting in MiniMax-H3 by honoring `train_time_embedder` and `train_delta_embedder` options in the AnyFlow distillation config.

**Testing**

* Added comprehensive tests to validate the new `diffusion_target` behavior, correct anchoring of targets, adaptive weighting logic, and the ability to freeze time embedders in LoRA targeting. [[1]](diffhunk://#diff-1923fea834eb577a48d00c5d8cbc8462fb56898164b3417f48d633cab003e35eR412-R487) [[2]](diffhunk://#diff-6ec9151a8d14ca198c9608ce0827285b9d03417d9650460664bb2097a19e015eR1267-R1293)