### PR TITLE
improve minimax h3 LoRA swapped-gate detection; write metadata indicating the order

### DIFF
--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -956,7 +956,8 @@ class ModelFoundation(ABC):
                 combined.append(target)
         return combined
 
-    def _prepare_init_lora_state_dict(self, state_dict: dict) -> dict:
+    def _prepare_init_lora_state_dict(self, state_dict: dict, metadata: Optional[dict] = None) -> dict:
+        del metadata
         return state_dict
 
     def _load_init_lora_state_dict(self) -> dict | None:
@@ -965,12 +966,18 @@ class ModelFoundation(ABC):
             return None
 
         import safetensors.torch
+        from diffusers.loaders.lora_base import LORA_ADAPTER_METADATA_KEY
+        from safetensors import safe_open
 
         try:
             state_dict = safetensors.torch.load_file(init_lora_path)
+            with safe_open(init_lora_path, framework="pt", device="cpu") as handle:
+                file_metadata = handle.metadata() or {}
+            raw_adapter_metadata = file_metadata.get(LORA_ADAPTER_METADATA_KEY)
+            adapter_metadata = json.loads(raw_adapter_metadata) if raw_adapter_metadata else None
         except Exception as exc:
             raise ValueError(f"Unable to inspect init_lora checkpoint `{init_lora_path}` for LoRA rank metadata.") from exc
-        return self._prepare_init_lora_state_dict(state_dict)
+        return self._prepare_init_lora_state_dict(state_dict, metadata=adapter_metadata)
 
     def _init_lora_config_kwargs(self, state_dict: dict | None = None) -> dict:
         state_dict = self._load_init_lora_state_dict() if state_dict is None else state_dict
@@ -1800,6 +1807,13 @@ class ModelFoundation(ABC):
         visit(component)
         return classes
 
