### PR TITLE
automatically enable audio_only when only audio given

### DIFF
--- a/documentation/quickstart/MINIMAX_H3.es.md
+++ b/documentation/quickstart/MINIMAX_H3.es.md
@@ -71,6 +71,10 @@ Negative prompting no forma parte del contrato base de H3. SimpleTuner mantiene 
 
 Usa `"av"` solo si el dataset tiene latentes de audio y quieres training conjunto audio/video. También puedes configurarlo por data backend con `h3_target_mode` o `minimax_h3_target_mode`.
 
+Para training solo de audio, `dataset_type: "audio"` es suficiente. Como H3 declara soporte para fake video,
+SimpleTuner registra `audio.audio_only: true` en la configuración normalizada, construye el video placeholder y excluye
+su loss. La opción explícita `audio_only` sigue siendo válida, pero no es necesaria.
+
 ## Atención sparse experimental
 
 MiniMax indica que H3 usó atención sparse 3D tipo MoBA durante su etapa final de entrenamiento. La versión pública inicial usa atención densa, y MiniMax no ha publicado la forma exacta de los bloques, el presupuesto de retención, el calendario de capas ni el kernel de producción. Por eso SimpleTuner mantiene esta aproximación experimental desactivada por defecto.

--- a/documentation/quickstart/MINIMAX_H3.hi.md
+++ b/documentation/quickstart/MINIMAX_H3.hi.md
@@ -71,6 +71,10 @@ Negative prompting base H3 contract का हिस्सा नहीं ह�
 
 `"av"` तभी use करें जब dataset में target audio latents हों और joint audio/video training चाहिए। Per-backend `h3_target_mode` या `minimax_h3_target_mode` भी set कर सकते हैं।
 
+Audio-only training के लिए `dataset_type: "audio"` पर्याप्त है। H3 fake-video support advertise करता है, इसलिए
+SimpleTuner normalized backend config में `audio.audio_only: true` record करता है, placeholder video stream बनाता है,
+और video loss mask करता है। Explicit `audio_only` setting valid है, लेकिन required नहीं है।
+
 ## Experimental Sparse Attention
 
 MiniMax बताता है कि H3 ने final training stage में video tokens के लिए MoBA-style 3D sparse attention इस्तेमाल किया। Initial public release dense attention use करता है, और MiniMax ने exact block shape, retention budget, layer schedule, या production kernel publish नहीं किया है। इसलिए SimpleTuner इस experimental approximation को default में disabled रखता है।

--- a/documentation/quickstart/MINIMAX_H3.ja.md
+++ b/documentation/quickstart/MINIMAX_H3.ja.md
@@ -71,6 +71,10 @@ Negative prompting は base H3 contract の一部ではありません。SimpleT
 
 dataset に target audio latents があり joint audio/video training したい場合だけ `"av"` を使います。data backend ごとに `h3_target_mode` または `minimax_h3_target_mode` でも設定できます。
 
+Audio-only training では `dataset_type: "audio"` だけで十分です。H3 は fake-video support を提供するため、
+SimpleTuner は normalized backend config に `audio.audio_only: true` を記録し、placeholder video stream を作成して
+video loss を mask します。明示的な `audio_only` も使用できますが、必須ではありません。
+
 ## Experimental Sparse Attention
 
 MiniMax は、H3 の最終 training stage で MoBA-style 3D sparse attention を video tokens に使ったと述べています。初期 public release は dense attention を使っており、MiniMax は正確な block shape、retention budget、layer schedule、production kernel をまだ公開していません。そのため SimpleTuner ではこの experimental approximation をデフォルトで無効にしています。

--- a/documentation/quickstart/MINIMAX_H3.md
+++ b/documentation/quickstart/MINIMAX_H3.md
@@ -71,6 +71,10 @@ By default, `minimax_h3_target_mode: "auto"` resolves to video-only and avoids a
 
 Use `"av"` only when the dataset has target audio latents and you want joint audio/video training. You can set `h3_target_mode` or `minimax_h3_target_mode` inside a data backend entry to opt only selected backends into audio.
 
