### PR TITLE
anyflow: swap unconditional aliases instead of popping them

### DIFF
--- a/simpletuner/helpers/distillation/anyflow/distiller.py
+++ b/simpletuner/helpers/distillation/anyflow/distiller.py
@@ -950,10 +950,17 @@ class AnyFlowDistiller(DistillationBase):
         batch.pop("encoder_attention_mask", None)
         if torch.is_tensor(negative_mask):
             batch["encoder_attention_mask"] = negative_mask
-        # Some families (e.g. Ideogram) read model-specific conditioning aliases ahead of the
-        # generic keys; drop them so the swapped unconditional embeds/mask take effect.
-        for alias in ("prompt_embeds", "attention_mask", "attention_masks"):
-            batch.pop(alias, None)
+        # Some families read model-specific conditioning aliases ahead of (or instead of) the
+        # generic keys: Ideogram prefers `prompt_embeds` when present, and Flux requires it.
+        # Swap the aliases to the unconditional tensors rather than popping them.
+        if "prompt_embeds" in batch:
+            batch["prompt_embeds"] = negative
+        for alias in ("attention_mask", "attention_masks"):
+            if alias in batch:
+                if torch.is_tensor(negative_mask):
+                    batch[alias] = negative_mask
+                else:
+                    batch.pop(alias)
         # Lets families with a dedicated unconditional model (e.g. Ideogram) dispatch to it.
         batch["is_unconditional_pass"] = True
         return batch

--- a/simpletuner/helpers/distillation/anyflow/distiller.py
+++ b/simpletuner/helpers/distillation/anyflow/distiller.py
@@ -961,6 +961,13 @@ class AnyFlowDistiller(DistillationBase):
                     batch[alias] = negative_mask
                 else:
                     batch.pop(alias)
+        negative_pooled = prepared_batch.get("negative_add_text_embeds")
+        if torch.is_tensor(negative_pooled):
+            if "add_text_embeds" in batch:
+                batch["add_text_embeds"] = negative_pooled
+            added_cond_kwargs = batch.get("added_cond_kwargs")
+            if isinstance(added_cond_kwargs, dict) and "text_embeds" in added_cond_kwargs:
+                batch["added_cond_kwargs"] = {**added_cond_kwargs, "text_embeds": negative_pooled}
         # Lets families with a dedicated unconditional model (e.g. Ideogram) dispatch to it.
         batch["is_unconditional_pass"] = True
         return batch

--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -5456,6 +5456,9 @@ class ModelFoundation(ABC):
         negative_attention_mask = batch.get("negative_encoder_attention_mask")
         if negative_attention_mask is not None and hasattr(negative_attention_mask, "to"):
             batch["negative_encoder_attention_mask"] = negative_attention_mask.to(device=self.accelerator.device)
+        negative_pooled_embeds = batch.get("negative_add_text_embeds")
+        if negative_pooled_embeds is not None and hasattr(negative_pooled_embeds, "to"):
+            batch["negative_add_text_embeds"] = negative_pooled_embeds.to(**target_device_kwargs)
 
         # Process additional conditioning if provided
         pooled_embeds = batch.get("add_text_embeds")

--- a/simpletuner/helpers/training/collate.py
+++ b/simpletuner/helpers/training/collate.py
@@ -1335,6 +1335,7 @@ def collate_fn(batch):
         "negative_prompt_embeds": unconditional_text_encoder_outputs.get("prompt_embeds"),
         "negative_text_token_tags": unconditional_text_encoder_outputs.get("text_token_tags"),
         "negative_encoder_attention_mask": unconditional_text_encoder_outputs.get("attention_masks"),
+        "negative_add_text_embeds": unconditional_text_encoder_outputs.get("pooled_prompt_embeds"),
         "add_text_embeds": all_text_encoder_outputs.get("pooled_prompt_embeds"),
         "t5xxl_ids": all_text_encoder_outputs.get("t5xxl_ids"),
         "t5xxl_weights": all_text_encoder_outputs.get("t5xxl_weights"),

--- a/tests/helpers/distillation/test_anyflow_distiller.py
+++ b/tests/helpers/distillation/test_anyflow_distiller.py
@@ -751,7 +751,7 @@ class AnyFlowDistillerTests(unittest.TestCase):
 
         self.assertNotIn("encoder_attention_mask", unconditional_batch)
 
-    def test_unconditional_batch_drops_model_specific_conditioning_aliases(self):
+    def test_unconditional_batch_swaps_model_specific_conditioning_aliases(self):
         batch = _prepared_batch()
         batch["prompt_embeds"] = torch.ones(2, 7, 4)
         batch["attention_mask"] = torch.ones(2, 7, dtype=torch.bool)
@@ -759,9 +759,21 @@ class AnyFlowDistillerTests(unittest.TestCase):
 
         unconditional_batch = AnyFlowDistiller._unconditional_batch(batch)
 
-        self.assertNotIn("prompt_embeds", unconditional_batch)
+        self.assertIs(unconditional_batch["prompt_embeds"], batch["negative_encoder_hidden_states"])
         self.assertNotIn("attention_mask", unconditional_batch)
         self.assertNotIn("attention_masks", unconditional_batch)
