### PR TITLE
distillation should disable lora_dropout unless force-enabled by user

### DIFF
--- a/simpletuner/diagnostics/h3_objective_geometry.py
+++ b/simpletuner/diagnostics/h3_objective_geometry.py
@@ -7,6 +7,7 @@ import random
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from types import MethodType
 from typing import Any, Iterable
 
 import numpy as np
@@ -390,7 +391,17 @@ def _first_raw_batch():
     return raw_batch
 
 
-def initialize_trainer(config: dict[str, Any]):
+def _forbid_text_encoder_load(model, *args, **kwargs):
+    del model, args, kwargs
+    raise RuntimeError("H3 objective geometry attempted to load the text encoder while --skip-text-encoder is active.")
+
+
+def _forbid_text_encoding(model, *args, **kwargs):
+    del model, args, kwargs
+    raise RuntimeError("H3 objective geometry missed the prepared text embedding cache.")
+
+
+def initialize_trainer(config: dict[str, Any], *, skip_text_encoder: bool = False):
     from simpletuner.helpers.training.attention_backend import AttentionBackendController, AttentionPhase
     from simpletuner.helpers.training.trainer import Trainer
 
@@ -398,10 +409,16 @@ def initialize_trainer(config: dict[str, Any]):
     trainer.init_noise_schedule()
     trainer.init_seed()
     trainer.init_huggingface_hub()
-    trainer.init_preprocessing_models()
+    if skip_text_encoder:
+        trainer.init_vae()
+        trainer.model.load_text_encoder = MethodType(_forbid_text_encoder_load, trainer.model)
+        trainer.model.encode_text_batch = MethodType(_forbid_text_encoding, trainer.model)
+    else:
+        trainer.init_preprocessing_models()
     trainer.init_precision(preprocessing_models_only=True)
     trainer.init_data_backend()
-    trainer.init_unload_text_encoder()
+    if not skip_text_encoder:
+        trainer.init_unload_text_encoder()
     trainer.init_unload_vae()
     trainer.init_load_base_model()
     trainer.init_delete_model_caches()
