### PR TITLE
metal-flash-attention fix for quantised attention backend selector

### DIFF
--- a/simpletuner/helpers/training/attention_backend.py
+++ b/simpletuner/helpers/training/attention_backend.py
@@ -43,15 +43,15 @@ _METAL_FLASH_ATTENTION_PROFILES = {
     "universal-metal-flash-attention": MetalFlashAttentionProfile(),
     "metal-flash-attention-int8": MetalFlashAttentionProfile(
         target_precision=3,
-        quant_mode=2,
+        quant_mode=0,
         target_precision_constant="QUANT_INT8",
-        quant_mode_constant="QUANT_BLOCK_WISE",
+        quant_mode_constant="QUANT_TENSOR_WISE",
     ),
     "metal-flash-attention-int4": MetalFlashAttentionProfile(
         target_precision=4,
-        quant_mode=2,
+        quant_mode=0,
         target_precision_constant="QUANT_INT4",
-        quant_mode_constant="QUANT_BLOCK_WISE",
+        quant_mode_constant="QUANT_TENSOR_WISE",
     ),
 }
 
@@ -936,9 +936,9 @@ def check_shape_growth_cache():
     torch.manual_seed(123)
     for seq_len in (512, 1024):
         shape = (1, 4, seq_len, 128)
-        query = torch.randn(shape, dtype=torch.float32, device="mps") * 0.02
-        key = torch.randn(shape, dtype=torch.float32, device="mps") * 0.02
-        value = torch.randn(shape, dtype=torch.float32, device="mps") * 0.02
+        query = (torch.randn(shape, dtype=torch.float32, device="mps") * 0.02).requires_grad_(True)
+        key = (torch.randn(shape, dtype=torch.float32, device="mps") * 0.02).requires_grad_(True)
+        value = (torch.randn(shape, dtype=torch.float32, device="mps") * 0.02).requires_grad_(True)
         torch.mps.synchronize()
         observed = selected_impl(
             query,
@@ -963,6 +963,11 @@ def check_shape_growth_cache():
                 + " observed_std="
                 + str(observed_std)
             )
+        observed.float().square().mean().backward()
+        torch.mps.synchronize()
+        for name, tensor in (("query", query), ("key", key), ("value", value)):
+            if tensor.grad is None or not torch.isfinite(tensor.grad).all().item():
+                raise SystemExit("Quantized UMFA shape-growth check produced invalid gradient for " + name)
 
 
 check_shape_growth_cache()

--- a/tests/test_attention_backend.py
+++ b/tests/test_attention_backend.py
@@ -133,7 +133,7 @@ class TestAttentionBackendPersistence(unittest.TestCase):
             clear_quantization_mode=lambda: None,
             set_quantization_mode=lambda precision, mode: None,
             QUANT_INT8=3,
-            QUANT_BLOCK_WISE=2,
+            QUANT_TENSOR_WISE=0,
         )
 
         def fake_import(name):
@@ -296,7 +296,7 @@ class TestAttentionBackendPersistence(unittest.TestCase):
             set_quantization_mode=lambda precision, mode: quantization_mode_calls.append((precision, mode)),
             clear_quantization_mode=lambda: quantization_mode_calls.append("clear"),
             QUANT_INT8=30,
-            QUANT_BLOCK_WISE=20,
+            QUANT_TENSOR_WISE=10,
         )
         config = type("Config", (object,), {"attention_mechanism": "metal-flash-attention-int8"})()
 
@@ -319,7 +319,7 @@ class TestAttentionBackendPersistence(unittest.TestCase):
         self.assertTrue(calls[0][5])
         self.assertEqual(calls[0][6], 0.5)
         self.assertFalse(calls[0][7])
-        self.assertEqual(quantization_mode_calls, [(30, 20)])
+        self.assertEqual(quantization_mode_calls, [(30, 10)])
 
     def test_restore_default_clears_metal_flash_attention_quantization_mode(self):
         quantization_mode_calls = []
