### PR TITLE
fix audio-only validation upload from h3 model

### DIFF
--- a/simpletuner/helpers/models/minimaxh3/model.py
+++ b/simpletuner/helpers/models/minimaxh3/model.py
@@ -1207,8 +1207,17 @@ class MiniMaxH3(VideoModelFoundation):
     def should_precompute_validation_negative_prompt(self) -> bool:
         return False
 
+    def validation_audio_sample_rate(self) -> Optional[int]:
+        if getattr(self, "audio_vae", None) is None:
+            self._load_audio_vae(move_to_device=False)
+        sampling_rate = getattr(getattr(self.audio_vae, "config", None), "sampling_rate", None)
+        return int(sampling_rate) if sampling_rate else None
+
     def update_pipeline_call_kwargs(self, pipeline_kwargs):
         pipeline_kwargs.setdefault("minimax_h3_target_mode", self._configured_h3_target_mode())
+        num_frames = getattr(self.config, "validation_num_video_frames", None)
+        if num_frames:
+            pipeline_kwargs.setdefault("num_frames", int(num_frames))
         guidance_scale_real = pipeline_kwargs.pop("guidance_scale_real", None)
         if guidance_scale_real is None:
             guidance_scale_real = getattr(self.config, "validation_guidance_real", None)

--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -3872,7 +3872,7 @@ class Validation:
 
     @staticmethod
     def _extract_pipeline_media(pipeline_result, *, audio_only: bool = False):
-        for field_name in ("frames", "images", "audios", "audio", "videos"):
+        for field_name in ("frames", "images", "videos", "audios", "audio"):
             if not hasattr(pipeline_result, field_name):
                 continue
             current_results = getattr(pipeline_result, field_name)


### PR DESCRIPTION
This pull request introduces improvements to audio and video validation handling in the model and training helper code. The main changes enhance how audio sample rates and video frame counts are managed, and adjust the extraction order of media fields during validation.

**Model improvements:**

* Added a new method `validation_audio_sample_rate` to `minimaxh3/model.py` to retrieve the audio sample rate from the model's audio VAE configuration, ensuring the VAE is loaded if necessary.
* Updated `update_pipeline_call_kwargs` to include `num_frames` from the model's config as a pipeline argument if available, improving support for video validation settings.

**Validation helper refinement:**

* Changed the extraction order of media fields in `_extract_pipeline_media` to prioritize `videos` before `audios` and `audio`, which can affect which media type is selected during validation.