### PR TITLE
h3 unsloth checkpointing + sparse attn recompile fix

### DIFF
--- a/simpletuner/helpers/models/minimaxh3/transformer.py
+++ b/simpletuner/helpers/models/minimaxh3/transformer.py
@@ -791,13 +791,10 @@ class MiniMaxH3AttnProcessor:
                 model_name="MiniMax-H3",
             )
         sparse_config = getattr(attn, "_h3_sparse_attention_config", None)
-        sparse_layer_index = int(getattr(attn, "_h3_sparse_layer_index", -1))
-        use_sparse_attention = (
-            sparse_attention_layout is not None
-            and sparse_config is not None
-            and sparse_config.enabled
-            and sparse_layer_index >= sparse_config.start_layer
-        )
+        use_sparse_attention = sparse_attention_layout is not None and sparse_config is not None and sparse_config.enabled
+        if use_sparse_attention:
+            sparse_layer_index = int(getattr(attn, "_h3_sparse_layer_index", -1))
+            use_sparse_attention = sparse_layer_index >= sparse_config.start_layer
         if use_sparse_attention:
             cp_config = context_parallel_config(self._parallel_config)
             if attention_mask is not None and cp_config is None and sparse_attention_layout.packed_valid_mask is None:

--- a/simpletuner/helpers/models/minimaxmusic/transformer.py
+++ b/simpletuner/helpers/models/minimaxmusic/transformer.py
@@ -242,6 +242,7 @@ class MiniMaxMusic3Transformer1DModel(ModelMixin, ConfigMixin, PeftAdapterMixin)
         self.postprocess_conv = nn.Conv1d(in_channels, in_channels, 1, bias=False)
 
         self.gradient_checkpointing = False
+        self.gradient_checkpointing_backend = "torch"
         self.gradient_checkpointing_interval = None
         self.gradient_checkpointing_segment_stride = None
         self._musubi_block_swap = MusubiBlockSwapManager.build(
@@ -250,6 +251,9 @@ class MiniMaxMusic3Transformer1DModel(ModelMixin, ConfigMixin, PeftAdapterMixin)
             swap_device=musubi_block_swap_device,
             logger=logger,
         )
+
+    def set_gradient_checkpointing_backend(self, backend: str):
+        self.gradient_checkpointing_backend = backend
 
     def set_gradient_checkpointing_interval(self, interval: int):
         self.gradient_checkpointing_interval = interval
@@ -428,7 +432,17 @@ class MiniMaxMusic3Transformer1DModel(ModelMixin, ConfigMixin, PeftAdapterMixin)
                 self.gradient_checkpointing_interval,
                 self.gradient_checkpointing_segment_stride,
             ):
-                hidden_states = self._gradient_checkpointing_func(block, hidden_states, rotary_emb)
+                if self.gradient_checkpointing_backend.startswith("unsloth"):
+                    from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
+
+                    hidden_states = offloaded_checkpoint(
+                        block,
+                        hidden_states,
+                        rotary_emb,
+                        use_reentrant=False,
+                    )
+                else:
+                    hidden_states = self._gradient_checkpointing_func(block, hidden_states, rotary_emb)
             else:
                 hidden_states = block(hidden_states, rotary_emb)
             if hidden_states_buffer is not None:

--- a/tests/test_minimaxmusic_model.py
+++ b/tests/test_minimaxmusic_model.py
@@ -94,6 +94,23 @@ class MiniMaxMusicModelTests(unittest.TestCase):
         self.assertEqual(registered.NAME, "MiniMax Music 3")
         self.assertIn("music3", registered.get_flavour_choices())
 
+    @patch("simpletuner.helpers.training.offloaded_gradient_checkpointer.offloaded_checkpoint")
+    def test_unsloth_checkpointing_backend_uses_offloaded_checkpoint(self, offloaded_checkpoint):
+        transformer = _tiny_transformer().train()
+        transformer.gradient_checkpointing = True
+        transformer.set_gradient_checkpointing_backend("unsloth")
+        transformer.set_gradient_checkpointing_interval(2)
+        offloaded_checkpoint.side_effect = lambda function, *args, **kwargs: function(*args)
+
+        transformer(
+            hidden_states=torch.randn(1, 4, 6, requires_grad=True),
+            timestep=torch.ones(1),
+            encoder_hidden_states=torch.randn(1, 6, 8),
+        )
+
+        offloaded_checkpoint.assert_called_once()
+        self.assertFalse(offloaded_checkpoint.call_args.kwargs["use_reentrant"])
+
     def test_minimaxmusic_supports_audio_only_training(self):
         self.assertTrue(MiniMaxMusic.supports_audio_only_training())
 

--- a/tests/test_segmented_checkpointing_model_support.py
+++ b/tests/test_segmented_checkpointing_model_support.py
@@ -49,6 +49,7 @@ class MiniMaxMusicSegmentedCheckpointingSupportTests(unittest.TestCase):
         assert_checkpointing_controls(
             self,
             MiniMaxMusic3Transformer1DModel,
+            backend=True,
             interval=True,
             stride=True,
         )


### PR DESCRIPTION
This pull request introduces improvements to the gradient checkpointing mechanism in the `MiniMaxMusic3Transformer1DModel`, specifically adding support for selecting different checkpointing backends and integrating an "unsloth" backend with offloaded checkpointing. Additionally, the pull request refines the logic for sparse attention activation in the MiniMax-H3 transformer and updates the corresponding tests to cover the new functionality.

**Gradient checkpointing enhancements:**

* Added a new `gradient_checkpointing_backend` attribute and a `set_gradient_checkpointing_backend` method to allow selecting the checkpointing backend (defaulting to "torch") in `minimaxmusic/transformer.py`. The forward pass now uses the "unsloth" backend with `offloaded_checkpoint` when specified, otherwise defaults to the existing checkpointing function. [[1]](diffhunk://#diff-d7d7ca859dd061170c953690de535060870400d0d887c069afd497d148a624eaR245) [[2]](diffhunk://#diff-d7d7ca859dd061170c953690de535060870400d0d887c069afd497d148a624eaR255-R257) [[3]](diffhunk://#diff-d7d7ca859dd061170c953690de535060870400d0d887c069afd497d148a624eaR435-R444)

**Sparse attention logic refinement:**

* Refined the logic for determining when to activate sparse attention in `minimaxh3/transformer.py`, ensuring that the `sparse_layer_index` check is only performed when relevant configuration is present.

**Testing improvements:**

* Added a unit test to verify that the "unsloth" checkpointing backend correctly invokes `offloaded_checkpoint` and disables the reentrant checkpointing feature.
* Updated the checkpointing controls test to include the `backend` parameter, ensuring backend selection is covered by the test suite.