@@ -332,7 +332,7 @@ class TestAttentionBackendPersistence(unittest.TestCase):
             set_quantization_mode=lambda precision, mode: quantization_mode_calls.append((precision, mode)),
             clear_quantization_mode=lambda: quantization_mode_calls.append("clear"),
             QUANT_INT8=3,
-            QUANT_BLOCK_WISE=2,
+            QUANT_TENSOR_WISE=0,
         )
         config = type("Config", (object,), {"attention_mechanism": "metal-flash-attention-int8"})()
 
@@ -343,16 +343,16 @@ class TestAttentionBackendPersistence(unittest.TestCase):
             AttentionBackendController.apply(config, AttentionPhase.TRAIN)
             AttentionBackendController.restore_default()
 
-        self.assertEqual(quantization_mode_calls, [(3, 2), "clear"])
+        self.assertEqual(quantization_mode_calls, [(3, 0), "clear"])
         self.assertIsNone(AttentionBackendController._metal_flash_attention_extension)
 
     def test_metal_flash_attention_int4_profile_uses_target_precision_4(self):
         profile = attention_backend_module._METAL_FLASH_ATTENTION_PROFILES["metal-flash-attention-int4"]
 
         self.assertEqual(profile.target_precision, 4)
-        self.assertEqual(profile.quant_mode, 2)
+        self.assertEqual(profile.quant_mode, 0)
         self.assertEqual(profile.target_precision_constant, "QUANT_INT4")
-        self.assertEqual(profile.quant_mode_constant, "QUANT_BLOCK_WISE")
+        self.assertEqual(profile.quant_mode_constant, "QUANT_TENSOR_WISE")
 
     def test_metal_flash_attention_wrapper_falls_back_when_unsupported(self):
         calls = []


### PR DESCRIPTION
This pull request updates the quantization mode for Metal Flash Attention profiles and improves the test coverage and gradient validation for quantized attention. The most important changes are grouped below:

**Quantization Mode Updates:**

* Changed the quantization mode for both `metal-flash-attention-int8` and `metal-flash-attention-int4` profiles from block-wise (`quant_mode=2`, `QUANT_BLOCK_WISE`) to tensor-wise (`quant_mode=0`, `QUANT_TENSOR_WISE`) in `attention_backend.py` and updated all related test constants and assertions to match. [[1]](diffhunk://#diff-6da6dc24805551ae0f36427540a6e78d6ca4387f97148bae69571b6b49eb9b65L46-R54) [[2]](diffhunk://#diff-64fd7fd193dac573e0ea5c44da5733d0cc166b7fbeae4fd50f6ee4a1e0121a80L136-R136) [[3]](diffhunk://#diff-64fd7fd193dac573e0ea5c44da5733d0cc166b7fbeae4fd50f6ee4a1e0121a80L299-R299) [[4]](diffhunk://#diff-64fd7fd193dac573e0ea5c44da5733d0cc166b7fbeae4fd50f6ee4a1e0121a80L322-R322) [[5]](diffhunk://#diff-64fd7fd193dac573e0ea5c44da5733d0cc166b7fbeae4fd50f6ee4a1e0121a80L335-R335) [[6]](diffhunk://#diff-64fd7fd193dac573e0ea5c44da5733d0cc166b7fbeae4fd50f6ee4a1e0121a80L346-R355)

**Testing and Validation Improvements:**

* In `check_shape_growth_cache`, enabled gradient computation for `query`, `key`, and `value` tensors, and added a check to ensure the gradients are finite after backward propagation, raising an error if not. [[1]](diffhunk://#diff-6da6dc24805551ae0f36427540a6e78d6ca4387f97148bae69571b6b49eb9b65L939-R941) [[2]](diffhunk://#diff-6da6dc24805551ae0f36427540a6e78d6ca4387f97148bae69571b6b49eb9b65R966-R970)