+    def _lora_state_dict_load_kwargs(self) -> dict:
+        return {}
+
+    def _prepare_loaded_lora_state_dict(self, state_dict: dict, metadata: Optional[dict] = None) -> dict:
+        del metadata
+        return state_dict
+
     def load_lora_weights(self, models, input_dir):
         """
         Generalized LoRA loading method.
@@ -1842,10 +1856,19 @@ class ModelFoundation(ABC):
                 )
 
         pipeline_cls = self.PIPELINE_CLASSES[PipelineTypes.TEXT2IMG]
-        lora_state = pipeline_cls.lora_state_dict(input_dir)
+        lora_load_kwargs = self._lora_state_dict_load_kwargs()
+        lora_state = pipeline_cls.lora_state_dict(input_dir, **lora_load_kwargs)
         network_alphas = None
+        adapter_metadata = None
 
-        if isinstance(lora_state, tuple):
+        if lora_load_kwargs.get("return_lora_metadata") and isinstance(lora_state, tuple):
+            if len(lora_state) == 2:
+                lora_state_dict, adapter_metadata = lora_state
+            elif len(lora_state) >= 3:
+                lora_state_dict, network_alphas, adapter_metadata = lora_state[:3]
+            else:
+                lora_state_dict = lora_state[0]
+        elif isinstance(lora_state, tuple):
             if len(lora_state) >= 2:
                 lora_state_dict, maybe_network_alphas = lora_state[:2]
                 if isinstance(maybe_network_alphas, dict) or maybe_network_alphas is None:
@@ -1866,6 +1889,7 @@ class ModelFoundation(ABC):
 
         if not isinstance(lora_state_dict, dict):
             raise ValueError("LoRA checkpoint did not return a state dictionary.")
+        lora_state_dict = self._prepare_loaded_lora_state_dict(lora_state_dict, metadata=adapter_metadata)
 
         def _normalise_alpha_map(alpha_dict: dict) -> dict:
             if not alpha_dict:

--- a/simpletuner/helpers/models/minimaxh3/model.py
+++ b/simpletuner/helpers/models/minimaxh3/model.py
@@ -579,7 +579,35 @@ class MiniMaxH3(VideoModelFoundation):
             target_swiglu_gate_first=self._h3_transformer_uses_gate_first_swiglu(),
         )
 
-    def _prepare_init_lora_state_dict(self, state_dict: dict) -> dict:
+    def _prepare_plain_h3_lora_swiglu_layout(self, state_dict: dict, metadata: Optional[dict]) -> dict:
+        from simpletuner.helpers.models.minimaxh3.modular_pipeline import (
+            _convert_minimax_h3_diffusers_swiglu_lora_layout,
+            _minimax_h3_swiglu_gate_first_from_metadata,
+        )
+
+        source_gate_first = _minimax_h3_swiglu_gate_first_from_metadata(
+            metadata,
+            target_prefix=self._h3_lora_component_name(),
+        )
+        if source_gate_first is None:
+            return state_dict
+        return _convert_minimax_h3_diffusers_swiglu_lora_layout(
+            state_dict,
+            source_gate_first=source_gate_first,
+            target_gate_first=self._h3_transformer_uses_gate_first_swiglu(),
+        )
+
+    def _lora_state_dict_load_kwargs(self) -> dict:
+        return {"return_lora_metadata": True}
+
+    def _prepare_loaded_lora_state_dict(self, state_dict: dict, metadata: Optional[dict] = None) -> dict:
+        from simpletuner.helpers.models.minimaxh3.modular_pipeline import _is_minimax_h3_native_lora_state_dict
+
+        if _is_minimax_h3_native_lora_state_dict(state_dict):
+            return state_dict
+        return self._prepare_plain_h3_lora_swiglu_layout(state_dict, metadata)
+
+    def _prepare_init_lora_state_dict(self, state_dict: dict, metadata: Optional[dict] = None) -> dict:
         from simpletuner.helpers.models.minimaxh3.modular_pipeline import (
             _convert_minimax_h3_comfy_lora_to_diffusers,
             _is_minimax_h3_native_lora_state_dict,
@@ -592,7 +620,7 @@ class MiniMaxH3(VideoModelFoundation):
         ):
             lora_format = PEFTLoRAFormat.COMFYUI
         if lora_format != PEFTLoRAFormat.COMFYUI:
-            return state_dict
+            return self._prepare_plain_h3_lora_swiglu_layout(state_dict, metadata)
         converted, network_alphas = _convert_minimax_h3_comfy_lora_to_diffusers(
             state_dict,
             target_prefix=self._h3_lora_component_name(),
@@ -608,6 +636,18 @@ class MiniMaxH3(VideoModelFoundation):
         for key, alpha in network_alphas.items():
             prepared[key] = torch.tensor(alpha, dtype=torch.float32)
         return prepared
+
+    def save_lora_weights(self, *args, **kwargs):
+        from simpletuner.helpers.models.minimaxh3.modular_pipeline import MINIMAX_H3_SWIGLU_GATE_FIRST_METADATA_KEY
+
+        metadata_key = f"{self.MODEL_SUBFOLDER}_lora_adapter_metadata"
+        adapter_metadata = dict(kwargs.get(metadata_key) or {})
+        lora_format = normalize_lora_format(getattr(self.config, "lora_format", None))
+        adapter_metadata[MINIMAX_H3_SWIGLU_GATE_FIRST_METADATA_KEY] = (
+            lora_format == PEFTLoRAFormat.COMFYUI or self._h3_transformer_uses_gate_first_swiglu()
+        )
+        kwargs[metadata_key] = adapter_metadata
+        return super().save_lora_weights(*args, **kwargs)
 
     def get_lora_target_layers(self):
         manual_targets = self._get_peft_lora_target_modules()

--- a/simpletuner/helpers/models/minimaxh3/modular_pipeline.py
+++ b/simpletuner/helpers/models/minimaxh3/modular_pipeline.py
@@ -47,6 +47,7 @@ _MINIMAX_H3_NATIVE_LORA_PREFIXES = (
     "condition_proj.",
     "time_embedder.",
 )
+MINIMAX_H3_SWIGLU_GATE_FIRST_METADATA_KEY = "swiglu_gate_first"
 
 
 def _strip_comfy_lora_prefix(key: str) -> str:
@@ -74,6 +75,54 @@ def _is_minimax_h3_native_lora_state_dict(state_dict: Dict[str, Any]) -> bool:
         if key.startswith(_MINIMAX_H3_NATIVE_LORA_PREFIXES):
             return True
     return False
+
+
+def _minimax_h3_swiglu_gate_first_from_metadata(
+    metadata: Optional[dict],
+    *,
+    target_prefix: str,
+) -> Optional[bool]:
+    if not metadata:
+        return None
+
+    candidate_keys = (
+        f"{target_prefix}.{MINIMAX_H3_SWIGLU_GATE_FIRST_METADATA_KEY}",
+        f"transformer.{MINIMAX_H3_SWIGLU_GATE_FIRST_METADATA_KEY}",
+        f"transformer_ref.{MINIMAX_H3_SWIGLU_GATE_FIRST_METADATA_KEY}",
+        MINIMAX_H3_SWIGLU_GATE_FIRST_METADATA_KEY,
+    )
+    for key in candidate_keys:
+        if key not in metadata:
+            continue
+        value = metadata[key]
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, int) and value in (0, 1):
+            return bool(value)
+        if isinstance(value, str) and value.strip().lower() in ("true", "false"):
+            return value.strip().lower() == "true"
+        raise ValueError(f"MiniMax-H3 LoRA metadata `{key}` must be a boolean, received {value!r}.")
+    return None
+
+
+def _convert_minimax_h3_diffusers_swiglu_lora_layout(
+    state_dict: Dict[str, Any],
+    *,
+    source_gate_first: bool,
+    target_gate_first: bool,
+) -> Dict[str, Any]:
+    if source_gate_first == target_gate_first:
+        return state_dict
+
+    converted = dict(state_dict)
+    for key, value in state_dict.items():
+        if ".ff.net.0.proj" not in key or not key.endswith(_LORA_B_SUFFIXES) or not torch.is_tensor(value):
+            continue
+        if value.ndim == 0 or value.shape[0] % 2 != 0:
+            raise ValueError(f"MiniMax-H3 SwiGLU LoRA tensor `{key}` cannot be split into gate/value rows.")
+        first, second = value.chunk(2, dim=0)
+        converted[key] = torch.cat((second, first), dim=0).contiguous()
+    return converted
 
 
 def _map_comfy_lora_module(module_key: str, target_prefix: str) -> list[str]:
@@ -386,6 +435,8 @@ class MiniMaxH3LoraLoaderMixin(LoraBaseMixin):
         subfolder = kwargs.pop("subfolder", None)
         weight_name = kwargs.pop("weight_name", None)
         use_safetensors = kwargs.pop("use_safetensors", None)
+        return_lora_metadata = kwargs.pop("return_lora_metadata", False)
+        metadata = kwargs.pop("metadata", None)
 
         allow_pickle = False
         if use_safetensors is None:
@@ -396,7 +447,7 @@ class MiniMaxH3LoraLoaderMixin(LoraBaseMixin):
             "file_type": "attn_procs_weights",
             "framework": "pytorch",
         }
-        state_dict, _ = _fetch_state_dict(
+        state_dict, metadata = _fetch_state_dict(
             pretrained_model_name_or_path_or_dict=pretrained_model_name_or_path_or_dict,
             weight_name=weight_name,
             use_safetensors=use_safetensors,
@@ -409,8 +460,9 @@ class MiniMaxH3LoraLoaderMixin(LoraBaseMixin):
             subfolder=subfolder,
             user_agent=user_agent,
             allow_pickle=allow_pickle,
+            metadata=metadata,
         )
-        return state_dict
+        return (state_dict, metadata) if return_lora_metadata else state_dict
 
     def load_lora_weights(
         self,
@@ -432,7 +484,15 @@ class MiniMaxH3LoraLoaderMixin(LoraBaseMixin):
             pretrained_model_name_or_path_or_dict = pretrained_model_name_or_path_or_dict.copy()
 
         lora_format = normalize_lora_format(kwargs.pop("lora_format", None))
-        state_dict = self.lora_state_dict(pretrained_model_name_or_path_or_dict, **kwargs)
+        loaded = self.lora_state_dict(
+            pretrained_model_name_or_path_or_dict,
+            return_lora_metadata=True,
+            **kwargs,
+        )
+        if isinstance(loaded, tuple):
+            state_dict, adapter_metadata = loaded
+        else:
+            state_dict, adapter_metadata = loaded, None
         if not isinstance(state_dict, dict):
             raise ValueError("MiniMax-H3 LoRA checkpoint did not return a state dict.")
 
@@ -453,6 +513,17 @@ class MiniMaxH3LoraLoaderMixin(LoraBaseMixin):
                 target_prefix=self.transformer_name,
                 target_swiglu_gate_first=self._transformer_uses_gate_first_swiglu(transformer),
             )
+        else:
+            source_gate_first = _minimax_h3_swiglu_gate_first_from_metadata(
+                adapter_metadata,
+                target_prefix=self.transformer_name,
+            )
+            if source_gate_first is not None:
+                state_dict = _convert_minimax_h3_diffusers_swiglu_lora_layout(
+                    state_dict,
+                    source_gate_first=source_gate_first,
+                    target_gate_first=self._transformer_uses_gate_first_swiglu(transformer),
+                )
 
         transformer_prefix = f"{self.transformer_name}."
         transformer_state_dict = {}

--- a/simpletuner/helpers/models/minimaxh3/transformer.py
+++ b/simpletuner/helpers/models/minimaxh3/transformer.py
@@ -26,7 +26,7 @@ import torch.nn as nn
 from diffusers.configuration_utils import ConfigMixin, register_to_config
 from diffusers.loaders import PeftAdapterMixin
 from diffusers.models._modeling_parallel import ContextParallelInput
-from diffusers.models.attention import AttentionMixin, AttentionModuleMixin
+from diffusers.models.attention import AttentionMixin, AttentionModuleMixin, FeedForward
 from diffusers.models.attention_dispatch import AttentionBackendName, _AttentionBackendRegistry, dispatch_attention_fn
 from diffusers.models.cache_utils import CacheMixin
 from diffusers.models.embeddings import TimestepEmbedding, Timesteps
@@ -355,6 +355,26 @@ def _map_minimax_h3_comfy_key_to_diffusers(key: str) -> list[str]:
     return [key]
 
 
+def _convert_minimax_h3_native_swiglu_to_diffusers(key: str, tensor: torch.Tensor) -> torch.Tensor:
+    """Convert native H3 ``[gate; value]`` FFN rows to Diffusers' ``[value; gate]`` order."""
+    if not key.endswith(".mlp.fc1.weight"):
+        return tensor
+    if tensor.ndim == 0 or tensor.shape[0] % 2 != 0:
+        raise RuntimeError(f"MiniMax-H3 SwiGLU tensor {key} cannot be split into gate/value rows")
+    gate, value = tensor.chunk(2, dim=0)
+    return torch.cat((value, gate), dim=0).contiguous()
+
+
+def _convert_minimax_h3_native_swiglu_scale_to_diffusers(key: str, scale: torch.Tensor) -> torch.Tensor:
+    """Apply the native H3 FFN row conversion to a per-output-row quantization scale."""
+    if not key.endswith(".mlp.fc1.weight") or scale.ndim == 0 or scale.numel() == 1:
+        return scale
+    if scale.shape[0] % 2 != 0:
+        raise RuntimeError(f"MiniMax-H3 SwiGLU scale for {key} cannot be split into gate/value rows")
+    gate, value = scale.chunk(2, dim=0)
+    return torch.cat((value, gate), dim=0).contiguous()
+
+
 def _count_indexed_blocks(keys: set[str], prefix: str) -> int:
     indices = set()
     for key in keys:
