### PR TITLE
Add Gazingstars Anima 2.9B flavour

### DIFF
--- a/simpletuner/helpers/models/anima/model.py
+++ b/simpletuner/helpers/models/anima/model.py
@@ -12,16 +12,11 @@ from simpletuner.helpers.models.common import ImageModelFoundation, ModelTypes, 
 from simpletuner.helpers.models.registry import ModelRegistry
 from simpletuner.helpers.training.crepa import CrepaMode
 
-from .loading import (
-    _QWEN_TOKENIZER_SOURCE,
-    _T5_TOKENIZER_SOURCE,
-    coerce_anima_scheduler,
-    load_prompt_tokenizer,
-    load_text_encoder_single_file,
-    load_vae_single_file,
-    resolve_text_encoder_dtype,
-    resolve_vae_scale_factor,
-)
+from .loading import _QWEN_TOKENIZER_SOURCE, _T5_TOKENIZER_SOURCE, coerce_anima_scheduler, load_prompt_tokenizer
+from .loading import load_text_encoder as load_default_text_encoder
+from .loading import load_text_encoder_single_file
+from .loading import load_vae as load_default_vae
+from .loading import load_vae_single_file, resolve_text_encoder_dtype, resolve_vae_scale_factor
 from .options import AnimaLoaderOptions
 from .pipeline import AnimaPipeline
 from .scheduler import AnimaFlowMatchEulerDiscreteScheduler
@@ -76,7 +71,11 @@ class Anima(ImageModelFoundation):
         "preview": "CalamitousFelicitousness/Anima-sdnext-diffusers",
         "gazingstars123-2.9b": "Gazingstars123/Anima-2.9B",
     }
