### PR TITLE
Add real Ideogram 4 unconditional transformer support

### DIFF
--- a/documentation/quickstart/IDEOGRAM4.es.md
+++ b/documentation/quickstart/IDEOGRAM4.es.md
@@ -129,7 +129,20 @@ La validación de Ideogram está desactivada hasta que la habilites:
 }
 ```
 
-Este flag es temporal. La ruta CFG upstream de Ideogram espera un transformer unconditional separado, mientras que SimpleTuner actualmente entrena solo el transformer conditional por defecto. Con el flag activo, la validación usa el transformer conditional también para el negative/unconditional pass, así que todavía puedes revisar prompts y negative prompts.
+La ruta CFG upstream de Ideogram espera un transformer unconditional separado que solo procesa imagen. Con `ideogram_validation=true` a solas, la validación aproxima el unconditional pass pasando los negative-prompt embeds por el transformer conditional, así que todavía puedes revisar prompts y negative prompts.
+
+Para ejecutar CFG asimétrico real en lugar del proxy, carga el transformer unconditional separado:
+
+```json
+{
+  "ideogram_validation": true,
+  "ideogram_load_unconditional_transformer": true
+}
+```
+
+Esto carga el transformer unconditional congelado (solo imagen) de Ideogram 4 junto al conditional. La validación ejecuta entonces el unconditional pass real con conditioning de texto en ceros, y la destilación AnyFlow calcula sus targets de fused guidance contra la rama unconditional real en lugar del proxy con negative prompts. Reserva unos 10 GiB extra de VRAM para el checkpoint FP8, o unos 18 GiB cuando `ideogram_fp8_base_upcast=true` lo decuantiza a bf16.
+
+Si no cabe, activa `ideogram_uncond_ramtorch=true` para mantener el transformer unconditional en RAM de CPU vía RamTorch y transmitir sus capas al acelerador en cada forward pass, sacrificando velocidad de generación por VRAM.
 
 ## Formato de captions
 

--- a/documentation/quickstart/IDEOGRAM4.hi.md
+++ b/documentation/quickstart/IDEOGRAM4.hi.md
@@ -129,7 +129,20 @@ Ideogram validation opt-in है:
 }
 ```
 
-यह temporary flag है। Ideogram का upstream CFG inference path अलग unconditional transformer expect करता है, जबकि SimpleTuner अभी default रूप से सिर्फ conditional transformer train करता है। इस flag के साथ validation conditional transformer को negative/unconditional pass के लिए भी use करता है, ताकि prompts और negative prompts जांचे जा सकें।
+Ideogram का upstream CFG inference path एक अलग, केवल image वाला unconditional transformer expect करता है। सिर्फ `ideogram_validation=true` के साथ validation negative-prompt embeds को conditional transformer से गुजारकर unconditional pass का approximation करता है, ताकि prompts और negative prompts जांचे जा सकें।
+
+Proxy की जगह असली asymmetric CFG चलाने के लिए अलग unconditional transformer load करें:
+
+```json
+{
+  "ideogram_validation": true,
+  "ideogram_load_unconditional_transformer": true
+}
+```
+
+यह Ideogram 4 का frozen, केवल image वाला unconditional transformer conditional के साथ load करता है। Validation फिर zeroed text conditioning के साथ असली unconditional pass चलाता है, और AnyFlow distillation अपने fused guidance targets negative-prompt proxy की बजाय असली unconditional branch के खिलाफ compute करता है। FP8 checkpoint के लिए लगभग 10 GiB extra VRAM रखें, या `ideogram_fp8_base_upcast=true` से bf16 में dequantize करने पर लगभग 18 GiB।
+
+अगर VRAM कम पड़े तो `ideogram_uncond_ramtorch=true` सेट करें: unconditional transformer RamTorch के जरिए CPU RAM में रहता है और हर forward pass पर layers accelerator को stream होती हैं (generation speed की कीमत पर VRAM बचत)।
 
 ## Caption format
 

