### PR TITLE
webshart: accept .txt sidecar captions

### DIFF
--- a/simpletuner/helpers/metadata/backends/webshart.py
+++ b/simpletuner/helpers/metadata/backends/webshart.py
@@ -512,8 +512,12 @@ class WebshartMetadataBackend(MetadataBackend):
                             continue
                         bucket_key, sample_metadata = prepared
                         if require_captions and not sample_metadata.get("captions"):
-                            statistics["skipped"]["caption_missing"] += 1
-                            continue
+                            # Captions may live as sibling .txt tar members instead of embedded
+                            # metadata (e.g. cc12m); get_caption() range-reads those at runtime.
+                            caption_member = Path(str(entry["filename"])).with_suffix(".txt").name
+                            if caption_member not in (shard_metadata.get("files") or {}):
+                                statistics["skipped"]["caption_missing"] += 1
+                                continue
                         aspect_ratio_bucket_updates.setdefault(bucket_key, []).append(sample_path)
                         metadata_updates[sample_path] = sample_metadata
                         if sample_metadata.get("captions"):

--- a/tests/test_webshart_backend.py
+++ b/tests/test_webshart_backend.py
@@ -218,8 +218,8 @@ class TestWebshartMetadataCaptionFiltering(unittest.TestCase):
 
     def _entries(self):
         return [
-            {"path": "captioned.webp", "captions": ["a caption"]},
-            {"path": "uncaptioned.webp", "captions": None},
+            {"path": "captioned.webp", "filename": "captioned.webp", "captions": ["a caption"]},
+            {"path": "uncaptioned.webp", "filename": "uncaptioned.webp", "captions": None},
         ]
 
     def test_webshart_caption_strategy_skips_caption_less_samples(self):
@@ -236,6 +236,24 @@ class TestWebshartMetadataCaptionFiltering(unittest.TestCase):
         )
         self.assertEqual(backend.filtering_statistics["skipped"]["caption_missing"], 1)
         self.assertEqual(backend.filtering_statistics["total_processed"], 1)
+
+    def test_webshart_caption_strategy_accepts_txt_sidecar_samples(self):
+        backend = self._build_backend(self._entries())
+        backend.data_backend.get_shard_metadata = Mock(
+            return_value={"files": {"uncaptioned.txt": {"offset": 0, "length": 10}}}
+        )
+        with patch(
+            "simpletuner.helpers.metadata.backends.webshart.StateTracker.get_data_backend_config",
+            return_value={"caption_strategy": "webshart"},
+        ):
+            backend.compute_aspect_ratio_bucket_indices()
+
+        self.assertEqual(
+            backend.aspect_ratio_bucket_indices["1.0"],
+            ["webshart://0/0/captioned.webp", "webshart://0/0/uncaptioned.webp"],
+        )
+        self.assertEqual(backend.filtering_statistics["skipped"]["caption_missing"], 0)
+        self.assertEqual(backend.filtering_statistics["total_processed"], 2)
 
     def test_other_caption_strategies_keep_caption_less_samples(self):
         backend = self._build_backend(self._entries())


### PR DESCRIPTION
This pull request updates the handling of captions in the `webshart` metadata backend to support caption sidecar files (e.g., `.txt` files) as an alternative to embedded metadata. It also updates the test suite to reflect and verify this new behavior.

**Support for caption sidecar files:**

* Updated `compute_aspect_ratio_bucket_indices` in `webshart.py` to check for the existence of a `.txt` sidecar file in the shard metadata when a sample lacks embedded captions, allowing such samples to be accepted if the sidecar exists.

**Test suite improvements:**

* Modified test entries in `test_webshart_backend.py` to include the `filename` field, aligning with the backend's expectations.
* Added a new test, `test_webshart_caption_strategy_accepts_txt_sidecar_samples`, to verify that samples with `.txt` sidecar files are correctly accepted and not skipped as missing captions.