@@ -411,7 +431,7 @@ def _infer_minimax_h3_config_from_checkpoint(checkpoint) -> dict[str, Any]:
             ),
             "rope_freq_dim": _get_checkpoint_tensor(checkpoint, "rope.inv_freq").shape[0] if has_rope else 16,
             "adaln_curve_grid": adaln_curve_table.shape[0] if has_adaln_curve else None,
-            "swiglu_gate_first": True,
+            "swiglu_gate_first": False,
         }
 
     if "proj_in.weight" in raw_keys:
@@ -893,7 +913,10 @@ class MiniMaxH3TokenRefinerBlock(nn.Module):
             qk_norm_eps=qk_norm_eps,
         )
         self.norm2 = nn.RMSNorm(hidden_size, eps=norm_eps)
-        self.ff = MiniMaxH3FeedForward(hidden_size, inner_dim=ffn_dim, bias=False, gate_first=swiglu_gate_first)
+        if swiglu_gate_first:
+            self.ff = MiniMaxH3FeedForward(hidden_size, inner_dim=ffn_dim, bias=False, gate_first=True)
+        else:
+            self.ff = FeedForward(hidden_size, inner_dim=ffn_dim, activation_fn="swiglu", bias=False)
 
     def forward(
         self,
@@ -1021,7 +1044,10 @@ class MiniMaxH3TransformerBlock(nn.Module):
             qk_norm_eps=qk_norm_eps,
         )
         self.norm2 = nn.RMSNorm(hidden_size, eps=norm_eps)
