### PR TITLE
restore warmup LR correctly across resume world sizes

### DIFF
--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -4719,6 +4719,44 @@ class Trainer:
             f"missing checkpoint completion guard {CHECKPOINT_GUARD_FILENAME}",
         )
 
+    def _restore_constant_scheduler_lr(
+        self,
+        lr_scheduler,
+        optimizer_param_groups: list[dict[str, Any]],
+        configured_base_lrs: list[float | None],
+        global_step: int,
+    ) -> None:
+        if self.config.lr_scheduler not in ("constant", "constant_with_warmup") or self.config.is_schedulefree:
+            return
+
+        process_multiplier = 1 if getattr(lr_scheduler, "split_batches", False) else self.accelerator.num_processes
+        scheduler_step = int(global_step) * max(1, int(process_multiplier))
+        warmup_steps = 0
+        if self.config.lr_scheduler == "constant_with_warmup":
+            warmup_steps = int(getattr(self.config, "lr_warmup_steps", 0)) * max(1, int(process_multiplier))
+        warmup_scale = min(1.0, scheduler_step / max(1, warmup_steps)) if warmup_steps > 0 else 1.0
+
+        restored_lrs = [float(base_lr) * warmup_scale if base_lr is not None else None for base_lr in configured_base_lrs]
+        scheduler_state = lr_scheduler.state_dict()
+        scheduler_state["base_lrs"] = list(configured_base_lrs)
+        scheduler_state["_last_lr"] = list(restored_lrs)
+        if "last_epoch" in scheduler_state:
+            scheduler_state["last_epoch"] = scheduler_step
+        if "_step_count" in scheduler_state:
+            scheduler_state["_step_count"] = scheduler_step + 1
+        lr_scheduler.load_state_dict(scheduler_state)
+
+        for group_index, group in enumerate(optimizer_param_groups):
+            if group_index >= len(restored_lrs) or restored_lrs[group_index] is None:
+                continue
+            group["initial_lr"] = configured_base_lrs[group_index]
+            group["lr"] = restored_lrs[group_index]
+
+        logger.info(
+            f"Restored {self.config.lr_scheduler} scheduler at global step {global_step} "
+            f"(scheduler step {scheduler_step}) with learning rates {restored_lrs}."
+        )
+
     def init_resume_checkpoint(self, lr_scheduler):
         # Potentially load in the weights and states from a previous save
         self.config.total_steps_remaining_at_start = self.config.max_train_steps
@@ -4740,7 +4778,7 @@ class Trainer:
             raw_param_groups = getattr(self.optimizer, "param_groups", None)
             if isinstance(raw_param_groups, list):
                 optimizer_param_groups = raw_param_groups
-        configured_param_group_lrs = [group.get("lr") for group in optimizer_param_groups]
+        configured_param_group_lrs = [group.get("initial_lr", group.get("lr")) for group in optimizer_param_groups]
 
         while True:
             checkpoint_dir = None
@@ -4812,29 +4850,6 @@ class Trainer:
         if getattr(self, "distiller", None) is not None:
             logger.info(f"Loading DCM checkpoint states..")
             self.distiller.on_load_checkpoint(checkpoint_dir)
-        try:
-            if self.config.lr_scheduler in ("constant", "constant_with_warmup") and not self.config.is_schedulefree:
-                for group_index, group in enumerate(optimizer_param_groups):
-                    if "lr" not in group:
-                        continue
-                    if group_index < len(configured_param_group_lrs) and configured_param_group_lrs[group_index] is not None:
-                        group["lr"] = configured_param_group_lrs[group_index]
-                for k, v in lr_scheduler.state_dict().items():
-                    if k in ("base_lrs", "_last_lr"):
-                        for group_index, configured_lr in enumerate(configured_param_group_lrs):
-                            if configured_lr is not None and group_index < len(v):
-                                v[group_index] = configured_lr
-        except Exception as e:
-            event = notification_event(
-                message="Could not update learning rate scheduler LR value.",
-                severity="warning",
-                job_id=self.job_id,
-            )
-            self._emit_event(event)
-            logger.error(
-                f"Could not update lr_scheduler {self.config.lr_scheduler} learning rate to {self.config.learning_rate} upon resume: {e}"
-            )
-
         event = lifecycle_stage_event(
             key="init_resume_checkpoint",
             label="Resume Checkpoint",
@@ -4854,6 +4869,23 @@ class Trainer:
                 )
         self.state["global_resume_step"] = self.state["global_step"] = StateTracker.get_global_step()
         StateTracker.set_global_resume_step(self.state["global_resume_step"])