-    DIFFUSERS_LAYOUT_PATHS = set(HUGGINGFACE_PATHS.values())
+    SINGLE_FILE_HUGGINGFACE_FILENAMES = {
+        "gazingstars123-2.9b": "Anima-2.9B-preview-v1.safetensors",
+    }
+    SINGLE_FILE_LAYOUT_PATHS = {"Gazingstars123/Anima-2.9B"}
+    DIFFUSERS_LAYOUT_PATHS = set(HUGGINGFACE_PATHS.values()) - SINGLE_FILE_LAYOUT_PATHS
     MODEL_LICENSE = "other"
 
     TEXT_ENCODER_CONFIGURATION = {
@@ -260,6 +259,8 @@ class Anima(ImageModelFoundation):
             model_path = getattr(self.config, "pretrained_model_name_or_path", None)
         if isinstance(model_path, str):
             normalized_path = model_path.rstrip("/")
+            if normalized_path in self.SINGLE_FILE_LAYOUT_PATHS:
+                return False
             if normalized_path in self.DIFFUSERS_LAYOUT_PATHS:
                 return True
             model_dir = Path(model_path)
@@ -272,16 +273,74 @@ class Anima(ImageModelFoundation):
         flavour = getattr(self.config, "model_flavour", None)
         return flavour in self.HUGGINGFACE_PATHS and self.HUGGINGFACE_PATHS[flavour] in self.DIFFUSERS_LAYOUT_PATHS
 
+    def _single_file_transformer_filename(self, model_path: Optional[str] = None) -> Optional[str]:
+        if model_path is None:
+            model_path = getattr(self.config, "pretrained_model_name_or_path", None)
+        normalized_path = model_path.rstrip("/") if isinstance(model_path, str) else None
+
+        flavour = getattr(self.config, "model_flavour", None)
+        if flavour in self.SINGLE_FILE_HUGGINGFACE_FILENAMES:
+            flavour_path = self.HUGGINGFACE_PATHS[flavour]
+            if normalized_path in (None, flavour_path):
+                return self.SINGLE_FILE_HUGGINGFACE_FILENAMES[flavour]
+
+        for single_file_flavour, filename in self.SINGLE_FILE_HUGGINGFACE_FILENAMES.items():
+            if normalized_path == self.HUGGINGFACE_PATHS[single_file_flavour]:
+                return filename
+        return None
+
+    def _uses_single_file_repo_layout(self, model_path: Optional[str] = None) -> bool:
+        if model_path is None:
+            model_path = getattr(self.config, "pretrained_model_name_or_path", None)
+        if isinstance(model_path, str) and model_path.rstrip("/") in self.SINGLE_FILE_LAYOUT_PATHS:
+            return True
+        if model_path is not None:
+            return False
+
+        flavour = getattr(self.config, "model_flavour", None)
+        return flavour in self.HUGGINGFACE_PATHS and self.HUGGINGFACE_PATHS[flavour] in self.SINGLE_FILE_LAYOUT_PATHS
+
     def _add_hf_token_kwarg(self, load_kwargs: dict) -> None:
         token = getattr(self.config, "token", None)
         if token not in (None, False):
             load_kwargs["token"] = token
 
-    def load_model(self, move_to_device: bool = True):
-        self.MODEL_SUBFOLDER = (
-            self.DIFFUSERS_MODEL_SUBFOLDER if self._uses_diffusers_repo_layout() else "split_files/diffusion_models"
+    def pretrained_load_args(self, pretrained_load_args: dict) -> dict:
+        args = super().pretrained_load_args(pretrained_load_args)
+        model_path = getattr(self.config, "pretrained_transformer_model_name_or_path", None) or getattr(
+            self.config, "pretrained_model_name_or_path", None
         )
+        filename = self._single_file_transformer_filename(model_path)
+        if filename is not None:
+            args["filename"] = filename
+        return args
+
+    def load_model(self, move_to_device: bool = True):
+        model_path = getattr(self.config, "pretrained_transformer_model_name_or_path", None) or getattr(
+            self.config, "pretrained_model_name_or_path", None
+        )
+        if self._uses_diffusers_repo_layout(model_path):
+            self.MODEL_SUBFOLDER = self.DIFFUSERS_MODEL_SUBFOLDER
+        elif self._uses_single_file_repo_layout(model_path):
+            self.MODEL_SUBFOLDER = None
+        else:
+            self.MODEL_SUBFOLDER = "split_files/diffusion_models"
         return super().load_model(move_to_device=move_to_device)
+
+    def setup_training_noise_schedule(self):
+        if not self._uses_single_file_repo_layout():
+            return super().setup_training_noise_schedule()
+
+        shift = getattr(self.config, "flow_schedule_shift", None)
+        if shift is None:
+            shift = 3.0
+        self.noise_schedule = AnimaFlowMatchEulerDiscreteScheduler(
+            num_train_timesteps=1000,
+            shift=shift,
+            use_dynamic_shifting=False,
+        )
+        self.config.prediction_type = "flow_matching"
+        return self.config, self.noise_schedule
 
     def _prompt_tokenizer_sources(self) -> tuple[str, str]:
         qwen_tokenizer_source = self._get_optional_config_model_path("qwen_text_encoder_model_name_or_path")
@@ -379,6 +438,21 @@ class Anima(ImageModelFoundation):
                 self.load_text_tokenizer()
             return
 
+        if self._uses_single_file_repo_layout(model_path):
+            text_encoder = load_default_text_encoder(
+                device=load_device,
+                dtype=dtype,
+                options=self._loader_options(),
+            )
+            self.text_encoders = [text_encoder]
+            self.text_encoder = text_encoder
+            self.text_encoder_1 = text_encoder
+            if not move_to_device:
+                text_encoder.to("cpu")
+            if getattr(self, "prompt_tokenizer", None) is None:
+                self.load_text_tokenizer()
+            return
+
         weight_path = _resolve_weight_path(
             model_path,
             filename=DEFAULT_ANIMA_TEXT_ENCODER_FILENAME,
@@ -422,6 +496,17 @@ class Anima(ImageModelFoundation):
             self.vae = self.AUTOENCODER_CLASS.from_pretrained(**load_kwargs)
             self.vae.eval().requires_grad_(False)
             self.vae.to(device=load_device, dtype=self.config.weight_dtype)
+            self.AUTOENCODER_SCALING_FACTOR = getattr(self.vae.config, "scaling_factor", 1.0)
+            if not move_to_device:
+                self.vae.to("cpu")
+            return
+
+        if self._uses_single_file_repo_layout(model_path):
+            self.vae = load_default_vae(
+                device=load_device,
+                dtype=self.config.weight_dtype,
+                options=self._loader_options(),
+            )
             self.AUTOENCODER_SCALING_FACTOR = getattr(self.vae.config, "scaling_factor", 1.0)
             if not move_to_device:
                 self.vae.to("cpu")

--- a/simpletuner/helpers/models/anima/transformer.py
+++ b/simpletuner/helpers/models/anima/transformer.py
@@ -735,7 +735,7 @@ class AnimaTransformerModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         state_dict = _strip_net_prefix(state_dict)
         core_state_dict, llm_adapter_state_dict = _convert_anima_state_dict_to_diffusers(state_dict)
 
-        transformer = cls()
+        transformer = cls(**_infer_anima_transformer_kwargs(state_dict))
         missing, unexpected = transformer.load_state_dict(
             {**core_state_dict, **llm_adapter_state_dict},
             strict=False,
@@ -808,6 +808,88 @@ def _strip_net_prefix(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Te
     return dict(state_dict)
 
 
+_ANIMA_SINGLE_FILE_IGNORED_KEYS = {
+    "pos_embedder.dim_spatial_range",
+    "pos_embedder.dim_temporal_range",
+    "pos_embedder.seq",
+}
+
+
+def _block_indices_from_keys(state_dict: dict[str, torch.Tensor], prefix: str) -> set[int]:
+    block_re = re.compile(rf"^{re.escape(prefix)}\.(\d+)\.")
+    return {int(match.group(1)) for key in state_dict if (match := block_re.match(key))}
+
+
+def _infer_contiguous_block_count(state_dict: dict[str, torch.Tensor], prefix: str) -> int:
+    block_indices = _block_indices_from_keys(state_dict, prefix)
+    if not block_indices:
+        raise RuntimeError(f"Anima checkpoint is missing {prefix}.* weights.")
+    expected_indices = set(range(max(block_indices) + 1))
+    if block_indices != expected_indices:
+        missing = sorted(expected_indices - block_indices)
+        raise RuntimeError(f"Anima checkpoint has non-contiguous {prefix} indices; missing: {missing}")
+    return len(block_indices)
+
+
+def _tensor_shape(state_dict: dict[str, torch.Tensor], key: str) -> tuple[int, ...]:
+    if key not in state_dict:
+        raise RuntimeError(f"Anima checkpoint is missing required key: {key}")
+    return tuple(state_dict[key].shape)
+
+
+def _infer_anima_transformer_kwargs(state_dict: dict[str, torch.Tensor]) -> dict[str, Any]:
+    num_layers = _infer_contiguous_block_count(state_dict, "blocks")
+    adapter_layers = _infer_contiguous_block_count(state_dict, "llm_adapter.blocks")
+
+    patch_weight_shape = _tensor_shape(state_dict, "x_embedder.proj.1.weight")
+    hidden_size, patch_input_size = patch_weight_shape
+    final_out_features = _tensor_shape(state_dict, "final_layer.linear.weight")[0]
+    patch_size = (1, 2, 2)
+    patch_volume = patch_size[0] * patch_size[1] * patch_size[2]
+    if patch_input_size % patch_volume != 0:
+        raise RuntimeError(f"Anima patch embed input size {patch_input_size} is not divisible by {patch_volume}.")
+    if final_out_features % patch_volume != 0:
+        raise RuntimeError(f"Anima output projection size {final_out_features} is not divisible by {patch_volume}.")
+
+    concat_padding_mask = True
+    in_channels = patch_input_size // patch_volume - int(concat_padding_mask)
+    out_channels = final_out_features // patch_volume
+    if in_channels <= 0 or out_channels <= 0:
+        raise RuntimeError(
+            f"Anima checkpoint has invalid channel dimensions: in_channels={in_channels}, out_channels={out_channels}."
+        )
+
+    q_norm_size = _tensor_shape(state_dict, "blocks.0.self_attn.q_norm.weight")[0]
+    if hidden_size % q_norm_size != 0:
+        raise RuntimeError(f"Anima hidden size {hidden_size} is not divisible by q_norm size {q_norm_size}.")
+    num_attention_heads = hidden_size // q_norm_size
+
+    mlp_hidden_size = _tensor_shape(state_dict, "blocks.0.mlp.layer1.weight")[0]
+    if mlp_hidden_size % hidden_size != 0:
+        raise RuntimeError(f"Anima MLP hidden size {mlp_hidden_size} is not divisible by hidden size {hidden_size}.")
+
+    adapter_vocab_size, adapter_dim = _tensor_shape(state_dict, "llm_adapter.embed.weight")
+    adapter_q_norm_size = _tensor_shape(state_dict, "llm_adapter.blocks.0.self_attn.q_norm.weight")[0]
+    if adapter_dim % adapter_q_norm_size != 0:
+        raise RuntimeError(f"Anima adapter dim {adapter_dim} is not divisible by adapter q_norm size {adapter_q_norm_size}.")
+
+    return {
+        "in_channels": in_channels,
+        "out_channels": out_channels,
+        "num_attention_heads": num_attention_heads,
+        "attention_head_dim": q_norm_size,
+        "num_layers": num_layers,
+        "mlp_ratio": mlp_hidden_size / hidden_size,
+        "text_embed_dim": _tensor_shape(state_dict, "blocks.0.cross_attn.k_proj.weight")[1],
+        "adaln_lora_dim": _tensor_shape(state_dict, "blocks.0.adaln_modulation_self_attn.1.weight")[0],
+        "patch_size": patch_size,
+        "adapter_vocab_size": adapter_vocab_size,
+        "adapter_dim": adapter_dim,
+        "adapter_layers": adapter_layers,
+        "adapter_heads": adapter_dim // adapter_q_norm_size,
+    }
+
+
 def _convert_anima_state_dict_to_diffusers(
     state_dict: dict[str, torch.Tensor],
 ) -> tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]:
@@ -849,6 +931,9 @@ def _convert_anima_state_dict_to_diffusers(
 
     block_re = re.compile(r"^blocks\.(\d+)\.(.+)$")
     for key, value in state_dict.items():
+        if key in _ANIMA_SINGLE_FILE_IGNORED_KEYS:
+            continue
+
         if key.startswith("llm_adapter."):
             adapter[".".join(["llm_adapter", key.removeprefix("llm_adapter.")])] = value
             continue

--- a/simpletuner/simpletuner_sdk/configuration.py
+++ b/simpletuner/simpletuner_sdk/configuration.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from simpletuner.helpers.logging import get_logger
 
@@ -11,7 +11,6 @@ from fastapi import APIRouter, BackgroundTasks, HTTPException, status
 from pydantic import BaseModel, field_validator
 
 from simpletuner.helpers.configuration.cmd_args import get_default_config
-from simpletuner.helpers.configuration.json_file import normalize_args
 from simpletuner.simpletuner_sdk import thread_keeper
 from simpletuner.simpletuner_sdk.api_state import APIState
 from simpletuner.simpletuner_sdk.server.services.config_store import ConfigStore
@@ -101,8 +100,9 @@ class Configuration:
                 os.remove(file)
 
     def _config_save(self, job_config: ConfigModel):
-        job_config.trainer_config.setdefault("--report_to", "none")
-        job_config.trainer_config.setdefault("report_to", "none")
+        report_to = job_config.trainer_config.get("report_to", job_config.trainer_config.get("--report_to", "none"))
+        job_config.trainer_config["report_to"] = report_to
+        job_config.trainer_config.pop("--report_to", None)
 
         with open("config/multidatabackend.json", mode="w") as file_handler:
             json.dump(job_config.dataloader_config, file_handler, indent=4)
@@ -154,11 +154,24 @@ class Configuration:
         defaults = get_default_config()
         return {f"--{key}": value for key, value in defaults.items() if value not in (None, "")}
 
-    def _build_trainer_cli_args(self, trainer_config: Dict[str, Any]) -> List[str]:
-        base_config = self._load_base_trainer_config()
+    def _normalize_trainer_config_keys(self, trainer_config: Dict[str, Any]) -> Dict[str, Any]:
+        normalized = {}
+        for key, value in (trainer_config or {}).items():
+            if not isinstance(key, str):
+                normalized[key] = value
+                continue
+            normalized_key = key.lstrip("-")
+            if key.startswith("-") and normalized_key in normalized:
+                continue
+            normalized[normalized_key] = value
+        return normalized
+
+    def _build_trainer_config(self, trainer_config: Dict[str, Any]) -> Dict[str, Any]:
+        base_config = self._normalize_trainer_config_keys(self._load_base_trainer_config())
         merged_config = dict(base_config)
-        merged_config.update(trainer_config or {})
-        return normalize_args(merged_config)
+        merged_config.update(self._normalize_trainer_config_keys(trainer_config))
+        merged_config["__skip_config_fallback__"] = True
+        return merged_config
 
     async def check(self, job_config: ConfigModel):
         """
@@ -174,8 +187,8 @@ class Configuration:
             self._config_clear()
             self._config_save(job_config)
             TrainerClass = _import_trainer_class()
-            cli_args = self._build_trainer_cli_args(job_config.trainer_config)
-            trainer = TrainerClass(config=cli_args)
+            trainer_config = self._build_trainer_config(job_config.trainer_config)
+            trainer = TrainerClass(config=trainer_config)
             return {
                 "status": "success",
                 "result": "Configuration validated successfully",
@@ -224,8 +237,8 @@ class Configuration:
         try:
             logger.info("Creating new Trainer instance..")
             TrainerClass = _import_trainer_class()
-            cli_args = self._build_trainer_cli_args(job_config.trainer_config)
-            trainer = TrainerClass(config=cli_args, job_id=job_id)
+            trainer_config = self._build_trainer_config(job_config.trainer_config)
+            trainer = TrainerClass(config=trainer_config, job_id=job_id)
         except Exception as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -282,8 +295,9 @@ class Configuration:
         self._config_save(job_config)
 
         # Prepare config for subprocess
+        trainer_config = self._build_trainer_config(job_config.trainer_config)
         config_dict = {
-            "trainer_config": job_config.trainer_config,
+            "trainer_config": trainer_config,
             "dataloader_config": job_config.dataloader_config,
             "webhook_config": job_config.webhook_config,
             "job_id": job_id,

--- a/tests/test_anima_model.py
+++ b/tests/test_anima_model.py
@@ -17,7 +17,7 @@ class TestAnimaModel(unittest.TestCase):
         self.assertEqual(Anima.NAME, "Anima")
         self.assertEqual(Anima.DEFAULT_MODEL_FLAVOUR, "preview-3")
 
-    def test_model_flavours_use_converted_diffusers_repos(self):
+    def test_model_flavours_use_supported_repo_layouts(self):
         from simpletuner.helpers.models.anima.model import Anima
 
         self.assertEqual(
@@ -44,6 +44,11 @@ class TestAnimaModel(unittest.TestCase):
             Anima.HUGGINGFACE_PATHS["gazingstars123-2.9b"],
             "Gazingstars123/Anima-2.9B",
         )
+        self.assertEqual(
+            Anima.SINGLE_FILE_HUGGINGFACE_FILENAMES["gazingstars123-2.9b"],
+            "Anima-2.9B-preview-v1.safetensors",
+        )
+        self.assertNotIn("Gazingstars123/Anima-2.9B", Anima.DIFFUSERS_LAYOUT_PATHS)
 
     def test_diffusers_layout_switches_component_sources(self):
         from simpletuner.helpers.models.anima.model import Anima
@@ -87,6 +92,95 @@ class TestAnimaModel(unittest.TestCase):
                 "circlestone-labs/Anima-Base-v1.0-Diffusers::t5_tokenizer",
             ),
         )
+
+    def test_gazingstars_flavour_uses_top_level_single_file_transformer(self):
+        from simpletuner.helpers.models.anima.model import Anima
+        from simpletuner.helpers.models.common import ImageModelFoundation
+
+        model = Anima.__new__(Anima)
+        model.config = SimpleNamespace(
+            pretrained_model_name_or_path="Gazingstars123/Anima-2.9B",
+            pretrained_transformer_model_name_or_path=None,
+            model_flavour="gazingstars123-2.9b",
+        )
+
+        self.assertFalse(model._uses_diffusers_repo_layout())
+        self.assertTrue(model._uses_single_file_repo_layout())
+        self.assertEqual(
+            model._single_file_transformer_filename(),
+            "Anima-2.9B-preview-v1.safetensors",
+        )
+        self.assertEqual(
+            model.pretrained_load_args({})["filename"],
+            "Anima-2.9B-preview-v1.safetensors",
+        )
+
+        with patch.object(ImageModelFoundation, "load_model", return_value="loaded") as mock_load_model:
+            self.assertEqual(model.load_model(move_to_device=False), "loaded")
+
+        self.assertIsNone(model.MODEL_SUBFOLDER)
+        mock_load_model.assert_called_once_with(move_to_device=False)
+
+    def test_gazingstars_layout_uses_default_text_encoder_and_vae_sources(self):
+        from simpletuner.helpers.models.anima.model import Anima
+
+        model = Anima.__new__(Anima)
+        model.accelerator = SimpleNamespace(device=torch.device("cpu"))
+        model.config = SimpleNamespace(
+            pretrained_model_name_or_path="Gazingstars123/Anima-2.9B",
+            pretrained_text_encoder_model_name_or_path=None,
+            qwen_text_encoder_model_name_or_path=None,
+            model_flavour="gazingstars123-2.9b",
+            revision=None,
+            text_encoder_revision=None,
+            weight_dtype=torch.float32,
+            local_files_only=True,
+            cache_dir=None,
+            force_download=False,
+            token=False,
+        )
+        model.prompt_tokenizer = object()
+        model.text_encoders = None
+        text_encoder = MagicMock()
+        vae = MagicMock(config=SimpleNamespace(scaling_factor=0.18215))
+
+        with (
+            patch(
+                "simpletuner.helpers.models.anima.model.load_default_text_encoder", return_value=text_encoder
+            ) as mock_text_encoder,
+            patch("simpletuner.helpers.models.anima.model.load_default_vae", return_value=vae) as mock_vae,
+        ):
+            model.load_text_encoder(move_to_device=False)
+            model.load_vae(move_to_device=False)
+
+        mock_text_encoder.assert_called_once()
+        mock_vae.assert_called_once()
+        self.assertIs(model.text_encoder, text_encoder)
+        self.assertIs(model.vae, vae)
+        self.assertEqual(model.AUTOENCODER_SCALING_FACTOR, 0.18215)
+
+    def test_gazingstars_layout_uses_builtin_training_scheduler(self):
+        from simpletuner.helpers.models.anima.model import Anima
+        from simpletuner.helpers.models.anima.scheduler import AnimaFlowMatchEulerDiscreteScheduler
+        from simpletuner.helpers.models.common import ImageModelFoundation
+
+        model = Anima.__new__(Anima)
+        model.config = SimpleNamespace(
+            pretrained_model_name_or_path="Gazingstars123/Anima-2.9B",
+            model_flavour="gazingstars123-2.9b",
+            flow_schedule_shift=2.5,
+            prediction_type=None,
+        )
+
+        with patch.object(ImageModelFoundation, "setup_training_noise_schedule") as mock_base_scheduler:
+            config, scheduler = model.setup_training_noise_schedule()
+
+        mock_base_scheduler.assert_not_called()
+        self.assertIs(config, model.config)
+        self.assertIs(scheduler, model.noise_schedule)
+        self.assertIsInstance(scheduler, AnimaFlowMatchEulerDiscreteScheduler)
+        self.assertEqual(scheduler.config.shift, 2.5)
+        self.assertEqual(model.config.prediction_type, "flow_matching")
 
     def test_diffusers_layout_loads_text_encoder_and_vae_from_standard_subfolders(self):
         from simpletuner.helpers.models.anima.model import Anima
@@ -202,6 +296,52 @@ class TestAnimaModel(unittest.TestCase):
         mock_from_single_file.assert_called_once()
         self.assertEqual(mock_from_single_file.call_args.args[0], "circlestone-labs/Anima")
         self.assertEqual(mock_from_single_file.call_args.kwargs["subfolder"], "transformer")
+
+    def test_single_file_converter_ignores_rope_buffers(self):
+        from simpletuner.helpers.models.anima.transformer import _convert_anima_state_dict_to_diffusers
+
+        state_dict = {
+            "x_embedder.proj.1.weight": torch.empty(2048, 68),
+            "pos_embedder.dim_spatial_range": torch.empty(21),
+            "pos_embedder.dim_temporal_range": torch.empty(22),
+            "pos_embedder.seq": torch.empty(256),
+        }
+
+        core, adapter = _convert_anima_state_dict_to_diffusers(state_dict)
+
+        self.assertEqual(
+            set(core),
+            {"core.patch_embed.proj.weight"},
+        )
+        self.assertEqual(adapter, {})
+
+    def test_single_file_loader_infers_gazingstars_architecture(self):
+        from simpletuner.helpers.models.anima.transformer import _infer_anima_transformer_kwargs
+
+        state_dict = {
+            "x_embedder.proj.1.weight": torch.empty(2048, 68),
+            "final_layer.linear.weight": torch.empty(64, 2048),
+            "blocks.0.self_attn.q_norm.weight": torch.empty(128),
+            "blocks.0.cross_attn.k_proj.weight": torch.empty(2048, 1024),
+            "blocks.0.mlp.layer1.weight": torch.empty(8192, 2048),
+            "blocks.0.adaln_modulation_self_attn.1.weight": torch.empty(256, 2048),
+            "llm_adapter.embed.weight": torch.empty(32128, 1024),
+            "llm_adapter.blocks.0.self_attn.q_norm.weight": torch.empty(64),
+        }
+        for block_index in range(40):
+            state_dict[f"blocks.{block_index}.self_attn.q_proj.weight"] = torch.empty(2048, 2048)
+        for block_index in range(6):
+            state_dict[f"llm_adapter.blocks.{block_index}.self_attn.q_proj.weight"] = torch.empty(1024, 1024)
+
+        kwargs = _infer_anima_transformer_kwargs(state_dict)
+
+        self.assertEqual(kwargs["num_layers"], 40)
+        self.assertEqual(kwargs["adapter_layers"], 6)
+        self.assertEqual(kwargs["in_channels"], 16)
+        self.assertEqual(kwargs["out_channels"], 16)
+        self.assertEqual(kwargs["num_attention_heads"], 16)
+        self.assertEqual(kwargs["attention_head_dim"], 128)
+        self.assertEqual(kwargs["adapter_heads"], 16)
 
     def test_pipeline_load_without_base_model_uses_cached_embed_components_only(self):
         from simpletuner.helpers.models.anima.model import Anima

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -34,6 +34,40 @@ class ConfigurationEndpointTests(AsyncAPITestCase, unittest.IsolatedAsyncioTestC
 
         self.assertEqual(result["status"], "success")
 
+    async def test_configuration_check_passes_merged_dict_without_fallback(self) -> None:
+        config_api = Configuration()
+        job_config = ConfigModel(
+            trainer_config={"model_type": "lora", "model_family": "anima", "report_to": "wandb"},
+            dataloader_config=[],
+            webhook_config={},
+            job_id="test_check_payload",
+        )
+
+        with patch.object(
+            config_api,
+            "_load_base_trainer_config",
+            return_value={
+                "model_family": "flux",
+                "learning_rate": 1e-4,
+                "--report_to": "tensorboard",
+                "--data_backend_config": "stale/multidatabackend.json",
+            },
+        ):
+            with patch("simpletuner.helpers.training.trainer.Trainer") as mock_trainer_cls:
+                mock_trainer_cls.return_value = Mock()
+                result = await config_api.check(job_config)
+
+        self.assertEqual(result["status"], "success")
+        trainer_payload = mock_trainer_cls.call_args.kwargs["config"]
+        self.assertIsInstance(trainer_payload, dict)
+        self.assertEqual(trainer_payload["model_family"], "anima")
+        self.assertEqual(trainer_payload["learning_rate"], 1e-4)
+        self.assertEqual(trainer_payload["report_to"], "wandb")
+        self.assertEqual(trainer_payload["data_backend_config"], "config/multidatabackend.json")
+        self.assertNotIn("--data_backend_config", trainer_payload)
+        self.assertNotIn("--report_to", trainer_payload)
+        self.assertTrue(trainer_payload["__skip_config_fallback__"])
+
     async def test_configuration_run_endpoint_subprocess_mode(self) -> None:
         config_api = Configuration()
         job_config = ConfigModel(
@@ -50,6 +84,47 @@ class ConfigurationEndpointTests(AsyncAPITestCase, unittest.IsolatedAsyncioTestC
 
         self.assertIn("subprocess", result["result"])
         mock_submit.assert_called_once()
+
+    async def test_configuration_run_passes_merged_dict_without_fallback(self) -> None:
+        config_api = Configuration()
+        job_config = ConfigModel(
+            trainer_config={"model_type": "lora", "model_family": "anima", "--report_to": "wandb"},
+            dataloader_config=[],
+            webhook_config={},
+            job_id="test_run_payload",
+        )
+        APIState.clear_state()
+
+        with patch.object(
+            config_api,
+            "_load_base_trainer_config",
+            return_value={
+                "model_family": "flux",
+                "learning_rate": 1e-4,
+                "--report_to": "tensorboard",
+                "--data_backend_config": "stale/multidatabackend.json",
+            },
+        ):
+            with patch("simpletuner.helpers.training.trainer.Trainer") as mock_trainer_cls:
+                trainer = Mock()
+                mock_trainer_cls.return_value = trainer
+                with patch("simpletuner.simpletuner_sdk.thread_keeper.submit_job") as mock_submit:
+                    result = await config_api.run(job_config)
+
+        self.assertEqual(result["status"], "success")
+        trainer_payload = mock_trainer_cls.call_args.kwargs["config"]
+        self.assertIsInstance(trainer_payload, dict)
+        self.assertEqual(trainer_payload["model_family"], "anima")
+        self.assertEqual(trainer_payload["learning_rate"], 1e-4)
+        self.assertEqual(trainer_payload["report_to"], "wandb")
+        self.assertEqual(trainer_payload["data_backend_config"], "config/multidatabackend.json")
+        self.assertNotIn("--data_backend_config", trainer_payload)
+        self.assertNotIn("--report_to", trainer_payload)
+        self.assertTrue(trainer_payload["__skip_config_fallback__"])
+        state_trainer_config = APIState.get_state("current_job")["trainer_config"]
+        self.assertEqual(state_trainer_config["report_to"], "wandb")
+        self.assertNotIn("--report_to", state_trainer_config)
+        mock_submit.assert_called_once_with("test_run_payload", trainer.run)
 
     async def test_concurrent_job_prevention(self) -> None:
         config_api = Configuration()


### PR DESCRIPTION
## Summary
- add Gazingstars123/Anima-2.9B as the gazingstars123-2.9b Anima flavour
- handle the repo as a top-level single-file checkpoint, with default Anima component sources and built-in training scheduler
- fix API trainer config merging so posted jobs are passed as mappings without stale dashed aliases
- infer Anima single-file architecture from checkpoint weights and ignore non-persistent RoPE buffers

## Root Cause
Gazingstars123/Anima-2.9B publishes the transformer as a top-level safetensors file rather than a Diffusers transformer subfolder. The API configuration endpoint was converting merged config to CLI args before handing it to Trainer, which made programmatic loading parse a list and could fall back to stale active config.

## Validation
- `.venv/bin/python -m unittest -v tests.test_api_integration.ConfigurationEndpointTests tests.test_anima_model`
- `git diff --check`
- Local API smoke on localhost:8001 with RareConcepts/Domokun; configuration check passed and a one-step gazingstars123-2.9b LoRA job completed.