### PR TITLE
Wire caption batch sizing and align WebUI eligibility

### DIFF
--- a/simpletuner/helpers/data_backend/factory.py
+++ b/simpletuner/helpers/data_backend/factory.py
@@ -4481,6 +4481,7 @@ class FactoryRegistry:
         if isinstance(metadata_backend, CaptionMetadataBackend) and not built_on_rank:
             metadata_backend.load_image_metadata()
 
+        self._create_caption_dataloader(backend, init_backend)
         StateTracker.register_data_backend(init_backend)
         self.caption_backends[init_backend["id"]] = init_backend
         info_log(f"(id={init_backend['id']}) Caption dataset registered.")

--- a/simpletuner/simpletuner_sdk/server/data/dataset_blueprints.py
+++ b/simpletuner/simpletuner_sdk/server/data/dataset_blueprints.py
@@ -51,7 +51,7 @@ _BLUEPRINTS: List[BackendBlueprint] = [
         {
             "id": "local-image",
             "backendType": "local",
-            "datasetTypes": ["image", "video", "conditioning", "eval"],
+            "datasetTypes": ["image", "video", "caption"],
             "label": "local media backend",
             "description": "use filesystem folders or network mounts for primary training data",
             "defaults": {
@@ -100,6 +100,7 @@ _BLUEPRINTS: List[BackendBlueprint] = [
                         {"value": "text_embeds", "label": "text embeds"},
                         {"value": "image_embeds", "label": "image embeds"},
                         {"value": "audio", "label": "audio"},
+                        {"value": "caption", "label": "caption"},
                         {"value": "eval", "label": "eval"},
                     ],
                 },
@@ -718,7 +719,7 @@ _BLUEPRINTS: List[BackendBlueprint] = [
         {
             "id": "huggingface-image",
             "backendType": "huggingface",
-            "datasetTypes": ["image", "video"],
+            "datasetTypes": ["image", "video", "caption"],
             "label": "hugging face dataset",
             "description": "stream images from the hugging face hub",
             "defaults": {
@@ -1041,7 +1042,7 @@ _BLUEPRINTS: List[BackendBlueprint] = [
         {
             "id": "aws-image",
             "backendType": "aws",
-            "datasetTypes": ["image", "video"],
+            "datasetTypes": ["image", "video", "caption"],
             "label": "aws s3 bucket",
             "description": "pull media from an s3 bucket using botocore",
             "defaults": {
@@ -1151,6 +1152,24 @@ _BLUEPRINTS: List[BackendBlueprint] = [
 ]
 
 
+def _create_local_auxiliary_blueprint() -> BackendBlueprint:
+    source = next(blueprint for blueprint in _BLUEPRINTS if blueprint.id == "local-image")
+    blueprint = source.model_copy(deep=True)
+    blueprint.id = "local-auxiliary"
+    blueprint.datasetTypes = ["conditioning", "eval"]
+    blueprint.label = "local auxiliary media backend"
+    blueprint.description = "use filesystem folders or network mounts for paired conditioning or evaluation data"
+    blueprint.fields = [field for field in blueprint.fields if field.id != "train_batch_size"]
+    blueprint.metadata = BlueprintMetadata(
+        tags=["conditioning", "eval", "local"],
+        docsUrl=docs_url("DATALOADER.md"),
+    )
+    return blueprint
+
+
+_BLUEPRINTS.append(_create_local_auxiliary_blueprint())
+
+
 def _memory_filesystem_fields() -> List[DatasetField]:
     return [
         DatasetField(
@@ -1158,7 +1177,7 @@ def _memory_filesystem_fields() -> List[DatasetField]:
             label="memory filesystem path",
             description="empty directory used as the memory filesystem mount",
             type="text",
-            placeholder="/tmp/simpletuner-memory/my-cache",
+            placeholder="/mnt/simpletuner-memory/my-cache",
             advanced=True,
         ),
         DatasetField(

--- a/simpletuner/static/js/dataloader-section-component.js
+++ b/simpletuner/static/js/dataloader-section-component.js
@@ -49,6 +49,8 @@ const SKIP_DISCOVERY_OPTIONS = [
     }
 ];
 
+const TRAIN_BATCH_SIZE_DATASET_TYPES = new Set(['image', 'video', 'audio', 'caption']);
+
 window.CONDITIONING_GENERATOR_TYPES = window.CONDITIONING_GENERATOR_TYPES || CONDITIONING_GENERATOR_TYPES;
 
 const DATASET_COLLAPSE_SECTION_MAP = {
@@ -368,6 +370,18 @@ function dataloaderSectionComponent() {
         return labels.some(label =>
             label && label.toLowerCase().includes(query)
         );
+    },
+    supportsTrainBatchSize(dataset) {
+        const datasetType = typeof dataset?.dataset_type === 'string'
+            ? dataset.dataset_type.toLowerCase()
+            : '';
+        return TRAIN_BATCH_SIZE_DATASET_TYPES.has(datasetType);
+    },
+    onDatasetTypeChange(dataset) {
+        if (dataset && !this.supportsTrainBatchSize(dataset)) {
+            delete dataset.train_batch_size;
+        }
+        this.markAsUnsaved();
     },
 
     // Modal methods

--- a/simpletuner/templates/components/dataloader/dataset_list_item.html
+++ b/simpletuner/templates/components/dataloader/dataset_list_item.html
@@ -26,7 +26,7 @@
     <!-- Type Selector -->
     <select class="form-select form-select-sm list-item-type-select"
             x-model="dataset.dataset_type"
-            @change="markAsUnsaved()"
+            @change="onDatasetTypeChange(dataset)"
             @click.stop>
         <option value="">Type...</option>
         <option value="image">Image</option>

--- a/simpletuner/templates/components/dataloader/sections/advanced.html
+++ b/simpletuner/templates/components/dataloader/sections/advanced.html
@@ -37,7 +37,7 @@
                                    placeholder="0">
                             <div class="form-text">Set to 0 for a single pass. Each repeat adds another sweep through the dataset.</div>
                         </div>
-                        <div class="col-md-4">
+                        <div class="col-md-4" x-show="supportsTrainBatchSize(dataset)">
                             <label class="form-label">Batch Size</label>
                             <input type="number" class="form-control form-control-sm"
                                    min="1"

--- a/simpletuner/templates/components/dataloader/sections/basic.html
+++ b/simpletuner/templates/components/dataloader/sections/basic.html
@@ -19,7 +19,7 @@
                 <label class="form-label">Type <span class="text-danger">*</span></label>
                 <select class="form-control form-control-sm"
                         x-model="dataset.dataset_type"
-                        @change="markAsUnsaved()"
+                        @change="onDatasetTypeChange(dataset)"
                         :class="{'is-invalid': hasFieldError(dataset.id, 'dataset_type')}">
                     <option value="">Select type...</option>
                     <option value="image">🖼️ Image</option>

--- a/simpletuner/templates/components/dataloader/sections/basic_body.html
+++ b/simpletuner/templates/components/dataloader/sections/basic_body.html
@@ -188,7 +188,7 @@
                        placeholder="0">
                 <div class="form-text small">0 = single pass, 1+ = extra sweeps</div>
             </div>
-            <div class="col-md-4">
+            <div class="col-md-4" x-show="supportsTrainBatchSize(editingDataset)">
                 <label class="form-label small">Batch Size <a x-show="showDocLinks" href="{{ docs_url('DATALOADER.md#train_batch_size') }}" target="_blank" class="text-muted" title="Documentation"><sup><i class="fas fa-external-link-alt fa-xs"></i></sup></a></label>
                 <input type="number"
                        class="form-control form-control-sm"

--- a/simpletuner/templates/trainer_htmx.html
+++ b/simpletuner/templates/trainer_htmx.html
@@ -1944,15 +1944,19 @@ function trainerComponent() {
             if (dataset.dataset_type === 'text_embeds' || dataset.dataset_type === 'image_embeds') {
                 const writeBatch = this._coerceInt(dataset.write_batch_size);
                 dataset.write_batch_size = Number.isFinite(writeBatch) && writeBatch > 0 ? writeBatch : 128;
-                delete dataset.train_batch_size;
             } else {
                 delete dataset.write_batch_size;
+            }
+
+            if (['image', 'video', 'audio', 'caption'].includes(dataset.dataset_type)) {
                 const trainBatch = this._coerceInt(dataset.train_batch_size);
                 if (Number.isFinite(trainBatch) && trainBatch > 0) {
                     dataset.train_batch_size = trainBatch;
                 } else {
                     delete dataset.train_batch_size;
                 }
+            } else {
+                delete dataset.train_batch_size;
             }
 
             dataset._showAdvanced = Boolean(dataset._showAdvanced);
@@ -2667,7 +2671,6 @@ function trainerComponent() {
                 }
 
                 if (cleaned.dataset_type === 'text_embeds' || cleaned.dataset_type === 'image_embeds') {
-                    delete cleaned.train_batch_size;
                     const writeBatchSize = this._coerceInt(dataset.write_batch_size);
                     if (Number.isFinite(writeBatchSize) && writeBatchSize > 0) {
                         cleaned.write_batch_size = writeBatchSize;
@@ -2703,12 +2706,17 @@ function trainerComponent() {
                     delete cleaned.caption_filter_list;
                     delete cleaned.text_cache_ondemand;
                     delete cleaned.text_cache_disable;
+                }
+
+                if (['image', 'video', 'audio', 'caption'].includes(normalizedDatasetType)) {
                     const trainBatchSize = this._coerceInt(dataset.train_batch_size);
                     if (Number.isFinite(trainBatchSize) && trainBatchSize > 0) {
                         cleaned.train_batch_size = trainBatchSize;
                     } else {
                         delete cleaned.train_batch_size;
                     }
+                } else {
+                    delete cleaned.train_batch_size;
                 }
 
                 if (['image', 'video'].includes(cleaned.dataset_type)) {
@@ -6037,7 +6045,7 @@ function trainerComponent() {
                         <div>
                             <p class="mb-2">This is where your training configurations will be saved. Each config contains model settings, dataset references, and training parameters.</p>
                             <p class="mb-2"><strong>Already using SimpleTuner CLI?</strong> Point this to your existing configs directory and the UI will auto-discover your configurations.</p>
-                            <p class="mb-0 text-muted small">Example: <code>/home/you/simpletuner/configs</code></p>
+                            <p class="mb-0 text-muted small">Example: <code>/mnt/you/simpletuner/configs</code></p>
                         </div>
                     </div>
                     <!-- Step 2: Output Directory -->
@@ -6047,7 +6055,7 @@ function trainerComponent() {
                             <p class="mb-2">Training outputs include: validation images, data caches, checkpoints, LoRAs, optimizer states, dataloader status, random states, and model cards.</p>
                             <p class="mb-2"><strong>Disk space:</strong> LoRA training requires modest space (a few GB). Full model checkpoints require significantly more (10-50+ GB per checkpoint).</p>
                             <p class="mb-2"><strong>Multi-node users:</strong> Use network-shared storage accessible from all nodes at the same path.</p>
-                            <p class="mb-0 text-muted small">Example: <code>/home/you/simpletuner/output</code></p>
+                            <p class="mb-0 text-muted small">Example: <code>/mnt/you/simpletuner/output</code></p>
                         </div>
                     </div>
                     <!-- Step 3: Datasets Directory -->
@@ -6058,7 +6066,7 @@ function trainerComponent() {
                             <p class="mb-2"><strong>Uploading datasets:</strong> If you plan to upload datasets through the web interface, they will land in this directory.</p>
                             <p class="mb-2"><strong>Disk space:</strong> Datasets can be large (multiple GB to TB). Ensure sufficient space for your training images.</p>
                             <p class="mb-2">Leave blank to allow selecting datasets from anywhere on the filesystem (less secure).</p>
-                            <p class="mb-0 text-muted small">Example: <code>/home/you/datasets</code></p>
+                            <p class="mb-0 text-muted small">Example: <code>/mnt/you/datasets</code></p>
                         </div>
                     </div>
                 </div>

--- a/tests/js/dataloader_batch_size_eligibility.test.js
+++ b/tests/js/dataloader_batch_size_eligibility.test.js
@@ -1,0 +1,43 @@
+require('../../simpletuner/static/js/dataloader-section-component.js');
+
+
+describe('Dataloader train batch size eligibility', () => {
+    let component;
+
+    beforeEach(() => {
+        component = window.dataloaderSectionComponent();
+        component.markAsUnsaved = jest.fn();
+    });
+
+    test.each(['image', 'video', 'audio', 'caption'])(
+        'allows independently sampled %s datasets',
+        (datasetType) => {
+            expect(component.supportsTrainBatchSize({ dataset_type: datasetType })).toBe(true);
+        }
+    );
+
+    test.each(['conditioning', 'eval', 'text_embeds', 'image_embeds'])(
+        'rejects %s datasets',
+        (datasetType) => {
+            expect(component.supportsTrainBatchSize({ dataset_type: datasetType })).toBe(false);
+        }
+    );
+
+    test('removes an existing override when the dataset type becomes unsupported', () => {
+        const dataset = { dataset_type: 'conditioning', train_batch_size: 4 };
+
+        component.onDatasetTypeChange(dataset);
+
+        expect(dataset).not.toHaveProperty('train_batch_size');
+        expect(component.markAsUnsaved).toHaveBeenCalledTimes(1);
+    });
+
+    test('preserves an existing override when the dataset type remains supported', () => {
+        const dataset = { dataset_type: 'caption', train_batch_size: 4 };
+
+        component.onDatasetTypeChange(dataset);
+
+        expect(dataset.train_batch_size).toBe(4);
+        expect(component.markAsUnsaved).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/test_dataset_blueprints.py
+++ b/tests/test_dataset_blueprints.py
@@ -24,5 +24,25 @@ class TestMemoryDatasetBlueprints(unittest.TestCase):
             self.assertFalse(fields["memory_filesystem_sudo"].defaultValue)
 
 
+class TestTrainBatchSizeBlueprints(unittest.TestCase):
+    def test_train_batch_size_only_applies_to_independently_sampled_datasets(self):
+        lookup = get_blueprint_lookup()
+        supported_types = {"image", "video", "audio", "caption"}
+
+        for (_backend_type, dataset_type), blueprint in lookup.items():
+            fields = {field.id for field in blueprint.fields}
+            self.assertEqual(
+                "train_batch_size" in fields,
+                dataset_type in supported_types,
+                f"Unexpected train_batch_size eligibility for {blueprint.backendType}/{dataset_type}",
+            )
+
+    def test_local_caption_blueprint_exposes_train_batch_size(self):
+        blueprint = find_blueprint("local", "caption")
+
+        self.assertIsNotNone(blueprint)
+        self.assertIn("train_batch_size", {field.id for field in blueprint.fields})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_factory_caption_backend.py
+++ b/tests/test_factory_caption_backend.py
@@ -1,0 +1,103 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from simpletuner.helpers.data_backend.caption_sampler import CaptionSampler
+from simpletuner.helpers.data_backend.factory import FactoryRegistry
+from simpletuner.helpers.metadata.backends.caption import CaptionMetadataBackend
+
+
+class _CaptionConfig:
+    def validate(self, *_args, **_kwargs):
+        return None
+
+
+class _CaptionMetadata(CaptionMetadataBackend):
+    def __init__(self, events):
+        self.events = events
+
+    def load_image_metadata(self):
+        self.events.append("load")
+
+    def list_metadata_ids(self):
+        return []
+
+    def __len__(self):
+        return 0
+
+
+class FactoryCaptionBackendTests(unittest.TestCase):
+    def _configure_backend(self, *, global_batch_size, dataset_batch_size=None):
+        events = []
+        metadata_backend = _CaptionMetadata(events)
+        accelerator = SimpleNamespace(
+            is_local_main_process=True,
+            num_processes=2,
+            process_index=0,
+            wait_for_everyone=lambda: events.append("wait"),
+        )
+        factory = FactoryRegistry.__new__(FactoryRegistry)
+        factory.args = SimpleNamespace(
+            train_batch_size=global_batch_size,
+            seed=123,
+            skip_file_discovery="caption",
+        )
+        factory.accelerator = accelerator
+        factory.caption_backends = {}
+
+        backend = {
+            "id": "captions",
+            "type": "local",
+            "dataset_type": "caption",
+            "instance_data_dir": "data/captions",
+        }
+        if dataset_batch_size is not None:
+            backend["train_batch_size"] = dataset_batch_size
+
+        def init_backend_config(config, _args, _accelerator):
+            runtime_config = {"repeats": 0}
+            if "train_batch_size" in config:
+                runtime_config["train_batch_size"] = config["train_batch_size"]
+            return {
+                "id": config["id"],
+                "config": runtime_config,
+                "dataset_type": config["dataset_type"],
+            }
+
+        with (
+            patch("simpletuner.helpers.data_backend.factory.create_backend_config", return_value=_CaptionConfig()),
+            patch("simpletuner.helpers.data_backend.factory.init_backend_config", side_effect=init_backend_config),
+            patch(
+                "simpletuner.helpers.data_backend.factory.build_backend_from_config",
+                return_value={
+                    "data_backend": MagicMock(),
+                    "metadata_backend": metadata_backend,
+                    "instance_data_dir": backend["instance_data_dir"],
+                },
+            ),
+            patch("simpletuner.helpers.data_backend.factory.StateTracker") as state_tracker,
+        ):
+            state_tracker.register_data_backend.side_effect = lambda _backend: events.append("register")
+            factory._configure_caption_backend(backend)
+            registered_backend = state_tracker.register_data_backend.call_args.args[0]
+
+        return registered_backend, events
+
+    def test_caption_backend_uses_dataset_batch_size_override(self):
+        registered_backend, events = self._configure_backend(global_batch_size=8, dataset_batch_size=3)
+
+        self.assertIsInstance(registered_backend["sampler"], CaptionSampler)
+        self.assertEqual(registered_backend["sampler"].batch_size, 3)
+        self.assertIs(registered_backend["train_dataloader"].sampler, registered_backend["sampler"])
+        self.assertEqual(events, ["wait", "load", "register"])
+
+    def test_caption_backend_uses_global_batch_size_fallback(self):
+        registered_backend, _events = self._configure_backend(global_batch_size=5)
+
+        self.assertIsInstance(registered_backend["sampler"], CaptionSampler)
+        self.assertEqual(registered_backend["sampler"].batch_size, 5)
+        self.assertIn("train_dataloader", registered_backend)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_webui_e2e.py
+++ b/tests/test_webui_e2e.py
@@ -830,7 +830,7 @@ class FormDirtyStateFlowTestCase(_TrainerPageMixin, WebUITestCase):
             wait_for_save_state(False)
 
             # Easy Mode change enables Save
-            basic_tab.set_output_dir("/tmp/dirty-easy-mode")
+            basic_tab.set_output_dir(str(self.home_path.parent / "dirty-easy-mode"))
             wait_for_save_state(True)
 
             save_via_ui()
@@ -855,7 +855,7 @@ class FormDirtyStateFlowTestCase(_TrainerPageMixin, WebUITestCase):
 
             # Save clears, new edits re-enable
             trainer_page.switch_to_basic_tab()
-            basic_tab.set_output_dir("/tmp/dirty-easy-mode-2")
+            basic_tab.set_output_dir(str(self.home_path.parent / "dirty-easy-mode-2"))
             wait_for_save_state(True)
 
         self.for_each_browser("test_save_button_dirty_state", scenario)
@@ -1019,7 +1019,7 @@ class TrainingWorkflowTestCase(_TrainerPageMixin, WebUITestCase):
             self.dismiss_onboarding(driver)
             trainer_page.wait_for_tab("basic")
             basic_tab.set_model_name("flux-test-model")
-            basic_tab.set_output_dir("/tmp/test-output")
+            basic_tab.set_output_dir(str(self.home_path.parent / "test-output"))
             trainer_page.switch_to_model_tab()
             trainer_page.wait_for_tab("model")
             basic_tab.set_base_model("jimmycarter/LibreFlux-SimpleTuner")
@@ -1055,7 +1055,7 @@ class TrainingWorkflowTestCase(_TrainerPageMixin, WebUITestCase):
             trainer_page.wait_for_tab("basic")
 
             basic_tab.set_model_name("failure-job")
-            basic_tab.set_output_dir("/tmp/failure-output")
+            basic_tab.set_output_dir(str(self.home_path.parent / "failure-output"))
 
             trainer_page.start_training()
 
@@ -1616,7 +1616,7 @@ class ToastNotificationsTestCase(_TrainerPageMixin, WebUITestCase):
             trainer_page.navigate_to_trainer()
             self.dismiss_onboarding(driver)
             trainer_page.wait_for_tab("basic")
-            basic_tab.set_output_dir("/tmp/toast-position")
+            basic_tab.set_output_dir(str(self.home_path.parent / "toast-position"))
             basic_tab.save_changes()
 
             toast_container = driver.find_element(By.CSS_SELECTOR, ".toast-container")
@@ -1757,7 +1757,7 @@ class DatasetBuilderViewModeTestCase(_TrainerPageMixin, WebUITestCase):
         self.for_each_browser("test_dataset_modal", scenario)
 
     def test_dataset_train_batch_size_marks_unsaved_and_saves_clean_json(self) -> None:
-        """Dataset train_batch_size should update Alpine state, mark dirty, and serialize."""
+        """Dataset train_batch_size should only render and serialize for supported dataset types."""
         self.seed_defaults()
 
         def scenario(driver, _browser):
@@ -1813,6 +1813,66 @@ class DatasetBuilderViewModeTestCase(_TrainerPageMixin, WebUITestCase):
             )
             self.assertTrue(state["dirty"])
             self.assertEqual(state["trainBatchSize"], 3)
+
+            driver.execute_script(
+                """
+                const select = document.querySelectorAll('.list-item-type-select')[arguments[0]];
+                select.value = 'conditioning';
+                select.dispatchEvent(new Event('input', { bubbles: true }));
+                select.dispatchEvent(new Event('change', { bubbles: true }));
+                """,
+                dataset_index,
+            )
+            unsupported_state = WebDriverWait(driver, 5).until(
+                lambda d: d.execute_script(
+                    """
+                    const comp = window.dataloaderSectionComponentInstance;
+                    const store = window.Alpine && Alpine.store ? Alpine.store('trainer') : null;
+                    if (!comp || !store || !Array.isArray(comp.datasets)) { return null; }
+                    const dataset = comp.datasets[arguments[0]];
+                    const saved = store.prepareDatasetsForSave(comp.datasets)[arguments[0]] || {};
+                    return dataset.dataset_type === 'conditioning'
+                        && !Object.prototype.hasOwnProperty.call(dataset, 'train_batch_size')
+                        && !Object.prototype.hasOwnProperty.call(saved, 'train_batch_size')
+                        ? { datasetType: dataset.dataset_type }
+                        : null;
+                    """,
+                    dataset_index,
+                )
+            )
+            self.assertEqual(unsupported_state["datasetType"], "conditioning")
+
+            hidden_for_conditioning = WebDriverWait(driver, 5).until(
+                lambda d: d.execute_script(
+                    """
+                    const input = document.querySelector('.dataset-modal input[x-model\\\\.number\\\\.lazy="editingDataset.train_batch_size"]');
+                    const field = input ? input.closest('.col-md-4') : null;
+                    return field ? window.getComputedStyle(field).display === 'none' : false;
+                    """
+                )
+            )
+            self.assertTrue(hidden_for_conditioning)
+
+            eval_state = WebDriverWait(driver, 5).until(
+                lambda d: d.execute_script(
+                    """
+                    const comp = window.dataloaderSectionComponentInstance;
+                    const store = window.Alpine && Alpine.store ? Alpine.store('trainer') : null;
+                    const dataset = comp && Array.isArray(comp.datasets) ? comp.datasets[arguments[0]] : null;
+                    if (!dataset || !store) { return null; }
+                    dataset.train_batch_size = 7;
+                    dataset.dataset_type = 'eval';
+                    comp.onDatasetTypeChange(dataset);
+                    const saved = store.prepareDatasetsForSave(comp.datasets)[arguments[0]] || {};
+                    return !Object.prototype.hasOwnProperty.call(dataset, 'train_batch_size')
+                        && !Object.prototype.hasOwnProperty.call(saved, 'train_batch_size')
+                        ? { datasetType: dataset.dataset_type }
+                        : null;
+                    """,
+                    dataset_index,
+                )
+            )
+            self.assertEqual(eval_state["datasetType"], "eval")
 
         self.for_each_browser("test_dataset_train_batch_size_marks_unsaved_and_saves_clean_json", scenario)
 


### PR DESCRIPTION
## What
- Attach the existing caption dataset, sampler, collate function, and dataloader after caption metadata ingestion.
- Apply caption dataset overrides and the global fallback to the caption sampler.
- Show and serialize per-dataset batch size only for image, video, audio, and caption datasets.
- Remove stale overrides when a dataset changes to conditioning or eval.
- Split local primary and auxiliary blueprints so server-provided fields match runtime eligibility.
- Normalize touched public examples and E2E path fixtures to identity-free values.

## Why
Caption backends were registered without invoking the existing dataloader builder, so the advertised batch override never reached training. The WebUI also exposed and saved overrides for eval, which runtime forces to one, and conditioning, which is paired auxiliary data.

## Impact
Caption-aware distillers receive trainable caption batches with the resolved dataset size. Unsupported UI paths no longer retain misleading values, while image, video, audio, and caption behavior remains available.

## Validation
- `.venv/bin/python -m unittest -v -f tests.test_factory_caption_backend tests.test_dataset_blueprints tests.test_dataset_plan tests.test_dataset_routes` (67 passed)
- `npm test -- --runInBand tests/js/dataloader_batch_size_eligibility.test.js tests/js/dataset_management.test.js` (39 passed)
- Feature-specific Selenium E2E passed with `SIMPLETUNER_SELENIUM_TESTS=1`.
- Three existing E2E workflows affected by fixture normalization passed.
- The existing form dirty-state E2E reproduced a timeout on both this branch and `origin/main`.
- `git diff --check`