--- a/documentation/quickstart/IDEOGRAM4.ja.md
+++ b/documentation/quickstart/IDEOGRAM4.ja.md
@@ -129,7 +129,20 @@ Ideogram の検証は明示的に有効化するまで無効です:
 }
 ```
 
-これは一時的なフラグです。上流の Ideogram CFG 推論は別の unconditional transformer を想定していますが、SimpleTuner は現在デフォルトで conditional transformer のみを学習します。有効化すると、検証では conditional transformer を negative/unconditional pass にも使うため、プロンプトと negative prompt の挙動を確認できます。
+上流の Ideogram CFG 推論は、画像のみを処理する別の unconditional transformer を想定しています。`ideogram_validation=true` のみの場合、検証は negative prompt の embeds を conditional transformer に通して unconditional pass を近似するため、プロンプトと negative prompt の挙動を確認できます。
+
+プロキシではなく本物の非対称 CFG を実行するには、別の unconditional transformer を読み込みます:
+
+```json
+{
+  "ideogram_validation": true,
+  "ideogram_load_unconditional_transformer": true
+}
+```
+
+これは Ideogram 4 の凍結された画像専用 unconditional transformer を conditional と並行して読み込みます。検証はテキスト conditioning をゼロにした本物の unconditional pass を実行し、AnyFlow 蒸留は fused guidance のターゲットを negative prompt によるプロキシではなく本物の unconditional ブランチに対して計算します。FP8 チェックポイントでは約 10 GiB、`ideogram_fp8_base_upcast=true` で bf16 に逆量子化する場合は約 18 GiB の追加 VRAM を見込んでください。
+
+VRAM が足りない場合は `ideogram_uncond_ramtorch=true` を設定すると、unconditional transformer を RamTorch 経由で CPU RAM に保持し、forward pass ごとにレイヤーをアクセラレータへストリーミングします（生成速度と引き換えに VRAM を節約）。
 
 ## Caption 形式
 

--- a/documentation/quickstart/IDEOGRAM4.md
+++ b/documentation/quickstart/IDEOGRAM4.md
@@ -192,7 +192,20 @@ Ideogram validation is disabled unless you opt in:
 }
 ```
 
-This is temporary. Ideogram's upstream inference path expects an unconditional transformer for CFG, while SimpleTuner currently trains only the conditional transformer by default. With `ideogram_validation=true`, validation uses the conditional transformer for the negative/unconditional pass so you can still check prompt and negative-prompt behaviour.
+Ideogram's upstream inference path expects a separate image-only unconditional transformer for CFG. With `ideogram_validation=true` alone, validation approximates the unconditional pass by feeding negative-prompt embeds through the conditional transformer so you can still check prompt and negative-prompt behaviour.
+
+To run real asymmetric CFG instead of the proxy, load the separate unconditional transformer:
+
+```json
+{
+  "ideogram_validation": true,
+  "ideogram_load_unconditional_transformer": true
+}
+```
+
+This loads Ideogram 4's frozen image-only unconditional transformer alongside the conditional one. Validation then runs the real unconditional pass with zeroed text conditioning, and AnyFlow distillation computes its fused-guidance targets against the real unconditional branch instead of the negative-prompt proxy. Budget roughly 10 GiB extra VRAM for the FP8 checkpoint, or about 18 GiB when `ideogram_fp8_base_upcast=true` dequantizes it to bf16.
+
+If that does not fit, set `ideogram_uncond_ramtorch=true` to hold the unconditional transformer in CPU RAM via RamTorch and stream its layers to the accelerator per forward pass, trading generation speed for VRAM.
 
 Use JSON-style validation prompts whenever possible. Short natural-language prompts can trigger Ideogram's built-in filtering or weak prompt behaviour, while structured prompts are more reliable.
 

--- a/documentation/quickstart/IDEOGRAM4.pt-BR.md
+++ b/documentation/quickstart/IDEOGRAM4.pt-BR.md
@@ -129,7 +129,20 @@ A validação do Ideogram fica desativada até você optar por ela:
 }
 ```
 
-Este é um flag temporário. O caminho upstream de inferência CFG do Ideogram espera um transformer unconditional separado, enquanto o SimpleTuner atualmente treina apenas o transformer conditional por padrão. Com o flag ativo, a validação usa o transformer conditional também para o negative/unconditional pass, permitindo verificar prompts e negative prompts.
+O caminho upstream de inferência CFG do Ideogram espera um transformer unconditional separado que processa apenas imagem. Com `ideogram_validation=true` sozinho, a validação aproxima o unconditional pass passando os negative-prompt embeds pelo transformer conditional, permitindo verificar prompts e negative prompts.
+
+Para executar CFG assimétrico real em vez do proxy, carregue o transformer unconditional separado:
+
+```json
+{
+  "ideogram_validation": true,
+  "ideogram_load_unconditional_transformer": true
+}
+```
+
+Isso carrega o transformer unconditional congelado (apenas imagem) do Ideogram 4 ao lado do conditional. A validação passa a executar o unconditional pass real com conditioning de texto zerado, e a destilação AnyFlow calcula seus targets de fused guidance contra o branch unconditional real em vez do proxy com negative prompts. Reserve cerca de 10 GiB extras de VRAM para o checkpoint FP8, ou cerca de 18 GiB quando `ideogram_fp8_base_upcast=true` desquantiza para bf16.
+
+Se não couber, defina `ideogram_uncond_ramtorch=true` para manter o transformer unconditional na RAM da CPU via RamTorch e transmitir suas camadas ao acelerador a cada forward pass, trocando velocidade de geração por VRAM.
 
 ## Formato das captions
 

--- a/documentation/quickstart/IDEOGRAM4.zh.md
+++ b/documentation/quickstart/IDEOGRAM4.zh.md
@@ -129,7 +129,20 @@ Ideogram 验证默认关闭。要启用：
 }
 ```
 
