### PR TITLE
Fix pipeline runtime conditioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -340,7 +340,7 @@ base_deps = [
     "aiosqlite>=0.19.0",
     "httpx>=0.28.0",
     "psutil>=5.9.0",
-    "webshart>=0.4.6",
+    "webshart>=0.5.2",
 ]
 
 # Nightly CUDA extras contain direct URLs that PyPI rejects, so only include them

--- a/simpletuner/helpers/models/ideogram/pipeline.py
+++ b/simpletuner/helpers/models/ideogram/pipeline.py
@@ -1029,6 +1029,12 @@ class Ideogram4Pipeline(Ideogram4LoraLoaderMixin):
             s_val = float(schedule(step_intervals[i].unsqueeze(0)).item())
             t = torch.full((batch_size,), t_val, dtype=torch.float32, device=self.device)
 
+            # FlowMap-conditioned (AnyFlow) students predict the mean velocity over the
+            # jump [t -> s]; pass the jump destination so the Euler update is the exact jump.
+            flowmap_kwargs = {}
+            if getattr(self.conditional_transformer, "flowmap_deltatime_type", None) is not None:
+                flowmap_kwargs["r_timestep"] = torch.full((batch_size,), s_val, dtype=torch.float32, device=self.device)
+
             pos_z = torch.cat([text_z_padding, z], dim=1)
             pos_out = self.conditional_transformer(
                 llm_features=llm_features,
@@ -1037,6 +1043,7 @@ class Ideogram4Pipeline(Ideogram4LoraLoaderMixin):
                 position_ids=inputs["position_ids"],
                 segment_ids=inputs["segment_ids"],
                 indicator=inputs["indicator"],
+                **flowmap_kwargs,
             )
             pos_v = pos_out[:, max_text_tokens:]
 
@@ -1051,6 +1058,7 @@ class Ideogram4Pipeline(Ideogram4LoraLoaderMixin):
                         position_ids=neg_inputs["position_ids"],
                         segment_ids=neg_inputs["segment_ids"],
                         indicator=neg_inputs["indicator"],
+                        **flowmap_kwargs,
                     )
                     neg_v = neg_out[:, neg_max_text_tokens:]
                 else:

--- a/simpletuner/helpers/models/wan/pipeline.py
+++ b/simpletuner/helpers/models/wan/pipeline.py
@@ -202,6 +202,12 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
 
         return prompt_embeds
 
+    @staticmethod
+    def _repeat_prompt_embeds(prompt_embeds: torch.Tensor, num_videos_per_prompt: int) -> torch.Tensor:
+        batch_size, seq_len, _ = prompt_embeds.shape
+        prompt_embeds = prompt_embeds.repeat(1, num_videos_per_prompt, 1)
+        return prompt_embeds.view(batch_size * num_videos_per_prompt, seq_len, -1)
+
     def encode_prompt(
         self,
         prompt: Union[str, List[str]],
@@ -230,6 +236,8 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 device=device,
                 dtype=dtype,
             )
+        else:
+            prompt_embeds = self._repeat_prompt_embeds(prompt_embeds, num_videos_per_prompt)
 
         if do_classifier_free_guidance and negative_prompt_embeds is None:
             negative_prompt = negative_prompt or ""
@@ -254,6 +262,8 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 device=device,
                 dtype=dtype,
             )
+        elif negative_prompt_embeds is not None:
+            negative_prompt_embeds = self._repeat_prompt_embeds(negative_prompt_embeds, num_videos_per_prompt)
 
         return prompt_embeds, negative_prompt_embeds
 

--- a/tests/test_pipelines/test_wan_pipeline.py
+++ b/tests/test_pipelines/test_wan_pipeline.py
@@ -1,5 +1,26 @@
+import torch
+
 from tests.test_pipelines._common import PipelineTestCase, WanPromptCleaningMixin
 
 
 class TestWanPipeline(WanPromptCleaningMixin, PipelineTestCase):
     module_name = "wan"
+
+    def test_cached_prompt_embeds_repeat_for_each_requested_video(self):
+        pipeline = object.__new__(self.pipeline_module.WanPipeline)
+        prompt_embeds = torch.tensor([[[1.0]], [[2.0]]])
+        negative_prompt_embeds = torch.tensor([[[-1.0]], [[-2.0]]])
+
+        prompt_embeds, negative_prompt_embeds = pipeline.encode_prompt(
+            prompt=None,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            do_classifier_free_guidance=True,
+            num_videos_per_prompt=2,
+            device=torch.device("cpu"),
+        )
+
+        self.assertEqual(prompt_embeds.shape, (4, 1, 1))
+        self.assertEqual(negative_prompt_embeds.shape, (4, 1, 1))
+        self.assertTrue(torch.equal(prompt_embeds[:, 0, 0], torch.tensor([1.0, 1.0, 2.0, 2.0])))
+        self.assertTrue(torch.equal(negative_prompt_embeds[:, 0, 0], torch.tensor([-1.0, -1.0, -2.0, -2.0])))


### PR DESCRIPTION
Summary:
- Bump webshart to 0.5.2 for the runtime helper dependency.
- Pass the FlowMap jump destination as r_timestep during Ideogram AnyFlow pipeline sampling.
- Repeat cached WAN prompt embeds for num_videos_per_prompt, including cached negative prompt embeds for CFG.

Validation:
- .venv/bin/python -m unittest -v tests.test_pipelines.test_wan_pipeline tests.test_ideogram4_prompting
- .venv/bin/python -m isort --check-only setup.py simpletuner/helpers/models/ideogram/pipeline.py simpletuner/helpers/models/wan/pipeline.py tests/test_pipelines/test_wan_pipeline.py
- git diff --check