### PR TITLE
add metal-flash-attention install script and docs

### DIFF
--- a/documentation/experimental/METAL_FLASH_ATTENTION.es.md
+++ b/documentation/experimental/METAL_FLASH_ATTENTION.es.md
@@ -4,8 +4,8 @@
 
 ## Requisitos
 
-- Apple Silicon con MPS disponible.
-- Xcode command line tools con toolchain Metal.
+- macOS 15+ en Apple Silicon con MPS disponible.
+- Git, Swift 6+ y Xcode 16+ o command line tools equivalentes con toolchain Metal.
 - SimpleTuner instalado con dependencias Apple. El extra Apple requiere PyTorch `>=2.13.0`.
 - Un build UMFA que exponga `metal_flash_attention_autograd`, registre la dispatch key PyTorch `MPS` y exponga `clear_quantization_mode`. Los aliases cuantizados tambien requieren `metal_quantized_flash_attention_autograd`, `set_quantization_mode`, `QUANT_INT8`, `QUANT_INT4` y `QUANT_BLOCK_WISE`.
 
@@ -21,15 +21,31 @@ export UMFA_ROOT=/path/to/universal-metal-flash-attention
 export PYTHON="$ST_ROOT/.venv/bin/python"
 ```
 
+SimpleTuner incluye un helper que revisa la toolchain local, el entorno Python, el checkout UMFA, el submodulo MFA+, la libreria Swift FFI, el binding Python FFI y los probes del backend en SimpleTuner:
+
+```bash
+cd "$ST_ROOT"
+scripts/apple-metal-flash-attention.sh --check --umfa-root "$UMFA_ROOT" --python "$PYTHON"
+```
+
+Para dejar que el helper clone, compile e instale UMFA en ese entorno Python, ejecuta:
+
+```bash
+scripts/apple-metal-flash-attention.sh --install --umfa-root "$UMFA_ROOT" --python "$PYTHON"
+```
+
+La ruta de instalacion clona UMFA si hace falta, inicializa el submodulo MFA+ `metal-flash-attention` de UMFA, compila el producto Swift `MFAFFI`, compila la extension PyTorch custom-op in place e instala el binding `metal_sdpa_extension` en el Python seleccionado.
+
 Compila el paquete Swift e instala el paquete PyTorch FFI:
 
 ```bash
 cd "$UMFA_ROOT"
 git submodule update --init --recursive
-swift build -c release
+swift build -c release --product MFAFFI
 
 cd "$UMFA_ROOT/examples/pytorch-custom-op-ffi"
 "$PYTHON" -m pip install --upgrade pip setuptools wheel pybind11 numpy
+"$PYTHON" setup.py build_ext --inplace
 "$PYTHON" -m pip install --force-reinstall --no-deps --no-build-isolation --no-cache-dir .
 ```
 

--- a/documentation/experimental/METAL_FLASH_ATTENTION.hi.md
+++ b/documentation/experimental/METAL_FLASH_ATTENTION.hi.md
@@ -4,8 +4,8 @@
 
 ## Requirements
 
-- Apple Silicon with MPS available.
-- Xcode command line tools with Metal toolchain.
+- MPS available हो, ऐसे Apple Silicon पर macOS 15+.
+- Git, Swift 6+, और Metal toolchain के साथ Xcode 16+ या matching command line tools.
 - SimpleTuner Apple dependency set के साथ installed हो। Apple extra PyTorch `>=2.13.0` require करता है।
 - UMFA build में `metal_flash_attention_autograd` expose होना चाहिए, PyTorch `MPS` dispatch key register होनी चाहिए, और `clear_quantization_mode` expose होना चाहिए। Quantized aliases के लिए `metal_quantized_flash_attention_autograd`, `set_quantization_mode`, `QUANT_INT8`, `QUANT_INT4`, और `QUANT_BLOCK_WISE` भी चाहिए।
 
@@ -21,15 +21,31 @@ export UMFA_ROOT=/path/to/universal-metal-flash-attention
 export PYTHON="$ST_ROOT/.venv/bin/python"
 ```
 
+SimpleTuner में एक helper है जो local toolchain, Python environment, UMFA checkout, MFA+ submodule, Swift FFI library, Python FFI binding, और SimpleTuner backend probes जांचता है:
+
+```bash
+cd "$ST_ROOT"
+scripts/apple-metal-flash-attention.sh --check --umfa-root "$UMFA_ROOT" --python "$PYTHON"
+```
+
+Helper से UMFA को उसी Python environment में clone/build/install कराने के लिए चलाएं:
+
+```bash
+scripts/apple-metal-flash-attention.sh --install --umfa-root "$UMFA_ROOT" --python "$PYTHON"
+```
+
+Install path जरूरत होने पर UMFA clone करता है, UMFA के `metal-flash-attention` MFA+ submodule को initialize करता है, `MFAFFI` Swift product build करता है, PyTorch custom-op extension को in place build करता है, और selected Python environment में `metal_sdpa_extension` binding install करता है.
+
 Swift package build करें और PyTorch FFI package install करें:
 
 ```bash
 cd "$UMFA_ROOT"
 git submodule update --init --recursive
-swift build -c release
+swift build -c release --product MFAFFI
 
 cd "$UMFA_ROOT/examples/pytorch-custom-op-ffi"
 "$PYTHON" -m pip install --upgrade pip setuptools wheel pybind11 numpy
+"$PYTHON" setup.py build_ext --inplace
 "$PYTHON" -m pip install --force-reinstall --no-deps --no-build-isolation --no-cache-dir .
 ```
 