+For audio-only training, `dataset_type: "audio"` is sufficient. Because H3 advertises fake-video support, SimpleTuner
+records `audio.audio_only: true` in the normalized backend config, builds the placeholder video stream, and masks video
+loss. The explicit `audio_only` setting remains accepted but is not required.
+
 ## Experimental Sparse Attention
 
 MiniMax reports that H3 used train-aware, MoBA-style 3D sparse attention for video tokens during its final training stage. The initial public release uses dense attention, and MiniMax has not yet published the exact H3 block shape, retention budget, layer schedule, or production kernel. SimpleTuner therefore keeps its experimental approximation disabled by default.

--- a/documentation/quickstart/MINIMAX_H3.pt-BR.md
+++ b/documentation/quickstart/MINIMAX_H3.pt-BR.md
@@ -71,6 +71,10 @@ Negative prompting não faz parte do contrato base do H3. SimpleTuner mantém re
 
 Use `"av"` só quando o dataset tiver target audio latents e você quiser joint audio/video training. Também pode configurar por backend com `h3_target_mode` ou `minimax_h3_target_mode`.
 
+Para treino somente de audio, `dataset_type: "audio"` e suficiente. Como o H3 declara suporte a fake video, o
+SimpleTuner registra `audio.audio_only: true` na configuracao normalizada, cria o video placeholder e mascara a loss de
+video. A opcao explicita `audio_only` continua aceita, mas nao e obrigatoria.
+
 ## Atenção sparse experimental
 
 A MiniMax informa que o H3 usou atenção sparse 3D estilo MoBA durante a etapa final de treinamento. O release público inicial usa atenção densa, e a MiniMax ainda não publicou o block shape, retention budget, layer schedule ou kernel de produção exatos. Por isso o SimpleTuner deixa esta aproximação experimental desativada por padrão.

--- a/documentation/quickstart/MINIMAX_H3.zh.md
+++ b/documentation/quickstart/MINIMAX_H3.zh.md
@@ -71,6 +71,9 @@ Negative prompting 不属于基础 H3 契约。SimpleTuner 为 de-distilled chec
 
 只有当 dataset 有 target audio latents 并需要联合音视频训练时才使用 `"av"`。也可以在 data backend 中设置 `h3_target_mode` 或 `minimax_h3_target_mode`。
 
+仅音频训练只需设置 `dataset_type: "audio"`。H3 声明支持 fake video，因此 SimpleTuner 会在规范化后的 backend
+配置中记录 `audio.audio_only: true`，构建占位视频流，并屏蔽视频 loss。仍可显式设置 `audio_only`，但这不是必需的。
+
 ## 实验性 Sparse Attention
 
 MiniMax 表示 H3 在最终训练阶段对视频 token 使用了 MoBA 风格的 3D sparse attention。初始公开版本使用 dense attention，MiniMax 还没有发布准确的 block shape、retention budget、layer schedule 或生产 kernel。因此 SimpleTuner 默认关闭这个实验性近似实现。

--- a/simpletuner/helpers/data_backend/factory.py
+++ b/simpletuner/helpers/data_backend/factory.py
@@ -1532,46 +1532,18 @@ class FactoryRegistry:
             return False
         return result if isinstance(result, bool) else False
 
-    def _compute_implicit_audio_only_mode(self, data_backend_config: List[Dict[str, Any]]) -> bool:
-        """
-        Pre-scan config to determine if we're in implicit audio-only mode.
-
-        Implicit audio-only mode is when:
-        - Model supports audio-only training
-        - There are audio datasets
-        - There are NO video or image datasets
-        """
-        if not self._supports_audio_only_training():
-            return False
-
-        has_audio = False
-        has_video_or_image = False
-
-        for backend in data_backend_config:
-            if backend.get("disabled", False) or backend.get("disable", False):
-                continue
-            dataset_type = _backend_dataset_type(backend)
-            if dataset_type is DatasetType.AUDIO:
-                has_audio = True
-            elif dataset_type in (DatasetType.VIDEO, DatasetType.IMAGE):
-                has_video_or_image = True
-
-        return has_audio and not has_video_or_image
-
     def _is_audio_only_mode(self, backend: Dict[str, Any]) -> bool:
-        """
-        Check if a backend is in audio-only mode.
+        """Resolve whether an audio backend requires the model's fake-video stream."""
+        if _backend_dataset_type(backend) is not DatasetType.AUDIO:
+            return False
+        return bool(backend.get("audio", {}).get("audio_only", False)) or self._supports_audio_only_training()
 
-        Audio-only mode can be:
-        1. Explicit: audio.audio_only: true in the backend config
-        2. Implicit: precomputed at start of configure_data_backends
-        """
-        # Check explicit audio_only flag
-        if backend.get("audio", {}).get("audio_only", False):
-            return True
-
-        # Check implicit audio-only mode (precomputed)
-        return getattr(self, "_implicit_audio_only_mode", False)
+    def _materialize_audio_only_mode(self, backend: Dict[str, Any], init_backend: Dict[str, Any]) -> bool:
+        """Store the resolved audio-only mode in the normalized backend config."""
+        enabled = self._is_audio_only_mode(backend)
+        if enabled:
+            init_backend.setdefault("config", {}).setdefault("audio", {})["audio_only"] = True
+        return enabled
 
     def _uses_text_embeddings_cache(self) -> bool:
         """Return whether the active model uses text embedding caches."""
@@ -2860,9 +2832,6 @@ class FactoryRegistry:
         """
         self._log_performance_metrics("data_backend_config_start")
         self._prevalidate_backend_ids(data_backend_config)
-
-        # Precompute implicit audio-only mode before processing backends
-        self._implicit_audio_only_mode = self._compute_implicit_audio_only_mode(data_backend_config)
 
         if not self.text_embed_backends and self._uses_text_embeddings_cache():
             self.configure_text_embed_backends(data_backend_config)
@@ -4558,6 +4527,7 @@ class FactoryRegistry:
 
         init_backend = init_backend_config(backend, self.args, self.accelerator)
         dataset_type_enum = ensure_dataset_type(init_backend.get("dataset_type"), default=DatasetType.IMAGE)