-这是一个临时开关。上游 Ideogram CFG 推理路径预期有单独的 unconditional transformer；SimpleTuner 当前默认只训练 conditional transformer。启用后，验证会用 conditional transformer 做 negative/unconditional pass，因此仍可检查提示词和 negative prompt 的效果。
+上游 Ideogram CFG 推理路径预期有单独的、只处理图像的 unconditional transformer。仅启用 `ideogram_validation=true` 时，验证会把 negative prompt 的 embeds 送入 conditional transformer 来近似 unconditional pass，因此仍可检查提示词和 negative prompt 的效果。
+
+要运行真正的非对称 CFG 而不是这个代理路径，请加载单独的 unconditional transformer：
+
+```json
+{
+  "ideogram_validation": true,
+  "ideogram_load_unconditional_transformer": true
+}
+```
+
+这会在 conditional transformer 之外加载 Ideogram 4 冻结的、只处理图像的 unconditional transformer。验证随后会以清零的文本 conditioning 运行真正的 unconditional pass，AnyFlow 蒸馏的 fused guidance 目标也会基于真正的 unconditional 分支计算，而不是 negative prompt 代理。FP8 checkpoint 约需额外 10 GiB 显存；配合 `ideogram_fp8_base_upcast=true` 反量化为 bf16 时约需 18 GiB。
+
+如果显存不够，设置 `ideogram_uncond_ramtorch=true` 可以通过 RamTorch 把 unconditional transformer 保存在 CPU 内存中，每次 forward pass 将其层流式传输到加速器，以生成速度换取显存。
 
 ## Caption 格式
 

--- a/simpletuner/helpers/distillation/anyflow/distiller.py
+++ b/simpletuner/helpers/distillation/anyflow/distiller.py
@@ -954,6 +954,8 @@ class AnyFlowDistiller(DistillationBase):
         # generic keys; drop them so the swapped unconditional embeds/mask take effect.
         for alias in ("prompt_embeds", "attention_mask", "attention_masks"):
             batch.pop(alias, None)
+        # Lets families with a dedicated unconditional model (e.g. Ideogram) dispatch to it.
+        batch["is_unconditional_pass"] = True
         return batch
 
     def _slice_batch(self, prepared_batch: Dict[str, Any], requested_batch_size: int) -> Dict[str, Any]:

--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -3911,6 +3911,7 @@ class ModelFoundation(ABC):
         target_patterns: Optional[list[str]] = None,
         full_ramtorch: bool = False,
         percent: Optional[float] = None,
+        force: bool = False,
     ) -> int:
         """
         Apply RamTorch to a module's layers.
@@ -3922,8 +3923,10 @@ class ModelFoundation(ABC):
             full_ramtorch: If True, convert all supported layer types (Linear, Embedding,
                           Conv, LayerNorm) to bouncing versions. If False, only Linear.
             percent: Optional percentage (0-100) of eligible Linear layers to replace.
+            force: Apply even when --ramtorch is not globally enabled (e.g. component-level
+                   offload flags such as --ideogram_uncond_ramtorch).
         """
-        if module is None or not self._ramtorch_enabled():
+        if module is None or not (force or self._ramtorch_enabled()):
             return 0
 
         # Check if extensions are disabled via --ramtorch_disable_extensions