--- a/documentation/experimental/METAL_FLASH_ATTENTION.ja.md
+++ b/documentation/experimental/METAL_FLASH_ATTENTION.ja.md
@@ -4,8 +4,8 @@
 
 ## Requirements
 
-- MPS が使える Apple Silicon。
-- Metal toolchain を含む Xcode command line tools。
+- MPS が使える Apple Silicon 上の macOS 15+。
+- Git、Swift 6+、および Metal toolchain を含む Xcode 16+ または対応する command line tools。
 - Apple dependency set で SimpleTuner をインストールしていること。Apple extra は PyTorch `>=2.13.0` を要求します。
 - `metal_flash_attention_autograd` を公開し、PyTorch `MPS` dispatch key を登録し、`clear_quantization_mode` を公開する UMFA build。quantized aliases ではさらに `metal_quantized_flash_attention_autograd`、`set_quantization_mode`、`QUANT_INT8`、`QUANT_INT4`、`QUANT_BLOCK_WISE` が必要です。
 
@@ -21,15 +21,31 @@ export UMFA_ROOT=/path/to/universal-metal-flash-attention
 export PYTHON="$ST_ROOT/.venv/bin/python"
 ```
 
+SimpleTuner には、local toolchain、Python environment、UMFA checkout、MFA+ submodule、Swift FFI library、Python FFI binding、SimpleTuner backend probes を確認する helper があります:
+
+```bash
+cd "$ST_ROOT"
+scripts/apple-metal-flash-attention.sh --check --umfa-root "$UMFA_ROOT" --python "$PYTHON"
+```
+
+その Python environment に UMFA を clone/build/install させるには、次を実行します:
+
+```bash
+scripts/apple-metal-flash-attention.sh --install --umfa-root "$UMFA_ROOT" --python "$PYTHON"
+```
+
+install path は、必要なら UMFA を clone し、UMFA の `metal-flash-attention` MFA+ submodule を初期化し、`MFAFFI` Swift product を build し、PyTorch custom-op extension を in place で build して、選択した Python environment に `metal_sdpa_extension` binding を install します。
+
 Swift package を build し、PyTorch FFI package を install します:
 
 ```bash
 cd "$UMFA_ROOT"
 git submodule update --init --recursive
-swift build -c release
+swift build -c release --product MFAFFI
 
 cd "$UMFA_ROOT/examples/pytorch-custom-op-ffi"
 "$PYTHON" -m pip install --upgrade pip setuptools wheel pybind11 numpy
+"$PYTHON" setup.py build_ext --inplace
 "$PYTHON" -m pip install --force-reinstall --no-deps --no-build-isolation --no-cache-dir .
 ```
 

--- a/documentation/experimental/METAL_FLASH_ATTENTION.md
+++ b/documentation/experimental/METAL_FLASH_ATTENTION.md
@@ -4,8 +4,8 @@
 
 ## Requirements
 
-- Apple Silicon with MPS available.
-- Xcode command line tools with the Metal toolchain.
+- macOS 15+ on Apple Silicon with MPS available.
+- Git, Swift 6+, and Xcode 16+ or matching command line tools with the Metal toolchain.
 - SimpleTuner installed with the Apple dependency set. The Apple extra requires PyTorch `>=2.13.0`.
 - A UMFA build that exposes `metal_flash_attention_autograd`, registers the PyTorch `MPS` dispatch key, and exposes `clear_quantization_mode`. The quantized aliases also require `metal_quantized_flash_attention_autograd`, `set_quantization_mode`, `QUANT_INT8`, `QUANT_INT4`, and `QUANT_BLOCK_WISE`.
 
@@ -21,15 +21,31 @@ export UMFA_ROOT=/path/to/universal-metal-flash-attention
 export PYTHON="$ST_ROOT/.venv/bin/python"
 ```
 
+SimpleTuner includes a helper that checks the local toolchain, Python environment, UMFA checkout, MFA+ submodule, Swift FFI library, Python FFI binding, and SimpleTuner backend probes:
+
+```bash
+cd "$ST_ROOT"
+scripts/apple-metal-flash-attention.sh --check --umfa-root "$UMFA_ROOT" --python "$PYTHON"
+```
+
+To let the helper clone/build/install UMFA into that Python environment, run:
+
+```bash
+scripts/apple-metal-flash-attention.sh --install --umfa-root "$UMFA_ROOT" --python "$PYTHON"
+```
+
+The install path clones UMFA if needed, initializes UMFA's `metal-flash-attention` MFA+ submodule, builds the `MFAFFI` Swift product, builds the PyTorch custom-op extension in place, and installs the `metal_sdpa_extension` binding into the selected Python environment.
+
 Build the Swift package and install the PyTorch FFI package:
 
 ```bash
 cd "$UMFA_ROOT"
 git submodule update --init --recursive
-swift build -c release
+swift build -c release --product MFAFFI
 
 cd "$UMFA_ROOT/examples/pytorch-custom-op-ffi"
 "$PYTHON" -m pip install --upgrade pip setuptools wheel pybind11 numpy
+"$PYTHON" setup.py build_ext --inplace
 "$PYTHON" -m pip install --force-reinstall --no-deps --no-build-isolation --no-cache-dir .
 ```
 

