### PR TITLE
AnyFlow: trainable+persisted FlowMap delta embedders, minimaxmusic validation wrapper coverage

### DIFF
--- a/simpletuner/helpers/distillation/anyflow/distiller.py
+++ b/simpletuner/helpers/distillation/anyflow/distiller.py
@@ -1009,11 +1009,20 @@ class AnyFlowDistiller(DistillationBase):
         logs.update(self._delta_parameter_logs())
         return logs
 
+    _DELTA_PARAMETER_TAGS = (
+        "condition_embedder.delta_embedder",
+        "delta_adaln_embedder",
+        "delta_time_embed",
+        "delta_time_embedder",
+        "delta_timestep_embedder",
+        "delta_t_embedding",
+    )
+
     def _trainable_delta_parameters(self):
         for name, parameter in self._flowmap_component.named_parameters():
             if ".original_module." in name or not parameter.requires_grad:
                 continue
-            if "delta_adaln_embedder" in name or "delta_time_embedder" in name:
+            if any(tag in name for tag in self._DELTA_PARAMETER_TAGS):
                 yield name, parameter
 
     def _delta_parameter_logs(self) -> Dict[str, float]:

--- a/simpletuner/helpers/models/flowmap.py
+++ b/simpletuner/helpers/models/flowmap.py
@@ -5,7 +5,13 @@ import torch
 
 
 def clone_flowmap_embedder(embedder: torch.nn.Module) -> torch.nn.Module:
-    return copy.deepcopy(embedder)
+    # The clone is the FlowMap (t, r) delta embedder — the jump-conditioning parameters the
+    # AnyFlow student trains. The source embedder is frozen base weight, so the deepcopy
+    # inherits requires_grad=False and must be re-enabled or the conditioning can never learn.
+    clone = copy.deepcopy(embedder)
+    for parameter in clone.parameters():
+        parameter.requires_grad_(True)
+    return clone
 
 
 def validate_flowmap_deltatime_type(deltatime_type: str, *, model_name: str) -> str:

--- a/simpletuner/helpers/models/minimaxmusic/model.py
+++ b/simpletuner/helpers/models/minimaxmusic/model.py
@@ -991,10 +991,9 @@ class MiniMaxMusic(AudioModelFoundation):
         r_timestep = prepared_batch.get(self.FLOWMAP_R_TIMESTEP_BATCH_KEY)
         if r_timestep is None:
             return None
-        r_timestep = r_timestep.to(device=timestep.device, dtype=timestep.dtype)
-        if r_timestep.numel() > 0 and torch.max(r_timestep.detach().abs()) > 1.0:
-            r_timestep = (r_timestep / 1000.0).clamp(0.0, 1.0)
-        return r_timestep
+        # The AnyFlow distiller converts r through flow_matching_timesteps_from_sigmas,
+        # so values arrive in the transformer's [0, 1] flow-time domain already.
+        return r_timestep.to(device=timestep.device, dtype=timestep.dtype)
 
     def _select_crepa_hidden_states(self, prepared_batch: dict, hidden_states_buffer):
         if hidden_states_buffer is None:

--- a/simpletuner/helpers/training/adapter.py
+++ b/simpletuner/helpers/training/adapter.py
@@ -7,6 +7,9 @@ import torch
 ANYFLOW_SIDECAR_PREFIXES = (
     "condition_embedder.delta_embedder.",
     "delta_adaln_embedder.",
+    "delta_time_embedder.",
+    "delta_timestep_embedder.",
+    "delta_t_embedding.",
 )
 
 
@@ -35,7 +38,10 @@ def _sidecar_destination(model_state: dict, model_key: str, adapter_name: str):
     module_name, separator, parameter_name = model_key.rpartition(".")
     if not separator:
         return None
-    return model_state.get(f"{module_name}.modules_to_save.{adapter_name}.{parameter_name}")
+    destination = model_state.get(f"{module_name}.modules_to_save.{adapter_name}.{parameter_name}")
+    if destination is not None:
+        return destination
+    return model_state.get(f"{module_name}.base_layer.{parameter_name}")
 
 
 def determine_adapter_target_modules(args, unet, transformer):

