### PR TITLE
Fix on-demand text embed collation

### DIFF
--- a/simpletuner/helpers/caching/text_embeds.py
+++ b/simpletuner/helpers/caching/text_embeds.py
@@ -708,6 +708,7 @@ class TextEmbeddingCache(WebhookMixin):
                         is_validation=is_validation,
                     )
                     text_encoder_output = self.model.pack_text_embeddings_for_cache(text_encoder_output)
+                    text_encoder_output = self.model.unpack_text_embeddings_from_cache(text_encoder_output)
                     logger.debug(
                         f"Filename {filename} prompt embeds: {gather_dict_of_tensors_shapes(tensors=text_encoder_output)}, keys: {text_encoder_output.keys()}"
                     )

--- a/simpletuner/helpers/caching/text_embeds.py
+++ b/simpletuner/helpers/caching/text_embeds.py
@@ -707,6 +707,7 @@ class TextEmbeddingCache(WebhookMixin):
                         prompt_contexts=prompt_contexts,
                         is_validation=is_validation,
                     )
+                    text_encoder_output = self.model.pack_text_embeddings_for_cache(text_encoder_output)
                     logger.debug(
                         f"Filename {filename} prompt embeds: {gather_dict_of_tensors_shapes(tensors=text_encoder_output)}, keys: {text_encoder_output.keys()}"
                     )

--- a/simpletuner/helpers/models/ideogram/model.py
+++ b/simpletuner/helpers/models/ideogram/model.py
@@ -524,11 +524,12 @@ class Ideogram4(ImageModelFoundation):
                 attention_mask = item.get("attention_masks")
             if prompt_embeds.dim() == 3:
                 prompt_embeds = prompt_embeds.squeeze(0)
+            prompt_embeds = prompt_embeds.to("cpu")
             if attention_mask is None:
-                attention_mask = torch.ones(prompt_embeds.shape[0], dtype=torch.bool, device=prompt_embeds.device)
+                attention_mask = torch.ones(prompt_embeds.shape[0], dtype=torch.bool, device="cpu")
             elif attention_mask.dim() == 2:
                 attention_mask = attention_mask.squeeze(0)
-            attention_mask = attention_mask.to(dtype=torch.bool)
+            attention_mask = attention_mask.to(device="cpu", dtype=torch.bool)
             length = int(attention_mask.sum().item())
             prompt_embeds = prompt_embeds[:length]
             attention_mask = attention_mask[:length]

--- a/tests/test_ideogram4_prompting.py
+++ b/tests/test_ideogram4_prompting.py
@@ -109,6 +109,28 @@ class Ideogram4PromptingTests(unittest.TestCase):
         self.assertEqual(converted["prompt_embeds"].shape, (1, 2, 4))
         self.assertEqual(negative["negative_prompt_embeds"].shape, (1, 2, 4))
 
+    def test_text_embed_collation_normalizes_cache_batch_to_cpu(self):
+        model = Ideogram4.__new__(Ideogram4)
+        device = torch.device("cpu")
+        if torch.cuda.is_available():
+            device = torch.device("cuda")
+        elif torch.backends.mps.is_available():
+            device = torch.device("mps")
+        first = {
+            "prompt_embeds": torch.ones(1, 2, 4, device=device),
+            "attention_mask": torch.ones(1, 2, dtype=torch.bool, device=device),
+        }
+        second = {
+            "prompt_embeds": torch.ones(1, 1, 4),
+            "attention_masks": torch.ones(1, 1, dtype=torch.bool),
+        }
+
+        collated = model.collate_prompt_embeds([first, second])
+
+        self.assertEqual(collated["prompt_embeds"].device.type, "cpu")
+        self.assertEqual(collated["attention_masks"].device.type, "cpu")
+        self.assertEqual(collated["prompt_embeds"].shape, (2, 2, 4))
+
     def test_text_embed_cache_projection_uses_projection_component(self):
         model = Ideogram4.__new__(Ideogram4)
         model.config = types.SimpleNamespace(

--- a/tests/test_text_embeds.py
+++ b/tests/test_text_embeds.py
@@ -153,7 +153,9 @@ class TextEmbeddingCacheKeyTests(unittest.TestCase):
         cache.model.encode_text_batch.assert_not_called()
         self.assertEqual(cache.write_queue.qsize(), 0)
 
-    def test_ondemand_cache_miss_returns_packed_cache_format(self):
+    def test_ondemand_cache_miss_returns_unpacked_format(self):
+        """On-demand encode round-trips through pack then unpack so the
+        returned format matches what load_from_cache would return."""
         cache = _make_cache(TextEmbedCacheKey.CAPTION, text_cache_ondemand=True)
 
         class PackingModel(_DummyModel):
@@ -176,7 +178,12 @@ class TextEmbeddingCacheKeyTests(unittest.TestCase):
                 return packed
 
             def unpack_text_embeddings_from_cache(self, embeddings):
-                return embeddings
+                # Simulate restoring full width (mirrors load_from_cache path)
+                unpacked = dict(embeddings)
+                unpacked["prompt_embeds"] = torch.nn.functional.pad(
+                    embeddings["prompt_embeds"], (0, 2)
+                )
+                return unpacked
 
         cache.model = PackingModel()
         cache.load_from_cache = MagicMock(side_effect=FileNotFoundError("missing"))
@@ -186,9 +193,11 @@ class TextEmbeddingCacheKeyTests(unittest.TestCase):
             prompt_records=[{"prompt": "uncached prompt", "key": "uncached prompt", "metadata": {}}]
         )
 