--- a/documentation/experimental/METAL_FLASH_ATTENTION.pt-BR.md
+++ b/documentation/experimental/METAL_FLASH_ATTENTION.pt-BR.md
@@ -4,8 +4,8 @@
 
 ## Requisitos
 
-- Apple Silicon com MPS disponivel.
-- Xcode command line tools com toolchain Metal.
+- macOS 15+ em Apple Silicon com MPS disponivel.
+- Git, Swift 6+ e Xcode 16+ ou command line tools equivalentes com toolchain Metal.
 - SimpleTuner instalado com dependencias Apple. O extra Apple requer PyTorch `>=2.13.0`.
 - Um build UMFA que exponha `metal_flash_attention_autograd`, registre a dispatch key PyTorch `MPS` e exponha `clear_quantization_mode`. Os aliases quantizados tambem exigem `metal_quantized_flash_attention_autograd`, `set_quantization_mode`, `QUANT_INT8`, `QUANT_INT4` e `QUANT_BLOCK_WISE`.
 
@@ -21,15 +21,31 @@ export UMFA_ROOT=/path/to/universal-metal-flash-attention
 export PYTHON="$ST_ROOT/.venv/bin/python"
 ```
 
+O SimpleTuner inclui um helper que verifica a toolchain local, o ambiente Python, o checkout UMFA, o submodulo MFA+, a biblioteca Swift FFI, o binding Python FFI e os probes do backend no SimpleTuner:
+
+```bash
+cd "$ST_ROOT"
+scripts/apple-metal-flash-attention.sh --check --umfa-root "$UMFA_ROOT" --python "$PYTHON"
+```
+
+Para deixar o helper clonar, compilar e instalar UMFA nesse ambiente Python, execute:
+
+```bash
+scripts/apple-metal-flash-attention.sh --install --umfa-root "$UMFA_ROOT" --python "$PYTHON"
+```
+
+A rota de instalacao clona UMFA se necessario, inicializa o submodulo MFA+ `metal-flash-attention` do UMFA, compila o produto Swift `MFAFFI`, compila a extensao PyTorch custom-op in place e instala o binding `metal_sdpa_extension` no Python selecionado.
+
 Compile o pacote Swift e instale o pacote PyTorch FFI:
 
 ```bash
 cd "$UMFA_ROOT"
 git submodule update --init --recursive
-swift build -c release
+swift build -c release --product MFAFFI
 
 cd "$UMFA_ROOT/examples/pytorch-custom-op-ffi"
 "$PYTHON" -m pip install --upgrade pip setuptools wheel pybind11 numpy
+"$PYTHON" setup.py build_ext --inplace
 "$PYTHON" -m pip install --force-reinstall --no-deps --no-build-isolation --no-cache-dir .
 ```
 

--- a/documentation/experimental/METAL_FLASH_ATTENTION.zh.md
+++ b/documentation/experimental/METAL_FLASH_ATTENTION.zh.md
@@ -4,8 +4,8 @@
 
 ## Requirements
 
-- 支持 MPS 的 Apple Silicon。
-- 带 Metal toolchain 的 Xcode command line tools。
+- MPS 可用的 Apple Silicon，运行 macOS 15+。
+- Git、Swift 6+，以及带 Metal toolchain 的 Xcode 16+ 或匹配的 command line tools。
 - 使用 Apple dependency set 安装的 SimpleTuner。Apple extra 要求 PyTorch `>=2.13.0`。
 - UMFA build 必须暴露 `metal_flash_attention_autograd`，注册 PyTorch `MPS` dispatch key，并暴露 `clear_quantization_mode`。量化 aliases 还需要 `metal_quantized_flash_attention_autograd`、`set_quantization_mode`、`QUANT_INT8`、`QUANT_INT4` 和 `QUANT_BLOCK_WISE`。
 
@@ -21,15 +21,31 @@ export UMFA_ROOT=/path/to/universal-metal-flash-attention
 export PYTHON="$ST_ROOT/.venv/bin/python"
 ```
 
