### PR TITLE
h3: context parallel fix

### DIFF
--- a/simpletuner/helpers/models/minimaxh3/model.py
+++ b/simpletuner/helpers/models/minimaxh3/model.py
@@ -1592,6 +1592,18 @@ class MiniMaxH3(VideoModelFoundation):
             batch_size,
             self.accelerator.device,
         )
+        if text_valid_mask is not None and bool(text_valid_mask.any()):
+            # Trailing text padding forces a dense attention mask that the context-parallel
+            # attention dispatch cannot accept; trim it away and drop the mask when nothing
+            # in the batch is padded after trimming.
+            keep_len = int(text_valid_mask.any(dim=0).nonzero().max().item()) + 1
+            if keep_len < text_seq_len:
+                encoder_hidden_states = encoder_hidden_states[:, :keep_len]
+                text_token_tags = text_token_tags[:, :keep_len]
+                text_valid_mask = text_valid_mask[:, :keep_len]
+                text_seq_len = keep_len
+            if bool(text_valid_mask.all()):
+                text_valid_mask = None
         packed_target_video = patchify_video_latents(noisy_latents, patch_size).view(
             batch_size, -1, channels * patch_product
         )


### PR DESCRIPTION
This pull request improves the handling of padded text sequences in the `model_predict` method of `simpletuner/helpers/models/minimaxh3/model.py`. The main change ensures that unnecessary padding is trimmed from the input and that the attention mask is dropped when it is no longer needed, which helps prevent issues with the attention dispatch mechanism.

**Improvements to text padding and attention mask handling:**

* In `model_predict`, added logic to trim trailing text padding and drop the attention mask when all tokens are valid, ensuring compatibility with context-parallel attention dispatch and reducing unnecessary computation.