### PR TITLE
Fix Webshart multi-caption text precache

### DIFF
--- a/simpletuner/helpers/caching/text_embeds.py
+++ b/simpletuner/helpers/caching/text_embeds.py
@@ -670,10 +670,13 @@ class TextEmbeddingCache(WebhookMixin):
                                 f"\n-> error: {e}"
                                 f"\n-> id: {self.id}, data_backend id: {self.data_backend.id}"
                             )
-                            raise Exception(
-                                "Cache retrieval for text embed file failed. Ensure your dataloader config value for "
-                                "skip_file_discovery does not contain 'text', and that preserve_data_backend_cache is "
-                                "disabled or unset."
+                            raise RuntimeError(
+                                "Cache retrieval for text embed file failed. For Webshart or other multi-caption "
+                                "datasets, this can mean the existing text embedding cache was generated without every "
+                                "caption variant that training can request. Set text_cache_ondemand: true to compute "
+                                "missing embeds during training, or clear the text embedding cache and rerun precache. "
+                                "Also ensure skip_file_discovery does not contain 'text' and preserve_data_backend_cache "
+                                "is disabled or unset."
                             ) from e
                         if self.model.requires_text_embed_image_context() and not record.get("metadata"):
                             raise ValueError(

--- a/simpletuner/helpers/data_backend/webshart.py
+++ b/simpletuner/helpers/data_backend/webshart.py
@@ -338,7 +338,7 @@ class WebshartDataBackend(BaseDataBackend):
             }
         return self._shard_sample_index_cache[shard_idx].get(str(filename))
 
-    def get_caption(self, image_path: str) -> Optional[str]:
+    def get_caption(self, image_path: str) -> Optional[Union[str, List[str], dict]]:
         if not self.is_sample_id(image_path):
             return None
 
@@ -346,6 +346,10 @@ class WebshartDataBackend(BaseDataBackend):
         sample_metadata = self.get_shard_metadata(sample_ref.shard_idx).get(sample_ref.filename, {}) or {}
         caption = sample_metadata.get("captions")
         if caption:
+            if isinstance(caption, dict):
+                return caption
+            if isinstance(caption, list):
+                return [str(item).strip() for item in caption if item is not None and str(item).strip()]
             return str(caption).strip()
 
         caption_filename = Path(sample_ref.filename).with_suffix(".txt").name

--- a/simpletuner/helpers/metadata/backends/webshart.py
+++ b/simpletuner/helpers/metadata/backends/webshart.py
@@ -91,7 +91,7 @@ class WebshartMetadataBackend(MetadataBackend):
         if self.dataset_type not in {DatasetType.IMAGE, DatasetType.VIDEO, DatasetType.CONDITIONING, DatasetType.EVAL}:
             raise ValueError("WebshartMetadataBackend supports image, video, conditioning, and eval datasets only.")
 
-        self.caption_cache: Dict[str, Union[str, List[str]]] = {}
+        self.caption_cache: Dict[str, Union[str, List[str], dict]] = {}
 
         context = accelerator.main_process_first() if hasattr(accelerator, "main_process_first") else nullcontext()
         with context:
@@ -119,7 +119,7 @@ class WebshartMetadataBackend(MetadataBackend):
             return
         StateTracker.set_image_files([("", [], sample_ids)], data_backend_id=self.data_backend.id)
 
-    def caption_cache_entry(self, index: str) -> Optional[Union[str, List[str]]]:
+    def caption_cache_entry(self, index: str) -> Optional[Union[str, List[str], dict]]:
         index = self.data_backend.normalize_sample_id(index)
         caption = self.caption_cache.get(index, None)
         if caption is not None:

--- a/simpletuner/helpers/prompts.py
+++ b/simpletuner/helpers/prompts.py
@@ -267,6 +267,38 @@ class PromptHandler:
         self.tokenizers = tokenizers
 
     @staticmethod
+    def _caption_payload_is_multi_value(caption) -> bool:
+        return isinstance(caption, (list, tuple, dict, numpy.ndarray, pd.Series))
+
+    @staticmethod
+    def _normalize_caption_payload(caption) -> list[str]:
+        if caption is None:
+            return []
+        if isinstance(caption, bytes):
+            caption = caption.decode("utf-8")
+        if isinstance(caption, str):
+            caption = caption.strip()
+            return [caption] if caption else []
+        if isinstance(caption, dict):
+            captions = []
+            for value in caption.values():
+                captions.extend(PromptHandler._normalize_caption_payload(value))
+            return captions
+        if isinstance(caption, (list, tuple, numpy.ndarray, pd.Series)):
+            captions = []
+            for value in caption:
+                captions.extend(PromptHandler._normalize_caption_payload(value))
+            return captions
+        caption = str(caption).strip()
+        return [caption] if caption else []
+
+    @staticmethod
+    def _restore_caption_payload_shape(caption, caption_values: list[str]):
+        if PromptHandler._caption_payload_is_multi_value(caption):
+            return caption_values
+        return caption_values[0] if caption_values else ""
+
+    @staticmethod
     def retrieve_prompt_column_from_parquet(
         sampler_backend_id: str,
     ) -> str:
@@ -338,18 +370,10 @@ class PromptHandler:
             raise CaptionNotFoundError(
                 f"Could not locate caption for image {image_path} in sampler_backend {sampler_backend_id} with filename column {filename_column}, caption column {caption_column}, and a parquet database with {len(parquet_db)} entries."
             )
-        if type(image_caption) == bytes:
-            image_caption = image_caption.decode("utf-8")
-        if type(image_caption) == str:
-            image_caption = image_caption.strip()
-        if type(image_caption) in (list, tuple, numpy.ndarray, pd.Series):
-            image_caption = [str(item).strip() for item in image_caption if item is not None]
+        caption_values = PromptHandler._normalize_caption_payload(image_caption)
         if prepend_instance_prompt:
-            if type(image_caption) == list:
-                image_caption = [instance_prompt + " " + x for x in image_caption]
-            else:
-                image_caption = instance_prompt + " " + image_caption
-        return image_caption
+            caption_values = [instance_prompt + " " + x for x in caption_values]
+        return PromptHandler._restore_caption_payload_shape(image_caption, caption_values)
 
     @staticmethod
     def prepare_instance_prompt_from_filename(
@@ -460,22 +484,13 @@ class PromptHandler:
             if caption is None:
                 raise CaptionNotFoundError(f"Could not find caption for {image_path} in HuggingFace dataset")
 
-        # Process the caption
-        if isinstance(caption, bytes):
-            caption = caption.decode("utf-8")
-        if isinstance(caption, str):
-            caption = caption.strip()
-        if isinstance(caption, (list, tuple, numpy.ndarray, pd.Series)):
-            caption = [str(item).strip() for item in caption if item is not None]
+        caption_values = PromptHandler._normalize_caption_payload(caption)
 
         # Prepend instance prompt if requested
         if prepend_instance_prompt and instance_prompt:
-            if isinstance(caption, list):
-                caption = [instance_prompt + " " + c for c in caption]
-            else:
-                caption = instance_prompt + " " + caption
+            caption_values = [instance_prompt + " " + c for c in caption_values]
 
-        return caption
+        return PromptHandler._restore_caption_payload_shape(caption, caption_values)
 
     @staticmethod
     def prepare_instance_prompt_from_webshart(
@@ -503,20 +518,12 @@ class PromptHandler:
         if caption is None:
             raise CaptionNotFoundError(f"Could not find caption for {image_path} in Webshart dataset")
 
-        if isinstance(caption, bytes):
-            caption = caption.decode("utf-8")
-        if isinstance(caption, str):
-            caption = caption.strip()
-        if isinstance(caption, (list, tuple, numpy.ndarray, pd.Series)):
-            caption = [str(item).strip() for item in caption if item is not None]
+        caption_values = PromptHandler._normalize_caption_payload(caption)
 
         if prepend_instance_prompt and instance_prompt:
-            if isinstance(caption, list):
-                caption = [instance_prompt + " " + c for c in caption]
-            else:
-                caption = instance_prompt + " " + caption
+            caption_values = [instance_prompt + " " + c for c in caption_values]
 
-        return caption
+        return PromptHandler._restore_caption_payload_shape(caption, caption_values)
 
     @staticmethod
     def magic_prompt(
@@ -625,7 +632,7 @@ class PromptHandler:
 
         # Apply shuffle expansion if enabled
         if shuffle_enabled and instance_prompt:
-            caption_values = instance_prompt if isinstance(instance_prompt, list) else [instance_prompt]
+            caption_values = PromptHandler._normalize_caption_payload(instance_prompt)
             expanded_captions = []
             for value in caption_values:
                 shuffled = CaptionShuffler.expand_with_shuffles(value, caption_shuffle_config)
@@ -795,7 +802,7 @@ class PromptHandler:
                     logger.error(f"Could not load caption for image {image_path}: {e}")
                     images_missing_captions.append(image_path)
                 else:
-                    caption_values = caption if isinstance(caption, (tuple, list, dict)) else [caption]
+                    caption_values = PromptHandler._normalize_caption_payload(caption)
 
                     # Apply shuffle expansion if enabled
                     if shuffle_enabled:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -13,6 +13,14 @@ class _DummyBackend:
         return self._files
 
 
+class _DummyMetadataBackend:
+    def __init__(self, captions):
+        self._captions = captions
+
+    def caption_cache_entry(self, image_path):
+        return self._captions.get(image_path)
+
+
 class PromptHandlerTests(unittest.TestCase):
     def test_instanceprompt_returns_entry_per_image(self):
         backend = _DummyBackend(["a.jpg", "b.jpg", "c.jpg"])
@@ -32,6 +40,50 @@ class PromptHandlerTests(unittest.TestCase):
         self.assertEqual(missing, [])
         self.assertEqual(captions, ["minecraft", "minecraft", "minecraft"])
         self.assertEqual(paths, ["a.jpg", "b.jpg", "c.jpg"])
+
+    def test_webshart_get_all_captions_expands_structured_caption_variants(self):
+        backend = _DummyBackend(["webshart://0/1/first.jpg", "webshart://0/2/second.jpg"])
+        metadata_backend = _DummyMetadataBackend(
+            {
+                "webshart://0/1/first.jpg": ["first primary", "first alternate"],
+                "webshart://0/2/second.jpg": {
+                    "primary": "second primary",
+                    "alternates": ["second alternate"],
+                },
+            }
+        )
+
+        with (
+            patch("simpletuner.helpers.prompts.StateTracker.get_data_backend_config", return_value={}),
+            patch("simpletuner.helpers.prompts.StateTracker.get_image_files", return_value=None),
+            patch(
+                "simpletuner.helpers.prompts.StateTracker.get_data_backend",
+                return_value={"metadata_backend": metadata_backend},
+            ),
+        ):
+            captions, missing, paths = PromptHandler.get_all_captions(
+                instance_data_dir="",
+                use_captions=True,
+                prepend_instance_prompt=False,
+                data_backend=backend,
+                caption_strategy="webshart",
+                return_image_paths=True,
+            )
+
+        self.assertEqual(missing, [])
+        self.assertEqual(
+            captions,
+            ["first primary", "first alternate", "second primary", "second alternate"],
+        )
+        self.assertEqual(
+            paths,
+            [
+                "webshart://0/1/first.jpg",
+                "webshart://0/1/first.jpg",
+                "webshart://0/2/second.jpg",
+                "webshart://0/2/second.jpg",
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_text_embeds.py
+++ b/tests/test_text_embeds.py
@@ -153,6 +153,28 @@ class TextEmbeddingCacheKeyTests(unittest.TestCase):
         cache.model.encode_text_batch.assert_not_called()
         self.assertEqual(cache.write_queue.qsize(), 0)
 
+    def test_cache_miss_error_mentions_multi_caption_workaround(self):
+        cache = _make_cache(TextEmbedCacheKey.CAPTION)
+
+        class CacheOnlyModel(_DummyModel):
+            def __init__(self):
+                super().__init__(TextEmbedCacheKey.CAPTION)
+
+            def unpack_text_embeddings_from_cache(self, embeddings):
+                return embeddings
+
+        cache.model = CacheOnlyModel()
+        cache.load_from_cache = MagicMock(side_effect=FileNotFoundError("missing"))
+
+        with self.assertRaisesRegex(RuntimeError, "multi-caption") as context:
+            cache.compute_prompt_embeddings_with_model(
+                prompt_records=[{"prompt": "alternate caption", "key": "alternate caption", "metadata": {}}]
+            )
+
+        message = str(context.exception)
+        self.assertIn("text_cache_ondemand: true", message)
+        self.assertIn("clear the text embedding cache and rerun precache", message)
+
     def test_resolve_key_value_caption_fallback(self):
         cache = _make_cache(TextEmbedCacheKey.CAPTION)
         record = {"prompt": "hello world"}

--- a/tests/test_webshart_backend.py
+++ b/tests/test_webshart_backend.py
@@ -144,6 +144,14 @@ class TestWebshartDataBackend(unittest.TestCase):
 
         self.assertEqual(caption, "A moving subject.")
 
+    def test_get_caption_preserves_indexed_caption_variants(self):
+        backend = WebshartDataBackend.__new__(WebshartDataBackend)
+        backend.get_shard_metadata = Mock(return_value={"sample.mp4": {"captions": ["first caption", "second caption"]}})
+
+        caption = backend.get_caption("webshart://2/7/sample.mp4")
+
+        self.assertEqual(caption, ["first caption", "second caption"])
+
     def test_video_metadata_uses_indexed_frame_fields_and_probe_geometry(self):
         backend = WebshartMetadataBackend.__new__(WebshartMetadataBackend)
         backend.dataset_type = DatasetType.VIDEO


### PR DESCRIPTION
## Summary
- preserve list and dictionary caption payloads from Webshart indices
- normalize structured caption variants through shared prompt handling
- explain multi-caption cache misses with actionable remediation

## Testing
- `.venv/bin/python -m unittest -v tests.test_prompts tests.test_text_embeds tests.test_webshart_backend`
- `.venv/bin/python -m unittest -v -f` (6,091 tests, 192 skipped)

Closes #3091