+SimpleTuner 提供一个 helper，用来检查本地 toolchain、Python environment、UMFA checkout、MFA+ submodule、Swift FFI library、Python FFI binding，以及 SimpleTuner backend probes:
+
+```bash
+cd "$ST_ROOT"
+scripts/apple-metal-flash-attention.sh --check --umfa-root "$UMFA_ROOT" --python "$PYTHON"
+```
+
+如果要让 helper 把 UMFA clone/build/install 到这个 Python environment，运行:
+
+```bash
+scripts/apple-metal-flash-attention.sh --install --umfa-root "$UMFA_ROOT" --python "$PYTHON"
+```
+
+install path 会在需要时 clone UMFA，初始化 UMFA 的 `metal-flash-attention` MFA+ submodule，构建 `MFAFFI` Swift product，in place 构建 PyTorch custom-op extension，并把 `metal_sdpa_extension` binding 安装进所选 Python environment。
+
 构建 Swift package 并安装 PyTorch FFI package:
 
 ```bash
 cd "$UMFA_ROOT"
 git submodule update --init --recursive
-swift build -c release
+swift build -c release --product MFAFFI
 
 cd "$UMFA_ROOT/examples/pytorch-custom-op-ffi"
 "$PYTHON" -m pip install --upgrade pip setuptools wheel pybind11 numpy
+"$PYTHON" setup.py build_ext --inplace
 "$PYTHON" -m pip install --force-reinstall --no-deps --no-build-isolation --no-cache-dir .
 ```
 

