### PR TITLE
Support audio-only datasets for LTX-2 and MiniMax-H3

### DIFF
--- a/documentation/DATALOADER.es.md
+++ b/documentation/DATALOADER.es.md
@@ -137,12 +137,17 @@ Los backends de audio admiten un bloque `audio` dedicado para que los metadatos 
 }
 ```
 
+Cuando todos los datasets multimedia habilitados usan `dataset_type: "audio"`, las familias de video con
+`SUPPORTS_FAKE_VIDEO_STREAM` activan automáticamente el entrenamiento solo de audio. LTX-2 usa su rama nativa de
+audio; MiniMax-H3 conserva un token espacial de video falso por frame latente y enmascara la pérdida de video. LoRA
+estándar selecciona `AUDIO_LORA_TARGET` automáticamente, salvo que se configure `peft_lora_target_modules`.
+
 - **`bucket_strategy`** – actualmente `duration` es el valor por defecto y recorta clips en buckets espaciados uniformemente para que el muestreo por GPU respete el cálculo de batch.
 - **`duration_interval`** – redondeo del bucket en segundos (por defecto **3** si no se configura). Con `15`, un clip de 77 s queda en el bucket de 75 s. Esto evita que un clip largo deje a otras ranks sin muestras y fuerza el truncado al mismo intervalo.
 - **`max_duration_seconds`** – los clips más largos que esto se omiten por completo durante el descubrimiento de metadatos, así que pistas excepcionalmente largas no consumen buckets inesperadamente.
 - **`truncation_mode`** – determina qué parte del clip se conserva cuando ajustamos al intervalo del bucket. Opciones: `beginning`, `end` o `random` (default: `beginning`).
-- **`audio_only`** – modo de entrenamiento solo audio (LTX-2): entrena solo la generación de audio sin archivos de video. Los latentes de video se ponen a cero automáticamente y la pérdida de video se enmascara.
-- **`target_resolution`** – resolución de video objetivo para el modo solo audio (usada para calcular dimensiones de latentes).
+- **`audio_only`** – override de compatibilidad para el modo solo audio; las configuraciones compuestas solo por audio lo activan automáticamente en LTX-2 y MiniMax-H3.
+- **`target_resolution`** – override legado; los streams falsos automáticos usan la geometría mínima del modelo.
 - La configuración estándar de audio (número de canales, directorio de caché) se mapea directamente al backend de audio en tiempo de ejecución creado por `simpletuner.helpers.data_backend.factory`. Se evita el padding intencionalmente: los clips se truncan en lugar de extenderse para mantener el comportamiento consistente con entrenadores de difusión como ACE-Step.
 
 #### Configuración de audio para entrenamiento S2V
@@ -172,8 +177,8 @@ Esto crea automáticamente un dataset `my-videos_audio` y lo enlaza vía `s2v_da
 | `audio.auto_split` | bool | true | Genera automáticamente dataset de audio desde archivos de video. Default true cuando la sección `audio` está presente. Para modelos que requieren S2V, default true incluso sin sección `audio`. |
 | `audio.source_from_video` | bool | false | (Auto-configurado) Indica que el audio se extrae del video |
 | `audio.allow_zero_audio` | bool | false | Genera audio con ceros para videos sin stream de audio |
-| `audio.audio_only` | bool | false | Modo de entrenamiento solo audio (LTX-2): entrena generación de audio sin archivos de video |
-| `audio.target_resolution` | int | null | Resolución de video objetivo para modo solo audio (usada para calcular dimensiones de latentes) |
+| `audio.audio_only` | bool | false | Override de compatibilidad; una configuración compuesta solo por audio lo activa automáticamente para LTX-2 y MiniMax-H3 |
+| `audio.target_resolution` | int | null | Override legado; el stream falso automático usa la geometría mínima de tokens de la familia |
 | `audio.sample_rate` | int | 16000 | Tasa de muestreo objetivo para extracción de audio |
 | `audio.channels` | int | 1 | Número de canales de audio (1=mono, 2=estéreo) |
 | `audio.bucket_strategy` | string | "duration" | Estrategia de bucketing para muestras de audio |

--- a/documentation/DATALOADER.hi.md
+++ b/documentation/DATALOADER.hi.md
@@ -137,12 +137,17 @@ Audio backends एक dedicated `audio` block सपोर्ट करते �
 }
 ```
 
+जब सभी enabled media datasets `dataset_type: "audio"` इस्तेमाल करते हैं, तब `SUPPORTS_FAKE_VIDEO_STREAM` वाली video
+model families अपने आप audio-only training चुनती हैं। LTX-2 अपना native audio-only branch इस्तेमाल करता है।
+MiniMax-H3 हर latent frame के लिए एक fake spatial video token रखता है और video loss को mask करता है। Standard LoRA
+अपने आप `AUDIO_LORA_TARGET` चुनता है; explicit `peft_lora_target_modules` को प्राथमिकता मिलती है।
+
 - **`bucket_strategy`** – फिलहाल `duration` डिफ़ॉल्ट है और clips को समान अंतराल वाले buckets में truncate करता है ताकि per‑GPU sampling batch गणना का सम्मान करे।
 - **`duration_interval`** – seconds में bucket rounding (unset होने पर डिफ़ॉल्ट **3**)। `15` के साथ, 77s clip 75s bucket में जाएगा। यह single long clips को अन्य ranks को starve करने से रोकता है और truncation को समान interval पर मजबूर करता है।
 - **`max_duration_seconds`** – इससे लंबे clips metadata discovery के दौरान पूरी तरह skip किए जाते हैं ताकि अत्यधिक लंबे tracks अनपेक्षित रूप से buckets न भरें।
 - **`truncation_mode`** – bucket interval पर snap करते समय clip का कौन‑सा हिस्सा रखा जाए। विकल्प: `beginning`, `end`, या `random` (डिफ़ॉल्ट: `beginning`)।
-- **`audio_only`** – केवल ऑडियो ट्रेनिंग मोड (LTX-2): वीडियो फाइलों के बिना केवल ऑडियो जेनरेशन ट्रेन करता है। वीडियो latents स्वचालित रूप से शून्य हो जाते हैं और वीडियो loss मास्क हो जाता है।
-- **`target_resolution`** – केवल ऑडियो मोड के लिए लक्ष्य वीडियो resolution (latent dimensions की गणना के लिए उपयोग)।
+- **`audio_only`** – audio-only mode का compatibility override; केवल-audio config इसे LTX-2 और MiniMax-H3 के लिए अपने आप enable करता है।
+- **`target_resolution`** – legacy override; automatic fake stream model की minimal token geometry इस्तेमाल करता है।
 - standard audio settings (channel count, cache directory) सीधे `simpletuner.helpers.data_backend.factory` द्वारा बनाए गए runtime audio backend पर मैप होते हैं। Padding जानबूझकर नहीं किया जाता—clips truncate होते हैं ताकि behavior ACE-Step जैसे diffusion trainers के साथ consistent रहे।
 
 #### S2V training के लिए Audio configuration
@@ -172,8 +177,8 @@ Audio backends एक dedicated `audio` block सपोर्ट करते �
 | `audio.auto_split` | bool | true | Video files से audio dataset auto-generate करें। `audio` section मौजूद होने पर default true। S2V-required models के लिए `audio` section न होने पर भी default true। |
 | `audio.source_from_video` | bool | false | (Auto-set) दर्शाता है कि audio video से extract किया गया है |
 | `audio.allow_zero_audio` | bool | false | बिना audio stream वाले videos के लिए zero-filled audio generate करें |
-| `audio.audio_only` | bool | false | केवल audio training mode (LTX-2): video files के बिना audio generation train करें |
-| `audio.target_resolution` | int | null | केवल audio mode के लिए target video resolution (latent dimensions गणना हेतु) |
+| `audio.audio_only` | bool | false | Compatibility override; केवल-audio dataset config इसे LTX-2 और MiniMax-H3 के लिए अपने आप enable करता है |
+| `audio.target_resolution` | int | null | Legacy override; automatic fake stream model family की minimal token geometry इस्तेमाल करता है |
 | `audio.sample_rate` | int | 16000 | Audio extraction के लिए target sample rate |
 | `audio.channels` | int | 1 | Audio channels की संख्या (1=mono, 2=stereo) |
 | `audio.bucket_strategy` | string | "duration" | Audio samples के लिए bucketing strategy |

--- a/documentation/DATALOADER.ja.md
+++ b/documentation/DATALOADER.ja.md
@@ -137,12 +137,17 @@
 }
 ```
 