+        is_audio_only_dataset = self._materialize_audio_only_mode(backend, init_backend)
         if (
             dataset_type_enum in {DatasetType.IMAGE, DatasetType.VIDEO, DatasetType.CONDITIONING}
             and "cache_dir_vae" not in backend
@@ -4618,9 +4588,7 @@ class FactoryRegistry:
             self.data_backends[init_backend["id"]] = init_backend
             return
 
-        # For audio-only datasets, we need to discover files but skip bucket splitting
-        # Audio-only can be explicit (audio.audio_only: true) or implicit (only audio datasets, no video/image)
-        is_audio_only_dataset = dataset_type_enum is DatasetType.AUDIO and self._is_audio_only_mode(backend)
+        # Audio-only datasets contain no video stream to split into spatial buckets.
         self._handle_bucket_operations(backend, init_backend, conditioning_type, skip_bucket_split=is_audio_only_dataset)
 
         self._create_dataset_and_sampler(backend, init_backend, conditioning_type)

--- a/simpletuner/helpers/training/collate.py
+++ b/simpletuner/helpers/training/collate.py
@@ -627,22 +627,11 @@ def collate_fn(batch):
     data_backend = StateTracker.get_data_backend(batch_backend_id)
     training_data_root = data_backend.get("config", {}).get("instance_data_dir")
 
-    # Check for audio-only mode on models that support training without source video.
-    # Can be explicit (audio.audio_only: true) or implicit (audio dataset + model supports audio-only)
+    # Factory normalization resolves model capability and explicit configuration once.
     backend_config_for_audio_check = data_backend.get("config", {})
-    is_audio_only = False
-    if backend_config_for_audio_check.get("dataset_type") == "audio":
-        audio_config = backend_config_for_audio_check.get("audio", {})
-        explicit_audio_only = audio_config.get("audio_only", False)
-        # Check for implicit audio-only mode: model supports it and this is an audio dataset
-        implicit_audio_only = False
-        model_for_audio_check = StateTracker.get_model()
-        if model_for_audio_check is not None:
-            try:
-                implicit_audio_only = bool(model_for_audio_check.supports_audio_only_training())
-            except (AttributeError, TypeError):
-                implicit_audio_only = False
-        is_audio_only = explicit_audio_only or implicit_audio_only
+    is_audio_only = backend_config_for_audio_check.get("dataset_type") == "audio" and bool(
+        backend_config_for_audio_check.get("audio", {}).get("audio_only", False)
+    )
 
     model = StateTracker.get_model()
     uses_audio_tokens = False

--- a/tests/test_audio_collate.py
+++ b/tests/test_audio_collate.py
@@ -76,6 +76,37 @@ class TestAudioCollate(unittest.TestCase):
         self.assertIsNotNone(result["latent_batch"])
         self.assertEqual(result["latent_batch"].shape, (2, *latent_shape))
 
+    def test_collate_uses_normalized_audio_only_mode(self):
+        self.mock_backend.get.side_effect = lambda key, default=None: {
+            "config": {
+                "dataset_type": "audio",
+                "instance_data_dir": "/tmp",
+                "audio": {"audio_only": True},
+            }
+        }.get(key, default)
+        batch = [
+            {
+                "training_samples": [
+                    {"image_path": "a.wav", "data_backend_id": "b1", "instance_prompt_text": "a"},
+                    {"image_path": "b.wav", "data_backend_id": "b1", "instance_prompt_text": "b"},
+                ],
+                "conditioning_samples": [],
+            }
+        ]
+        latents = [
+            {"latents": torch.randn(2, 16, 100)},
+            {"latents": torch.randn(2, 16, 100)},
+        ]
+
+        with patch("simpletuner.helpers.training.collate.compute_latents", return_value=latents):
+            result = collate_fn(batch)
+
+        self.assertTrue(result["is_audio_only"])
+        self.assertIsNone(result["latent_batch"])
+        self.assertEqual(result["audio_latent_batch"].shape, (2, 2, 16, 100))
+        torch.testing.assert_close(result["audio_latent_mask"], torch.ones(2))
+        torch.testing.assert_close(result["video_latent_mask"], torch.zeros(2))
+
     def test_check_latent_shapes_variable_lengths(self):
         # Verify check_latent_shapes raises error for differing lengths in training data
         latents = [torch.randn(8, 16, 100), torch.randn(8, 16, 110)]

--- a/tests/test_factory_edge_cases.py
+++ b/tests/test_factory_edge_cases.py
@@ -103,6 +103,48 @@ class TestFactoryEdgeCases(unittest.TestCase):
             json.dump(config_data, f, indent=2)
         return config_path
 
+    def test_audio_dataset_materializes_audio_only_for_capable_model(self):
+        from simpletuner.helpers.data_backend.factory import FactoryRegistry
+
+        self.model.supports_audio_only_training.return_value = True
+        factory = FactoryRegistry(
+            args=self.args,
+            accelerator=self.accelerator,
+            text_encoders=self.text_encoders,
+            tokenizers=self.tokenizers,
+            model=self.model,
+        )
+        initialized = {
+            "dataset_type": "audio",
+            "config": {"dataset_type": "audio", "audio": {}},
+        }
+
+        enabled = factory._materialize_audio_only_mode({"dataset_type": "audio"}, initialized)
+
+        self.assertTrue(enabled)
+        self.assertTrue(initialized["config"]["audio"]["audio_only"])
+
+    def test_audio_dataset_does_not_materialize_audio_only_for_incapable_model(self):
+        from simpletuner.helpers.data_backend.factory import FactoryRegistry
+
+        self.model.supports_audio_only_training.return_value = False
+        factory = FactoryRegistry(
+            args=self.args,
+            accelerator=self.accelerator,
+            text_encoders=self.text_encoders,
+            tokenizers=self.tokenizers,
+            model=self.model,
+        )
+        initialized = {
+            "dataset_type": "audio",
+            "config": {"dataset_type": "audio", "audio": {}},
+        }
+
+        enabled = factory._materialize_audio_only_mode({"dataset_type": "audio"}, initialized)
+
+        self.assertFalse(enabled)
+        self.assertNotIn("audio_only", initialized["config"]["audio"])
+
     def test_config_file_not_found(self):
         """Test behavior when config file doesn't exist."""
         from simpletuner.helpers.data_backend.factory import FactoryRegistry


### PR DESCRIPTION
This pull request refactors and clarifies how audio-only training mode is determined and handled in SimpleTuner, ensuring that the "audio_only" flag is normalized in backend configs based on both explicit configuration and model capability. It also updates documentation in multiple languages to reflect these changes, and adds new tests to confirm correct behavior.

**Audio-only mode normalization and backend configuration:**

* Refactored the logic for determining audio-only mode in `FactoryRegistry`: removed implicit global audio-only mode, and instead normalized the `audio.audio_only` flag per-backend based on explicit config or model capability (`supports_audio_only_training`). The `_materialize_audio_only_mode` method now writes this resolved state into the backend config, ensuring downstream code and collate functions can rely on a single, normalized source. [[1]](diffhunk://#diff-57615ebb58fa92a702515b29c5d3dcee1e1ac481ee2f71564229f128a28894feL1535-R1546) [[2]](diffhunk://#diff-57615ebb58fa92a702515b29c5d3dcee1e1ac481ee2f71564229f128a28894feL2864-L2866) [[3]](diffhunk://#diff-57615ebb58fa92a702515b29c5d3dcee1e1ac481ee2f71564229f128a28894feR4530) [[4]](diffhunk://#diff-57615ebb58fa92a702515b29c5d3dcee1e1ac481ee2f71564229f128a28894feL4621-R4591)
* Updated `collate_fn` to use only the normalized `audio_only` flag in backend config, simplifying the logic and removing redundant checks for implicit audio-only mode.

**Documentation updates:**

* Added clarifications to the quickstart documentation in English, Chinese, Japanese, Hindi, Portuguese, and Spanish, explaining that for audio-only training, setting `dataset_type: "audio"` is sufficient; SimpleTuner will automatically handle fake video streams and loss masking if the model supports it, and explicit `audio_only` is optional. [[1]](diffhunk://#diff-4138c95ed60a8de84709ae0d3ae6923aaa9dfae92e7132c7373f6db183287664R74-R77) [[2]](diffhunk://#diff-c1fccc5d9af098cfebafe2da0a31c82f103b6d98bfb053ade29b41ad1f5bbe0cR74-R76) [[3]](diffhunk://#diff-c1512f8181f8e51966f020566433c0903c40f78df29ea0c8072f26f5bc356aa9R74-R77) [[4]](diffhunk://#diff-d2fa9b98d893d11ed20b3ea0507426e3a50bd8155d856488ab4d0bc16cfbf3f9R74-R77) [[5]](diffhunk://#diff-fc317a05a0243cb9163537535d7ae3261bd91214c79973c0bc95d63c86116f96R74-R77) [[6]](diffhunk://#diff-306c889b8d9e47b76fbb4b8ab0f557dbd9227ac8cc0f0156a4ceeb7fdd727ef8R74-R77)

**Testing improvements:**

* Added tests to verify that the backend config is correctly normalized with the `audio_only` flag when the model supports audio-only training, and that it is omitted otherwise.
* Added a test to ensure `collate_fn` uses the normalized `audio_only` mode and produces the correct outputs for audio-only datasets.