### PR TITLE
Fix multiline filename-keyed text caches

### DIFF
--- a/simpletuner/helpers/caching/text_embeds.py
+++ b/simpletuner/helpers/caching/text_embeds.py
@@ -136,7 +136,7 @@ class TextEmbeddingCache(WebhookMixin):
                 normalized = f"{dataset_id}:{canonicalize_data_uri(data_path)}"
         return normalized
 
-    def create_hash(self, key_value):
+    def create_hash(self, key_value, prompt=None):
         normalized_key = self._normalize_key_value(key_value)
         # Precomputed part of the format string
         hash_format = f"-{self.model_type}"
@@ -144,6 +144,10 @@ class TextEmbeddingCache(WebhookMixin):
         # Reuse the hash object
         md5_hash = hashlib.md5()
         md5_hash.update(str(normalized_key).encode())
+        # Path keys preserve sample context but are shared by multiline caption alternatives.
+        if self._requires_path_based_keys and prompt:
+            md5_hash.update(b"\0prompt\0")
+            md5_hash.update(str(prompt).encode())
         # logger.debug(f"Hashing caption: {caption}")
         result = md5_hash.hexdigest() + hash_format
         # logger.debug(f"-> {result}")
@@ -171,11 +175,14 @@ class TextEmbeddingCache(WebhookMixin):
 
     def hash_prompt_with_path(self, prompt_record: PromptCacheRecord):
         key_value = self._resolve_cache_key_value(prompt_record)
-        return os.path.join(self.cache_dir, self.create_hash(key_value) + ".pt")
+        return os.path.join(
+            self.cache_dir,
+            self.create_hash(key_value, prompt=prompt_record.get("prompt")) + ".pt",
+        )
 
     def hash_prompt(self, prompt_record: PromptCacheRecord):
         key_value = prompt_record.get("key") or prompt_record.get("prompt")
-        return self.create_hash(key_value) + ".pt"
+        return self.create_hash(key_value, prompt=prompt_record.get("prompt")) + ".pt"
 
     def _normalize_prompt_records(self, prompts: Optional[Sequence[Any]]) -> List[PromptCacheRecord]:
         normalized: List[PromptCacheRecord] = []

--- a/tests/test_text_embeds.py
+++ b/tests/test_text_embeds.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from contextlib import contextmanager
 from threading import Event, Thread
@@ -247,6 +248,29 @@ class TextEmbeddingCacheKeyTests(unittest.TestCase):
 
         self.assertEqual(path_normalized, canonical)
 
+    def test_path_keyed_hash_distinguishes_prompt_variants(self):
+        cache = _make_cache(TextEmbedCacheKey.DATASET_AND_FILENAME)
+        first = cache.hash_prompt_with_path({"prompt": "caption one", "key": "dataset-1:path/to/sample.png"})
+        second = cache.hash_prompt_with_path({"prompt": "caption two", "key": "dataset-1:path/to/sample.png"})
+
+        self.assertNotEqual(first, second)
+
+    def test_caption_keyed_hash_does_not_add_prompt_component(self):
+        cache = _make_cache(TextEmbedCacheKey.CAPTION)
+        first = cache.hash_prompt_with_path({"prompt": "caption one", "key": "shared-key"})
+        second = cache.hash_prompt_with_path({"prompt": "caption two", "key": "shared-key"})
+
+        self.assertEqual(first, second)
+
+    def test_path_keyed_empty_prompt_preserves_sentinel_hash(self):
+        cache = _make_cache(TextEmbedCacheKey.DATASET_AND_FILENAME)
+        record = {"prompt": "", "key": "__caption_dropout__"}
+
+        self.assertEqual(
+            cache.hash_prompt_with_path(record),
+            os.path.join(cache.cache_dir, cache.create_hash("__caption_dropout__") + ".pt"),
+        )
+
     def test_normalize_prompts_infers_key_from_metadata(self):
         cache = _make_cache(TextEmbedCacheKey.DATASET_AND_FILENAME)
         record = {
@@ -291,7 +315,7 @@ class TextEmbeddingCacheKeyTests(unittest.TestCase):
         )
 
     @patch("simpletuner.helpers.caching.text_embeds.StateTracker.get_text_cache_files", return_value={})