--- a/simpletuner/helpers/models/field_registry/ideogram.py
+++ b/simpletuner/helpers/models/field_registry/ideogram.py
@@ -132,3 +132,39 @@ def register_fields(registry) -> None:
             order=39,
         )
     )
+
+    registry._add_field(
+        ConfigField(
+            name="ideogram_load_unconditional_transformer",
+            arg_name="--ideogram_load_unconditional_transformer",
+            ui_label="Ideogram Unconditional Transformer",
+            field_type=FieldType.CHECKBOX,
+            tab="model",
+            section="model_specific",
+            model_specific=["ideogram"],
+            default_value=False,
+            help_text="Load Ideogram 4's frozen image-only unconditional transformer for real asymmetric CFG during validation and distillation.",
+            tooltip="Costs ~10 GiB extra VRAM for the FP8 checkpoint, or ~18 GiB with --ideogram_fp8_base_upcast. The unconditional transformer is never trained or adapter-wrapped.",
+            importance=ImportanceLevel.ADVANCED,
+            dependencies=[FieldDependency(field="model_family", operator="equals", value="ideogram")],
+            order=40,
+        )
+    )
+
+    registry._add_field(
+        ConfigField(
+            name="ideogram_uncond_ramtorch",
+            arg_name="--ideogram_uncond_ramtorch",
+            ui_label="Ideogram Unconditional RamTorch",
+            field_type=FieldType.CHECKBOX,
+            tab="model",
+            section="model_specific",
+            model_specific=["ideogram"],
+            default_value=False,
+            help_text="Hold the Ideogram 4 unconditional transformer in CPU RAM via RamTorch instead of fully on-GPU.",
+            tooltip="Requires --ideogram_load_unconditional_transformer. Layers stream to the accelerator per forward pass, trading speed for VRAM.",
+            importance=ImportanceLevel.ADVANCED,
+            dependencies=[FieldDependency(field="model_family", operator="equals", value="ideogram")],
+            order=41,
+        )
+    )

--- a/simpletuner/helpers/models/ideogram/model.py
+++ b/simpletuner/helpers/models/ideogram/model.py
@@ -105,7 +105,42 @@ class Ideogram4(ImageModelFoundation):
             self.model.to(self.accelerator.device)
         self.apply_gradient_checkpointing_settings()
         self.apply_model_specific_freeze()
+        self.unconditional_transformer = None
+        if getattr(self.config, "ideogram_load_unconditional_transformer", False):
+            self.load_unconditional_transformer()
         return self.model
+
+    def load_unconditional_transformer(self):
+        """Load Ideogram 4's frozen image-only unconditional transformer for asymmetric CFG."""
+        repo_id = self._repo_id()
+        pipe_config = Ideogram4PipelineConfig(weights_repo=repo_id)
+        state_dict = _load_indexed_or_single_state_dict(repo_id, pipe_config.unconditional_index_filename)
+        base_precision = getattr(self.config, "base_model_precision", None) or "no_change"
+        quantization_requested = base_precision != "no_change"
+        if is_fp8_state_dict(state_dict) and (
+            getattr(self.config, "ideogram_fp8_base_upcast", False) or quantization_requested
+        ):
+            state_dict = dequantize_fp8_state_dict(state_dict, self.config.weight_dtype)
+        use_ramtorch = bool(getattr(self.config, "ideogram_uncond_ramtorch", False))
+        device = torch.device("cpu") if use_ramtorch else self.accelerator.device
+        transformer = _build_transformer(
+            Ideogram4Config(),
+            state_dict,
+            device,
+            self.config.weight_dtype,
+        )
+        transformer.requires_grad_(False)
+        transformer.eval()
+        if use_ramtorch:
+            self._apply_ramtorch_layers(
+                transformer,
+                "ideogram_unconditional_transformer",
+                percent=self._ramtorch_transformer_percent(),
+                full_ramtorch=True,
+                force=True,
+            )
+        self.unconditional_transformer = transformer
+        return transformer
 
     def load_vae(self, move_to_device: bool = True):
         repo_id = getattr(self.config, "pretrained_model_name_or_path", None) or self.HUGGINGFACE_PATHS["fp8"]
