### PR TITLE
minimax h3: batch dimension fix for sparse attention

### DIFF
--- a/simpletuner/helpers/models/minimaxh3/model.py
+++ b/simpletuner/helpers/models/minimaxh3/model.py
@@ -48,6 +48,7 @@ from simpletuner.helpers.models.minimaxh3.packing import (
 from simpletuner.helpers.models.minimaxh3.pipeline import MiniMaxH3Pipeline
 from simpletuner.helpers.models.minimaxh3.pipeline_ref import MiniMaxH3Ref2VAPipeline
 from simpletuner.helpers.models.minimaxh3.scheduler import MiniMaxH3Scheduler
+from simpletuner.helpers.models.minimaxh3.sparse_attention import initialize_minimax_h3_flex_attention
 from simpletuner.helpers.models.minimaxh3.transformer import MiniMaxH3Transformer3DModel
 from simpletuner.helpers.models.registry import ModelRegistry
 from simpletuner.helpers.musubi_block_swap import apply_musubi_pretrained_defaults
@@ -171,6 +172,9 @@ class MiniMaxH3(VideoModelFoundation):
 
     def __init__(self, config: dict, accelerator):
         super().__init__(config, accelerator)
+        sparse_mode = str(getattr(self.config, "minimax_h3_sparse_attention", "disabled") or "disabled").lower()
+        if sparse_mode not in {"disabled", "none", "full", "dense"}:
+            initialize_minimax_h3_flex_attention()
         self.audio_vae = None
         self.processor = None
         self._warned_missing_audio = False
@@ -1235,29 +1239,100 @@ class MiniMaxH3(VideoModelFoundation):
         batch["audio_noisy_latents"] = audio_noisy.to(device=target_device, dtype=target_dtype)
         return batch
 
-    def _resolve_text_token_tags(self, prepared_batch: dict, text_seq_len: int, device: torch.device) -> torch.Tensor:
+    def _resolve_text_token_tags(
+        self,
+        prepared_batch: dict,
+        text_seq_len: int,
+        batch_size: int,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
         tags = prepared_batch.get("text_token_tags")
         if tags is None:
             text_output = prepared_batch.get("text_encoder_output")
             if isinstance(text_output, dict):
                 tags = text_output.get("text_token_tags")
         if tags is None:
-            return torch.full((text_seq_len,), MINIMAX_H3_TEXT_TAG, dtype=torch.long, device=device)
+            return torch.full((text_seq_len,), MINIMAX_H3_TEXT_TAG, dtype=torch.long, device=device), None
         tags = tags.to(device=device, dtype=torch.long)
         if tags.ndim == 1:
             if tags.shape[0] != text_seq_len:
                 raise ValueError(f"MiniMax-H3 text_token_tags length {tags.shape[0]} != prompt length {text_seq_len}.")
-            return tags
+            return tags, None
         if tags.ndim == 2:
+            if tags.shape[0] != batch_size:
+                raise ValueError(f"MiniMax-H3 text_token_tags batch {tags.shape[0]} != latent batch {batch_size}.")
             if tags.shape[1] != text_seq_len:
                 raise ValueError(f"MiniMax-H3 text_token_tags length {tags.shape[1]} != prompt length {text_seq_len}.")
-            if not torch.all(tags == tags[0:1]):
-                raise ValueError(
-                    "MiniMax-H3 batched training currently requires identical packed text token layouts. "
-                    "Use train_batch_size=1 or group prompts with identical H3 token/tag lengths."
-                )
-            return tags[0]
+            live_mask = tags >= 0
+            text_lengths = live_mask.sum(dim=1)
+            expected_live_mask = torch.arange(text_seq_len, device=device).unsqueeze(0) < text_lengths.unsqueeze(1)
+            if not bool(torch.equal(live_mask, expected_live_mask)):
+                raise ValueError("MiniMax-H3 batched text padding must be trailing.")
+            layout_tags = tags.max(dim=0).values
+            if bool((layout_tags < 0).any()):
+                raise ValueError("MiniMax-H3 batched text layout contains a column that is padding for every sample.")
+            if bool((live_mask & (tags != layout_tags.unsqueeze(0))).any()):
+                raise ValueError("MiniMax-H3 batched training requires matching non-padding text modality layouts.")
+            return layout_tags, None if bool(live_mask.all()) else live_mask
         raise ValueError(f"MiniMax-H3 text_token_tags must be 1-D or 2-D, got {tuple(tags.shape)}.")
+
+    @staticmethod
+    def _batch_timestep_values(value: torch.Tensor, batch_size: int, name: str) -> torch.Tensor:
+        value = torch.as_tensor(value, dtype=torch.float32)
+        if value.ndim == 0:
+            return value.expand(batch_size)
+        if value.shape[0] != batch_size:
+            raise ValueError(f"MiniMax-H3 {name} timestep batch {value.shape[0]} != latent batch {batch_size}.")
+        return value.reshape(batch_size, -1)[:, 0]
+
+    @staticmethod
+    def _batched_row_timesteps(
+        layout,
+        video_timesteps: torch.Tensor,
+        audio_timesteps: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        rows = []
+        for video_timestep, audio_timestep in zip(video_timesteps, audio_timesteps):
+            values, indices = build_row_timesteps(
+                layout,
+                video_timestep=float(video_timestep.item()),
+                audio_timestep=float(audio_timestep.item()),
+                condition_video_timestep=MINIMAX_H3_KEYFRAME_NOISE_AUG,
+                condition_audio_timestep=MINIMAX_H3_KEYFRAME_NOISE_AUG,
+            )
+            rows.append(values[indices])
+        row_timesteps = torch.stack(rows)
+        values, indices = torch.unique(row_timesteps, sorted=True, return_inverse=True)
+        indices = indices.view_as(row_timesteps)
+        return (values, indices[0]) if row_timesteps.shape[0] == 1 else (values, indices)
+
+    @staticmethod
+    def _batched_row_timestep_intervals(
+        layout,
+        video_timesteps: torch.Tensor,
+        audio_timesteps: torch.Tensor,
+        video_r_timesteps: torch.Tensor,
+        audio_r_timesteps: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        rows = []
+        for values in zip(video_timesteps, audio_timesteps, video_r_timesteps, audio_r_timesteps):
+            video_timestep, audio_timestep, video_r_timestep, audio_r_timestep = values
+            timesteps, r_timesteps, indices = build_row_timestep_intervals(
+                layout,
+                video_timestep=float(video_timestep.item()),
+                audio_timestep=float(audio_timestep.item()),
+                condition_video_timestep=MINIMAX_H3_KEYFRAME_NOISE_AUG,
+                condition_audio_timestep=MINIMAX_H3_KEYFRAME_NOISE_AUG,
+                video_r_timestep=float(video_r_timestep.item()),
+                audio_r_timestep=float(audio_r_timestep.item()),
+            )
+            rows.append(torch.stack((timesteps[indices], r_timesteps[indices]), dim=-1))
+        row_pairs = torch.stack(rows)
+        pairs, indices = torch.unique(row_pairs.view(-1, 2), dim=0, sorted=True, return_inverse=True)
+        indices = indices.view(row_pairs.shape[:-1])
+        if row_pairs.shape[0] == 1:
+            indices = indices[0]
+        return pairs[:, 0], pairs[:, 1], indices
 
     def _audio_latent_channels(self) -> int:
         transformer = getattr(self, "model", None)
@@ -1327,11 +1402,15 @@ class MiniMaxH3(VideoModelFoundation):
         patch_size = tuple(getattr(transformer.config, "patch_size", (1, 2, 2)))
         patch_product = int(patch_size[0] * patch_size[1] * patch_size[2])
         batch_size, channels, latent_frames, latent_height, latent_width = noisy_latents.shape
+        text_seq_len = encoder_hidden_states.shape[1]
         use_audio = use_audio and latent_frames > 1
         if use_audio:
             audio_noisy = audio_noisy.to(self.accelerator.device, dtype=self.config.weight_dtype)
-        text_token_tags = self._resolve_text_token_tags(
-            prepared_batch, encoder_hidden_states.shape[1], self.accelerator.device
+        text_token_tags, text_valid_mask = self._resolve_text_token_tags(
+            prepared_batch,
+            text_seq_len,
+            batch_size,
+            self.accelerator.device,
         )
         packed_target_video = patchify_video_latents(noisy_latents, patch_size).view(
             batch_size, -1, channels * patch_product
@@ -1384,44 +1463,41 @@ class MiniMaxH3(VideoModelFoundation):
             patch_size=patch_size,
             keyframe_anchors=keyframe_anchors,
         )
-        video_timestep = self._scalar_timestep(prepared_batch["timesteps"], "video")
+        video_timesteps = self._batch_timestep_values(prepared_batch["timesteps"], batch_size, "video")
         if use_audio:
-            audio_timestep = self._scalar_timestep(
+            audio_timesteps = self._batch_timestep_values(
                 prepared_batch.get("audio_timesteps", prepared_batch["timesteps"]),
+                batch_size,
                 "audio",
             )
         else:
-            audio_timestep = video_timestep
+            audio_timesteps = video_timesteps
         flowmap_r_timesteps = prepared_batch.get(self.FLOWMAP_R_TIMESTEP_BATCH_KEY)
         r_timestep = None
         if flowmap_r_timesteps is not None:
-            video_r_timestep = self._scalar_timestep(flowmap_r_timesteps, "video r")
+            video_r_timesteps = self._batch_timestep_values(flowmap_r_timesteps, batch_size, "video r")
             if use_audio:
-                video_r_sigma = torch.tensor([1.0 - video_r_timestep], dtype=torch.float32)
+                video_r_sigma = 1.0 - video_r_timesteps
                 audio_r_sigma = self._shift_sigmas_between_schedules(
                     video_r_sigma,
                     float(getattr(self.config, "flow_schedule_shift", 12.0) or 12.0),
                     float(getattr(self.config, "audio_flow_schedule_shift", 3.0) or 3.0),
                 )
-                audio_r_timestep = float(1.0 - audio_r_sigma[0].item())
+                audio_r_timesteps = 1.0 - audio_r_sigma
             else:
-                audio_r_timestep = video_r_timestep
-            timestep, r_timestep, timestep_indices = build_row_timestep_intervals(
+                audio_r_timesteps = video_r_timesteps
+            timestep, r_timestep, timestep_indices = self._batched_row_timestep_intervals(
                 layout,
-                video_timestep=video_timestep,
-                audio_timestep=audio_timestep,
-                condition_video_timestep=MINIMAX_H3_KEYFRAME_NOISE_AUG,
-                condition_audio_timestep=MINIMAX_H3_KEYFRAME_NOISE_AUG,
-                video_r_timestep=video_r_timestep,
-                audio_r_timestep=audio_r_timestep,
+                video_timesteps,
+                audio_timesteps,
+                video_r_timesteps,
+                audio_r_timesteps,
             )
         else:
-            timestep, timestep_indices = build_row_timesteps(
+            timestep, timestep_indices = self._batched_row_timesteps(
                 layout,
-                video_timestep=video_timestep,
-                audio_timestep=audio_timestep,
-                condition_video_timestep=MINIMAX_H3_KEYFRAME_NOISE_AUG,
-                condition_audio_timestep=MINIMAX_H3_KEYFRAME_NOISE_AUG,
+                video_timesteps,
+                audio_timesteps,
             )
 
         token_tags = layout.token_tags.to(self.accelerator.device)
@@ -1429,6 +1505,17 @@ class MiniMaxH3(VideoModelFoundation):
         video_indices = layout.video_indices.to(self.accelerator.device)
         audio_indices = layout.audio_indices.to(self.accelerator.device)
         text_indices = layout.text_indices.to(self.accelerator.device)
+        packed_valid_mask = None
+        if text_valid_mask is not None:
+            packed_valid_mask = torch.ones(
+                (batch_size, layout.sequence_length),
+                device=self.accelerator.device,
+                dtype=torch.bool,
+            )
+            packed_valid_mask[:, text_indices] = text_valid_mask
+            text_lengths = text_valid_mask.sum(dim=1)
+            position_ids = position_ids.unsqueeze(0).expand(batch_size, -1, -1).clone()
+            position_ids[:, text_seq_len:, 0] += (text_lengths - text_seq_len).to(position_ids.dtype).unsqueeze(1)
         timestep = timestep.to(device=self.accelerator.device, dtype=self.config.weight_dtype)
         if r_timestep is not None:
             r_timestep = r_timestep.to(device=self.accelerator.device, dtype=self.config.weight_dtype)
@@ -1461,6 +1548,7 @@ class MiniMaxH3(VideoModelFoundation):
             "video_indices": video_indices,
             "audio_indices": audio_indices,
             "text_indices": text_indices,
+            "packed_valid_mask": packed_valid_mask,
             "attention_kwargs": {},
             "skip_layers": prepared_batch.get("skip_layers"),
             "force_keep_mask": force_keep_mask,

--- a/simpletuner/helpers/models/minimaxh3/sparse_attention.py
+++ b/simpletuner/helpers/models/minimaxh3/sparse_attention.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from threading import Lock
 
 import torch
 import torch.nn.functional as F
 
 H3_SPARSE_ATTENTION_MODES = ("disabled", "moba3d")
+_FLEX_ATTENTION_COMPILE_LOCK = Lock()
+_COMPILED_FLEX_ATTENTION = None
 
 
 def parse_h3_sparse_block_shape(
@@ -76,6 +79,7 @@ class MiniMaxH3SparseAttentionLayout:
     target_start: int
     target_shape: tuple[int, int, int]
     trailing_padding: int = 0
+    packed_valid_mask: torch.Tensor | None = None
 
     def validate(self, sequence_length: int) -> None:
         target_tokens = math.prod(self.target_shape)
@@ -288,6 +292,19 @@ def _route_video_blocks(
     return block_counts, block_indices
 
 
+def initialize_minimax_h3_flex_attention():
+    """Create the compiled FlexAttention wrapper before entering the model forward."""
+    global _COMPILED_FLEX_ATTENTION
+
+    if _COMPILED_FLEX_ATTENTION is None:
+        with _FLEX_ATTENTION_COMPILE_LOCK:
+            if _COMPILED_FLEX_ATTENTION is None:
+                from torch.nn.attention.flex_attention import flex_attention
+
+                _COMPILED_FLEX_ATTENTION = torch.compile(flex_attention, dynamic=False)
+    return _COMPILED_FLEX_ATTENTION
+
+
 @torch.compiler.disable
 def _flex_attention(
     query: torch.Tensor,
@@ -295,12 +312,7 @@ def _flex_attention(
     value: torch.Tensor,
     block_mask,
 ) -> torch.Tensor:
-    from torch.nn.attention.flex_attention import flex_attention
-
-    compiled = getattr(_flex_attention, "_compiled", None)
-    if compiled is None:
-        compiled = torch.compile(flex_attention, dynamic=False)
-        _flex_attention._compiled = compiled
+    compiled = initialize_minimax_h3_flex_attention()
     return compiled(query, key, value, block_mask=block_mask)
 
 
@@ -332,9 +344,24 @@ def minimax_h3_sparse_attention(
         shared_head_group=shared_head_group,
     )
     valid_rows = _valid_rows(reordered_layout, query.device)
+    if layout.packed_valid_mask is not None:
+        packed_valid_mask = layout.packed_valid_mask.to(device=query.device, dtype=torch.bool)
+        if packed_valid_mask.shape != (
+            query.shape[0],
+            layout.target_start + math.prod(layout.target_shape) + layout.trailing_padding,
+        ):
+            raise ValueError(
+                "MiniMax-H3 sparse packed validity mask must have shape `[batch, sequence]`, got "
+                f"{tuple(packed_valid_mask.shape)}."
+            )
+        valid_rows = (
+            valid_rows.unsqueeze(0) & _reorder_qkv(packed_valid_mask[:, None, :, None], reordered_layout)[:, 0, :, 0]
+        )
 
     def mask_mod(batch_index, head_index, query_index, key_index):
-        return valid_rows[query_index] & valid_rows[key_index]
+        if valid_rows.ndim == 1:
+            return valid_rows[query_index] & valid_rows[key_index]
+        return valid_rows[batch_index, query_index] & valid_rows[batch_index, key_index]
 
     block_mask = BlockMask.from_kv_blocks(
         block_counts,

--- a/simpletuner/helpers/models/minimaxh3/transformer.py
+++ b/simpletuner/helpers/models/minimaxh3/transformer.py
@@ -55,6 +55,7 @@ from .activations import MiniMaxH3FeedForward
 from .sparse_attention import (
     MiniMaxH3SparseAttentionConfig,
     MiniMaxH3SparseAttentionLayout,
+    initialize_minimax_h3_flex_attention,
     minimax_h3_sparse_attention,
     minimax_h3_sparse_attention_ulysses,
 )
@@ -477,7 +478,8 @@ class MiniMaxH3TransformerOutput(BaseOutput):
 def _apply_rotary_emb(hidden_states: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
     r"""
     Rotate the leading `rotary_dim` channels of every head and pass the remaining channels through unchanged.
-    `hidden_states` is `(batch_size, seq_len, num_heads, head_dim)` and `cos`/`sin` are `(seq_len, rotary_dim)`.
+    `hidden_states` is `(batch_size, seq_len, num_heads, head_dim)` and `cos`/`sin` are either
+    `(seq_len, rotary_dim)` or `(batch_size, seq_len, rotary_dim)`.
     """
     rotary_dim = cos.shape[-1]
     hidden_states_rotary = hidden_states[..., :rotary_dim]
@@ -572,11 +574,11 @@ class MiniMaxH3RotaryPosEmbed(nn.Module):
         self.register_buffer("inv_freq", inv_freq, persistent=False)
 
     def forward(self, position_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        # position_ids: (seq_len, 3) -> cos/sin: (seq_len, 2 * 3 * rope_freq_dim)
+        # position_ids: (..., seq_len, 3) -> cos/sin: (..., seq_len, 2 * 3 * rope_freq_dim)
         position_ids = position_ids.to(torch.float32)
         inv_freq = self.inv_freq.to(device=position_ids.device)
-        freqs = position_ids.unsqueeze(-1) * inv_freq.view(1, 1, -1)  # (seq_len, 3, rope_freq_dim)
-        freqs_t, freqs_h, freqs_w = freqs.unbind(dim=1)
+        freqs = position_ids.unsqueeze(-1) * inv_freq.view(1, 1, -1)
+        freqs_t, freqs_h, freqs_w = freqs.unbind(dim=-2)
         freqs = torch.cat((freqs_t, freqs_h, freqs_w), dim=-1)
         freqs = torch.cat((freqs, freqs), dim=-1)
         return freqs.cos(), freqs.sin()
@@ -778,8 +780,10 @@ class MiniMaxH3AttnProcessor:
         )
         if use_sparse_attention:
             cp_config = context_parallel_config(self._parallel_config)
-            if attention_mask is not None and cp_config is None:
+            if attention_mask is not None and cp_config is None and sparse_attention_layout.packed_valid_mask is None:
                 raise ValueError("MiniMax-H3 sparse attention cannot be combined with a packed attention mask yet.")
+            if reference_mask is not None and attention_mask is not None:
+                raise ValueError("MiniMax-H3 sparse attention cannot combine batched padding with CachedKV masking yet.")
             if cp_config is not None:
                 hidden_states = minimax_h3_sparse_attention_ulysses(
                     query,
@@ -894,12 +898,13 @@ class MiniMaxH3TokenRefinerBlock(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
         checkpoint_ffn: bool = False,
         checkpoint_fn: Any | None = None,
         offload_attention: bool = False,
     ) -> torch.Tensor:
         with activation_offload_context(offload_attention, label=f"{self.__class__.__qualname__}:attention"):
-            hidden_states = hidden_states + self.attn(self.norm1(hidden_states))
+            hidden_states = hidden_states + self.attn(self.norm1(hidden_states), attention_mask=attention_mask)
         if checkpoint_ffn:
             if checkpoint_fn is None:
                 raise ValueError("checkpoint_fn is required when checkpoint_ffn=True")
@@ -947,6 +952,7 @@ class MiniMaxH3TokenRefiner(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
         checkpoint_backend: str = "torch",
         offload_attention: bool = False,
     ) -> torch.Tensor:
@@ -964,6 +970,7 @@ class MiniMaxH3TokenRefiner(nn.Module):
                 if checkpoint_backend.endswith("-ffn"):
                     hidden_states = block(
                         hidden_states,
+                        attention_mask=attention_mask,
                         checkpoint_ffn=True,
                         checkpoint_fn=checkpoint_fn,
                         offload_attention=offload_attention,
@@ -973,12 +980,17 @@ class MiniMaxH3TokenRefiner(nn.Module):
                     def run_checkpointed_block(checkpoint_hidden_states, checkpoint_block=block):
                         return checkpoint_block(
                             checkpoint_hidden_states,
+                            attention_mask=attention_mask,
                             offload_attention=offload_attention,
                         )
 
                     hidden_states = checkpoint_fn(run_checkpointed_block, hidden_states, use_reentrant=False)
             else:
-                hidden_states = block(hidden_states, offload_attention=offload_attention)
+                hidden_states = block(
+                    hidden_states,
+                    attention_mask=attention_mask,
+                    offload_attention=offload_attention,
+                )
         return self.final_norm(hidden_states)
 
 
@@ -1366,6 +1378,8 @@ class MiniMaxH3Transformer3DModel(ModelMixin, ConfigMixin, AttentionMixin, PeftA
                 f"MiniMax-H3 sparse start layer {config.start_layer} is outside the "
                 f"{len(self.transformer_blocks)}-layer transformer."
             )
+        if config.enabled:
+            initialize_minimax_h3_flex_attention()
         self._h3_sparse_attention_config = config
         for layer_index, block in enumerate(self.transformer_blocks):
             block.attn._h3_sparse_layer_index = layer_index
@@ -1859,6 +1873,7 @@ class MiniMaxH3Transformer3DModel(ModelMixin, ConfigMixin, AttentionMixin, PeftA
         video_indices: torch.Tensor,
         audio_indices: torch.Tensor,
         text_indices: torch.Tensor,
+        packed_valid_mask: torch.Tensor | None = None,
         attention_kwargs: dict[str, Any] | None = None,
         skip_layers: list[int] | None = None,
         force_keep_mask: torch.Tensor | None = None,
@@ -1885,13 +1900,14 @@ class MiniMaxH3Transformer3DModel(ModelMixin, ConfigMixin, AttentionMixin, PeftA
             timestep (`torch.Tensor` of shape `(num_timesteps,)`):
                 The *distinct* timestep values present in the packed sequence, in `[0, 1]` and unscaled. One forward
                 serves rows at different noise levels (target video, target audio, conditioning rows).
-            timestep_indices (`torch.Tensor` of shape `(seq_len,)`):
+            timestep_indices (`torch.Tensor` of shape `(seq_len,)` or `(batch_size, seq_len)`):
                 For every row of the packed sequence, the index of its timestep in `timestep`.
             token_tags (`torch.Tensor` of shape `(seq_len,)`):
                 For every row of the packed sequence, its modality: `0` video, `1` text, `2` audio, `-1` padding.
                 Padding rows form their own attention document and never reach the outputs.
-            position_ids (`torch.Tensor` of shape `(seq_len, 3)`):
-                The `(t, h, w)` rotary coordinates of every row of the packed sequence.
+            position_ids (`torch.Tensor` of shape `(seq_len, 3)` or `(batch_size, seq_len, 3)`):
+                The `(t, h, w)` rotary coordinates of every row of the packed sequence. Batched coordinates preserve
+                each sample's unpadded text-length origin.
             video_indices (`torch.Tensor` of shape `(num_video_tokens,)`):
                 Positions of the video rows in the packed sequence.
             audio_indices (`torch.Tensor` of shape `(num_audio_tokens,)`):
@@ -1918,18 +1934,37 @@ class MiniMaxH3Transformer3DModel(ModelMixin, ConfigMixin, AttentionMixin, PeftA
                 `video_indices` and `audio_indices`.
         """
         # `attention_kwargs` is consumed by the `@apply_lora_scale` decorator on this method.
-        if position_ids.ndim != 2 or position_ids.shape[-1] != 3:
-            raise ValueError(f"`position_ids` must be a `(seq_len, 3)` tensor, got {list(position_ids.shape)}.")
-        sequence_length = position_ids.shape[0]
-        if token_tags.shape != (sequence_length,) or timestep_indices.shape != (sequence_length,):
+        valid_position_ids = position_ids.ndim == 2 or (
+            position_ids.ndim == 3 and position_ids.shape[0] == hidden_states.shape[0]
+        )
+        if not valid_position_ids or position_ids.shape[-1] != 3:
             raise ValueError(
-                "`token_tags` and `timestep_indices` must both be `(seq_len,)` tensors matching `position_ids`, got "
+                "`position_ids` must be `(seq_len, 3)` or `(batch, seq_len, 3)`, got " f"{list(position_ids.shape)}."
+            )
+        sequence_length = position_ids.shape[-2]
+        valid_timestep_indices = timestep_indices.shape == (sequence_length,) or timestep_indices.shape == (
+            hidden_states.shape[0],
+            sequence_length,
+        )
+        if token_tags.shape != (sequence_length,) or not valid_timestep_indices:
+            raise ValueError(
+                "`token_tags` must be `(seq_len,)` and `timestep_indices` must be `(seq_len,)` or "
+                "`(batch, seq_len)` tensors matching `position_ids`, got "
                 f"{list(token_tags.shape)} and {list(timestep_indices.shape)} for seq_len={sequence_length}."
             )
+        if packed_valid_mask is not None:
+            packed_valid_mask = packed_valid_mask.to(device=hidden_states.device, dtype=torch.bool)
+            if packed_valid_mask.shape != (hidden_states.shape[0], sequence_length):
+                raise ValueError(
+                    "`packed_valid_mask` must be `(batch, seq_len)`, got "
+                    f"{list(packed_valid_mask.shape)} for batch={hidden_states.shape[0]}, seq_len={sequence_length}."
+                )
 
         parallel_config = getattr(self, "_parallel_config", None)
         cp_config = context_parallel_config(parallel_config)
         cp_active = cp_config is not None
+        if cp_active and (position_ids.ndim == 3 or timestep_indices.ndim == 2 or packed_valid_mask is not None):
+            raise ValueError("MiniMax-H3 batched packed layouts are not supported with context parallelism yet.")
         sparse_config = self._h3_sparse_attention_config
         if sparse_config.enabled and cp_active:
             ring_degree = int(getattr(cp_config, "ring_degree", 1) or 1)
@@ -1960,8 +1995,14 @@ class MiniMaxH3Transformer3DModel(ModelMixin, ConfigMixin, AttentionMixin, PeftA
         audio_embeds = self.audio_proj_in(audio_hidden_states.to(self.audio_proj_in.weight.dtype))
         text_embeds = self.context_embedder(encoder_hidden_states.to(self.context_embedder.weight.dtype))
         self.token_refiner.gradient_checkpointing = self.gradient_checkpointing
+        text_attention_mask = None
+        if packed_valid_mask is not None:
+            text_is_pad = ~packed_valid_mask.index_select(1, text_indices)
+            if bool(text_is_pad.any()):
+                text_attention_mask = text_is_pad[:, None, :, None] == text_is_pad[:, None, None, :]
         text_embeds = self.token_refiner(
             text_embeds,
+            attention_mask=text_attention_mask,
             checkpoint_backend=self.gradient_checkpointing_backend,
             offload_attention=self.gradient_checkpointing_offload_attention,
         )
@@ -1988,9 +2029,13 @@ class MiniMaxH3Transformer3DModel(ModelMixin, ConfigMixin, AttentionMixin, PeftA
         # are discarded, and excluding padding keys keeps every live row exact.
         attention_mask = None
         is_pad = token_tags < 0
+        if packed_valid_mask is not None:
+            is_pad = (~packed_valid_mask) | is_pad.unsqueeze(0)
         if bool(is_pad.any()):
             if cp_active:
                 attention_mask = (~is_pad)[None, None, None, :]
+            elif is_pad.ndim == 2:
+                attention_mask = is_pad[:, None, :, None] == is_pad[:, None, None, :]
             else:
                 attention_mask = is_pad[None, :] == is_pad[:, None]
 
@@ -2002,6 +2047,8 @@ class MiniMaxH3Transformer3DModel(ModelMixin, ConfigMixin, AttentionMixin, PeftA
         reference_kv_cache = None
         reference_kv_stats = None
         if reference_mode is H3_REFERENCE_MODE.CachedKV and not grad_enabled:
+            if packed_valid_mask is not None:
+                raise ValueError("MiniMax-H3 CachedKV reference mode does not support batched text padding yet.")
             if cp_active:
                 raise ValueError("MiniMax-H3 CachedKV reference mode does not support context_parallel_size yet.")
             reference_mask = self._build_reference_mask(
@@ -2072,6 +2119,7 @@ class MiniMaxH3Transformer3DModel(ModelMixin, ConfigMixin, AttentionMixin, PeftA
                 target_start=unpadded_sequence_length - target_video_rows,
                 target_shape=target_shape,
                 trailing_padding=sequence_length - unpadded_sequence_length,
+                packed_valid_mask=packed_valid_mask,
             )
             if use_routing:
                 raise ValueError("MiniMax-H3 sparse attention cannot be combined with TREAD routing yet.")

--- a/tests/test_minimaxh3.py
+++ b/tests/test_minimaxh3.py
@@ -175,6 +175,18 @@ class TestMiniMaxH3RotaryPosEmbed(unittest.TestCase):
         self.assertEqual(cos.shape, (4, 12))
         self.assertEqual(sin.shape, (4, 12))
 
+    def test_supports_per_sample_position_ids(self):
+        rope = MiniMaxH3RotaryPosEmbed(rope_freq_dim=2)
+        position_ids = torch.arange(24, dtype=torch.float32).view(2, 4, 3)
+
+        cos, sin = rope(position_ids)
+
+        self.assertEqual(cos.shape, (2, 4, 12))
+        self.assertEqual(sin.shape, (2, 4, 12))
+        expected_cos, expected_sin = rope(position_ids[1])
+        self.assertTrue(torch.equal(cos[1], expected_cos))
+        self.assertTrue(torch.equal(sin[1], expected_sin))
+
 
 class TestMiniMaxH3ContextParallelLayout(unittest.TestCase):
     def test_pads_odd_layout_to_context_parallel_degree(self):
@@ -1364,6 +1376,53 @@ class MiniMaxH3Tests(unittest.TestCase):
         output = wrapper.model_predict(prepared_batch)
         self.assertEqual(output["model_prediction"].shape, (1, 2, 2, 2, 2))
         self.assertEqual(output["audio_prediction"].shape, (1, 2, 3, 2))
+
+    def test_model_predict_batches_variable_text_lengths_and_timesteps_exactly(self):
+        torch.manual_seed(17)
+        wrapper = MiniMaxH3.__new__(MiniMaxH3)
+        wrapper.model = tiny_h3_transformer(num_layers=1).eval()
+        wrapper.model.enable_flowmap_time_conditioning(gate_value=0.25, deltatime_type="r")
+        wrapper.accelerator = SimpleNamespace(device=torch.device("cpu"))
+        wrapper.config = SimpleNamespace(weight_dtype=torch.float32)
+        wrapper.LATENT_CHANNEL_COUNT = 2
+        wrapper.unwrap_model = lambda model=None: model
+
+        noisy_latents = torch.randn(2, 2, 2, 2, 2)
+        encoder_hidden_states = torch.randn(2, 5, 6)
+        encoder_hidden_states[0, 3:] = 0
+        text_token_tags = torch.tensor(
+            [
+                [MINIMAX_H3_TEXT_TAG, MINIMAX_H3_TEXT_TAG, MINIMAX_H3_TEXT_TAG, -1, -1],
+                [MINIMAX_H3_TEXT_TAG] * 5,
+            ],
+            dtype=torch.long,
+        )
+        timesteps = torch.tensor([0.25, 0.75])
+        r_timesteps = torch.tensor([0.5, 0.9])
+        prepared_batch = {
+            "noisy_latents": noisy_latents,
+            "encoder_hidden_states": encoder_hidden_states,
+            "timesteps": timesteps,
+            "text_token_tags": text_token_tags,
+            "flowmap_r_timesteps": r_timesteps,
+            "minimax_h3_target_mode": "video",
+        }
+
+        with torch.no_grad():
+            batched = wrapper.model_predict(prepared_batch)["model_prediction"]
+            individual = []
+            for batch_index, text_length in enumerate((3, 5)):
+                single_batch = {
+                    "noisy_latents": noisy_latents[batch_index : batch_index + 1],
+                    "encoder_hidden_states": encoder_hidden_states[batch_index : batch_index + 1, :text_length],
+                    "timesteps": timesteps[batch_index : batch_index + 1],
+                    "text_token_tags": text_token_tags[batch_index : batch_index + 1, :text_length],
+                    "flowmap_r_timesteps": r_timesteps[batch_index : batch_index + 1],
+                    "minimax_h3_target_mode": "video",
+                }
+                individual.append(wrapper.model_predict(single_batch)["model_prediction"])
+
+        self.assertTrue(torch.allclose(batched, torch.cat(individual), atol=1e-5, rtol=1e-5))
 
     def test_model_predict_video_target_mode_omits_audio_rows(self):
         wrapper = MiniMaxH3.__new__(MiniMaxH3)


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the MiniMax-H3 model, mainly focused on enhanced support for batched and sparse attention, improved handling of text token tags and validity masks, and more robust and modular attention initialization. The changes also include updates to the rotary embedding logic and better error handling for mask combinations.

**Sparse and Flex Attention Improvements:**
- Added `initialize_minimax_h3_flex_attention()` for thread-safe, one-time compilation of the FlexAttention kernel, and updated all relevant call sites to use this initializer. This improves performance and ensures correct initialization in multi-threaded environments. [[1]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fR51) [[2]](diffhunk://#diff-a036cd66bd1a5fceb8815f348db2b8220be3cf5f705d137a2ef97f0306cf1845R295-R315) [[3]](diffhunk://#diff-0e31056fee25c3548ad29942a179564a24bdf95aae593af3f5f9afeeb67e112dR58)
- The sparse attention layout now supports an optional `packed_valid_mask`, and the sparse attention implementation applies this mask per batch to enforce valid token positions. [[1]](diffhunk://#diff-a036cd66bd1a5fceb8815f348db2b8220be3cf5f705d137a2ef97f0306cf1845R82) [[2]](diffhunk://#diff-a036cd66bd1a5fceb8815f348db2b8220be3cf5f705d137a2ef97f0306cf1845R347-R364)

**Text Token Tag Handling and Batch Robustness:**
- Refactored `_resolve_text_token_tags` to handle both 1D and 2D (batched) tags, returning a validity mask for non-padding tokens and enforcing stricter checks for batched input consistency.
- Updated `model_predict` to consistently use batched timesteps, propagate validity masks, and adjust position IDs as needed for batched text with padding. [[1]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fR1405-R1413) [[2]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fL1387-R1518) [[3]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fR1551)

**Transformer and Rotary Embedding Updates:**
- The rotary embedding logic now supports both per-batch and per-sequence position IDs, improving flexibility for batched input. [[1]](diffhunk://#diff-0e31056fee25c3548ad29942a179564a24bdf95aae593af3f5f9afeeb67e112dL480-R482) [[2]](diffhunk://#diff-0e31056fee25c3548ad29942a179564a24bdf95aae593af3f5f9afeeb67e112dL575-R581)
- Transformer blocks and the main forward pass now accept and propagate `attention_mask`, supporting more flexible masking and improved error handling for incompatible mask combinations. [[1]](diffhunk://#diff-0e31056fee25c3548ad29942a179564a24bdf95aae593af3f5f9afeeb67e112dR901-R907) [[2]](diffhunk://#diff-0e31056fee25c3548ad29942a179564a24bdf95aae593af3f5f9afeeb67e112dR955) [[3]](diffhunk://#diff-0e31056fee25c3548ad29942a179564a24bdf95aae593af3f5f9afeeb67e112dR973) [[4]](diffhunk://#diff-0e31056fee25c3548ad29942a179564a24bdf95aae593af3f5f9afeeb67e112dL781-R786)

**Error Handling and Validation:**
- Improved error messages and validation for mask shape mismatches and unsupported combinations of attention masks and reference masks in sparse attention mode. [[1]](diffhunk://#diff-0e31056fee25c3548ad29942a179564a24bdf95aae593af3f5f9afeeb67e112dL781-R786) [[2]](diffhunk://#diff-a036cd66bd1a5fceb8815f348db2b8220be3cf5f705d137a2ef97f0306cf1845R347-R364)

These changes improve the model's robustness, flexibility, and efficiency, particularly for batched and sparse attention scenarios.