-        self.ff = MiniMaxH3FeedForward(hidden_size, inner_dim=ffn_dim, bias=False, gate_first=swiglu_gate_first)
+        if swiglu_gate_first:
+            self.ff = MiniMaxH3FeedForward(hidden_size, inner_dim=ffn_dim, bias=False, gate_first=True)
+        else:
+            self.ff = FeedForward(hidden_size, inner_dim=ffn_dim, activation_fn="swiglu", bias=False)
         self.adaln_proj = MiniMaxH3AdaLayerNormModulation(
             time_embed_dim=time_embed_dim,
             hidden_size=hidden_size,
@@ -1640,6 +1666,7 @@ class MiniMaxH3Transformer3DModel(ModelMixin, ConfigMixin, AttentionMixin, PeftA
                     continue
 
                 tensor = checkpoint.get_tensor(raw_key)
+                tensor = _convert_minimax_h3_native_swiglu_to_diffusers(key, tensor)
                 if tensor.dtype in _COMFY_FP8_DTYPES:
                     from simpletuner.helpers.models.z_image.quantized_loading import _decode_comfy_quant
 
@@ -1659,6 +1686,7 @@ class MiniMaxH3Transformer3DModel(ModelMixin, ConfigMixin, AttentionMixin, PeftA
                             f"{quant_metadata.get('format')!r}"
                         )
                     scale = checkpoint.get_tensor(scale_key).to(torch.float32)
+                    scale = _convert_minimax_h3_native_swiglu_scale_to_diffusers(key, scale)
                     if len(mapped_keys) == 3:
                         if tensor.shape[0] % 3 != 0:
                             raise RuntimeError(f"MiniMax-H3 FP8 tensor {raw_key} cannot be split into q/k/v tensors")
@@ -1699,6 +1727,7 @@ class MiniMaxH3Transformer3DModel(ModelMixin, ConfigMixin, AttentionMixin, PeftA
                     if hadamard_group_size <= 0:
                         raise RuntimeError(f"MiniMax-H3 ConvRot tensor {raw_key} has invalid convrot_groupsize")
                     scale = checkpoint.get_tensor(scale_key)
+                    scale = _convert_minimax_h3_native_swiglu_scale_to_diffusers(key, scale)
                     if len(mapped_keys) == 3:
                         if tensor.shape[0] % 3 != 0 or scale.shape[0] % 3 != 0:
                             raise RuntimeError(f"MiniMax-H3 ConvRot tensor {raw_key} cannot be split into q/k/v tensors")

--- a/tests/test_minimaxh3.py
+++ b/tests/test_minimaxh3.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 import torch
 from accelerate.utils.operations import convert_to_fp32
 from PIL import Image
+from safetensors import safe_open
 from safetensors.torch import load_file, save_file
 
 from simpletuner.helpers.acceleration import AccelerationBackend
@@ -21,10 +22,12 @@ from simpletuner.helpers.models.minimaxh3.denoise import _denoiser_inputs, _pred
 from simpletuner.helpers.models.minimaxh3.encoders import MiniMaxH3TextEncoderStep
 from simpletuner.helpers.models.minimaxh3.model import MiniMaxH3
 from simpletuner.helpers.models.minimaxh3.modular_pipeline import (
+    MINIMAX_H3_SWIGLU_GATE_FIRST_METADATA_KEY,
     MiniMaxH3ModularPipeline,
     MiniMaxH3Ref2VAModularPipeline,
     _convert_minimax_h3_comfy_lora_to_diffusers,
     _convert_minimax_h3_diffusers_lora_to_comfyui,
+    _convert_minimax_h3_diffusers_swiglu_lora_layout,
 )
 from simpletuner.helpers.models.minimaxh3.packing import (
     MINIMAX_H3_FPS,
@@ -54,6 +57,8 @@ from simpletuner.helpers.models.minimaxh3.transformer import (
     MiniMaxH3RotaryPosEmbed,
     MiniMaxH3Transformer3DModel,
     MiniMaxH3TransformerOutput,
+    _convert_minimax_h3_native_swiglu_scale_to_diffusers,
+    _convert_minimax_h3_native_swiglu_to_diffusers,
     _gather_h3_context_parallel_output,
     _pad_h3_context_parallel_layout,
     resolve_h3_reference_mode,
@@ -1020,6 +1025,62 @@ class MiniMaxH3Tests(unittest.TestCase):
         expected = torch.nn.functional.silu(torch.tensor([[0.5, -1.0]])) * torch.tensor([[1.0, -3.0]])
 
         self.assertTrue(torch.allclose(result, expected))
+
+    def test_native_swiglu_conversion_preserves_forward_and_backward(self):
+        torch.manual_seed(23)
+        hidden_states = torch.randn(2, 3, requires_grad=True)
+        native_weight = torch.randn(8, 3, requires_grad=True)
+        down_weight = torch.randn(3, 4, requires_grad=True)
+
+        native_gate, native_value = torch.nn.functional.linear(hidden_states, native_weight).chunk(2, dim=-1)
+        native_output = torch.nn.functional.linear(torch.nn.functional.silu(native_gate) * native_value, down_weight)
+        native_grads = torch.autograd.grad(native_output.square().sum(), (hidden_states, native_weight, down_weight))
+
+        converted_hidden = hidden_states.detach().clone().requires_grad_()
+        converted_weight = _convert_minimax_h3_native_swiglu_to_diffusers(
+            "blocks.0.mlp.fc1.weight",
+            native_weight.detach(),
+        ).requires_grad_()
+        converted_down = down_weight.detach().clone().requires_grad_()
+        converted_value, converted_gate = torch.nn.functional.linear(converted_hidden, converted_weight).chunk(2, dim=-1)
+        converted_output = torch.nn.functional.linear(
+            converted_value * torch.nn.functional.silu(converted_gate),
+            converted_down,
+        )
+        converted_grads = torch.autograd.grad(
+            converted_output.square().sum(),
+            (converted_hidden, converted_weight, converted_down),
+        )
+
+        self.assertTrue(torch.equal(native_output, converted_output))
+        self.assertTrue(torch.allclose(native_grads[0], converted_grads[0], atol=1e-6, rtol=1e-6))
+        self.assertTrue(
+            torch.allclose(
+                native_grads[1],
+                _convert_minimax_h3_native_swiglu_to_diffusers(
+                    "blocks.0.mlp.fc1.weight",
+                    converted_grads[1],
+                ),
+                atol=1e-6,
+                rtol=1e-6,
+            )
+        )
+        self.assertTrue(torch.allclose(native_grads[2], converted_grads[2], atol=1e-6, rtol=1e-6))
+
+    def test_native_swiglu_conversion_reorders_quantization_scales(self):
+        scale = torch.arange(8, dtype=torch.float32).view(8, 1)
+
+        converted = _convert_minimax_h3_native_swiglu_scale_to_diffusers(
+            "blocks.0.mlp.fc1.weight",
+            scale,
+        )
+
+        self.assertTrue(torch.equal(converted, torch.cat((scale[4:], scale[:4]), dim=0)))
+        scalar = torch.tensor(0.125)
+        self.assertIs(
+            _convert_minimax_h3_native_swiglu_scale_to_diffusers("blocks.0.mlp.fc1.weight", scalar),
+            scalar,
+        )
 
     def test_transformer_propagates_comfy_swiglu_gate_first_config(self):
         model = tiny_h3_transformer(swiglu_gate_first=True)
@@ -2467,9 +2528,34 @@ class MiniMaxH3Tests(unittest.TestCase):
                 weights[f"{prefix}.lora_B.weight"] = torch.randn(4, 2)
             save_function(weights, output_path)
             saved = load_file(output_path)
+            with safe_open(output_path, framework="pt", device="cpu") as handle:
+                adapter_metadata = json.loads(handle.metadata()["lora_adapter_metadata"])
 
         self.assertIn("diffusion_model.blocks.0.attn.qkv_proj.lora_A.weight", saved)
         self.assertNotIn("diffusion_model.transformer_blocks.0.attn.to_q.lora_A.weight", saved)
+        self.assertTrue(adapter_metadata[MINIMAX_H3_SWIGLU_GATE_FIRST_METADATA_KEY])
+
+    def test_model_diffusers_lora_save_marks_hidden_first_swiglu_layout(self):
+        model = object.__new__(MiniMaxH3)
+        model.config = SimpleNamespace(
+            controlnet=False,
+            lora_format="diffusers",
+            model_family="minimaxh3",
+        )
+        model.model = tiny_h3_transformer(swiglu_gate_first=False)
+        model.accelerator = SimpleNamespace(unwrap_model=lambda model, keep_fp32_wrapper=True: model)
+        pipeline_class = model.PIPELINE_CLASSES[PipelineTypes.TEXT2IMG]
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.object(pipeline_class, "save_lora_weights") as save_lora_weights:
+            model.save_lora_weights(
+                tmpdir,
+                transformer_lora_layers={"transformer_blocks.0.ff.net.0.proj.lora_A.weight": torch.ones(2, 3)},
+                transformer_lora_adapter_metadata={"adapter": "h3"},
+            )
+
+        adapter_metadata = save_lora_weights.call_args.kwargs["transformer_lora_adapter_metadata"]
+        self.assertEqual(adapter_metadata["adapter"], "h3")
+        self.assertFalse(adapter_metadata[MINIMAX_H3_SWIGLU_GATE_FIRST_METADATA_KEY])
 
     def test_training_resume_imports_native_comfy_lora_keys(self):
         wrapper = object.__new__(MiniMaxH3)
@@ -2532,6 +2618,49 @@ class MiniMaxH3Tests(unittest.TestCase):
         self.assertIn("time_embedder.linear_1.lora_B.weight", loaded)
         self.assertNotIn("blocks.0.attn.qkv_proj.lora_A.weight", loaded)
 
+    def test_training_resume_uses_metadata_for_ambiguous_diffusers_swiglu_layout(self):
+        wrapper = object.__new__(MiniMaxH3)
+        wrapper.config = SimpleNamespace(
+            controlnet=False,
+            lora_format="diffusers",
+            model_flavour="fl2va",
+            train_text_encoder=False,
+        )
+        wrapper.model = tiny_h3_transformer(swiglu_gate_first=False)
+        wrapper.controlnet = None
+        wrapper.text_encoders = []
+        wrapper.accelerator = SimpleNamespace(
+            unwrap_model=lambda model, keep_fp32_wrapper=True: model,
+        )
+        gate = torch.full((4, 4), 1.0)
+        hidden = torch.full((4, 4), 2.0)
+        prefix = "transformer.transformer_blocks.0.ff.net.0.proj"
+        source_state_dict = {
+            f"{prefix}.lora_A.weight": torch.randn(4, 8),
+            f"{prefix}.lora_B.weight": torch.cat((gate, hidden), dim=0),
+        }
+        pipeline_class = wrapper.PIPELINE_CLASSES[PipelineTypes.TEXT2IMG]
+
+        with (
+            patch.object(
+                pipeline_class,
+                "lora_state_dict",
+                return_value=(source_state_dict, {"transformer.swiglu_gate_first": True}),
+            ) as lora_state_dict,
+            patch("peft.utils.set_peft_model_state_dict") as set_peft_state,
+        ):
+            set_peft_state.return_value = SimpleNamespace(unexpected_keys=[])
+            wrapper.load_lora_weights([wrapper.model], "unused")
+
+        lora_state_dict.assert_called_once_with("unused", return_lora_metadata=True)
+        loaded = set_peft_state.call_args.args[1]
+        self.assertTrue(
+            torch.equal(
+                loaded["transformer_blocks.0.ff.net.0.proj.lora_B.weight"],
+                torch.cat((hidden, gate), dim=0),
+            )
+        )
+
     def test_training_resume_fails_when_peft_rejects_every_lora_key(self):
         wrapper = object.__new__(MiniMaxH3)
         wrapper.config = SimpleNamespace(
@@ -2590,6 +2719,42 @@ class MiniMaxH3Tests(unittest.TestCase):
             )
         )
 
+    def test_comfy_lora_swiglu_conversion_preserves_adapter_forward(self):
+        torch.manual_seed(29)
+        hidden_states = torch.randn(2, 3)
+        native_base = torch.randn(8, 3)
+        native_down = torch.randn(2, 3)
+        native_up = torch.randn(8, 2)
+
+        native_projection = torch.nn.functional.linear(
+            hidden_states,
+            native_base + native_up @ native_down,
+        )
+        native_gate, native_value = native_projection.chunk(2, dim=-1)
+        native_output = torch.nn.functional.silu(native_gate) * native_value
+
+        converted, _network_alphas = _convert_minimax_h3_comfy_lora_to_diffusers(
+            {
+                "blocks.0.mlp.fc1.lora_A.weight": native_down,
+                "blocks.0.mlp.fc1.lora_B.weight": native_up,
+            },
+            target_prefix="transformer",
+        )
+        canonical_base = _convert_minimax_h3_native_swiglu_to_diffusers(
+            "blocks.0.mlp.fc1.weight",
+            native_base,
+        )
+        canonical_down = converted["transformer.transformer_blocks.0.ff.net.0.proj.lora.down.weight"]
+        canonical_up = converted["transformer.transformer_blocks.0.ff.net.0.proj.lora.up.weight"]
+        canonical_projection = torch.nn.functional.linear(
+            hidden_states,
+            canonical_base + canonical_up @ canonical_down,
+        )
+        canonical_value, canonical_gate = canonical_projection.chunk(2, dim=-1)
+        canonical_output = canonical_value * torch.nn.functional.silu(canonical_gate)
+
+        self.assertTrue(torch.equal(canonical_output, native_output))
+
     def test_comfy_lora_conversion_preserves_swiglu_rows_for_gate_first_target(self):
         gate = torch.full((2, 4), 1.0)
         hidden = torch.full((2, 4), 2.0)
@@ -2611,6 +2776,32 @@ class MiniMaxH3Tests(unittest.TestCase):
                 fc1_up,
             )
         )
+
+    def test_diffusers_lora_layout_conversion_swaps_only_swiglu_up_rows(self):
+        down = torch.randn(2, 4)
+        gate = torch.full((3, 2), 1.0)
+        hidden = torch.full((3, 2), 2.0)
+        attention_up = torch.randn(4, 2)
+        state_dict = {
+            "transformer.transformer_blocks.0.ff.net.0.proj.lora_A.weight": down,
+            "transformer.transformer_blocks.0.ff.net.0.proj.lora_B.weight": torch.cat((gate, hidden), dim=0),
+            "transformer.transformer_blocks.0.attn.to_q.lora_B.weight": attention_up,
+        }
+
+        converted = _convert_minimax_h3_diffusers_swiglu_lora_layout(
+            state_dict,
+            source_gate_first=True,
+            target_gate_first=False,
+        )
+
+        self.assertIs(converted["transformer.transformer_blocks.0.ff.net.0.proj.lora_A.weight"], down)
+        self.assertTrue(
+            torch.equal(
+                converted["transformer.transformer_blocks.0.ff.net.0.proj.lora_B.weight"],
+                torch.cat((hidden, gate), dim=0),
+            )
+        )
+        self.assertIs(converted["transformer.transformer_blocks.0.attn.to_q.lora_B.weight"], attention_up)
 
     def test_lora_loader_detects_bare_h3_native_layout(self):
         pipe = MiniMaxH3ModularPipeline.__new__(MiniMaxH3ModularPipeline)
@@ -2637,6 +2828,49 @@ class MiniMaxH3Tests(unittest.TestCase):
             )
         )
         self.assertEqual(kwargs["adapter_name"], "h3")