@@ -160,7 +195,7 @@ class Ideogram4(ImageModelFoundation):
         transformer = self.unwrap_model(self.model, keep_fp32_wrapper=False)
         pipeline = Ideogram4Pipeline(
             conditional_transformer=transformer,
-            unconditional_transformer=None,
+            unconditional_transformer=getattr(self, "unconditional_transformer", None),
             text_encoder=self.text_encoders[0],
             text_tokenizer=self.tokenizers[0],
             autoencoder=self.vae,
@@ -268,7 +303,7 @@ class Ideogram4(ImageModelFoundation):
             self._logged_text_encoder_devices = True
         encoder_shell = Ideogram4Pipeline(
             conditional_transformer=None,
-            unconditional_transformer=None,
+            unconditional_transformer=getattr(self, "unconditional_transformer", None),
             text_encoder=self.text_encoders[0],
             text_tokenizer=tokenizer,
             autoencoder=None,
@@ -597,6 +632,48 @@ class Ideogram4(ImageModelFoundation):
         )
         return flowmap_batch
 
+    def _use_unconditional_transformer(self, prepared_batch: dict) -> bool:
+        return (
+            bool(prepared_batch.get("is_unconditional_pass"))
+            and getattr(self, "unconditional_transformer", None) is not None
+        )
+
+    def _unconditional_model_predict(
+        self,
+        prepared_batch: dict,
+        packed_latents: torch.Tensor,
+        prompt_embeds: torch.Tensor,
+        latent_height: int,
+        latent_width: int,
+    ) -> dict:
+        # Mirrors the pipeline's asymmetric-CFG branch: image tokens only (no text
+        # padding), zeroed llm conditioning, and no flowmap kwargs (the unconditional
+        # transformer is never adapter-trained).
+        batch_size, image_tokens, _channels = packed_latents.shape
+        position_ids = self._image_position_ids(batch_size, latent_height, latent_width)
+        segment_ids = torch.ones(batch_size, image_tokens, dtype=torch.long, device=self.accelerator.device)
+        indicator = torch.full(
+            (batch_size, image_tokens), OUTPUT_IMAGE_INDICATOR, dtype=torch.long, device=self.accelerator.device
+        )
+        llm_features = torch.zeros(
+            batch_size,
+            image_tokens,
+            prompt_embeds.shape[-1],
+            dtype=prompt_embeds.dtype,
+            device=self.accelerator.device,
+        )
+        timesteps = self._prepare_model_predict_timesteps(prepared_batch["timesteps"], batch_size=batch_size)
+        model_output = self.unconditional_transformer(
+            llm_features=llm_features,
+            x=packed_latents,
+            t=timesteps,
+            position_ids=position_ids,
+            segment_ids=segment_ids,
+            indicator=indicator,
+        )
+        model_prediction = self._unpack_latents(model_output, latent_height, latent_width)
+        return {"model_prediction": self.raw_model_prediction_to_model_prediction(model_prediction)}
+
     def model_predict(self, prepared_batch):
         noisy_latents = prepared_batch["noisy_latents"].to(device=self.accelerator.device, dtype=self.config.weight_dtype)
         batch_size, _channels, latent_height, latent_width = noisy_latents.shape
@@ -607,6 +684,14 @@ class Ideogram4(ImageModelFoundation):
         if prompt_embeds is None:
             prompt_embeds = prepared_batch["encoder_hidden_states"]
         prompt_embeds = prompt_embeds.to(device=self.accelerator.device, dtype=torch.float32)
+        if self._use_unconditional_transformer(prepared_batch):
+            return self._unconditional_model_predict(
+                prepared_batch,
+                packed_latents,
+                prompt_embeds,
+                latent_height,
+                latent_width,
+            )
         attention_mask = prepared_batch.get("encoder_attention_mask")
         if attention_mask is None:
             attention_mask = prepared_batch.get("attention_mask")
@@ -712,6 +797,10 @@ class Ideogram4(ImageModelFoundation):
     def check_user_config(self):
         super().check_user_config()
         self.config.prediction_type = "flow_matching"
+        if getattr(self.config, "ideogram_uncond_ramtorch", False) and not getattr(
+            self.config, "ideogram_load_unconditional_transformer", False
+        ):
+            raise ValueError("--ideogram_uncond_ramtorch requires --ideogram_load_unconditional_transformer.")
 
     def log_model_devices(self):
         super().log_model_devices()

--- a/tests/helpers/distillation/test_anyflow_distiller.py
+++ b/tests/helpers/distillation/test_anyflow_distiller.py
@@ -1086,6 +1086,14 @@ class AnyFlowUnconditionalBatchTests(unittest.TestCase):
         self.assertNotIn("attention_mask", unconditional_batch)
         self.assertNotIn("attention_masks", unconditional_batch)
 
+    def test_unconditional_batch_marks_unconditional_pass(self):
+        batch = _prepared_batch()
+
+        unconditional_batch = AnyFlowDistiller._unconditional_batch(batch)
+
+        self.assertTrue(unconditional_batch["is_unconditional_pass"])
+        self.assertNotIn("is_unconditional_pass", batch)
+
 
 class AnyFlowDeltaEmbedderTests(unittest.TestCase):
     def test_clone_flowmap_embedder_is_trainable(self):

--- a/tests/test_ideogram_fp8_linear.py
+++ b/tests/test_ideogram_fp8_linear.py
@@ -213,6 +213,8 @@ class IdeogramFp8BaseUpcastTests(unittest.TestCase):
         model.config.pretrained_transformer_model_name_or_path = None
         model.config.pretrained_model_name_or_path = "ideogram-ai/ideogram-4-fp8"
         model.config.ideogram_fp8_base_upcast = upcast
+        model.config.ideogram_load_unconditional_transformer = False
+        model.config.ideogram_uncond_ramtorch = False
         model.config.base_model_precision = base_model_precision
         model.config.weight_dtype = torch.bfloat16
         model.accelerator = mock.Mock()

--- a/tests/test_ideogram_unconditional.py
+++ b/tests/test_ideogram_unconditional.py
@@ -1,0 +1,200 @@
+import unittest
+from unittest import mock
+
+import torch
+
+from simpletuner.helpers.models.ideogram.constants import OUTPUT_IMAGE_INDICATOR
+from simpletuner.helpers.models.ideogram.quantized_loading import is_fp8_state_dict, quantize_weight_to_fp8
+
+CONDITIONAL_INDEX = "transformer/diffusion_pytorch_model.safetensors.index.json"
+UNCONDITIONAL_INDEX = "unconditional_transformer/diffusion_pytorch_model.safetensors.index.json"
+
+
+def _make_model(
+    load_unconditional: bool = False,
+    uncond_ramtorch: bool = False,
+    upcast: bool = False,
+    base_model_precision: str = "no_change",
+):
+    from simpletuner.helpers.models.ideogram.model import Ideogram4
+
+    model = Ideogram4.__new__(Ideogram4)
+    model.config = mock.Mock()
+    model.config.pretrained_transformer_model_name_or_path = None
+    model.config.pretrained_model_name_or_path = "ideogram-ai/ideogram-4-fp8"
+    model.config.ideogram_fp8_base_upcast = upcast
+    model.config.ideogram_load_unconditional_transformer = load_unconditional
+    model.config.ideogram_uncond_ramtorch = uncond_ramtorch
+    model.config.base_model_precision = base_model_precision
+    model.config.weight_dtype = torch.bfloat16
+    model.accelerator = mock.Mock()
+    model.accelerator.device = torch.device("cpu")
+    model.apply_gradient_checkpointing_settings = mock.Mock()
+    model.apply_model_specific_freeze = mock.Mock()
+    return model
+
+
+def _fp8_state_dict():
+    weight, scale = quantize_weight_to_fp8(torch.randn(3, 4))
+    return {"proj.weight": weight, "proj.weight_scale": scale}
+
+
+class IdeogramUnconditionalLoadTests(unittest.TestCase):
+    def test_flag_off_leaves_unconditional_transformer_none(self):
+        from simpletuner.helpers.models.ideogram import model as ideogram_model
+
+        model = _make_model(load_unconditional=False)
+        with mock.patch.object(ideogram_model, "_load_indexed_or_single_state_dict", return_value=_fp8_state_dict()):
+            with mock.patch.object(ideogram_model, "_build_transformer", return_value=mock.Mock()) as build:
+                model.load_model(move_to_device=False)
+
+        self.assertIsNone(model.unconditional_transformer)
+        self.assertEqual(build.call_count, 1)
+
+    def test_flag_on_loads_frozen_unconditional_transformer(self):
+        from simpletuner.helpers.models.ideogram import model as ideogram_model
+
+        model = _make_model(load_unconditional=True)
+        uncond = torch.nn.Linear(2, 2)
+        uncond.train()
+        with mock.patch.object(
+            ideogram_model, "_load_indexed_or_single_state_dict", return_value=_fp8_state_dict()
+        ) as load_sd:
+            with mock.patch.object(ideogram_model, "_build_transformer", side_effect=[mock.Mock(), uncond]) as build:
+                model.load_model(move_to_device=False)
+
+        self.assertEqual(build.call_count, 2)
+        requested = [call.args[1] for call in load_sd.call_args_list]
+        self.assertEqual(requested, [CONDITIONAL_INDEX, UNCONDITIONAL_INDEX])
+        self.assertIs(model.unconditional_transformer, uncond)
+        self.assertFalse(uncond.training)
+        self.assertTrue(all(not param.requires_grad for param in uncond.parameters()))
+
+    def test_uncond_load_respects_fp8_base_upcast(self):
+        from simpletuner.helpers.models.ideogram import model as ideogram_model
+
+        model = _make_model(load_unconditional=True, upcast=True)
+        with mock.patch.object(
+            ideogram_model, "_load_indexed_or_single_state_dict", side_effect=lambda *_: _fp8_state_dict()
+        ):
+            with mock.patch.object(
+                ideogram_model, "_build_transformer", side_effect=[mock.Mock(), torch.nn.Linear(2, 2)]
+            ) as build:
+                model.load_model(move_to_device=False)
+
+        uncond_state_dict = build.call_args_list[1].args[1]
+        self.assertFalse(is_fp8_state_dict(uncond_state_dict))
+        self.assertEqual(uncond_state_dict["proj.weight"].dtype, torch.bfloat16)
+
+    def test_uncond_load_default_keeps_fp8_state_dict(self):
+        from simpletuner.helpers.models.ideogram import model as ideogram_model
+
+        model = _make_model(load_unconditional=True)
+        state_dict = _fp8_state_dict()
+        with mock.patch.object(ideogram_model, "_load_indexed_or_single_state_dict", return_value=state_dict):
+            with mock.patch.object(
+                ideogram_model, "_build_transformer", side_effect=[mock.Mock(), torch.nn.Linear(2, 2)]
+            ) as build:
+                model.load_model(move_to_device=False)
+
+        self.assertIs(build.call_args_list[1].args[1], state_dict)
+
+    def test_uncond_ramtorch_builds_on_cpu_and_applies_ramtorch(self):
+        from simpletuner.helpers.models.ideogram import model as ideogram_model
+
+        model = _make_model(load_unconditional=True, uncond_ramtorch=True)
+        model.accelerator.device = torch.device("meta")
+        model._apply_ramtorch_layers = mock.Mock(return_value=1)
+        model._ramtorch_transformer_percent = mock.Mock(return_value=None)
+        uncond = torch.nn.Linear(2, 2)
+        with mock.patch.object(ideogram_model, "_load_indexed_or_single_state_dict", return_value=_fp8_state_dict()):
+            with mock.patch.object(ideogram_model, "_build_transformer", side_effect=[mock.Mock(), uncond]) as build:
+                model.load_model(move_to_device=False)
+
+        self.assertEqual(build.call_args_list[1].args[2], torch.device("cpu"))
+        model._apply_ramtorch_layers.assert_called_once()
+        self.assertIs(model._apply_ramtorch_layers.call_args.args[0], uncond)
+        self.assertTrue(model._apply_ramtorch_layers.call_args.kwargs["force"])
+        self.assertTrue(model._apply_ramtorch_layers.call_args.kwargs["full_ramtorch"])
+
+    def test_uncond_ramtorch_requires_load_flag(self):
+        from simpletuner.helpers.models.common import ImageModelFoundation
+
+        model = _make_model(load_unconditional=False, uncond_ramtorch=True)
+        with mock.patch.object(ImageModelFoundation, "check_user_config"):
+            with self.assertRaises(ValueError):
+                model.check_user_config()
+
+
+class IdeogramUnconditionalDispatchTests(unittest.TestCase):
+    def _make_predict_model(self, with_uncond: bool = True):
+        from simpletuner.helpers.models.ideogram.model import Ideogram4
+
+        model = Ideogram4.__new__(Ideogram4)
+        model.config = mock.Mock()
+        model.config.weight_dtype = torch.float32
+        model.accelerator = mock.Mock()
+        model.accelerator.device = torch.device("cpu")
+        model.model = mock.Mock(side_effect=lambda **kwargs: torch.zeros_like(kwargs["x"]))
+        model.unconditional_transformer = (
+            mock.Mock(side_effect=lambda **kwargs: torch.zeros_like(kwargs["x"])) if with_uncond else None
+        )
+        return model
+
+    def _prepared_batch(self, unconditional: bool = False):
+        batch = {
+            "noisy_latents": torch.randn(1, 128, 2, 2),
+            "timesteps": torch.tensor([500.0]),
+            "encoder_hidden_states": torch.randn(1, 5, 16),
+        }
+        if unconditional:
+            batch["is_unconditional_pass"] = True
+        return batch
+
+    def test_use_unconditional_transformer_decision(self):
+        model = self._make_predict_model(with_uncond=True)
+        self.assertTrue(model._use_unconditional_transformer({"is_unconditional_pass": True}))
+        self.assertFalse(model._use_unconditional_transformer({}))
+
+        model.unconditional_transformer = None
+        self.assertFalse(model._use_unconditional_transformer({"is_unconditional_pass": True}))
+
+    def test_marked_batch_dispatches_to_unconditional_transformer(self):
+        model = self._make_predict_model(with_uncond=True)
+        batch = self._prepared_batch(unconditional=True)
+        batch["flowmap_r_timesteps"] = torch.tensor([250.0])
+
+        output = model.model_predict(batch)
+
+        model.unconditional_transformer.assert_called_once()
+        model.model.assert_not_called()
+        call_kwargs = model.unconditional_transformer.call_args.kwargs
+        self.assertEqual(tuple(call_kwargs["x"].shape), (1, 4, 128))
+        self.assertEqual(tuple(call_kwargs["llm_features"].shape), (1, 4, 16))
+        self.assertTrue(torch.all(call_kwargs["llm_features"] == 0))
+        self.assertEqual(tuple(call_kwargs["position_ids"].shape), (1, 4, 3))
+        self.assertTrue(torch.all(call_kwargs["segment_ids"] == 1))
+        self.assertTrue(torch.all(call_kwargs["indicator"] == OUTPUT_IMAGE_INDICATOR))
+        self.assertNotIn("r_timestep", call_kwargs)
+        self.assertEqual(tuple(output["model_prediction"].shape), (1, 128, 2, 2))
+
+    def test_unmarked_batch_uses_conditional_transformer(self):
+        model = self._make_predict_model(with_uncond=True)
+
+        output = model.model_predict(self._prepared_batch(unconditional=False))
+
+        model.model.assert_called_once()
+        model.unconditional_transformer.assert_not_called()
+        self.assertEqual(tuple(output["model_prediction"].shape), (1, 128, 2, 2))
+
+    def test_marked_batch_without_unconditional_transformer_uses_proxy_path(self):
+        model = self._make_predict_model(with_uncond=False)
+
+        output = model.model_predict(self._prepared_batch(unconditional=True))
+
+        model.model.assert_called_once()
+        self.assertEqual(tuple(output["model_prediction"].shape), (1, 128, 2, 2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Ideogram 4 performs CFG through a second, image-only unconditional transformer with zeroed text conditioning. Until now SimpleTuner approximated the unconditional branch by running negative prompts through the conditional transformer, which produces structurally different guidance — particularly visible as noisy targets when AnyFlow distillation fuses guidance at higher scales.

- `--ideogram_load_unconditional_transformer` loads the frozen unconditional transformer through the same indexed state-dict machinery as the conditional path, respecting `--ideogram_fp8_base_upcast`, and wires it into both pipeline constructions so validation runs the real asymmetric-CFG branch.
- `--ideogram_uncond_ramtorch` builds the unconditional transformer on CPU and streams its layers to the accelerator per forward pass via the shared `_apply_ramtorch_layers` helper (new `force` flag bypasses the global `--ramtorch` gate), for fitting both transformers on smaller cards. VRAM cost of the resident option: ~10 GiB fp8, ~18 GiB upcast.
- AnyFlow's `_unconditional_batch` marks batches with `is_unconditional_pass`, and `Ideogram4.model_predict` dispatches marked batches to the unconditional transformer with zeroed llm conditioning, so fused-guidance distillation trains against the model's true unconditional output.
- Quickstart Validation section documents both options (en, es, ja, zh, hi, pt-BR).

## Testing

`.venv/bin/python -m unittest tests.test_ideogram_unconditional tests.test_ideogram_fp8_linear tests.helpers.distillation.test_anyflow_distiller -v -f` — 75 tests pass (1 environment-dependent skip). Coverage includes flag-off/flag-on loading, fp8 upcast handling, the ramtorch offload path, model_predict dispatch geometry, and the unconditional batch marker.