--- a/simpletuner/helpers/training/save_hooks.py
+++ b/simpletuner/helpers/training/save_hooks.py
@@ -94,6 +94,44 @@ def merge_safetensors_files(directory, metadata=None):
     logger.info(f"All tensors have been merged and saved into {output_file_path}")
 
 
+def _collect_anyflow_sidecar_state(module) -> dict[str, torch.Tensor]:
+    """FlowMap delta-embedder tensors ride in the LoRA file as sidecar keys.
+
+    PEFT's state dict only covers adapter layers; without this, trained AnyFlow jump
+    conditioning is silently dropped at every save.
+    """
+    from simpletuner.helpers.training.adapter import ANYFLOW_SIDECAR_PREFIXES
+
+    state_dict = getattr(module, "state_dict", None)
+    if not callable(state_dict):
+        return {}
+
+    collected: dict[str, tuple[int, torch.Tensor]] = {}
+    for name, tensor in state_dict().items():
+        if not name.startswith(ANYFLOW_SIDECAR_PREFIXES):
+            continue
+        if ".lora_" in name or ".lora_magnitude_vector" in name or ".original_module." in name:
+            continue
+
+        logical_name = name
+        priority = 1
+        if ".modules_to_save." in name:
+            module_name, wrapped_name = name.split(".modules_to_save.", 1)
+            adapter_name, separator, parameter_name = wrapped_name.partition(".")
+            if not separator:
+                continue
+            logical_name = f"{module_name}.{parameter_name}"
+            priority = 3 if adapter_name == "default" else 2
+        elif ".base_layer." in name:
+            logical_name = name.replace(".base_layer.", ".", 1)
+
+        previous = collected.get(logical_name)
+        if previous is None or priority > previous[0]:
+            collected[logical_name] = (priority, tensor)
+
+    return {name: value for name, (_, value) in collected.items()}
+
+
 def _collect_wrapped_component_classes(accelerator, component):
     classes = set()
     seen = set()
@@ -771,8 +809,10 @@ class SaveHookManager:
             self.ema_model.store(trainable_parameters)
             self.ema_model.copy_to(trainable_parameters)
             ema_trained_component = unwrap_model(self.accelerator, self.model.get_trained_component())
+            ema_peft_state = get_peft_model_state_dict(ema_trained_component)
+            ema_peft_state.update(_collect_anyflow_sidecar_state(ema_trained_component))
             lora_save_parameters = {
-                f"{self.model.MODEL_SUBFOLDER}_lora_layers": get_peft_model_state_dict(ema_trained_component),
+                f"{self.model.MODEL_SUBFOLDER}_lora_layers": ema_peft_state,
             }
             ema_modules_to_save = {self.model.MODEL_SUBFOLDER: ema_trained_component}
             ema_metadata = _collate_lora_metadata(ema_modules_to_save)
@@ -819,9 +859,9 @@ class SaveHookManager:
                 modules_to_save["controlnet"] = unwrapped_model
             elif isinstance(unwrapped_model, tuple(trained_component_classes)):
                 # unet_lora_layers or transformer_lora_layers
