### PR TITLE
webshart: memoize shard metadata, ignore empty caption cache files

### DIFF
--- a/simpletuner/helpers/data_backend/webshart.py
+++ b/simpletuner/helpers/data_backend/webshart.py
@@ -88,6 +88,8 @@ class WebshartDataBackend(BaseDataBackend):
         self.dataset_type = ensure_dataset_type(dataset_type, default=DatasetType.IMAGE)
         self.optimize_captions = bool(optimize_captions)
         self._shard_sample_index_cache: dict[int, dict[str, int]] = {}
+        self._shard_metadata_cache: dict[int, dict] = {}
+        self._shard_metadata_cache_limit = 8
 
         Path(self.cache_dir).mkdir(parents=True, exist_ok=True)
         Path(self.metadata_cache_dir).mkdir(parents=True, exist_ok=True)
@@ -525,7 +527,16 @@ class WebshartDataBackend(BaseDataBackend):
         return int(value)
 
     def get_shard_metadata(self, shard_idx: int) -> dict:
-        return dict(self.loader.get_metadata(shard_idx))
+        # Caption scans call this once per sample; without memoization each call
+        # re-fetches and copies the full shard metadata (~200ms x dataset size).
+        shard_idx = int(shard_idx)
+        cached = self._shard_metadata_cache.get(shard_idx)
+        if cached is None:
+            cached = dict(self.loader.get_metadata(shard_idx))
+            if len(self._shard_metadata_cache) >= self._shard_metadata_cache_limit:
+                self._shard_metadata_cache.pop(next(iter(self._shard_metadata_cache)))
+            self._shard_metadata_cache[shard_idx] = cached
+        return cached
 
     def list_shard_sample_aspect_buckets(
         self,

--- a/simpletuner/helpers/metadata/backends/webshart.py
+++ b/simpletuner/helpers/metadata/backends/webshart.py
@@ -137,8 +137,13 @@ class WebshartMetadataBackend(MetadataBackend):
         if self.data_backend.exists(path):
             try:
                 raw = self.data_backend.read(path)
-                self.caption_cache = json.loads(raw)
-                return
+                loaded = json.loads(raw)
+                # An empty cache file (written before captions were indexed) must not
+                # short-circuit the rebuild below, or it wedges every startup into
+                # per-sample caption lookups.
+                if loaded:
+                    self.caption_cache = loaded
+                    return
             except Exception as exc:
                 logger.warning("Error loading webshart caption cache, regenerating when buckets refresh: %s", exc)
         self.caption_cache = {}

--- a/tests/test_webshart_backend.py
+++ b/tests/test_webshart_backend.py
@@ -337,3 +337,55 @@ class TestWebshartOptimizeCaptionsConfig(unittest.TestCase):
             with self.subTest(backend_dict=backend_dict):
                 config = self._config_from(backend_dict)
                 self.assertEqual(config.webshart_optimize_captions, expected)
+
+
+class TestWebshartShardMetadataMemoization(unittest.TestCase):
+    def _backend(self, limit=8):
+        backend = WebshartDataBackend.__new__(WebshartDataBackend)
+        backend._shard_metadata_cache = {}
+        backend._shard_metadata_cache_limit = limit
+        backend.loader = Mock(get_metadata=Mock(side_effect=lambda idx: {"file.jpg": {"captions": f"shard {idx}"}}))
+        return backend
+
+    def test_repeat_lookups_hit_cache(self):
+        backend = self._backend()
+
+        first = backend.get_shard_metadata(3)
+        second = backend.get_shard_metadata(3)
+
+        self.assertIs(first, second)
+        backend.loader.get_metadata.assert_called_once_with(3)
+
+    def test_cache_evicts_oldest_shard_at_limit(self):
+        backend = self._backend(limit=2)
+
+        backend.get_shard_metadata(1)
+        backend.get_shard_metadata(2)
+        backend.get_shard_metadata(3)
+
+        self.assertEqual(sorted(backend._shard_metadata_cache), [2, 3])
+        backend.get_shard_metadata(1)
+        self.assertEqual(backend.loader.get_metadata.call_count, 4)
+
+
+class TestWebshartCaptionCacheLoad(unittest.TestCase):
+    def _metadata_backend(self, cache_payload):
+        backend = WebshartMetadataBackend.__new__(WebshartMetadataBackend)
+        backend.cache_file = "aspect_ratio_bucket_indices_test.json"
+        backend.data_backend = Mock(exists=Mock(return_value=True), read=Mock(return_value=cache_payload))
+        backend.image_metadata = {"webshart://0/1/sample.jpg": {"captions": "a red bicycle"}}
+        return backend
+
+    def test_empty_cache_file_regenerates_from_image_metadata(self):
+        backend = self._metadata_backend("{}")
+
+        backend._load_caption_cache()
+
+        self.assertEqual(backend.caption_cache, {"webshart://0/1/sample.jpg": "a red bicycle"})
+
+    def test_populated_cache_file_is_used_directly(self):
+        backend = self._metadata_backend('{"webshart://0/1/sample.jpg": "cached caption"}')
+
+        backend._load_caption_cache()
+
+        self.assertEqual(backend.caption_cache, {"webshart://0/1/sample.jpg": "cached caption"})


### PR DESCRIPTION
## What

Fixes the ~27-minute "Loading captions" phase on every training startup for webshart datasets.

Two compounding bugs:

1. **`get_shard_metadata` had no memoization** — caption scans call it once per *sample*, and each call re-fetched and copied the entire shard metadata dict (~200ms). 65k samples ≈ 27 minutes, repeated on every launch. A bounded (8-shard) cache turns the scan into a dict lookup after the first sample of each shard; bucket iteration is shard-sequential so the hit rate is ~100%.

2. **An empty persisted caption cache wedged the slow path permanently.** A `*_captions.json` written before captions were indexed (e.g. before the dataset's hub metadata was fixed with `webshart optimize-captions`) contains `{}`; `_load_caption_cache` early-returned on any successful load, skipping the rebuild fallback — so every subsequent startup ran the per-sample slow path and never refreshed the file.

## Testing

`.venv/bin/python -m unittest tests.test_webshart_backend -f` — all pass, including new coverage for cache hits, bounded eviction, empty-file regeneration, and populated-file fast path.