+有効なメディアデータセットがすべて `dataset_type: "audio"` の場合、`SUPPORTS_FAKE_VIDEO_STREAM` を持つ動画モデルは
+自動的に音声のみトレーニングになります。LTX-2 はネイティブの音声専用ブランチを使用します。MiniMax-H3 は latent
+frame ごとに 1 個の偽動画空間トークンを保持し、動画 loss をマスクします。標準 LoRA では
+`AUDIO_LORA_TARGET` が自動選択され、明示した `peft_lora_target_modules` が優先されます。
+
 - **`bucket_strategy`** – 現在は `duration` が既定で、クリップを等間隔のバケットに切り詰め、GPU ごとのサンプリングがバッチ計算に合うようにします。
 - **`duration_interval`** – バケット丸めを秒単位で指定します（未設定時の既定は **3**）。`15` にすると、77 秒のクリップは 75 秒に丸められます。これにより、単一の長いクリップが他のランクを阻害するのを防ぎ、同じ間隔で切り詰められます。
 - **`max_duration_seconds`** – これを超える長さのクリップはメタデータ探索時に完全にスキップされるため、極端に長いトラックがバケットを予期せず消費しません。
 - **`truncation_mode`** – バケット間隔に揃える際に保持するクリップの部分を決めます。選択肢: `beginning`、`end`、`random`（既定: `beginning`）。
-- **`audio_only`** – 音声のみトレーニングモード（LTX-2）: 動画ファイルなしで音声生成のみをトレーニングします。動画潜在変数は自動的にゼロになり、動画損失はマスクされます。
-- **`target_resolution`** – 音声のみモードでのターゲット動画解像度（潜在変数の次元計算に使用）。
+- **`audio_only`** – 音声のみモードの互換用 override。音声のみの構成では LTX-2 と MiniMax-H3 に対して自動的に有効化されます。
+- **`target_resolution`** – レガシー override。自動 fake stream はモデルの最小トークン形状を使用します。
 - 標準の音声設定（チャンネル数、キャッシュディレクトリなど）は `simpletuner.helpers.data_backend.factory` によって作成されるランタイム音声バックエンドに直接マッピングされます。パディングは意図的に回避され、クリップは延長ではなく切り詰められるため、ACE-Step のような拡散トレーナーの挙動と整合します。
 
 #### S2V トレーニング用の音声設定
@@ -172,8 +177,8 @@
 | `audio.auto_split` | bool | true | ビデオファイルからオーディオデータセットを自動生成。`audio` セクションが存在する場合、デフォルトは true。S2V 必須モデルでは `audio` セクションがなくてもデフォルトで true。 |
 | `audio.source_from_video` | bool | false | （自動設定）オーディオがビデオから抽出されたことを示す |
 | `audio.allow_zero_audio` | bool | false | 音声ストリームのないビデオに対してゼロ埋めオーディオを生成 |
-| `audio.audio_only` | bool | false | 音声のみトレーニングモード（LTX-2）：ビデオファイルなしで音声生成のみトレーニング |
-| `audio.target_resolution` | int | null | 音声のみモードのターゲットビデオ解像度（latent 次元の計算に使用） |
+| `audio.audio_only` | bool | false | 互換用 override。音声のみの構成では LTX-2 と MiniMax-H3 に対して自動的に有効化 |
+| `audio.target_resolution` | int | null | レガシー override。自動 fake stream はモデルファミリーの最小トークン形状を使用 |
 | `audio.sample_rate` | int | 16000 | 音声抽出のターゲットサンプルレート |
 | `audio.channels` | int | 1 | オーディオチャンネル数（1=モノラル、2=ステレオ） |
 | `audio.bucket_strategy` | string | "duration" | オーディオサンプルのバケット戦略 |

--- a/documentation/DATALOADER.md
+++ b/documentation/DATALOADER.md
@@ -137,6 +137,12 @@ Audio backends support a dedicated `audio` block so metadata and bucket math sta
 }
 ```
 
+When every enabled media dataset has `dataset_type: "audio"`, video model families with
+`SUPPORTS_FAKE_VIDEO_STREAM` automatically enter audio-only training. LTX-2 uses its native audio-only transformer
+branch. MiniMax-H3 keeps one fake spatial video token per latent frame in its packed sequence and masks the video
+loss. Standard LoRA training automatically selects the family-defined `AUDIO_LORA_TARGET`; an explicit
+`peft_lora_target_modules` list still takes precedence. No video dataset or fake-stream command-line option is needed.
+
 - **`bucket_strategy`** – currently `duration` is the default and truncates clips into evenly spaced buckets so per-GPU sampling respects batch math.
 - **`duration_interval`** – bucket rounding in seconds (defaults to **3** when unset). With `15`, a 77 s clip is bucketed at 75 s. This prevents single long clips from starving other ranks and forces truncation to the same interval.
 - **`max_duration_seconds`** – clips longer than this are skipped entirely during metadata discovery so exceptionally long tracks don't consume buckets unexpectedly.
@@ -173,8 +179,8 @@ This automatically creates a `my-videos_audio` dataset and links it via `s2v_dat
 | `audio.auto_split` | bool | true | Auto-generate audio dataset from video files. Defaults to true when an `audio` section is present. For S2V-required models, defaults to true even without an `audio` section. |
 | `audio.source_from_video` | bool | false | (Auto-set) Indicates audio is extracted from video |
 | `audio.allow_zero_audio` | bool | false | Generate zero-filled audio for videos without audio streams |
