### PR TITLE
block lora_init_step being higher than max_train_steps

### DIFF
--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -2278,8 +2278,19 @@ class Trainer:
             raise ValueError("init_lora_step cannot be combined with resume_from_checkpoint.")
 
         max_train_steps = getattr(self.config, "max_train_steps", None)
-        if max_train_steps not in (None, 0) and initial_step >= int(max_train_steps):
-            raise ValueError(f"init_lora_step ({initial_step}) must be smaller than max_train_steps ({max_train_steps}).")
+        if max_train_steps not in (None, 0):
+            max_train_steps = int(max_train_steps)
+            if initial_step >= max_train_steps:
+                if inferred_from_metadata:
+                    raise ValueError(
+                        "init_lora metadata reports global_step "
+                        f"{initial_step}, which is greater than or equal to max_train_steps ({max_train_steps}). "
+                        "For a fresh run from this adapter, set init_lora_step: 0 explicitly. "
+                        f"To continue scheduler/accounting from the adapter step, raise max_train_steps above {initial_step}."
+                    )
+                raise ValueError(
+                    f"init_lora_step ({initial_step}) must be smaller than max_train_steps ({max_train_steps})."
+                )
         if inferred_from_metadata:
             self.config.init_lora_step = initial_step
             logger.info("Using global step %s from init_lora safetensors metadata.", initial_step)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -2302,6 +2302,23 @@ class TestTrainer(unittest.TestCase):
             self.assertEqual(trainer._initial_lora_step(), 1500)
             self.assertEqual(trainer.config.init_lora_step, 1500)
 
+    def test_initial_lora_step_rejects_metadata_step_at_max_with_fresh_run_hint(self):
+        with tempfile.NamedTemporaryFile(suffix=".safetensors") as lora_file:
+            save_file({"weight": torch.ones(1)}, lora_file.name, metadata={"global_step": "1500"})
+            trainer = object.__new__(Trainer)
+            trainer.config = SimpleNamespace(
+                init_lora=lora_file.name,
+                init_lora_step=None,
+                resume_from_checkpoint=None,
+                max_train_steps=100,
+            )
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "init_lora metadata reports global_step 1500.*init_lora_step: 0.*max_train_steps above 1500",
+            ):
+                trainer._initial_lora_step()
+
     def test_initial_lora_step_explicit_zero_overrides_safetensors_metadata(self):
         with tempfile.NamedTemporaryFile(suffix=".safetensors") as lora_file:
             save_file({"weight": torch.ones(1)}, lora_file.name, metadata={"global_step": "1500"})


### PR DESCRIPTION
This pull request improves validation and error messaging for the `init_lora_step` logic in the trainer, especially when using LoRA safetensors metadata. It ensures that if the inferred step from metadata is greater than or equal to `max_train_steps`, users receive clearer guidance on how to proceed. A new test is added to verify this behavior.

Validation and error handling improvements:

* Updated `_initial_lora_step` in `trainer.py` to provide a more informative error message when the LoRA metadata's `global_step` is greater than or equal to `max_train_steps`, including hints for users on how to resolve the issue.

Testing enhancements:

* Added a test (`test_initial_lora_step_rejects_metadata_step_at_max_with_fresh_run_hint`) in `test_trainer.py` to ensure that the improved error message is raised and contains guidance when this condition occurs.