+
+    def test_lora_loader_uses_metadata_for_ambiguous_diffusers_swiglu_layout(self):
+        pipe = MiniMaxH3ModularPipeline.__new__(MiniMaxH3ModularPipeline)
+        pipe.transformer = FakeLoraTarget()
+        pipe.transformer.config = SimpleNamespace(swiglu_gate_first=False)
+        gate = torch.full((2, 4), 1.0)
+        hidden = torch.full((2, 4), 2.0)
+        state_dict = {
+            "transformer.transformer_blocks.0.ff.net.0.proj.lora_A.weight": torch.randn(4, 16),
+            "transformer.transformer_blocks.0.ff.net.0.proj.lora_B.weight": torch.cat((gate, hidden), dim=0),
+        }
+        pipe.lora_state_dict = lambda _path, **_kwargs: (
+            state_dict,
+            {"transformer.swiglu_gate_first": True},
+        )
+
+        pipe.load_lora_weights("unused", adapter_name="h3")
+
+        loaded_state_dict, _kwargs = pipe.transformer.calls[0]
+        self.assertTrue(
+            torch.equal(
+                loaded_state_dict["transformer.transformer_blocks.0.ff.net.0.proj.lora_B.weight"],
+                torch.cat((hidden, gate), dim=0),
+            )
+        )
+
+    def test_lora_loader_leaves_unmarked_diffusers_swiglu_layout_unchanged(self):
+        pipe = MiniMaxH3ModularPipeline.__new__(MiniMaxH3ModularPipeline)
+        pipe.transformer = FakeLoraTarget()
+        pipe.transformer.config = SimpleNamespace(swiglu_gate_first=False)
+        up = torch.randn(4, 2)
+        pipe.lora_state_dict = lambda _path, **_kwargs: {
+            "transformer.transformer_blocks.0.ff.net.0.proj.lora_A.weight": torch.randn(2, 4),
+            "transformer.transformer_blocks.0.ff.net.0.proj.lora_B.weight": up,
+        }
+
+        pipe.load_lora_weights("unused", adapter_name="h3")
+
+        loaded_state_dict, _kwargs = pipe.transformer.calls[0]
+        self.assertIs(
+            loaded_state_dict["transformer.transformer_blocks.0.ff.net.0.proj.lora_B.weight"],
+            up,
+        )
 
     def test_init_lora_prepares_bare_h3_native_layout_and_targets(self):
         gate = torch.full((2, 4), 1.0)