+
+    def test_unconditional_batch_swaps_alias_masks_when_negative_mask_present(self):
+        batch = _prepared_batch()
+        batch["prompt_embeds"] = torch.ones(2, 7, 4)
+        batch["attention_mask"] = torch.ones(2, 7, dtype=torch.bool)
+        batch["attention_masks"] = torch.ones(2, 7, dtype=torch.bool)
+        batch["negative_encoder_attention_mask"] = torch.zeros(2, 5, dtype=torch.bool)
+
+        unconditional_batch = AnyFlowDistiller._unconditional_batch(batch)
+
+        self.assertIs(unconditional_batch["attention_mask"], batch["negative_encoder_attention_mask"])
+        self.assertIs(unconditional_batch["attention_masks"], batch["negative_encoder_attention_mask"])
 
     def test_onpolicy_initializes_separate_discriminator_adapter_and_optimizer(self):
         model = _FlowModel()
@@ -1071,7 +1083,7 @@ if __name__ == "__main__":
 
 
 class AnyFlowUnconditionalBatchTests(unittest.TestCase):
-    def test_unconditional_batch_drops_stale_mask_and_model_specific_aliases(self):
+    def test_unconditional_batch_drops_stale_mask_and_swaps_model_specific_aliases(self):
         batch = _prepared_batch()
         batch["encoder_attention_mask"] = torch.ones(2, 5, dtype=torch.long)
         batch["prompt_embeds"] = torch.ones(2, 7, 4)
@@ -1082,7 +1094,7 @@ class AnyFlowUnconditionalBatchTests(unittest.TestCase):
 
         self.assertIs(unconditional_batch["encoder_hidden_states"], batch["negative_encoder_hidden_states"])
         self.assertNotIn("encoder_attention_mask", unconditional_batch)
-        self.assertNotIn("prompt_embeds", unconditional_batch)
+        self.assertIs(unconditional_batch["prompt_embeds"], batch["negative_encoder_hidden_states"])
         self.assertNotIn("attention_mask", unconditional_batch)
         self.assertNotIn("attention_masks", unconditional_batch)
 

--- a/tests/helpers/distillation/test_anyflow_distiller.py
+++ b/tests/helpers/distillation/test_anyflow_distiller.py
@@ -1174,3 +1174,16 @@ class AnyFlowDeltaEmbedderTests(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as temp_dir:
             save_file(state, str(Path(temp_dir) / "adapter.safetensors"))
+
+    def test_unconditional_batch_swaps_negative_pooled_embeds(self):
+        batch = _prepared_batch()
+        batch["add_text_embeds"] = torch.ones(2, 8)
+        batch["added_cond_kwargs"] = {"text_embeds": batch["add_text_embeds"], "time_ids": torch.zeros(2, 6)}
+        batch["negative_add_text_embeds"] = torch.zeros(2, 8)
+
+        unconditional_batch = AnyFlowDistiller._unconditional_batch(batch)
+
+        self.assertIs(unconditional_batch["add_text_embeds"], batch["negative_add_text_embeds"])
+        self.assertIs(unconditional_batch["added_cond_kwargs"]["text_embeds"], batch["negative_add_text_embeds"])
+        self.assertIs(unconditional_batch["added_cond_kwargs"]["time_ids"], batch["added_cond_kwargs"]["time_ids"])
+        self.assertIs(batch["added_cond_kwargs"]["text_embeds"], batch["add_text_embeds"])


### PR DESCRIPTION
## What

Fixes AnyFlow's unconditional batch construction for families that key text conditioning on `prompt_embeds`, and completes the negative-conditioning swap for pooled projections.

`_unconditional_batch` popped the model-specific aliases (`prompt_embeds`, `attention_mask`, `attention_masks`) so swapped unconditional embeds would take effect for families that merely *prefer* those keys (Ideogram). But Flux *requires* `prompt_embeds` in `model_predict`, so any Flux run with `real_score_guidance_scale > 0` crashed with `KeyError: 'prompt_embeds'` inside `_apply_real_score_guidance`.

Changes:
- `_unconditional_batch` swaps aliases instead of popping: `prompt_embeds` gets the negative embeds; alias masks get the cached negative mask (or are dropped when none is cached, preserving prior stale-mask behaviour). Ideogram's proxy path reads the same negative tensor it previously reached via fallback.
- Collation caches the unconditional pooled projection as `negative_add_text_embeds`, `prepare_batch` moves it to the accelerator, and the unconditional batch swaps it into `add_text_embeds` and `added_cond_kwargs.text_embeds` — the unconditional pass no longer reuses the positive pooled embed for Flux/SDXL-style conditioning.

## Testing

`.venv/bin/python -m unittest tests.helpers.distillation.test_anyflow_distiller -f` — 57 tests pass, including alias-swap coverage, negative-mask swap, and the pooled-embed swap (verifying the original batch's added_cond_kwargs is not mutated).