+        try:
+            self._restore_constant_scheduler_lr(
+                lr_scheduler,
+                optimizer_param_groups,
+                configured_param_group_lrs,
+                self.state["global_resume_step"],
+            )
+        except Exception as e:
+            event = notification_event(
+                message="Could not update learning rate scheduler LR value.",
+                severity="warning",
+                job_id=self.job_id,
+            )
+            self._emit_event(event)
+            logger.error(
+                f"Could not update lr_scheduler {self.config.lr_scheduler} learning rate to {self.config.learning_rate} upon resume: {e}"
+            )
         if hasattr(self.model, "load_flow_custom_timestep_state"):
             self.model.load_flow_custom_timestep_state(
                 checkpoint_dir,

--- a/tests/test_resume_lr_scheduler.py
+++ b/tests/test_resume_lr_scheduler.py
@@ -66,6 +66,72 @@ class ResumeLRSchedulerTests(unittest.TestCase):
             trainer.accelerator.load_state.assert_called_once_with(str(checkpoint_dir))
             mock_attention_backend.assert_called_once_with(str(checkpoint_dir))
 
+    @patch("simpletuner.helpers.training.trainer.AttentionBackendController.on_load_checkpoint")
+    def test_constant_with_warmup_resume_rebases_progress_for_new_world_size(self, mock_attention_backend):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            checkpoint_dir = Path(tmpdir, "checkpoint-200")
+            checkpoint_dir.mkdir()
+            trainer = object.__new__(Trainer)
+            trainer.model = SimpleNamespace(reset_flow_custom_timestep_cursor=Mock())
+            trainer.config = SimpleNamespace(
+                output_dir=tmpdir,
+                resume_from_checkpoint=str(checkpoint_dir),
+                total_steps_remaining_at_start=25000,
+                global_resume_step=1,
+                num_train_epochs=1,
+                max_train_steps=25000,
+                musubi_blocks_to_swap=0,
+                lr_scheduler="constant_with_warmup",
+                lr_warmup_steps=1000,
+                learning_rate=5e-5,
+                is_schedulefree=False,
+                overrode_max_train_steps=False,
+                strict_epoch_limit=True,
+                optimizer="adamw",
+                delete_invalid_checkpoints=False,
+            )
+            trainer.accelerator = Mock(num_processes=8)
+            trainer.accelerator.load_state = Mock()
+            trainer.accelerator.wait_for_everyone = Mock()
+            trainer.state = {"global_step": 0, "first_epoch": 1, "current_epoch": 1}
+            trainer.optimizer = Mock(param_groups=[{"lr": 0.0, "initial_lr": 5e-5}])
+            trainer.distiller = None
+            trainer.job_id = "test-job"
+            trainer._emit_event = Mock()
+            trainer.checkpoint_manager = CheckpointManager(tmpdir)
+            scheduler_state = {
+                "base_lrs": [5e-5],
+                "last_epoch": 800,
+                "_step_count": 801,
+                "_last_lr": [1e-5],
+            }
+            lr_scheduler = Mock(split_batches=False)
+            lr_scheduler.state_dict.return_value = scheduler_state
+            trainer.accelerator.load_state.side_effect = lambda _checkpoint: trainer.optimizer.param_groups.__setitem__(
+                slice(None),
+                [{"lr": 1e-5, "initial_lr": 5e-5}],
+            )
+
+            with (
+                patch("simpletuner.helpers.training.state_tracker.StateTracker.get_data_backends", return_value={}),
+                patch("simpletuner.helpers.training.state_tracker.StateTracker.get_global_step", return_value=200),
+                patch("simpletuner.helpers.training.state_tracker.StateTracker.set_global_resume_step"),
+                patch("simpletuner.helpers.training.state_tracker.StateTracker.get_training_state", return_value={}),
+                patch("simpletuner.helpers.training.state_tracker.StateTracker.get_epoch", return_value=1),
+                patch("simpletuner.helpers.training.state_tracker.StateTracker.set_epoch"),
+            ):
+                trainer.init_resume_checkpoint(lr_scheduler=lr_scheduler)
+
+            self.assertEqual(trainer.optimizer.param_groups[0]["lr"], 1e-5)
+            self.assertEqual(trainer.optimizer.param_groups[0]["initial_lr"], 5e-5)
+            self.assertEqual(scheduler_state["base_lrs"], [5e-5])
+            self.assertEqual(scheduler_state["last_epoch"], 1600)
+            self.assertEqual(scheduler_state["_step_count"], 1601)
+            self.assertEqual(scheduler_state["_last_lr"], [1e-5])
+            lr_scheduler.load_state_dict.assert_called_once_with(scheduler_state)
+            trainer.accelerator.load_state.assert_called_once_with(str(checkpoint_dir))
+            mock_attention_backend.assert_called_once_with(str(checkpoint_dir))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request refactors and improves the logic for restoring learning rate (LR) scheduler state, particularly for "constant" and "constant_with_warmup" schedulers, when resuming training from a checkpoint. The main changes include centralizing LR restoration logic into a new helper method, updating how configured LRs are tracked, and adding a new test to validate correct LR restoration when the world size changes.

**Learning rate scheduler restoration improvements:**

* Added a new `_restore_constant_scheduler_lr` method in `trainer.py` to encapsulate and standardize the logic for restoring LR scheduler and optimizer parameter group LRs when resuming from a checkpoint. This method handles both constant and constant_with_warmup schedulers and accounts for world size changes.
* Replaced the previous inline LR restoration logic in `init_resume_checkpoint` with a call to the new helper method, improving maintainability and reducing code duplication. [[1]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27L4815-L4837) [[2]](diffhunk://#diff-d30c364c1e56eeedf96b453640743939160c5cc2e340108cd6b75150b9f54f27R4872-R4888)

**Configuration and parameter tracking:**

* Updated how configured parameter group LRs are determined: now prefers the `"initial_lr"` value if present, falling back to `"lr"` if not. This ensures the correct base LR is restored after resuming.

**Testing enhancements:**

* Added a new test `test_constant_with_warmup_resume_rebases_progress_for_new_world_size` to verify that LR restoration correctly handles changes in world size and maintains LR consistency after resuming from a checkpoint.