@@ -2676,6 +2910,39 @@ class MiniMaxH3Tests(unittest.TestCase):
         self.assertIn("transformer.transformer_blocks.0.ff.net.0.proj.lora_A.weight", prepared)
         self.assertEqual(prepared["transformer.transformer_blocks.0.ff.net.0.proj.alpha"].item(), 2.0)
         self.assertEqual(targets, ["transformer_blocks.0.ff.net.0.proj"])
+
+    def test_init_lora_uses_metadata_for_ambiguous_diffusers_swiglu_layout(self):
+        gate = torch.full((2, 4), 1.0)
+        hidden = torch.full((2, 4), 2.0)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            init_lora_path = f"{tmpdir}/h3-peft.safetensors"
+            save_file(
+                {
+                    "transformer.transformer_blocks.0.ff.net.0.proj.lora_A.weight": torch.randn(4, 16),
+                    "transformer.transformer_blocks.0.ff.net.0.proj.lora_B.weight": torch.cat((gate, hidden), dim=0),
+                },
+                init_lora_path,
+                metadata={
+                    "lora_adapter_metadata": json.dumps({"transformer.swiglu_gate_first": True}),
+                },
+            )
+            wrapper = MiniMaxH3.__new__(MiniMaxH3)
+            wrapper.config = SimpleNamespace(
+                init_lora=init_lora_path,
+                lora_format=None,
+                model_flavour="fl2va",
+            )
+            wrapper.model = tiny_h3_transformer(swiglu_gate_first=False)
+            wrapper.accelerator = SimpleNamespace(unwrap_model=lambda model, keep_fp32_wrapper=True: model)
+
+            prepared = wrapper._load_init_lora_state_dict()
+
+        self.assertTrue(
+            torch.equal(
+                prepared["transformer.transformer_blocks.0.ff.net.0.proj.lora_B.weight"],
+                torch.cat((hidden, gate), dim=0),
+            )
+        )
 
     def test_ref2va_lora_loader_retargets_transformer_prefix(self):
         pipe = MiniMaxH3Ref2VAModularPipeline.__new__(MiniMaxH3Ref2VAModularPipeline)