-| `audio.audio_only` | bool | false | Audio-only training mode (LTX-2): train audio generation without video files |
-| `audio.target_resolution` | int | null | Target video resolution for audio-only mode (used to compute latent dimensions) |
+| `audio.audio_only` | bool | false | Compatibility override for audio-only training; all-audio dataset configurations enable it automatically on LTX-2 and MiniMax-H3 |
+| `audio.target_resolution` | int | null | Legacy target resolution override; automatic fake streams use the model family's minimal token geometry |
 | `audio.sample_rate` | int | 16000 | Target sample rate for audio extraction |
 | `audio.channels` | int | 1 | Number of audio channels (1=mono, 2=stereo) |
 | `audio.bucket_strategy` | string | "duration" | Bucketing strategy for audio samples |

--- a/documentation/DATALOADER.pt-BR.md
+++ b/documentation/DATALOADER.pt-BR.md
@@ -137,12 +137,17 @@ Backends de áudio suportam um bloco `audio` dedicado para que metadados e cálc
 }
 ```
 
+Quando todos os datasets de mídia habilitados usam `dataset_type: "audio"`, famílias de vídeo com
+`SUPPORTS_FAKE_VIDEO_STREAM` entram automaticamente no treinamento apenas de áudio. LTX-2 usa seu branch nativo de
+áudio; MiniMax-H3 mantém um token espacial de vídeo falso por frame latente e mascara a loss de vídeo. LoRA padrão
+seleciona `AUDIO_LORA_TARGET` automaticamente, a menos que `peft_lora_target_modules` seja definido explicitamente.
+
 - **`bucket_strategy`** – atualmente `duration` é o padrão e trunca clipes em buckets espaçados de forma uniforme para que a amostragem por GPU respeite o cálculo de batch.
 - **`duration_interval`** – arredondamento de bucket em segundos (padrão **3** quando não definido). Com `15`, um clipe de 77 s é colocado no bucket de 75 s. Isso impede que clipes longos únicos prejudiquem outros ranks e força truncamento no mesmo intervalo.
 - **`max_duration_seconds`** – clipes mais longos que isso são ignorados durante a descoberta de metadados para que faixas excepcionalmente longas não consumam buckets inesperadamente.
 - **`truncation_mode`** – determina qual parte do clipe é mantida quando ajustamos para o intervalo do bucket. Opções: `beginning`, `end` ou `random` (padrão: `beginning`).
-- **`audio_only`** – modo de treinamento apenas áudio (LTX-2): treina apenas a geração de áudio sem arquivos de vídeo. Os latentes de vídeo são zerados automaticamente e a perda de vídeo é mascarada.
-- **`target_resolution`** – resolução de vídeo alvo para o modo apenas áudio (usada para calcular dimensões de latentes).
+- **`audio_only`** – override de compatibilidade para modo apenas áudio; configurações somente de áudio o ativam automaticamente em LTX-2 e MiniMax-H3.
+- **`target_resolution`** – override legado; fake streams automáticos usam a geometria mínima de tokens do modelo.
 - Configurações padrão de áudio (contagem de canais, diretório de cache) mapeiam diretamente para o backend de áudio em runtime criado por `simpletuner.helpers.data_backend.factory`. O padding é intencionalmente evitado — clipes são truncados em vez de estendidos para manter o comportamento consistente com treinadores de difusão como o ACE-Step.
 
 #### Configuração de áudio para treinamento S2V
@@ -172,8 +177,8 @@ Isso cria automaticamente um dataset `my-videos_audio` e o vincula via `s2v_data
 | `audio.auto_split` | bool | true | Gera automaticamente dataset de áudio a partir de arquivos de vídeo. Padrão true quando a seção `audio` está presente. Para modelos que exigem S2V, padrão true mesmo sem seção `audio`. |
 | `audio.source_from_video` | bool | false | (Auto-definido) Indica que o áudio é extraído do vídeo |
 | `audio.allow_zero_audio` | bool | false | Gera áudio zerado para vídeos sem stream de áudio |
-| `audio.audio_only` | bool | false | Modo de treinamento apenas áudio (LTX-2): treina geração de áudio sem arquivos de vídeo |
-| `audio.target_resolution` | int | null | Resolução de vídeo alvo para modo apenas áudio (usada para calcular dimensões de latentes) |
+| `audio.audio_only` | bool | false | Override de compatibilidade; configurações somente de áudio ativam o modo automaticamente para LTX-2 e MiniMax-H3 |
+| `audio.target_resolution` | int | null | Override legado; o fake stream automático usa a geometria mínima de tokens da família |
 | `audio.sample_rate` | int | 16000 | Taxa de amostragem alvo para extração de áudio |
 | `audio.channels` | int | 1 | Número de canais de áudio (1=mono, 2=estéreo) |
 | `audio.bucket_strategy` | string | "duration" | Estratégia de bucketing para amostras de áudio |