-                lora_save_parameters[f"{self.model.MODEL_SUBFOLDER}_lora_layers"] = get_peft_model_state_dict(
-                    unwrapped_model
-                )
+                component_peft_state = get_peft_model_state_dict(unwrapped_model)
+                component_peft_state.update(_collect_anyflow_sidecar_state(unwrapped_model))
+                lora_save_parameters[f"{self.model.MODEL_SUBFOLDER}_lora_layers"] = component_peft_state
                 modules_to_save[self.model.MODEL_SUBFOLDER] = unwrapped_model
             elif text_encoder_0_cls is not None and isinstance(unwrapped_model, text_encoder_0_cls):
                 lora_save_parameters["text_encoder_lora_layers"] = convert_state_dict_to_diffusers(

--- a/tests/helpers/distillation/test_anyflow_distiller.py
+++ b/tests/helpers/distillation/test_anyflow_distiller.py
@@ -6,6 +6,9 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import torch
+from peft import LoraConfig, inject_adapter_in_model
+from peft.utils import get_peft_model_state_dict
+from safetensors.torch import save_file
 
 import tests.test_stubs  # noqa: F401
 from simpletuner.helpers.distillation.anyflow.distiller import AnyFlowDistiller
@@ -1082,3 +1085,72 @@ class AnyFlowUnconditionalBatchTests(unittest.TestCase):
         self.assertNotIn("prompt_embeds", unconditional_batch)
         self.assertNotIn("attention_mask", unconditional_batch)
         self.assertNotIn("attention_masks", unconditional_batch)
+
+
+class AnyFlowDeltaEmbedderTests(unittest.TestCase):
+    def test_clone_flowmap_embedder_is_trainable(self):
+        from simpletuner.helpers.models.flowmap import clone_flowmap_embedder
+
+        frozen = torch.nn.Linear(4, 4)
+        frozen.requires_grad_(False)
+        clone = clone_flowmap_embedder(frozen)
+
+        self.assertTrue(all(p.requires_grad for p in clone.parameters()))
+        self.assertFalse(any(p.requires_grad for p in frozen.parameters()))
+
+    def test_sidecar_prefixes_cover_all_family_namings(self):
+        from simpletuner.helpers.training.adapter import ANYFLOW_SIDECAR_PREFIXES
+
+        for naming in (
+            "condition_embedder.delta_embedder.linear_1.weight",
+            "delta_adaln_embedder.table",
+            "delta_time_embedder.linear_1.weight",
+            "delta_timestep_embedder.linear_1.weight",
+            "delta_t_embedding.mlp_in.weight",
+        ):
+            with self.subTest(naming=naming):
+                self.assertTrue(naming.startswith(ANYFLOW_SIDECAR_PREFIXES))
+
+    def test_collect_anyflow_sidecar_state(self):
+        from simpletuner.helpers.training.save_hooks import _collect_anyflow_sidecar_state
+
+        class Toy(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.delta_t_embedding = torch.nn.Linear(2, 2)
+                self.other = torch.nn.Linear(2, 2)
+
+        collected = _collect_anyflow_sidecar_state(Toy())
+        self.assertEqual(
+            sorted(collected),
+            ["delta_t_embedding.bias", "delta_t_embedding.weight"],
+        )
+
+    def test_collect_anyflow_sidecar_state_excludes_peft_adapter_aliases(self):
+        from simpletuner.helpers.training.save_hooks import _collect_anyflow_sidecar_state
+
+        class Toy(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.delta_t_embedding = torch.nn.Module()
+                self.delta_t_embedding.linear_1 = torch.nn.Linear(2, 2)
+
+        model = Toy().requires_grad_(False)
+        model = inject_adapter_in_model(
+            LoraConfig(r=1, lora_alpha=1, target_modules=["delta_t_embedding.linear_1"]),
+            model,
+        )
+        state = get_peft_model_state_dict(model)
+        state.update(_collect_anyflow_sidecar_state(model))
+
+        self.assertEqual(
+            sorted(name for name in state if "delta_t_embedding" in name),
+            [
+                "delta_t_embedding.linear_1.bias",
+                "delta_t_embedding.linear_1.lora_A.weight",
+                "delta_t_embedding.linear_1.lora_B.weight",
+                "delta_t_embedding.linear_1.weight",
+            ],
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            save_file(state, str(Path(temp_dir) / "adapter.safetensors"))

--- a/tests/test_minimaxmusic_model.py
+++ b/tests/test_minimaxmusic_model.py
@@ -764,5 +764,50 @@ class MiniMaxMusicModelTests(unittest.TestCase):
         self.assertNotIn("diffusion_transformer.transformer.layers.0.self_attn.to_qkv.lora_A.weight", loaded)
 
 
+class MiniMaxMusicAnyFlowValidationWrapperTests(unittest.TestCase):
+    def test_install_pipeline_hooks_wraps_transformer_and_injects_r(self):
+        import numpy as np
+        from diffusers import FlowMatchEulerDiscreteScheduler
+
+        from simpletuner.helpers.distillation.anyflow.scheduler import AnyFlowValidationScheduler
+        from simpletuner.helpers.models.minimaxmusic.modular_blocks import MiniMaxMusic3Blocks
+
+        pipeline = MiniMaxMusic3ModularPipeline(MiniMaxMusic3Blocks())
+        transformer = _tiny_transformer()
+        transformer.enable_flowmap_time_conditioning(gate_value=0.25, deltatime_type="r")
+        scheduler = FlowMatchEulerDiscreteScheduler(num_train_timesteps=1, invert_sigmas=True)
+        pipeline.update_components(transformer=transformer, scheduler=scheduler)
+
+        validation_scheduler = AnyFlowValidationScheduler(scheduler, num_train_timesteps=1)
+        validation_scheduler.install_pipeline_hooks(pipeline, component_names=("transformer",))
+
+        # The denoise blocks resolve the component exactly like this attribute access,
+        # so a registry-backed pipeline must expose the wrapper here, not the raw module.
+        wrapped = pipeline.transformer
+        self.assertTrue(getattr(wrapped, "_anyflow_validation_wrapper", False))
+
+        received = {}
+
+        def capture_forward(*args, **kwargs):
+            received.update(kwargs)
+            return (torch.zeros(1, 4, 6),)
+
+        transformer.forward = capture_forward
+
+        sigmas = np.linspace(1.0, 0.25, 4)
+        scheduler.set_timesteps(sigmas=sigmas, device="cpu")
+        wrapped(
+            hidden_states=torch.zeros(1, 4, 6),
+            timestep=scheduler.timesteps[0].expand(1),
+            encoder_hidden_states=torch.zeros(1, 6, 8),
+            return_dict=False,
+        )
+
+        r_timestep = received.get("r_timestep")
+        self.assertIsNotNone(r_timestep)
+        self.assertTrue(torch.all(r_timestep >= received["timestep"]))
+        self.assertTrue(torch.all(r_timestep <= 1.0))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Lands the AnyFlow delta-embedder fix chain plus fixes from a review of the minimaxmusic AnyFlow implementation.

### Delta embedders were frozen and unsaved for every family

`clone_flowmap_embedder` deepcopied the frozen base time embedder, so the FlowMap (t, r) delta embedder inherited `requires_grad=False` — jump conditioning only ever trained through shared-LoRA leakage. On top of that, LoRA saves dropped the delta tensors entirely: PEFT state dicts do not cover non-adapter modules and no save-side sidecar existed (`ANYFLOW_SIDECAR_PREFIXES` was load-only and covered 2 of 5 family namings). Symptom in practice: consistency-branch (full-jump) loss plateaus while the small-jump branch trains, and few-step renders stay wiry/fragmented.

- `clone_flowmap_embedder` re-enables gradients on the clone
- `ANYFLOW_SIDECAR_PREFIXES` extended to all five namings (`delta_time_embedder`, `delta_timestep_embedder`, `delta_t_embedding` added), with a `base_layer` fallback when resolving sidecar destinations
- save hooks merge delta-embedder tensors into both the main and EMA LoRA state dicts via `_collect_anyflow_sidecar_state`
- distiller delta drift telemetry (`anyflow_delta_weight_norm` / `anyflow_delta_drift`) now matches every family naming, including minimaxmusic's `delta_time_embed` — previously silently empty for that family

### minimaxmusic review fixes

- new test drives `install_pipeline_hooks` against the real `MiniMaxMusic3ModularPipeline` and asserts the wrapped transformer is what the denoise blocks resolve, with `r_timestep` injected — covering the silent-failure mode where a registry property would shadow the setattr and validation would sample without jump conditioning
- dropped the magnitude-conditional `/1000` rescale in `_flowmap_r_for_transformer`: the distiller always converts r through `flow_matching_timesteps_from_sigmas`, so values arrive in the [0, 1] flow-time domain already

Notes from the review that needed no change: minimaxmusic LoRA-targets the delta clone with a post-adapter trainability assertion (so LoRA runs never hit the frozen-clone bug), and its `flow_matching_timesteps_from_sigmas` override keeps t and r in the same 1−σ domain.

## Testing

`.venv/bin/python -m unittest tests.test_minimaxmusic_model tests.helpers.distillation.test_anyflow_distiller tests.test_lora_metadata -v -f` — 113 tests, all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)