@@ -2908,6 +3175,65 @@ class MiniMaxH3Tests(unittest.TestCase):
         self.assertEqual(tuple(loaded.config.patch_size), (1, 2, 2))
         self.assertFalse(loaded.config.swiglu_gate_first)
         self.assertFalse(loaded.rope.inv_freq.is_meta)
+
+    def test_single_file_native_loader_normalizes_swiglu_to_diffusers_order(self):
+        model = tiny_h3_transformer(num_layers=1)
+        native_state_dict = {}
+        for key, value in model.state_dict().items():
+            native_key = key
+            for source, target in (
+                ("audio_proj_in.", "audio_patch_proj."),
+                ("proj_in.", "video_patch_proj."),
+                ("context_embedder.", "condition_proj."),
+                ("time_embedder.linear_1.", "time_embedder.proj_in."),
+                ("time_embedder.linear_2.", "time_embedder.proj_out."),
+                ("norm_out.norm.", "final_layer.norm."),
+                ("norm_out.linear.", "final_layer.adaln_proj.linear."),
+                ("audio_proj_out.", "final_layer.audio_out."),
+                ("proj_out.", "final_layer.video_out."),
+            ):
+                if native_key.startswith(source):
+                    native_key = native_key.replace(source, target, 1)
+                    break
+            native_key = native_key.replace("token_refiner.refiner_blocks.", "token_refiner.blocks.", 1)
+            native_key = native_key.replace("transformer_blocks.", "blocks.", 1)
+            native_key = native_key.replace(".attn.norm_q.", ".attn.q_norm.")
+            native_key = native_key.replace(".attn.norm_k.", ".attn.k_norm.")
+            native_key = native_key.replace(".attn.to_out.0.", ".attn.out_proj.")
+            native_key = native_key.replace(".ff.net.0.proj.", ".mlp.fc1.")
+            native_key = native_key.replace(".ff.net.2.", ".mlp.fc2.")
+            if native_key.endswith(".mlp.fc1.weight"):
+                value, gate = value.chunk(2, dim=0)
+                value = torch.cat((gate, value), dim=0).contiguous()
+            native_state_dict[native_key] = value
+
+        for prefix in ("blocks.0", "token_refiner.blocks.0"):
+            q = native_state_dict.pop(f"{prefix}.attn.to_q.weight")
+            k = native_state_dict.pop(f"{prefix}.attn.to_k.weight")
+            v = native_state_dict.pop(f"{prefix}.attn.to_v.weight")
+            native_state_dict[f"{prefix}.attn.qkv_proj.weight"] = torch.cat((q, k, v), dim=0)
+        native_state_dict["rope.inv_freq"] = model.rope.inv_freq
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = f"{tmpdir}/tiny-h3-native.safetensors"
+            save_file(native_state_dict, path)
+            loaded = MiniMaxH3Transformer3DModel.from_single_file(path, torch_dtype=torch.float32)
+
+        self.assertFalse(loaded.config.swiglu_gate_first)
+        self.assertEqual(type(loaded.transformer_blocks[0].ff).__name__, "FeedForward")
+        self.assertTrue(
+            torch.equal(
+                loaded.transformer_blocks[0].ff.net[0].proj.weight,
+                model.transformer_blocks[0].ff.net[0].proj.weight,
+            )
+        )
+        inputs = tiny_inputs()
+        model.eval()
+        loaded.eval()
+        expected = model(**inputs)
+        actual = loaded(**inputs)
+        self.assertTrue(torch.equal(actual.sample, expected.sample))
+        self.assertTrue(torch.equal(actual.audio_sample, expected.audio_sample))
 
     def test_single_file_loader_accepts_trailing_safetensors_bytes(self):
         model = tiny_h3_transformer(num_layers=1)