--- a/scripts/apple-metal-flash-attention.sh
+++ b/scripts/apple-metal-flash-attention.sh
@@ -1,0 +1,529 @@
+#!/usr/bin/env bash
+set -u
+set -o pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+st_root="$(cd -- "$script_dir/.." >/dev/null 2>&1 && pwd)"
+
+mode="check"
+python_bin="${PYTHON:-$st_root/.venv/bin/python}"
+umfa_repo_url="${UMFA_REPO_URL:-https://github.com/bghira/universal-metal-flash-attention.git}"
+umfa_root="${UMFA_ROOT:-$st_root/../universal-metal-flash-attention}"
+skip_python_deps=0
+
+failures=0
+warnings=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/apple-metal-flash-attention.sh [--check]
+  scripts/apple-metal-flash-attention.sh --install [options]
+
+Options:
+  --check                 Inspect local dependencies and print the install plan. Default.
+  --install               Clone/build/install UMFA and its PyTorch FFI extension.
+  --umfa-root PATH        UMFA checkout path. Default: ../universal-metal-flash-attention.
+  --python PATH           Python executable. Default: .venv/bin/python.
+  --repo-url URL          UMFA git URL used when --install needs to clone it.
+  --skip-python-deps      Do not install/upgrade pip, setuptools, wheel, pybind11, numpy.
+  -h, --help              Show this help.
+
+Environment overrides:
+  UMFA_ROOT, PYTHON, UMFA_REPO_URL
+EOF
+}
+
+while (($#)); do
+  case "$1" in
+    --check)
+      mode="check"
+      shift
+      ;;
+    --install)
+      mode="install"
+      shift
+      ;;
+    --umfa-root)
+      if (($# < 2)); then
+        echo "Missing value for --umfa-root" >&2
+        exit 2
+      fi
+      umfa_root="$2"
+      shift 2
+      ;;
+    --python)
+      if (($# < 2)); then
+        echo "Missing value for --python" >&2
+        exit 2
+      fi
+      python_bin="$2"
+      shift 2
+      ;;
+    --repo-url)
+      if (($# < 2)); then
+        echo "Missing value for --repo-url" >&2
+        exit 2
+      fi
+      umfa_repo_url="$2"
+      shift 2
+      ;;
+    --skip-python-deps)
+      skip_python_deps=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+ok() {
+  printf '[ok] %s\n' "$1"
+}
+
+warn() {
+  warnings=$((warnings + 1))
+  printf '[warn] %s\n' "$1"
+}
+
+fail() {
+  failures=$((failures + 1))
+  printf '[fail] %s\n' "$1"
+}
+
+info() {
+  printf '[info] %s\n' "$1"
+}
+
+quote_arg() {
+  printf '%q' "$1"
+}
+
+command_path() {
+  command -v "$1" 2>/dev/null
+}
+
+check_command() {
+  local label="$1"
+  local cmd="$2"
+  local path
+
+  path="$(command_path "$cmd" || true)"
+  if [[ -n "$path" ]]; then
+    ok "$label: $path"
+  else
+    fail "$label: missing '$cmd'"
+  fi
+}
+
+check_macos() {
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    fail "macOS is required for Metal Flash Attention."
+    return
+  fi
+
+  local version major arch
+  version="$(sw_vers -productVersion 2>/dev/null || echo unknown)"
+  major="${version%%.*}"
+  arch="$(uname -m)"
+  ok "macOS detected: $version"
+
+  if [[ "$arch" == "arm64" ]]; then
+    ok "Apple Silicon architecture detected: $arch"
+  else
+    fail "Apple Silicon arm64 is required; detected '$arch'."
+  fi
+
+  if [[ "$major" =~ ^[0-9]+$ ]] && ((major >= 15)); then
+    ok "macOS version is compatible with the current UMFA package."
+  else
+    fail "Current UMFA package declares macOS 15+; detected '$version'."
+  fi
+}
+
+check_xcode() {
+  local selected sdk_path sdk_version metal_path metallib_path swift_version xcode_version xcode_major
+
+  selected="$(xcode-select -p 2>/dev/null || true)"
+  if [[ -n "$selected" ]]; then
+    ok "Xcode developer directory: $selected"
+  else
+    fail "Xcode command line tools are not selected. Run 'xcode-select --install' or select Xcode with xcode-select."
+  fi
+
+  sdk_path="$(xcrun --sdk macosx --show-sdk-path 2>/dev/null || true)"
+  if [[ -n "$sdk_path" ]]; then
+    ok "macOS SDK: $sdk_path"
+  else
+    fail "xcrun cannot find the macOS SDK."
+  fi
+
+  sdk_version="$(xcrun --sdk macosx --show-sdk-version 2>/dev/null || true)"
+  if [[ -n "$sdk_version" ]]; then
+    ok "macOS SDK version: $sdk_version"
+  fi
+
+  metal_path="$(xcrun --find metal 2>/dev/null || true)"
+  if [[ -n "$metal_path" ]]; then
+    ok "Metal compiler: $metal_path"
+  else
+    fail "xcrun cannot find the Metal compiler."
+  fi
+
+  metallib_path="$(xcrun --find metallib 2>/dev/null || true)"
+  if [[ -n "$metallib_path" ]]; then
+    ok "Metal library tool: $metallib_path"
+  else
+    fail "xcrun cannot find metallib."
+  fi
+
+  swift_version="$(swift --version 2>/dev/null | head -n 1 || true)"
+  if [[ -n "$swift_version" ]]; then
+    ok "Swift: $swift_version"
+    if [[ "$swift_version" =~ Swift[[:space:]]version[[:space:]]([0-9]+) ]] && ((${BASH_REMATCH[1]} < 6)); then
+      fail "Swift 6+ is required by UMFA."
+    fi
+  else
+    fail "Swift compiler is missing."
+  fi
+
+  xcode_version="$(xcodebuild -version 2>/dev/null | awk '/^Xcode / {print $2; exit}' || true)"
+  if [[ -n "$xcode_version" ]]; then
+    ok "Xcode: $xcode_version"
+    xcode_major="${xcode_version%%.*}"
+    if [[ "$xcode_major" =~ ^[0-9]+$ ]] && ((xcode_major < 16)); then
+      warn "Xcode 16+ is expected by UMFA's current SDK targets; detected Xcode $xcode_version."
+    fi
+  else
+    warn "xcodebuild did not report a full Xcode version; command line tools may still be usable if Swift and Metal are present."
+  fi
+}
+
+check_python() {
+  if [[ ! -x "$python_bin" ]]; then
+    fail "Python executable is missing or not executable: $python_bin"
+    return
+  fi
+
+  ok "Python: $python_bin"
+
+  "$python_bin" - <<'PY'
+import importlib.metadata
+import importlib.util
+import sys
+
+print(f"[info] Python version: {sys.version.split()[0]}")
+
+hard_missing = []
+soft_missing = []
+
+for package in ("torch", "numpy", "pybind11", "setuptools", "wheel"):
+    spec = importlib.util.find_spec(package)
+    if spec is None:
+        if package == "torch":
+            hard_missing.append(package)
+        else:
+            soft_missing.append(package)
+        print(f"[fail] Python package missing: {package}" if package == "torch" else f"[warn] Python package missing: {package}")
+        continue
+    try:
+        version = importlib.metadata.version(package)
+    except importlib.metadata.PackageNotFoundError:
+        version = "unknown"
+    print(f"[ok] Python package: {package} {version}")
+
+if hard_missing:
+    raise SystemExit(2)
+
+try:
+    import torch
+except Exception as exc:
+    print(f"[fail] torch import failed: {exc}")
+    raise SystemExit(2)
+
+mps_built = bool(getattr(torch.backends, "mps", None) and torch.backends.mps.is_built())
+mps_available = bool(getattr(torch.backends, "mps", None) and torch.backends.mps.is_available())
+print(f"[ok] torch version: {torch.__version__}")
+print(f"[{'ok' if mps_built else 'fail'}] torch.backends.mps.is_built(): {mps_built}")
+print(f"[{'ok' if mps_available else 'fail'}] torch.backends.mps.is_available(): {mps_available}")
+
+if not mps_built or not mps_available:
+    raise SystemExit(2)
+if soft_missing:
+    raise SystemExit(1)
+PY
+  case "$?" in
+    0)
+      ok "Python environment is ready for UMFA."
+      ;;
+    1)
+      warn "Python build dependencies are incomplete; --install can install the missing build packages."
+      ;;
+    *)
+      fail "Python environment is not ready for UMFA."
+      ;;
+  esac
+}
+
+check_umfa_source() {
+  if [[ ! -d "$umfa_root" ]]; then
+    warn "UMFA checkout not found: $umfa_root"
+    return
+  fi
+
+  ok "UMFA checkout: $umfa_root"
+
+  if [[ -f "$umfa_root/Package.swift" ]]; then
+    ok "UMFA Package.swift found."
+  else
+    fail "UMFA Package.swift is missing; this does not look like a UMFA checkout."
+  fi
+
+  if [[ -f "$umfa_root/.gitmodules" ]] && grep -q 'metal-flash-attention' "$umfa_root/.gitmodules"; then
+    ok "UMFA declares the MFA+ submodule."
+  else
+    warn "UMFA .gitmodules does not declare the MFA+ submodule."
+  fi
+
+  if [[ -f "$umfa_root/metal-flash-attention/Package.swift" ]]; then
+    ok "MFA+ submodule is initialized: metal-flash-attention/Package.swift"
+  else
+    warn "MFA+ submodule is not initialized. Run: git -C $(quote_arg "$umfa_root") submodule update --init --recursive"
+  fi
+
+  if command_path git >/dev/null && [[ -d "$umfa_root/.git" ]]; then
+    info "UMFA submodule status:"
+    git -C "$umfa_root" submodule status --recursive || warn "git submodule status failed for UMFA."
+  fi
+
+  if [[ -f "$umfa_root/.build/arm64-apple-macosx/release/libMFAFFI.dylib" ]]; then
+    ok "MFAFFI release library built."
+  else
+    warn "MFAFFI release library not found. Build with: swift build -c release --product MFAFFI"
+  fi
+
+  if [[ -f "$umfa_root/examples/pytorch-custom-op-ffi/setup.py" ]]; then
+    ok "PyTorch FFI setup.py found."
+  else
+    fail "PyTorch FFI setup.py is missing."
+  fi
+}
+
+check_extension_exports() {
+  if [[ ! -x "$python_bin" ]]; then
+    warn "Skipping metal_sdpa_extension import check because Python is unavailable."
+    return
+  fi
+
+  "$python_bin" - <<'PY'
+try:
+    import metal_sdpa_extension as ext
+except Exception as exc:
+    print(f"[warn] metal_sdpa_extension import failed: {exc}")
+    raise SystemExit(1)
+
+required = [
+    "metal_flash_attention_autograd",
+    "clear_quantization_mode",
+    "get_dispatch_stats",
+    "metal_quantized_flash_attention_autograd",
+    "set_quantization_mode",
+    "QUANT_INT8",
+    "QUANT_INT4",
+    "QUANT_BLOCK_WISE",
+]
+optional = ["QUANT_TENSOR_WISE", "rope_scaled_dot_product_attention"]
+missing = [name for name in required if not hasattr(ext, name)]
+if missing:
+    print("[fail] metal_sdpa_extension missing required exports: " + ", ".join(missing))
+    raise SystemExit(2)
+
+print("[ok] metal_sdpa_extension imports and exposes required UMFA symbols.")
+for name in optional:
+    print(f"[{'ok' if hasattr(ext, name) else 'warn'}] optional export {name}: {hasattr(ext, name)}")
+
+try:
+    print("[ok] get_dispatch_stats():", ext.get_dispatch_stats())
+except Exception as exc:
+    print(f"[fail] get_dispatch_stats() failed: {exc}")
+    raise SystemExit(2)
+PY
+  case "$?" in
+    0)
+      ok "UMFA Python FFI binding is importable."
+      ;;
+    1)
+      warn "UMFA Python FFI binding is not installed in this Python environment."
+      ;;
+    *)
+      fail "UMFA Python FFI binding is installed but missing required behavior."
+      ;;
+  esac
+}
+
+check_simpletuner_backend() {
+  if [[ ! -x "$python_bin" ]]; then
+    warn "Skipping SimpleTuner backend check because Python is unavailable."
+    return
+  fi
+
+  PYTHONPATH="$st_root${PYTHONPATH:+:$PYTHONPATH}" "$python_bin" - <<'PY'
+try:
+    from simpletuner.helpers.training.attention_backend import (
+        get_metal_flash_attention_unavailable_reason,
+        is_metal_flash_attention_available,
+    )
+except Exception as exc:
+    print(f"[warn] SimpleTuner attention backend import failed: {exc}")
+    raise SystemExit(1)
+
+backends = (
+    "metal-flash-attention",
+    "metal-flash-attention-int8",
+    "metal-flash-attention-int4",
+)
+all_available = True
+for backend in backends:
+    available = is_metal_flash_attention_available(backend)
+    reason = get_metal_flash_attention_unavailable_reason(backend)
+    print(f"[{'ok' if available else 'warn'}] {backend}: available={available} reason={reason}")
+    all_available = all_available and available
+
+raise SystemExit(0 if all_available else 1)
+PY
+  if [[ "$?" == "0" ]]; then
+    ok "SimpleTuner accepts all Metal Flash Attention backends."
+  else
+    warn "SimpleTuner does not currently accept every Metal Flash Attention backend; inspect the reason above."
+  fi
+}
+
+print_manual_steps() {
+  local q_python q_umfa q_st q_repo q_script
+  q_python="$(quote_arg "$python_bin")"
+  q_umfa="$(quote_arg "$umfa_root")"
+  q_st="$(quote_arg "$st_root")"
+  q_repo="$(quote_arg "$umfa_repo_url")"
+  q_script="$(quote_arg "$st_root/scripts/apple-metal-flash-attention.sh")"
+
+  cat <<EOF
+
+Install plan:
+  1. Use the same Python environment that runs SimpleTuner:
+       export ST_ROOT=$q_st
+       export PYTHON=$q_python
+       export UMFA_ROOT=$q_umfa
+
+  2. Clone UMFA if the checkout is missing:
+       git clone --recursive $q_repo "\$UMFA_ROOT"
+
+  3. Initialize the MFA+ submodule inside UMFA:
+       git -C "\$UMFA_ROOT" submodule update --init --recursive
+
+  4. Build the UMFA Swift FFI library:
+       cd "\$UMFA_ROOT"
+       swift build -c release --product MFAFFI
+
+  5. Build and install the PyTorch custom-op FFI binding into SimpleTuner's Python:
+       cd "\$UMFA_ROOT/examples/pytorch-custom-op-ffi"
+       "\$PYTHON" -m pip install --upgrade pip setuptools wheel pybind11 numpy
+       "\$PYTHON" setup.py build_ext --inplace
+       "\$PYTHON" -m pip install --force-reinstall --no-deps --no-build-isolation --no-cache-dir .
+
+  6. Re-run this diagnostic:
+       $q_script --check --umfa-root "\$UMFA_ROOT" --python "\$PYTHON"
+
+Run with --install to execute those steps now.
+EOF
+}
+
+run_cmd() {
+  printf '\n[run]'
+  printf ' %q' "$@"
+  printf '\n'
+  "$@"
+}
+
+run_in_dir() {
+  local cwd="$1"
+  shift
+
+  printf '\n[run] cd %q &&' "$cwd"
+  printf ' %q' "$@"
+  printf '\n'
+  (cd "$cwd" && "$@")
+}
+
+install_umfa() {
+  check_command "git" git
+  check_command "swift" swift
+
+  if ((failures > 0)); then
+    echo
+    fail "Required command checks failed; not starting install."
+    return 1
+  fi
+
+  if [[ ! -d "$umfa_root" ]]; then
+    run_cmd mkdir -p "$(dirname "$umfa_root")" || return 1
+    run_cmd git clone --recursive "$umfa_repo_url" "$umfa_root" || return 1
+  else
+    info "Using existing UMFA checkout: $umfa_root"
+  fi
+
+  if [[ ! -f "$umfa_root/Package.swift" ]]; then
+    fail "UMFA checkout does not contain Package.swift: $umfa_root"
+    return 1
+  fi
+
+  run_cmd git -C "$umfa_root" submodule update --init --recursive || return 1
+  run_in_dir "$umfa_root" swift build -c release --product MFAFFI || return 1
+
+  if ((skip_python_deps == 0)); then
+    run_cmd "$python_bin" -m pip install --upgrade pip setuptools wheel pybind11 numpy || return 1
+  fi
+
+  run_in_dir "$umfa_root/examples/pytorch-custom-op-ffi" "$python_bin" setup.py build_ext --inplace || return 1
+  run_in_dir "$umfa_root/examples/pytorch-custom-op-ffi" "$python_bin" -m pip install --force-reinstall --no-deps --no-build-isolation --no-cache-dir . || return 1
+}
+
+echo "SimpleTuner root: $st_root"
+echo "Python: $python_bin"
+echo "UMFA root: $umfa_root"
+echo "Mode: $mode"
+echo
+
+check_macos
+check_command "git" git
+check_command "xcrun" xcrun
+check_command "swift" swift
+check_command "clang" clang
+check_xcode
+check_python
+check_umfa_source
+check_extension_exports
+check_simpletuner_backend
+print_manual_steps
+
+if [[ "$mode" == "install" ]]; then
+  echo
+  info "Starting UMFA install."
+  install_umfa || exit 1
+  echo
+  info "Install completed. Running final import checks."
+  check_extension_exports
+  check_simpletuner_backend
+fi
+
+echo
+echo "Summary: $failures failure(s), $warnings warning(s)."
+if ((failures > 0)); then
+  exit 1
+fi