--- a/documentation/DATALOADER.zh.md
+++ b/documentation/DATALOADER.zh.md
@@ -137,12 +137,16 @@
 }
 ```
 
+当所有启用的媒体数据集都使用 `dataset_type: "audio"` 时，带有 `SUPPORTS_FAKE_VIDEO_STREAM` 的视频模型会自动进入纯音频训练。
+LTX-2 使用原生纯音频分支；MiniMax-H3 在打包序列中为每个 latent frame 保留一个伪视频空间 token，并屏蔽视频 loss。
+标准 LoRA 会自动选择 `AUDIO_LORA_TARGET`，但显式设置的 `peft_lora_target_modules` 仍然优先。
+
 - **`bucket_strategy`** – 当前默认是 `duration`，会将片段截断到等间隔桶中，使每 GPU 的采样符合批次计算。
 - **`duration_interval`** – 以秒为单位的分桶舍入（未设置时默认 **3**）。例如设为 `15` 时，77 秒的片段会归入 75 秒桶。这样可防止单个超长片段占用过多桶，并强制截断到统一间隔。
 - **`max_duration_seconds`** – 超过此时长的片段在元数据发现时会被完全跳过，避免异常长的音轨占用桶。
 - **`truncation_mode`** – 规定对齐到桶间隔时保留片段的哪一部分。可选：`beginning`、`end`、`random`（默认：`beginning`）。
-- **`audio_only`** – 纯音频训练模式（LTX-2）：不使用视频文件仅训练音频生成。视频 latents 会自动置零并屏蔽视频损失。
-- **`target_resolution`** – 纯音频模式下的目标视频分辨率（用于计算 latent 维度）。
+- **`audio_only`** – 纯音频模式的兼容性 override；纯音频配置会为 LTX-2 和 MiniMax-H3 自动启用。
+- **`target_resolution`** – 旧版 override；自动伪视频流使用模型的最小 token 几何。
 - 标准音频设置（声道数、缓存目录）会直接映射到 `simpletuner.helpers.data_backend.factory` 创建的运行时音频后端。刻意避免 padding——片段被截断而不是延长，以保持与 ACE-Step 等扩散训练器的行为一致。
 
 #### S2V 训练的音频配置
@@ -172,8 +176,8 @@
 | `audio.auto_split` | bool | true | 从视频文件自动生成音频数据集。当存在 `audio` 部分时默认为 true。对于要求 S2V 的模型，即使没有 `audio` 部分也默认为 true。 |
 | `audio.source_from_video` | bool | false | （自动设置）表示音频从视频中提取 |
 | `audio.allow_zero_audio` | bool | false | 为没有音频流的视频生成全零音频 |
-| `audio.audio_only` | bool | false | 纯音频训练模式（LTX-2）：不使用视频文件仅训练音频生成 |
-| `audio.target_resolution` | int | null | 纯音频模式下的目标视频分辨率（用于计算 latent 维度） |
+| `audio.audio_only` | bool | false | 兼容性 override；纯音频数据集配置会为 LTX-2 和 MiniMax-H3 自动启用此模式 |
+| `audio.target_resolution` | int | null | 旧版 override；自动伪视频流使用模型系列的最小 token 几何 |
 | `audio.sample_rate` | int | 16000 | 音频提取的目标采样率 |
 | `audio.channels` | int | 1 | 音频声道数（1=单声道，2=立体声） |
 | `audio.bucket_strategy` | string | "duration" | 音频样本的分桶策略 |

--- a/simpletuner/helpers/data_backend/factory.py
+++ b/simpletuner/helpers/data_backend/factory.py
@@ -383,7 +383,7 @@ def init_backend_config(backend: dict, args: dict, accelerator) -> dict:
             truncation_mode = "beginning"
         audio_block["truncation_mode"] = truncation_mode
 
-        # Audio-only mode: standalone audio training without video (e.g., LTX-2 audio-only)
+        # Audio-only mode: standalone audio training without source video.
         audio_only_raw = audio_block.get("audio_only") or source.get("audio_only")
         if audio_only_raw is not None:
             audio_block["audio_only"] = bool(audio_only_raw)
@@ -1640,7 +1640,7 @@ class FactoryRegistry:
     def _validate_audio_only_datasets(self, data_backend_config: List[Dict[str, Any]]) -> None:
         """
         Validate audio-only datasets are only used with models that support them.
-        Audio-only mode allows training on audio without video (e.g., LTX-2 audio-only training).
+        Audio-only mode allows compatible video families to train on audio without source video.
         """
         supports_audio_only = self._supports_audio_only_training()
 
@@ -1661,7 +1661,7 @@ class FactoryRegistry:
                     raise ValueError(
                         f"Audio-only dataset '{backend_id}' is configured with audio.audio_only=true, "
                         f"but the current model does not support audio-only training. "
-                        f"Audio-only mode is currently only supported by LTX-2. "
+                        f"The current model family does not advertise SUPPORTS_FAKE_VIDEO_STREAM. "
                         f"Either use a compatible model or remove the audio_only setting."
                     )
                 info_log(

--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -6529,6 +6529,36 @@ class VideoModelFoundation(VideoTransformMixin, ImageModelFoundation):
     does not do it by default.
     """
 
+    SUPPORTS_FAKE_VIDEO_STREAM = False
+    AUDIO_LORA_TARGET = None
+
+    @classmethod
+    def supports_audio_only_training(cls) -> bool:
+        """Return whether audio datasets can be trained without source video."""
+        return bool(cls.SUPPORTS_FAKE_VIDEO_STREAM)
+
+    def get_lora_target_layers(self):
+        manual_targets = self._get_peft_lora_target_modules()
+        if manual_targets:
+            return manual_targets
+
+        lora_type = str(getattr(self.config, "lora_type", "standard")).lower()
+        audio_only_data = self._data_has_audio and not self._data_has_images and not self._data_has_video
+        use_audio_default = (
+            lora_type == "standard"
+            and audio_only_data
+            and self.SUPPORTS_FAKE_VIDEO_STREAM
+            and not getattr(self.config, "controlnet", False)
+            and not getattr(self.config, "slider_lora_target", False)
+            and not getattr(self, "_data_has_grounding", False)
+        )
+        if use_audio_default:
+            if not self.AUDIO_LORA_TARGET:
+                raise ValueError(f"{self.NAME} supports audio-only datasets but does not define AUDIO_LORA_TARGET.")
+            return list(self.AUDIO_LORA_TARGET)
+
+        return super().get_lora_target_layers()
+
     @property
     def crepa_mode(self) -> CrepaMode:
         """Return shape interpretation mode for CREPA alignment.

--- a/simpletuner/helpers/models/ltxvideo2/model.py
+++ b/simpletuner/helpers/models/ltxvideo2/model.py
@@ -141,8 +141,24 @@ class LTXVideo2(VideoModelFoundation):
     # Only training the Attention blocks by default.
     DEFAULT_LYCORIS_TARGET = ["Attention"]
     DEFAULT_LORA_EXCLUDE_TARGETS = ".*connector.*|.*embedding.*"
-    # Audio-specific LoRA targets added when audio data is present.
-    AUDIO_LORA_TARGETS = [
+    SUPPORTS_FAKE_VIDEO_STREAM = True
+    AUDIO_LORA_TARGET = [
+        "audio_attn1.to_k",
+        "audio_attn1.to_q",
+        "audio_attn1.to_v",
+        "audio_attn1.to_out.0",
+        "audio_attn2.to_k",
+        "audio_attn2.to_q",
+        "audio_attn2.to_v",
+        "audio_attn2.to_out.0",
+        "audio_ff.net.0.proj",
+        "audio_ff.net.2",
+        "audio_proj_in",
+        "audio_proj_out",
+        "audio_caption_projection.linear_1",
+        "audio_caption_projection.linear_2",
+    ]
+    AUDIO_ADDITIONAL_LORA_TARGET = [
         "audio_proj_in",
         "audio_proj_out",
         "audio_caption_projection.linear_1",
@@ -222,7 +238,7 @@ class LTXVideo2(VideoModelFoundation):
         projection layers in the LoRA targets to enable learning audio features.
         """
         if self._data_has_audio:
-            return list(self.AUDIO_LORA_TARGETS)
+            return list(self.AUDIO_ADDITIONAL_LORA_TARGET)
         return []
 
     def supports_crepa_self_flow(self) -> bool:
@@ -314,25 +330,6 @@ class LTXVideo2(VideoModelFoundation):
         lora_type = getattr(self.config, "lora_type", "standard")
         if str(lora_type).lower() != "standard":
             return super().get_lora_target_layers()
-
-        if self._data_has_audio and not self._data_has_video:
-            # Audio-only: target just audio layers, not video layers
-            targets = [
-                "audio_attn1.to_k",
-                "audio_attn1.to_q",
-                "audio_attn1.to_v",
-                "audio_attn1.to_out.0",
-                "audio_attn2.to_k",
-                "audio_attn2.to_q",
-                "audio_attn2.to_v",
-                "audio_attn2.to_out.0",
-                "audio_ff.net.0.proj",
-                "audio_ff.net.2",
-            ]
-            for extra in self.AUDIO_LORA_TARGETS:
-                if extra not in targets:
-                    targets.append(extra)
-            return targets
 
         targets = super().get_lora_target_layers()
         if self._data_has_audio:
@@ -695,11 +692,6 @@ class LTXVideo2(VideoModelFoundation):
         return 47
 
     def supports_audio_inputs(self) -> bool:
-        return True
-
-    @classmethod
-    def supports_audio_only_training(cls) -> bool:
-        """LTX-2 supports training on audio-only datasets without video."""
         return True
 
     def supports_conditioning_dataset(self) -> bool:
@@ -1781,32 +1773,13 @@ class LTXVideo2(VideoModelFoundation):
         # Ensure frames satisfy LTX-2 constraint: frames % 8 == 1
         video_frames = self.adjust_video_frames(video_frames)
 
-        # Calculate video latent shape
+        # Calculate video latent shape. The LTX audio-only transformer skips the
+        # video branch, so one placeholder token per latent frame is sufficient.
         video_temporal_ratio = getattr(self.get_vae(), "temporal_compression_ratio", 8)
-        video_spatial_ratio = getattr(self.get_vae(), "spatial_compression_ratio", 32)
         latent_frames = (video_frames - 1) // video_temporal_ratio + 1
 
-        # Get resolution from latent_metadata or config
-        latent_metadata = batch.get("latent_metadata")
-        if latent_metadata and len(latent_metadata) > 0:
-            meta = latent_metadata[0]
-            height = meta.get("latent_height") or meta.get("original_size", (512, 512))[1]
-            width = meta.get("latent_width") or meta.get("original_size", (512, 512))[0]
-            # If these are pixel values, convert to latent dimensions
-            if height > 64:
-                height = height // video_spatial_ratio
-            if width > 64:
-                width = width // video_spatial_ratio
-        else:
-            # For audio-only training, use minimal resolution since video latents
-            # are just zeros with masked loss - no need to allocate large tensors
-            # Default to 64x64 (2x2 latent) which is the minimum practical size
-            default_res = 64
-            height = default_res // video_spatial_ratio  # 64 / 32 = 2
-            width = default_res // video_spatial_ratio  # 64 / 32 = 2
-
         batch_size = audio_latents.shape[0]
-        shape = (batch_size, self.LATENT_CHANNEL_COUNT, latent_frames, height, width)
+        shape = (batch_size, self.LATENT_CHANNEL_COUNT, latent_frames, 1, 1)
         return torch.zeros(shape, device=device, dtype=dtype)
 
     def _calculate_expected_audio_latent_length(self, batch: dict) -> int:

--- a/simpletuner/helpers/models/minimaxh3/model.py
+++ b/simpletuner/helpers/models/minimaxh3/model.py
@@ -33,17 +33,20 @@ from simpletuner.helpers.models.minimaxh3.encoders import MINIMAX_H3_DEFAULT_MAX
 from simpletuner.helpers.models.minimaxh3.modular_blocks_minimax_h3 import MiniMaxH3Blocks, MiniMaxH3Ref2VABlocks
 from simpletuner.helpers.models.minimaxh3.packing import (
     MINIMAX_H3_AUDIO_CHANNELS,
+    MINIMAX_H3_AUDIO_LATENTS_PER_SECOND,
     MINIMAX_H3_FPS,
     MINIMAX_H3_KEYFRAME_NOISE_AUG,
     MINIMAX_H3_PIXEL_MEAN,
     MINIMAX_H3_PIXEL_STD,
     MINIMAX_H3_TEXT_TAG,
+    align_num_frames,
     audio_latent_num_frames,
     build_packed_sequence,
     build_row_timestep_intervals,
     build_row_timesteps,
     patchify_video_latents,
     unpatchify_video_tokens,
+    video_latent_num_frames,
 )
 from simpletuner.helpers.models.minimaxh3.pipeline import MiniMaxH3Pipeline
 from simpletuner.helpers.models.minimaxh3.pipeline_ref import MiniMaxH3Ref2VAPipeline
@@ -98,6 +101,7 @@ def _is_single_file_path(path: Any) -> bool:
 class MiniMaxH3(VideoModelFoundation):
     SUPPORTS_MUON_CLIP = True
     AUTO_LORA_FORMAT_DETECTION = True
+    DEFAULT_AUDIO_CHANNELS = MINIMAX_H3_AUDIO_CHANNELS
     NAME = "MiniMax H3"
     MODEL_DESCRIPTION = "Joint audio-video flow-matching transformer"
     ENABLED_IN_WIZARD = True
@@ -157,6 +161,15 @@ class MiniMaxH3(VideoModelFoundation):
 
     DEFAULT_LORA_TARGET = ["to_q", "to_k", "to_v", "to_out.0"]
     DEFAULT_LYCORIS_TARGET = ["MiniMaxH3Attention", "FeedForward"]
+    SUPPORTS_FAKE_VIDEO_STREAM = True
+    AUDIO_LORA_TARGET = [
+        "to_q",
+        "to_k",
+        "to_v",
+        "to_out.0",
+        "audio_proj_in",
+        "audio_proj_out",
+    ]
 
     TEXT_ENCODER_CONFIGURATION = {
         "text_encoder": {
@@ -1103,6 +1116,12 @@ class MiniMaxH3(VideoModelFoundation):
     def uses_audio_latents(self) -> bool:
         return True
 
+    def get_vae_for_dataset_type(self, dataset_type: str):
+        if dataset_type == "audio":
+            self._load_audio_vae(move_to_device=True)
+            return self.audio_vae
+        return self.get_vae()
+
     @staticmethod
     def _normalise_h3_target_mode(value: Any, *, source: str = "MiniMax-H3 target mode") -> str:
         if value is None or value == "":
@@ -1137,6 +1156,9 @@ class MiniMaxH3(VideoModelFoundation):
     def _h3_target_mode_for_data_backend(self, data_backend_id: Optional[str] = None) -> str:
         mode = self._target_mode_from_backend_config(data_backend_id) or self._configured_h3_target_mode()
         if mode == "auto":
+            backend_config = StateTracker.get_data_backend_config(data_backend_id) if data_backend_id else {}
+            if (backend_config or {}).get("dataset_type") == "audio":
+                return "av"
             return "video"
         return mode
 
@@ -1239,6 +1261,44 @@ class MiniMaxH3(VideoModelFoundation):
             dtype=dtype,
         )
 
+    def _build_fake_video_latents(self, batch: dict, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+        audio_latents = batch.get("audio_latent_batch")
+        if isinstance(audio_latents, dict):
+            audio_latents = audio_latents.get("latents")
+        if not torch.is_tensor(audio_latents) or audio_latents.ndim != 4:
+            raise ValueError("MiniMax-H3 audio-only training requires cached audio latents before batch preparation.")
+
+        audio_length = int(audio_latents.shape[-1])
+        pixel_frames = max(
+            2,
+            round(audio_length / MINIMAX_H3_AUDIO_LATENTS_PER_SECOND * MINIMAX_H3_FPS),
+        )
+        latent_frames = video_latent_num_frames(align_num_frames(pixel_frames))
+        transformer = self.unwrap_model(self.model)
+        patch_size = tuple(getattr(transformer.config, "patch_size", (1, 2, 2)))
+        patch_t, patch_h, patch_w = patch_size
+        if latent_frames % patch_t:
+            latent_frames += patch_t - latent_frames % patch_t
+
+        return torch.zeros(
+            audio_latents.shape[0],
+            self.LATENT_CHANNEL_COUNT,
+            latent_frames,
+            patch_h,
+            patch_w,
+            device=device,
+            dtype=dtype,
+        )
+
+    def prepare_batch(self, batch: dict, state: dict) -> dict:
+        if batch.get("is_audio_only", False) and batch.get("latent_batch") is None:
+            batch["latent_batch"] = self._build_fake_video_latents(
+                batch,
+                self.accelerator.device,
+                self.config.weight_dtype,
+            )
+        return super().prepare_batch(batch=batch, state=state)
+
     def prepare_batch_conditions(self, batch: dict, state: dict) -> dict:
         batch = super().prepare_batch_conditions(batch=batch, state=state)
         target_device = self.accelerator.device
@@ -1303,12 +1363,13 @@ class MiniMaxH3(VideoModelFoundation):
                 f"MiniMax-H3 audio latents must have shape `[batch, 2, {audio_channels}, audio_latents]`, "
                 f"got {tuple(audio_latents.shape)}."
             )
-        expected_audio_latents = self._expected_audio_latents(batch["latents"])
-        if audio_latents.shape[-1] != expected_audio_latents:
-            raise ValueError(
-                f"MiniMax-H3 audio latent length {audio_latents.shape[-1]} does not match the video duration "
-                f"({expected_audio_latents}). Rebuild the audio VAE cache for this dataset."
-            )
+        if not batch.get("is_audio_only", False):
+            expected_audio_latents = self._expected_audio_latents(batch["latents"])
+            if audio_latents.shape[-1] != expected_audio_latents:
+                raise ValueError(
+                    f"MiniMax-H3 audio latent length {audio_latents.shape[-1]} does not match the video duration "
+                    f"({expected_audio_latents}). Rebuild the audio VAE cache for this dataset."
+                )
 
         if audio_mask is None:
             audio_mask = torch.ones(audio_latents.shape[0], device=target_device, dtype=torch.float32)
@@ -1722,11 +1783,15 @@ class MiniMaxH3(VideoModelFoundation):
         return total_loss, logs
 
     def _compute_av_loss(self, prepared_batch: dict, model_output, apply_conditioning_mask: bool = True):
-        video_loss = super().loss(
-            prepared_batch,
-            model_output,
-            apply_conditioning_mask=apply_conditioning_mask,
-        )
+        video_mask = prepared_batch.get("video_latent_mask")
+        if torch.is_tensor(video_mask) and bool(torch.all(video_mask == 0)):
+            video_loss = model_output["model_prediction"].float().sum() * 0.0
+        else:
+            video_loss = super().loss(
+                prepared_batch,
+                model_output,
+                apply_conditioning_mask=apply_conditioning_mask,
+            )
         if os.environ.get("SIMPLETUNER_MINIMAXH3_LOSS_DEBUG", "0") == "1":
             video_pred = model_output.get("model_prediction")
             latents = prepared_batch.get("latents")

--- a/simpletuner/helpers/training/collate.py
+++ b/simpletuner/helpers/training/collate.py
@@ -627,7 +627,7 @@ def collate_fn(batch):
     data_backend = StateTracker.get_data_backend(batch_backend_id)
     training_data_root = data_backend.get("config", {}).get("instance_data_dir")
 
-    # Check for audio-only mode (LTX-2 audio-only training)
+    # Check for audio-only mode on models that support training without source video.
     # Can be explicit (audio.audio_only: true) or implicit (audio dataset + model supports audio-only)
     backend_config_for_audio_check = data_backend.get("config", {})
     is_audio_only = False

--- a/tests/test_data_signals_lora_targets.py
+++ b/tests/test_data_signals_lora_targets.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 sys.path.append(os.getcwd())
 
-from simpletuner.helpers.models.common import ModelFoundation
+from simpletuner.helpers.models.common import ModelFoundation, VideoModelFoundation
 from simpletuner.helpers.models.ltxvideo2.model import LTXVideo2
 
 
@@ -54,7 +54,8 @@ class MockLTXVideo2(LTXVideo2):
         # Copy class attributes needed for LoRA target tests
         self.DEFAULT_LORA_TARGET = LTXVideo2.DEFAULT_LORA_TARGET
         self.DEFAULT_LYCORIS_TARGET = LTXVideo2.DEFAULT_LYCORIS_TARGET
-        self.AUDIO_LORA_TARGETS = LTXVideo2.AUDIO_LORA_TARGETS
+        self.AUDIO_LORA_TARGET = LTXVideo2.AUDIO_LORA_TARGET
+        self.AUDIO_ADDITIONAL_LORA_TARGET = LTXVideo2.AUDIO_ADDITIONAL_LORA_TARGET
 
 
 class TestDataSignalsBase(unittest.TestCase):
@@ -74,6 +75,10 @@ class TestDataSignalsBase(unittest.TestCase):
         self.assertFalse(model._data_has_images)
         self.assertFalse(model._data_has_video)
         self.assertFalse(model._data_has_audio)
+
+    def test_video_foundation_disables_fake_video_stream_by_default(self):
+        self.assertFalse(VideoModelFoundation.SUPPORTS_FAKE_VIDEO_STREAM)
+        self.assertFalse(VideoModelFoundation.supports_audio_only_training())
 
     def test_configure_data_signals_sets_flags(self):
         """configure_data_signals should set the appropriate flags."""
@@ -254,16 +259,24 @@ class TestLTXVideo2AudioLoraTargets(unittest.TestCase):
         self.assertIn("audio_proj_out", targets)
 
     def test_ltx2_audio_targets_constant(self):
-        """Verify LTX-2 AUDIO_LORA_TARGETS constant is correct."""
+        """Verify LTX-2 AUDIO_LORA_TARGET constant covers only audio modules."""
         expected = [
+            "audio_attn1.to_k",
+            "audio_attn1.to_q",
+            "audio_attn1.to_v",
+            "audio_attn1.to_out.0",
+            "audio_attn2.to_k",
+            "audio_attn2.to_q",
+            "audio_attn2.to_v",
+            "audio_attn2.to_out.0",
+            "audio_ff.net.0.proj",
+            "audio_ff.net.2",
             "audio_proj_in",
             "audio_proj_out",
             "audio_caption_projection.linear_1",
             "audio_caption_projection.linear_2",
-            "audio_ff.net.0.proj",
-            "audio_ff.net.2",
         ]
-        self.assertEqual(LTXVideo2.AUDIO_LORA_TARGETS, expected)
+        self.assertEqual(LTXVideo2.AUDIO_LORA_TARGET, expected)
 
     def test_ltx2_get_additional_lora_targets_returns_copy(self):
         """_get_additional_lora_targets should return a copy, not the class constant."""

--- a/tests/test_dataset_plan.py
+++ b/tests/test_dataset_plan.py
@@ -556,6 +556,14 @@ class AudioOnlyDatasetValidationTest(unittest.TestCase):
         # Should NOT require video/image when only audio datasets present
         self.assertFalse(any("image or video" in msg for msg in errors))
 
+    def test_minimaxh3_implicit_audio_only_allows_audio_dataset(self):
+        datasets = self._base_datasets()
+        datasets.append({"id": "audio", "dataset_type": "audio", "type": "local"})
+
+        validations = compute_validations(datasets, blueprints=[], model_family="minimaxh3")
+
+        self.assertFalse(any("image or video" in msg for msg in self._collect_errors(validations)))
+
     def test_ltxvideo2_explicit_audio_only_allows_audio_dataset(self):
         """LTX-2 with explicit audio_only flag should not require video or image datasets."""
         datasets = self._base_datasets()

--- a/tests/test_ltxvideo2_lora_targets.py
+++ b/tests/test_ltxvideo2_lora_targets.py
@@ -29,12 +29,14 @@ class _Transformer(torch.nn.Module):
 
 
 class LTXVideo2LoraTargetTests(unittest.TestCase):
-    def _model_foundation(self, *, has_audio: bool, manual_targets=None):
+    def _model_foundation(self, *, has_audio: bool, has_video: bool = True, manual_targets=None):
         model = object.__new__(LTXVideo2)
         model.config = SimpleNamespace(lora_type="standard", peft_lora_target_modules=manual_targets)
         model.model = _Transformer()
         model._data_has_audio = has_audio
-        model._data_has_video = True
+        model._data_has_video = has_video
+        model._data_has_images = False
+        model._data_has_grounding = False
         return model
 
     def test_video_only_lora_targets_exclude_video_to_audio_attention(self):
@@ -58,6 +60,30 @@ class LTXVideo2LoraTargetTests(unittest.TestCase):
         model = self._model_foundation(has_audio=False, manual_targets=["video_to_audio_attn.to_q"])
 
         self.assertEqual(model.get_lora_target_layers(), ["video_to_audio_attn.to_q"])
+
+    def test_audio_only_uses_audio_branch_targets(self):
+        model = self._model_foundation(has_audio=True, has_video=False)
+
+        self.assertEqual(model.get_lora_target_layers(), LTXVideo2.AUDIO_LORA_TARGET)
+
+    def test_audio_only_placeholder_is_one_token_per_frame(self):
+        model = self._model_foundation(has_audio=True, has_video=False)
+        model.LATENT_CHANNEL_COUNT = 4
+        model.config.framerate = 25
+        model.audio_vae = SimpleNamespace(
+            config=SimpleNamespace(sample_rate=16000, mel_hop_length=160),
+            temporal_compression_ratio=4,
+        )
+        model._load_audio_vae = lambda move_to_device=True: None
+        model.get_vae = lambda: SimpleNamespace(temporal_compression_ratio=8)
+        batch = {
+            "audio_latent_batch": torch.zeros(2, 8, 25, 16),
+            "latent_metadata": [{"original_size": (1024, 1024)}],
+        }
+
+        latents = model._build_empty_video_latents(batch, torch.device("cpu"), torch.float32)
+
+        self.assertEqual(latents.shape, (2, 4, 4, 1, 1))
 
 
 if __name__ == "__main__":

--- a/tests/test_minimaxh3.py
+++ b/tests/test_minimaxh3.py
@@ -33,6 +33,7 @@ from simpletuner.helpers.models.minimaxh3.modular_pipeline import (
     _convert_minimax_h3_diffusers_swiglu_lora_layout,
 )
 from simpletuner.helpers.models.minimaxh3.packing import (
+    MINIMAX_H3_AUDIO_LATENTS_PER_SECOND,
     MINIMAX_H3_FPS,
     MINIMAX_H3_PIXEL_MEAN,
     MINIMAX_H3_PIXEL_STD,
@@ -67,6 +68,7 @@ from simpletuner.helpers.models.minimaxh3.transformer import (
     resolve_h3_reference_mode,
 )
 from simpletuner.helpers.models.registry import ModelRegistry
+from simpletuner.helpers.training.state_tracker import StateTracker
 from simpletuner.helpers.training.validation import _validation_negative_prompt_record, prepare_validation_prompt_list
 
 
@@ -3619,6 +3621,118 @@ class MiniMaxH3Tests(unittest.TestCase):
         self.assertEqual(first["text_token_tags"].tolist(), [[1, 0]])
         self.assertEqual(second["prompt_embeds"].shape, (1, 3, 4))
         self.assertEqual(second["text_token_tags"].tolist(), [[1, 0, 1]])
+
+    def test_supports_fake_video_stream_with_audio_lora_target(self):
+        self.assertTrue(MiniMaxH3.SUPPORTS_FAKE_VIDEO_STREAM)
+        self.assertTrue(MiniMaxH3.supports_audio_only_training())
+        self.assertEqual(MiniMaxH3.DEFAULT_AUDIO_CHANNELS, 2)
+        self.assertIn("audio_proj_in", MiniMaxH3.AUDIO_LORA_TARGET)
+        self.assertIn("audio_proj_out", MiniMaxH3.AUDIO_LORA_TARGET)
+
+    def test_audio_only_data_uses_audio_lora_target(self):
+        wrapper = MiniMaxH3.__new__(MiniMaxH3)
+        wrapper.config = SimpleNamespace(
+            lora_type="standard",
+            peft_lora_target_modules=None,
+            controlnet=False,
+            slider_lora_target=False,
+        )
+        wrapper.configure_data_signals(has_audio=True)
+
+        self.assertEqual(wrapper.get_lora_target_layers(), MiniMaxH3.AUDIO_LORA_TARGET)
+
+    def test_manual_lora_target_overrides_audio_default(self):
+        wrapper = MiniMaxH3.__new__(MiniMaxH3)
+        wrapper.config = SimpleNamespace(
+            lora_type="standard",
+            peft_lora_target_modules=["custom.audio.layer"],
+            controlnet=False,
+            slider_lora_target=False,
+        )
+        wrapper.configure_data_signals(has_audio=True)
+
+        self.assertEqual(wrapper.get_lora_target_layers(), ["custom.audio.layer"])
+
+    def test_audio_backend_selects_av_target_mode_by_default(self):
+        wrapper = MiniMaxH3.__new__(MiniMaxH3)
+        wrapper.config = SimpleNamespace(minimax_h3_target_mode="auto")
+
+        with patch.object(StateTracker, "get_data_backend_config", return_value={"dataset_type": "audio"}):
+            self.assertEqual(wrapper._h3_target_mode_for_data_backend("music"), "av")
+            self.assertTrue(wrapper.uses_audio_latents_for_data_backend("music"))
+
+    def test_audio_dataset_uses_audio_vae(self):
+        wrapper = MiniMaxH3.__new__(MiniMaxH3)
+        wrapper.audio_vae = object()
+        wrapper._load_audio_vae = Mock()
+
+        result = wrapper.get_vae_for_dataset_type("audio")
+
+        wrapper._load_audio_vae.assert_called_once_with(move_to_device=True)
+        self.assertIs(result, wrapper.audio_vae)
+
+    def test_fake_video_stream_has_one_spatial_token_per_frame(self):
+        wrapper = MiniMaxH3.__new__(MiniMaxH3)
+        wrapper.model = tiny_h3_transformer(num_layers=1)
+        wrapper.LATENT_CHANNEL_COUNT = 2
+        wrapper.unwrap_model = lambda model=None: model
+        audio_length = 10 * MINIMAX_H3_AUDIO_LATENTS_PER_SECOND
+        batch = {"audio_latent_batch": torch.zeros(1, 2, 3, audio_length)}
+
+        latents = wrapper._build_fake_video_latents(batch, torch.device("cpu"), torch.float32)
+
+        self.assertEqual(latents.shape, (1, 2, 72, 2, 2))
+        packed = latents.shape[2] * (latents.shape[3] // 2) * (latents.shape[4] // 2)
+        self.assertEqual(packed, latents.shape[2])
+
+    def test_fake_video_stream_runs_joint_h3_forward(self):
+        wrapper = MiniMaxH3.__new__(MiniMaxH3)
+        wrapper.model = tiny_h3_transformer(num_layers=1)
+        wrapper.accelerator = SimpleNamespace(device=torch.device("cpu"))
+        wrapper.config = SimpleNamespace(weight_dtype=torch.float32)
+        wrapper.LATENT_CHANNEL_COUNT = 2
+        wrapper.unwrap_model = lambda model=None: model
+        audio_noisy = torch.randn(1, 2, 3, 2)
+        fake_video = wrapper._build_fake_video_latents(
+            {"audio_latent_batch": audio_noisy}, torch.device("cpu"), torch.float32
+        )
+
+        output = wrapper.model_predict(
+            {
+                "noisy_latents": fake_video,
+                "audio_noisy_latents": audio_noisy,
+                "encoder_hidden_states": torch.randn(1, 5, 6),
+                "timesteps": torch.tensor([0.25]),
+                "audio_timesteps": torch.tensor([0.5]),
+                "text_token_tags": torch.full((1, 5), MINIMAX_H3_TEXT_TAG, dtype=torch.long),
+                "minimax_h3_target_mode": "av",
+            }
+        )
+
+        self.assertEqual(output["model_prediction"].shape, fake_video.shape)
+        self.assertEqual(output["audio_prediction"].shape, audio_noisy.shape)
+
+    def test_audio_only_loss_ignores_fake_video_prediction(self):
+        wrapper = MiniMaxH3.__new__(MiniMaxH3)
+        wrapper.config = SimpleNamespace(audio_loss_weight=1.0)
+        video_prediction = torch.full((1, 2, 2, 2, 2), 100.0, requires_grad=True)
+        audio_prediction = torch.ones(1, 2, 3, 2, requires_grad=True)
+
+        loss, video_loss, audio_loss, _ = wrapper._compute_av_loss(
+            {
+                "video_latent_mask": torch.zeros(1),
+                "audio_latent_mask": torch.ones(1),
+                "audio_target": torch.zeros_like(audio_prediction),
+            },
+            {"model_prediction": video_prediction, "audio_prediction": audio_prediction},
+        )
+        loss.backward()
+
+        self.assertEqual(video_loss.item(), 0.0)
+        self.assertEqual(audio_loss.item(), 1.0)
+        self.assertEqual(loss.item(), 1.0)
+        self.assertTrue(torch.equal(video_prediction.grad, torch.zeros_like(video_prediction)))
+        self.assertTrue(bool(torch.all(audio_prediction.grad > 0)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add a video-model capability contract for training from audio-only datasets
- select family-specific audio LoRA targets when the configured media datasets are audio-only
- use the native LTX-2 audio branch and a duration-matched one-token fake video stream for MiniMax-H3
- route MiniMax-H3 audio caches through its audio VAE and mask fake-video loss
- document the automatic dataset behavior

## Validation

- 341 focused unit tests passed
- repository pre-commit hooks passed