-        self.assertEqual(output["prompt_embeds"].shape, torch.Size([1, 2, 2]))
+        # Output should be in unpacked format (full width), same as cache-hit path
+        self.assertEqual(output["prompt_embeds"].shape, torch.Size([1, 2, 4]))
+        # save_to_cache receives unpacked data; it re-packs internally
         saved_embeddings = cache.save_to_cache.call_args.args[1]
-        self.assertEqual(saved_embeddings["prompt_embeds"].shape, torch.Size([1, 2, 2]))
+        self.assertEqual(saved_embeddings["prompt_embeds"].shape, torch.Size([1, 2, 4]))
         self.assertEqual(cache.model.pack_input_dims, [4])
 
     def test_resolve_key_value_caption_fallback(self):

--- a/tests/test_text_embeds.py
+++ b/tests/test_text_embeds.py
@@ -153,6 +153,44 @@ class TextEmbeddingCacheKeyTests(unittest.TestCase):
         cache.model.encode_text_batch.assert_not_called()
         self.assertEqual(cache.write_queue.qsize(), 0)
 
+    def test_ondemand_cache_miss_returns_packed_cache_format(self):
+        cache = _make_cache(TextEmbedCacheKey.CAPTION, text_cache_ondemand=True)
+
+        class PackingModel(_DummyModel):
+            def __init__(self):
+                super().__init__(TextEmbedCacheKey.CAPTION)
+                self.pack_input_dims = []
+
+            def encode_text_batch(self, prompts, is_negative_prompt=False, prompt_contexts=None):
+                return {
+                    "prompt_embeds": torch.arange(1 * 2 * 4, dtype=torch.float32).reshape(1, 2, 4),
+                    "attention_mask": torch.ones(1, 2, dtype=torch.bool),
+                }
+
+            def pack_text_embeddings_for_cache(self, embeddings):
+                self.pack_input_dims.append(embeddings["prompt_embeds"].shape[-1])
+                if embeddings["prompt_embeds"].shape[-1] == 2:
+                    return embeddings
+                packed = dict(embeddings)
+                packed["prompt_embeds"] = embeddings["prompt_embeds"][..., :2].contiguous()
+                return packed
+
+            def unpack_text_embeddings_from_cache(self, embeddings):
+                return embeddings
+
+        cache.model = PackingModel()
+        cache.load_from_cache = MagicMock(side_effect=FileNotFoundError("missing"))
+        cache.save_to_cache = MagicMock()
+
+        output = cache.compute_prompt_embeddings_with_model(
+            prompt_records=[{"prompt": "uncached prompt", "key": "uncached prompt", "metadata": {}}]
+        )
+
+        self.assertEqual(output["prompt_embeds"].shape, torch.Size([1, 2, 2]))
+        saved_embeddings = cache.save_to_cache.call_args.args[1]
+        self.assertEqual(saved_embeddings["prompt_embeds"].shape, torch.Size([1, 2, 2]))
+        self.assertEqual(cache.model.pack_input_dims, [4])
+
     def test_resolve_key_value_caption_fallback(self):
         cache = _make_cache(TextEmbedCacheKey.CAPTION)
         record = {"prompt": "hello world"}


### PR DESCRIPTION
## Summary
- pack newly encoded text embeddings before returning them to collate
- normalize Ideogram mixed cached and on-demand prompt tensors to CPU
- cover packed cache output and mixed-batch collation

## Testing
- `.venv/bin/python -m unittest -v tests.test_text_embeds tests.test_ideogram4_prompting`
- `.venv/bin/python -m unittest -v -f` (6,090 tests, 192 skipped)

Closes #3092
