### PR TITLE
Default textfile lyrics for MiniMax Music

### DIFF
--- a/simpletuner/helpers/data_backend/factory.py
+++ b/simpletuner/helpers/data_backend/factory.py
@@ -777,13 +777,13 @@ def init_backend_config(backend: dict, args: dict, accelerator) -> dict:
     if is_audio_dataset:
         output["config"]["audio"] = _prepare_audio_settings(backend)
         model_family_value = str(_get_arg_value(args, "model_family", "") or "").lower()
-        if model_family_value == "ace_step" and output["config"].get("caption_strategy") == "textfile":
+        if model_family_value in {"ace_step", "minimaxmusic"} and output["config"].get("caption_strategy") == "textfile":
             audio_settings = output["config"]["audio"]
             if not any(audio_settings.get(key) for key in ("lyrics_filename_format", "lyrics_extension", "lyrics_suffix")):
                 default_lyrics_format = "{filename}.lyrics"
                 audio_settings["lyrics_filename_format"] = default_lyrics_format
                 warning_log(
-                    f"(id={backend['id']}) ACE-Step textfile datasets will also load lyrics beside each sample "
+                    f"(id={backend['id']}) Audio textfile datasets will also load lyrics beside each sample "
                     f"using '{default_lyrics_format}'. Set audio.lyrics_filename_format to match your naming scheme."
                 )
             output["config"]["audio"] = audio_settings

--- a/tests/test_audio_backend_config.py
+++ b/tests/test_audio_backend_config.py
@@ -17,6 +17,7 @@ class TestAudioBackendConfig(unittest.TestCase):
         self.args.audio_bucket_strategy = "duration"
         self.args.audio_duration_interval = 3.0
         self.args.audio_truncation_mode = "beginning"
+        self.args.model_family = "sdxl"
         self.args.train_batch_size = 1
         self.args.resolution = 512
         self.args.resolution_type = "pixel"
@@ -51,6 +52,37 @@ class TestAudioBackendConfig(unittest.TestCase):
         self.assertEqual(audio_conf.get("truncation_mode"), "random")
         # Should still have global defaults for unspecified
         self.assertEqual(audio_conf.get("max_duration_seconds"), 30.0)
+
+    def test_minimaxmusic_textfile_audio_defaults_to_lyrics_sidecar(self):
+        self.args.model_family = "minimaxmusic"
+        backend_config = {
+            "id": "test_audio",
+            "type": "local",
+            "dataset_type": "audio",
+            "caption_strategy": "textfile",
+            "instance_data_dir": "/tmp/audio",
+        }
+
+        result = init_backend_config(backend_config, self.args, self.accelerator)
+
+        audio_conf = result["config"]["audio"]
+        self.assertEqual(audio_conf.get("lyrics_filename_format"), "{filename}.lyrics")
+
+    def test_minimaxmusic_textfile_audio_preserves_explicit_lyrics_sidecar(self):
+        self.args.model_family = "minimaxmusic"
+        backend_config = {
+            "id": "test_audio",
+            "type": "local",
+            "dataset_type": "audio",
+            "caption_strategy": "textfile",
+            "instance_data_dir": "/tmp/audio",
+            "audio": {"lyrics_filename_format": "{stem}.lrc"},
+        }
+
+        result = init_backend_config(backend_config, self.args, self.accelerator)
+
+        audio_conf = result["config"]["audio"]
+        self.assertEqual(audio_conf.get("lyrics_filename_format"), "{stem}.lrc")
 
     @patch("simpletuner.helpers.audio.load_audio")
     def test_attach_audio_backend(self, mock_load_audio):


### PR DESCRIPTION
## Summary
- apply the `{filename}.lyrics` textfile audio sidecar default to MiniMax Music datasets as well as ACE-Step
- keep explicit lyrics filename, extension, and suffix settings unchanged

## Root Cause
MiniMax Music audio textfile datasets use caption and lyrics metadata, but the automatic lyrics sidecar default only ran for `model_family == "ace_step"`, so default `.lyrics` files were ignored unless users configured the audio lyrics path manually.

## Validation
- `.venv/bin/python -m unittest -v tests.test_audio_backend_config`
- `.venv/bin/python -m unittest -v tests.helpers.metadata.test_audio_backends`