### PR DESCRIPTION
See https://github.com/huggingface/diffusers/issues/14410 for additional context.

This pull request introduces comprehensive improvements to the handling of LoRA (Low-Rank Adaptation) weights and metadata for the MiniMax-H3 model in the `simpletuner` codebase. The main focus is on robustly supporting different LoRA formats (especially handling the "gate_first" ordering in SwiGLU layers), propagating and transforming metadata through load/save operations, and ensuring compatibility between native and diffusers LoRA layouts. Additional refactoring improves modularity and clarity.

### LoRA Metadata Handling and Propagation

* Added mechanisms to extract, propagate, and utilize LoRA adapter metadata (especially the `swiglu_gate_first` flag) throughout the loading and saving process, enabling correct transformation between native and diffusers LoRA formats. This includes new helper functions for extracting and interpreting metadata, and changes to method signatures to accept and pass metadata dictionaries. [[1]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR969-R980) [[2]](diffhunk://#diff-84e8987ec147e7814411010def69646b6686690113a05d6b362bdbe165b3f2cbR1810-R1816) [[3]](diffhunk://#diff-b35268137299894ddb721f990c29810ef4feea7b7acf5800847ab214f93d309eR80-R127) [[4]](diffhunk://#diff-b35268137299894ddb721f990c29810ef4feea7b7acf5800847ab214f93d309eR438-R439) [[5]](diffhunk://#diff-b35268137299894ddb721f990c29810ef4feea7b7acf5800847ab214f93d309eR463-R465) [[6]](diffhunk://#diff-b35268137299894ddb721f990c29810ef4feea7b7acf5800847ab214f93d309eL435-R495) [[7]](diffhunk://#diff-b35268137299894ddb721f990c29810ef4feea7b7acf5800847ab214f93d309eR516-R526) [[8]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fL582-R610) [[9]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fL595-R623) [[10]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fR640-R651)

### LoRA State Dict Transformation and Format Support

* Implemented logic to detect the source and target `swiglu_gate_first` order and convert LoRA state dicts as needed, ensuring compatibility between different implementations (e.g., native H3 vs. diffusers). This includes chunking and reordering tensor rows in LoRA weights and quantization scales. [[1]](diffhunk://#diff-b35268137299894ddb721f990c29810ef4feea7b7acf5800847ab214f93d309eR80-R127) [[2]](diffhunk://#diff-b35268137299894ddb721f990c29810ef4feea7b7acf5800847ab214f93d309eR438-R439) [[3]](diffhunk://#diff-0e31056fee25c3548ad29942a179564a24bdf95aae593af3f5f9afeeb67e112dR358-R377) [[4]](diffhunk://#diff-0e31056fee25c3548ad29942a179564a24bdf95aae593af3f5f9afeeb67e112dR1669) [[5]](diffhunk://#diff-0e31056fee25c3548ad29942a179564a24bdf95aae593af3f5f9afeeb67e112dR1689) [[6]](diffhunk://#diff-0e31056fee25c3548ad29942a179564a24bdf95aae593af3f5f9afeeb67e112dR1730)

### Model and Pipeline Refactoring

* Refactored model and pipeline logic to use new metadata-aware methods for loading and saving LoRA weights, and to correctly instantiate feedforward layers depending on the `swiglu_gate_first` flag. [[1]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fL582-R610) [[2]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fL595-R623) [[3]](diffhunk://#diff-f98e4f81cef6e7dcd6e4927c8af4a509122d1bd8226b26b31b6e50e0029fa39fR640-R651) [[4]](diffhunk://#diff-0e31056fee25c3548ad29942a179564a24bdf95aae593af3f5f9afeeb67e112dL896-R919) [[5]](diffhunk://#diff-0e31056fee25c3548ad29942a179564a24bdf95aae593af3f5f9afeeb67e112dL1024-R1050)

### Configuration and Defaults

* Changed the default for `swiglu_gate_first` in inferred configurations to `False`, improving compatibility with diffusers.

### Minor and Support Changes

* Added missing imports and constants, and improved test support for safetensors metadata. [[1]](diffhunk://#diff-b35268137299894ddb721f990c29810ef4feea7b7acf5800847ab214f93d309eR50) [[2]](diffhunk://#diff-0e31056fee25c3548ad29942a179564a24bdf95aae593af3f5f9afeeb67e112dL29-R29) [[3]](diffhunk://#diff-6ec9151a8d14ca198c9608ce0827285b9d03417d9650460664bb2097a19e015eR11)

These changes collectively provide robust, metadata-driven handling of LoRA weights for MiniMax-H3, ensuring correct operation across diverse LoRA formats and improving maintainability of the codebase.