### PR DESCRIPTION
This pull request updates the experimental Universal Metal Flash Attention (UMFA) documentation in multiple languages to clarify requirements for macOS and toolchains, and to add instructions for using new helper scripts in SimpleTuner. The changes improve clarity, add automation for setup, and ensure consistency across English, Spanish, Hindi, Japanese, Portuguese, and Chinese documentation.

**Key documentation improvements:**

*Requirements and prerequisites:*
- Updated minimum requirements to specify macOS 15+, Apple Silicon, Git, Swift 6+, and Xcode 16+ (or equivalent command line tools with the Metal toolchain) in all language variants. [[1]](diffhunk://#diff-8c8d3eca40da507ace163f787efa7628c93078aa199535f047c22f2d6a155d76L7-R8) [[2]](diffhunk://#diff-b958e30ae4e5cbde3a08c8deb491a38927832c3397b5d00b0a8faa597bc08a34L7-R8) [[3]](diffhunk://#diff-426471487e1c1de0da06001ee1c4808cf00535197ee58766a88e563419d4ab5eL7-R8) [[4]](diffhunk://#diff-fba5460969d8b9fb40305e622cf912715d787da597f8e881c2704dc34392117aL7-R8) [[5]](diffhunk://#diff-ebcdbc40788d4b93d43e1c63814e02f22ffbc3f741b895dcd8d66e9a6cf8c8f2L7-R8) [[6]](diffhunk://#diff-20dcca953bf9ac6da90e4b9c0a3aa2384334f13bbd848322bed39fca4f03fd15L7-R8)

*Helper script usage and automation:*
- Added instructions for using the new `apple-metal-flash-attention.sh` helper script in SimpleTuner to check the local environment and automate the clone/build/install process for UMFA. This includes both `--check` and `--install` usage examples. [[1]](diffhunk://#diff-8c8d3eca40da507ace163f787efa7628c93078aa199535f047c22f2d6a155d76R24-R48) [[2]](diffhunk://#diff-b958e30ae4e5cbde3a08c8deb491a38927832c3397b5d00b0a8faa597bc08a34R24-R48) [[3]](diffhunk://#diff-426471487e1c1de0da06001ee1c4808cf00535197ee58766a88e563419d4ab5eR24-R48) [[4]](diffhunk://#diff-fba5460969d8b9fb40305e622cf912715d787da597f8e881c2704dc34392117aR24-R48) [[5]](diffhunk://#diff-ebcdbc40788d4b93d43e1c63814e02f22ffbc3f741b895dcd8d66e9a6cf8c8f2R24-R48) [[6]](diffhunk://#diff-20dcca953bf9ac6da90e4b9c0a3aa2384334f13bbd848322bed39fca4f03fd15R24-R48)
- Described the steps performed by the install path: cloning UMFA if needed, initializing submodules, building the Swift product `MFAFFI`, building the PyTorch custom-op extension in place, and installing the Python binding. [[1]](diffhunk://#diff-8c8d3eca40da507ace163f787efa7628c93078aa199535f047c22f2d6a155d76R24-R48) [[2]](diffhunk://#diff-b958e30ae4e5cbde3a08c8deb491a38927832c3397b5d00b0a8faa597bc08a34R24-R48) [[3]](diffhunk://#diff-426471487e1c1de0da06001ee1c4808cf00535197ee58766a88e563419d4ab5eR24-R48) [[4]](diffhunk://#diff-fba5460969d8b9fb40305e622cf912715d787da597f8e881c2704dc34392117aR24-R48) [[5]](diffhunk://#diff-ebcdbc40788d4b93d43e1c63814e02f22ffbc3f741b895dcd8d66e9a6cf8c8f2R24-R48) [[6]](diffhunk://#diff-20dcca953bf9ac6da90e4b9c0a3aa2384334f13bbd848322bed39fca4f03fd15R24-R48)

*Manual build instructions:*
- Updated Swift build instructions to explicitly build the `MFAFFI` product. [[1]](diffhunk://#diff-8c8d3eca40da507ace163f787efa7628c93078aa199535f047c22f2d6a155d76R24-R48) [[2]](diffhunk://#diff-b958e30ae4e5cbde3a08c8deb491a38927832c3397b5d00b0a8faa597bc08a34R24-R48) [[3]](diffhunk://#diff-426471487e1c1de0da06001ee1c4808cf00535197ee58766a88e563419d4ab5eR24-R48) [[4]](diffhunk://#diff-fba5460969d8b9fb40305e622cf912715d787da597f8e881c2704dc34392117aR24-R48) [[5]](diffhunk://#diff-ebcdbc40788d4b93d43e1c63814e02f22ffbc3f741b895dcd8d66e9a6cf8c8f2R24-R48) [[6]](diffhunk://#diff-20dcca953bf9ac6da90e4b9c0a3aa2384334f13bbd848322bed39fca4f03fd15R24-R48)
- Added explicit step to build the PyTorch extension in place with `setup.py build_ext --inplace`. [[1]](diffhunk://#diff-8c8d3eca40da507ace163f787efa7628c93078aa199535f047c22f2d6a155d76R24-R48) [[2]](diffhunk://#diff-b958e30ae4e5cbde3a08c8deb491a38927832c3397b5d00b0a8faa597bc08a34R24-R48) [[3]](diffhunk://#diff-426471487e1c1de0da06001ee1c4808cf00535197ee58766a88e563419d4ab5eR24-R48) [[4]](diffhunk://#diff-fba5460969d8b9fb40305e622cf912715d787da597f8e881c2704dc34392117aR24-R48) [[5]](diffhunk://#diff-ebcdbc40788d4b93d43e1c63814e02f22ffbc3f741b895dcd8d66e9a6cf8c8f2R24-R48) [[6]](diffhunk://#diff-20dcca953bf9ac6da90e4b9c0a3aa2384334f13bbd848322bed39fca4f03fd15R24-R48)

These changes ensure that users in all supported languages have clear, up-to-date, and consistent instructions for setting up UMFA with SimpleTuner.