### PR TITLE
ideogram4 conditioning keys compatibility with anyflow

### DIFF
--- a/simpletuner/helpers/distillation/anyflow/distiller.py
+++ b/simpletuner/helpers/distillation/anyflow/distiller.py
@@ -954,8 +954,13 @@ class AnyFlowDistiller(DistillationBase):
         if torch.is_tensor(negative_tags):
             batch["text_token_tags"] = negative_tags
         negative_mask = prepared_batch.get("negative_encoder_attention_mask")
+        batch.pop("encoder_attention_mask", None)
         if torch.is_tensor(negative_mask):
             batch["encoder_attention_mask"] = negative_mask
+        # Some families (e.g. Ideogram) read model-specific conditioning aliases ahead of the
+        # generic keys; drop them so the swapped unconditional embeds/mask take effect.
+        for alias in ("prompt_embeds", "attention_mask", "attention_masks"):
+            batch.pop(alias, None)
         return batch
 
     def _slice_batch(self, prepared_batch: Dict[str, Any], requested_batch_size: int) -> Dict[str, Any]:

--- a/tests/helpers/distillation/test_anyflow_distiller.py
+++ b/tests/helpers/distillation/test_anyflow_distiller.py
@@ -1045,3 +1045,20 @@ class AnyFlowDistillerTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class AnyFlowUnconditionalBatchTests(unittest.TestCase):
+    def test_unconditional_batch_drops_stale_mask_and_model_specific_aliases(self):
+        batch = _prepared_batch()
+        batch["encoder_attention_mask"] = torch.ones(2, 5, dtype=torch.long)
+        batch["prompt_embeds"] = torch.ones(2, 7, 4)
+        batch["attention_mask"] = torch.ones(2, 7, dtype=torch.bool)
+        batch["attention_masks"] = torch.ones(2, 7, dtype=torch.bool)
+
+        unconditional_batch = AnyFlowDistiller._unconditional_batch(batch)
+
+        self.assertIs(unconditional_batch["encoder_hidden_states"], batch["negative_encoder_hidden_states"])
+        self.assertNotIn("encoder_attention_mask", unconditional_batch)
+        self.assertNotIn("prompt_embeds", unconditional_batch)
+        self.assertNotIn("attention_mask", unconditional_batch)
+        self.assertNotIn("attention_masks", unconditional_batch)


### PR DESCRIPTION
This pull request improves the handling of unconditional batches in the `AnyFlowDistiller` class and adds tests to ensure correct behavior. The main changes are focused on cleaning up model-specific keys in the batch and verifying this logic with new unit tests.

**Improvements to unconditional batch handling:**

* In `_unconditional_batch` in `distiller.py`, the method now removes the `encoder_attention_mask` and also drops model-specific aliases such as `prompt_embeds`, `attention_mask`, and `attention_masks` from the batch to prevent stale or conflicting conditioning information from being used.

**Test coverage enhancements:**

* Added `AnyFlowUnconditionalBatchTests` in `test_anyflow_distiller.py` to verify that `_unconditional_batch` correctly removes stale masks and model-specific aliases, ensuring the batch is properly sanitized for unconditional processing.