@@ -606,7 +623,9 @@ def _write_plots(
 def run_diagnostic(args: argparse.Namespace) -> None:
     args.output_dir.mkdir(parents=True, exist_ok=True)
     config = _diagnostic_config(args.config, args.output_dir)
-    trainer = initialize_trainer(config)
+    if args.skip_text_encoder:
+        config["validation_disable"] = True
+    trainer = initialize_trainer(config, skip_text_encoder=args.skip_text_encoder)
     try:
         _seed_everything(args.seed)
         raw_batch = _first_raw_batch()
@@ -703,6 +722,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--max-vector-elements", type=int, default=65536)
+    parser.add_argument(
+        "--skip-text-encoder",
+        action="store_true",
+        help="Require prepared text embeddings and never load or invoke the text encoder.",
+    )
     return parser
 
 

--- a/simpletuner/helpers/distillation/anyflow/distiller.py
+++ b/simpletuner/helpers/distillation/anyflow/distiller.py
@@ -60,6 +60,18 @@ class AnyFlowDistiller(DistillationBase):
 
     @classmethod
     def prepare_model_for_adapter(cls, model, config: Dict[str, Any]) -> None:
+        model_config = getattr(model, "config", None)
+        if isinstance(model_config, dict):
+            lora_dropout = model_config.get("lora_dropout", 0.0)
+        else:
+            lora_dropout = getattr(model_config, "lora_dropout", 0.0)
+        lora_dropout = float(lora_dropout or 0.0)
+        if lora_dropout != 0.0:
+            raise ValueError(
+                "AnyFlow requires lora_dropout=0.0. Independent dropout masks in the finite-difference forwards "
+                "corrupt the derivative target."
+            )
+
         component = cls._get_trained_component(model)
         enable_flowmap = getattr(component, "enable_flowmap_time_conditioning", None)
         if not callable(enable_flowmap):

--- a/simpletuner/helpers/distillation/common.py
+++ b/simpletuner/helpers/distillation/common.py
@@ -121,6 +121,15 @@ class DistillationBase:
         del config
         return set()
 
+    @classmethod
+    def adapter_dropout_override(cls) -> float | None:
+        """LoRA dropout the method's reference implementation trains with, or None to leave user config untouched.
+
+        Every currently supported reference (AnyFlow, DMD2, DCM, LCM-LoRA, Diffusion-DPO) trains adapters without
+        dropout; methods whose reference differs should override this.
+        """
+        return 0.0
+
     def toggle_adapter(self, enable=False):
         """
         Toggle the adapter on/off when using the same model for teacher and student.

--- a/simpletuner/helpers/distillation/factory.py
+++ b/simpletuner/helpers/distillation/factory.py
@@ -68,6 +68,20 @@ class DistillerFactory:
         distiller_cls.prepare_model_for_adapter(model, DistillerFactory._method_config(method, config))
 
     @staticmethod
+    def adapter_dropout_override(method: Union[str, DistillationMethod, None]) -> Optional[float]:
+        """Return the LoRA dropout a configured distillation method requires, or None."""
+        if isinstance(method, str):
+            if method.strip().lower() in {"", "none", "false", "0"}:
+                return None
+            method = DistillationMethod.from_string(method)
+        if method is None:
+            return None
+        distiller_cls = DistillationRegistry.get(method.value)
+        if distiller_cls is None:
+            return None
+        return distiller_cls.adapter_dropout_override()
+
+    @staticmethod
     def training_batch_requirements(
         method: Union[str, DistillationMethod, None],
         config: Dict[str, Any],

--- a/simpletuner/helpers/training/default_settings/safety_check.py
+++ b/simpletuner/helpers/training/default_settings/safety_check.py
@@ -21,6 +21,33 @@ from simpletuner.helpers.training.error_handling import validate_deepspeed_compa
 
 
 def safety_check(args, accelerator):
+    if getattr(args, "distillation_method", None):
+        from simpletuner.helpers.distillation.factory import DistillerFactory
+
+        dropout_override = DistillerFactory.adapter_dropout_override(args.distillation_method)
+        current_dropout = getattr(args, "lora_dropout", 0.0)
+        if dropout_override is not None and current_dropout != dropout_override:
+            force_enabled = os.environ.get("SIMPLETUNER_LORA_DROPOUT_FORCE_ENABLED", "").strip().lower() in (
+                "1",
+                "true",
+                "yes",
+                "on",
+            )
+            if force_enabled:
+                logger.warning(
+                    f"Keeping --lora_dropout={current_dropout} for {args.distillation_method} distillation because "
+                    "SIMPLETUNER_LORA_DROPOUT_FORCE_ENABLED is set; the reference implementation trains with "
+                    f"lora_dropout={dropout_override}."
+                )
+            else:
+                logger.warning(
+                    f"{args.distillation_method} distillation reference implementations train adapters with "
+                    f"lora_dropout={dropout_override}; overriding --lora_dropout={current_dropout}. Set "
+                    "SIMPLETUNER_LORA_DROPOUT_FORCE_ENABLED=1 to keep the configured value. Adapter dropout also "
+                    "injects amplified noise into finite-difference distillation targets."
+                )
+                args.lora_dropout = dropout_override
+
     if accelerator is not None and accelerator.num_processes > 1:
         # mulit-gpu safety checks & warnings
         if args.model_type == "lora" and args.lora_type == "standard":

--- a/tests/helpers/distillation/test_anyflow_distiller.py
+++ b/tests/helpers/distillation/test_anyflow_distiller.py
@@ -239,6 +239,13 @@ class AnyFlowDistillerTests(unittest.TestCase):
         self.assertEqual(model.component.flowmap_gate_value, 0.4)
         self.assertEqual(model.component.flowmap_deltatime_type, "t-r")
 
+    def test_adapter_preparation_rejects_lora_dropout(self):
+        model = _FlowModel()
+        model.config.lora_dropout = 0.1
+
+        with self.assertRaisesRegex(ValueError, "lora_dropout=0.0"):
+            AnyFlowDistiller.prepare_model_for_adapter(model, {})
+
     def test_factory_reports_guidance_conditioning_for_method_config_shapes(self):
         direct = DistillerFactory.training_batch_requirements(
             "anyflow",


### PR DESCRIPTION
This pull request introduces two main improvements: it adds a new safety mechanism for LoRA dropout settings in distillation methods, and it enhances diagnostic tooling for skipping the text encoder. The changes enforce that certain distillation methods (notably AnyFlow) require `lora_dropout=0.0`, provide a mechanism to automatically override user-supplied dropout values, and add a new CLI flag and logic to support running diagnostics without loading or invoking the text encoder.

**Distillation method dropout enforcement:**

* The `AnyFlowDistiller.prepare_model_for_adapter` method now raises an error if `lora_dropout` is not set to `0.0`, ensuring that dropout does not corrupt finite-difference distillation targets.
* The `DistillationBase` class adds an `adapter_dropout_override` method (defaulting to `0.0`), and the `DistillerFactory` exposes this logic so that distillation methods can specify required dropout values. [[1]](diffhunk://#diff-ef514fdba9033b25fbb59ad4181fc498c28a822694fed94712ae71d99337c481R124-R132) [[2]](diffhunk://#diff-e167edd9fbba7ea08d0d8001ae881dd32b0f584ffe153ac501c27f4805cd3ccfR70-R83)
* The `safety_check` function in `default_settings/safety_check.py` now checks if the configured distillation method requires a specific dropout value and overrides the user's setting unless an environment variable (`SIMPLETUNER_LORA_DROPOUT_FORCE_ENABLED`) is set. It also logs warnings to inform users of overrides or forced settings.
* A new test verifies that `AnyFlowDistiller` rejects nonzero dropout values.

**Diagnostic tool improvements:**

* The `h3_objective_geometry.py` diagnostic now supports a `--skip-text-encoder` flag, which disables loading and use of the text encoder, requiring precomputed text embeddings. The initialization logic is updated to enforce this, and validation is disabled if the flag is used. [[1]](diffhunk://#diff-296fc350765368695a0b7773da76613268e90442a319883ca0978fb9616e447dR10) [[2]](diffhunk://#diff-296fc350765368695a0b7773da76613268e90442a319883ca0978fb9616e447dL393-R420) [[3]](diffhunk://#diff-296fc350765368695a0b7773da76613268e90442a319883ca0978fb9616e447dL609-R628) [[4]](diffhunk://#diff-296fc350765368695a0b7773da76613268e90442a319883ca0978fb9616e447dR725-R729)