-    def test_compute_embeddings_deduplicates_uncached_multi_prompt_key(self, _mock_cache_files):
+    def test_compute_embeddings_caches_each_uncached_path_keyed_prompt(self, _mock_cache_files):
         cache = _make_cache(TextEmbedCacheKey.DATASET_AND_FILENAME)
         saved = []
         cache.save_to_cache = lambda filename, embeddings: saved.append((filename, embeddings))
@@ -337,9 +361,12 @@ class TextEmbeddingCacheKeyTests(unittest.TestCase):
 
         self.assertEqual(
             cache.model.calls,
-            [(["caption one"], [{"data_backend_id": "dataset-1", "dataset_relative_path": "path/to/sample.png"}])],
+            [
+                (["caption one"], [{"data_backend_id": "dataset-1", "dataset_relative_path": "path/to/sample.png"}]),
+                (["caption two"], [{"data_backend_id": "dataset-1", "dataset_relative_path": "path/to/sample.png"}]),
+            ],
         )
-        self.assertEqual(len(saved), 1)
+        self.assertEqual(len(saved), 2)
 
     @patch("simpletuner.helpers.caching.text_embeds.StateTracker.get_text_cache_files", return_value={})
     def test_compute_embeddings_does_not_resplit_rank_local_records(self, _mock_cache_files):


### PR DESCRIPTION
This pull request enhances the text embedding cache key logic to ensure that prompt variants are properly distinguished or shared in the cache, depending on the cache key type. It updates both the implementation and the test suite to validate this behavior.

**Cache Key Logic Improvements:**

* Updated `TextEmbedCacheKey.DATASET_AND_FILENAME` to include the prompt in the hash, ensuring that different prompts for the same file path are cached separately. (`simpletuner/helpers/caching/text_embeds.py`, [[1]](diffhunk://#diff-f8ca30b914bf6067832f4dcd621fc3fcae30c785ac6daf7737f042f9448c4003L139-R150) [[2]](diffhunk://#diff-f8ca30b914bf6067832f4dcd621fc3fcae30c785ac6daf7737f042f9448c4003L174-R185)
* Ensured that `TextEmbedCacheKey.CAPTION` does not include the prompt in the hash, so prompt variants with the same key share the same cache entry. (`simpletuner/helpers/caching/text_embeds.py`, [[1]](diffhunk://#diff-f8ca30b914bf6067832f4dcd621fc3fcae30c785ac6daf7737f042f9448c4003L139-R150) [[2]](diffhunk://#diff-f8ca30b914bf6067832f4dcd621fc3fcae30c785ac6daf7737f042f9448c4003L174-R185)

**Test Suite Enhancements:**

* Added tests to verify that path-keyed hashes distinguish between prompt variants, while caption-keyed hashes do not. (`tests/test_text_embeds.py`, [tests/test_text_embeds.pyR251-R273](diffhunk://#diff-3452fb61a5f9a66f47bcb84178f6419d25dea19b0e1f28dd13dfafebd538cc33R251-R273))
* Added a test to ensure that an empty prompt with a sentinel key produces the expected hash. (`tests/test_text_embeds.py`, [tests/test_text_embeds.pyR251-R273](diffhunk://#diff-3452fb61a5f9a66f47bcb84178f6419d25dea19b0e1f28dd13dfafebd538cc33R251-R273))
* Updated a test to check that each uncached path-keyed prompt is cached individually, and adjusted the expected number of saved cache files accordingly. (`tests/test_text_embeds.py`, [[1]](diffhunk://#diff-3452fb61a5f9a66f47bcb84178f6419d25dea19b0e1f28dd13dfafebd538cc33L294-R318) [[2]](diffhunk://#diff-3452fb61a5f9a66f47bcb84178f6419d25dea19b0e1f28dd13dfafebd538cc33L340-R369)

**Other:**

* Added a missing `import os` in the test file. (`tests/test_text_embeds.py`, [tests/test_text_embeds.pyR1](diffhunk://#diff-3452fb61a5f9a66f47bcb84178f6419d25dea19b0e1f28dd13dfafebd538cc33R1))