### PR TITLE
Fix H3 context-parallel attention fallback

### DIFF
--- a/documentation/quickstart/MINIMAX_H3.es.md
+++ b/documentation/quickstart/MINIMAX_H3.es.md
@@ -75,7 +75,7 @@ Para training solo de audio, `dataset_type: "audio"` es suficiente. Como H3 decl
 SimpleTuner registra `audio.audio_only: true` en la configuración normalizada, construye el video placeholder y excluye
 su loss. La opción explícita `audio_only` sigue siendo válida, pero no es necesaria.
 
-## Context parallelism
+## Paralelismo de contexto
 
 El context parallelism de H3 usa Ulysses con `context_parallel_strategy: "alltoall"`. La secuencia packed puede incluir
 padding hasta el grado CP, por lo que el backend de atención local debe aceptar una máscara. `native` y `cudnn` son

--- a/documentation/quickstart/MINIMAX_H3.es.md
+++ b/documentation/quickstart/MINIMAX_H3.es.md
@@ -75,6 +75,15 @@ Para training solo de audio, `dataset_type: "audio"` es suficiente. Como H3 decl
 SimpleTuner registra `audio.audio_only: true` en la configuración normalizada, construye el video placeholder y excluye
 su loss. La opción explícita `audio_only` sigue siendo válida, pero no es necesaria.
 
+## Context parallelism
+
+El context parallelism de H3 usa Ulysses con `context_parallel_strategy: "alltoall"`. La secuencia packed puede incluir
+padding hasta el grado CP, por lo que el backend de atención local debe aceptar una máscara. `native` y `cudnn` son
+compatibles; SimpleTuner reemplaza otros backends por `native` cuando CP está habilitado.
+
+Con unos 8k audio tokens, CP principalmente intercambia comunicación por menos memoria de activaciones y checkpointing
+más ligero. CP no divide los pesos por sí solo; compáralo con DDP salvo que la secuencia sea mayor o se combine con FSDP.
+
 ## Atención sparse experimental
 
 MiniMax indica que H3 usó atención sparse 3D tipo MoBA durante su etapa final de entrenamiento. La versión pública inicial usa atención densa, y MiniMax no ha publicado la forma exacta de los bloques, el presupuesto de retención, el calendario de capas ni el kernel de producción. Por eso SimpleTuner mantiene esta aproximación experimental desactivada por defecto.

--- a/documentation/quickstart/MINIMAX_H3.hi.md
+++ b/documentation/quickstart/MINIMAX_H3.hi.md
@@ -75,6 +75,15 @@ Audio-only training के लिए `dataset_type: "audio"` पर्याप�
 SimpleTuner normalized backend config में `audio.audio_only: true` record करता है, placeholder video stream बनाता है,
 और video loss mask करता है। Explicit `audio_only` setting valid है, लेकिन required नहीं है।
 
+## Context parallelism
+
+H3 context parallelism Ulysses को `context_parallel_strategy: "alltoall"` के साथ use करता है। Packed sequence को CP
+degree तक pad किया जा सकता है, इसलिए local attention backend को mask accept करना होगा। `native` और `cudnn` supported
+हैं; CP enabled होने पर SimpleTuner दूसरे backend choices को `native` से replace करता है।
+
+लगभग 8k audio tokens पर CP communication के बदले activation memory घटाता है और हल्का checkpointing देता है। CP अपने
+आप weights shard नहीं करता, इसलिए लंबी sequence या FSDP combination के बिना इसे DDP के विरुद्ध benchmark करें।
+
 ## Experimental Sparse Attention
 
 MiniMax बताता है कि H3 ने final training stage में video tokens के लिए MoBA-style 3D sparse attention इस्तेमाल किया। Initial public release dense attention use करता है, और MiniMax ने exact block shape, retention budget, layer schedule, या production kernel publish नहीं किया है। इसलिए SimpleTuner इस experimental approximation को default में disabled रखता है।

--- a/documentation/quickstart/MINIMAX_H3.ja.md
+++ b/documentation/quickstart/MINIMAX_H3.ja.md
@@ -75,6 +75,15 @@ Audio-only training では `dataset_type: "audio"` だけで十分です。H3 �
 SimpleTuner は normalized backend config に `audio.audio_only: true` を記録し、placeholder video stream を作成して
 video loss を mask します。明示的な `audio_only` も使用できますが、必須ではありません。
 
+## Context parallelism
+
+H3 context parallelism は Ulysses と `context_parallel_strategy: "alltoall"` を使用します。packed sequence は CP
+degree に合わせて padding される場合があるため、local attention backend は mask を受け付ける必要があります。
+`native` と `cudnn` をサポートし、CP 有効時のその他の backend は SimpleTuner が `native` に置き換えます。
+
+約 8k audio tokens では、CP は主に communication と引き換えに activation memory と checkpointing を減らします。
+CP 単体では weights を shard しないため、より長い sequence または FSDP との併用でなければ DDP と比較してください。
+
 ## Experimental Sparse Attention
 
 MiniMax は、H3 の最終 training stage で MoBA-style 3D sparse attention を video tokens に使ったと述べています。初期 public release は dense attention を使っており、MiniMax は正確な block shape、retention budget、layer schedule、production kernel をまだ公開していません。そのため SimpleTuner ではこの experimental approximation をデフォルトで無効にしています。

--- a/documentation/quickstart/MINIMAX_H3.md
+++ b/documentation/quickstart/MINIMAX_H3.md
@@ -75,6 +75,15 @@ For audio-only training, `dataset_type: "audio"` is sufficient. Because H3 adver
 records `audio.audio_only: true` in the normalized backend config, builds the placeholder video stream, and masks video
 loss. The explicit `audio_only` setting remains accepted but is not required.
 
+## Context parallelism
+
+H3 context parallelism uses Ulysses with `context_parallel_strategy: "alltoall"`. The packed sequence may be padded to
+the CP degree, so its local attention backend must accept a mask. `native` and `cudnn` are supported; SimpleTuner replaces
+other backend choices with `native` when CP is enabled.
+
+At roughly 8k audio tokens, CP mainly trades communication for lower activation memory and lighter checkpointing. CP
+does not shard weights by itself, so benchmark it against DDP unless the sequence is longer or CP is combined with FSDP.
+
 ## Experimental Sparse Attention
 
 MiniMax reports that H3 used train-aware, MoBA-style 3D sparse attention for video tokens during its final training stage. The initial public release uses dense attention, and MiniMax has not yet published the exact H3 block shape, retention budget, layer schedule, or production kernel. SimpleTuner therefore keeps its experimental approximation disabled by default.

--- a/documentation/quickstart/MINIMAX_H3.pt-BR.md
+++ b/documentation/quickstart/MINIMAX_H3.pt-BR.md
@@ -75,7 +75,7 @@ Para treino somente de audio, `dataset_type: "audio"` e suficiente. Como o H3 de
 SimpleTuner registra `audio.audio_only: true` na configuracao normalizada, cria o video placeholder e mascara a loss de
 video. A opcao explicita `audio_only` continua aceita, mas nao e obrigatoria.
 
-## Context parallelism
+## Paralelismo de contexto
 
 O context parallelism do H3 usa Ulysses com `context_parallel_strategy: "alltoall"`. A sequencia packed pode receber
 padding ate o grau CP, entao o backend de attention local precisa aceitar uma mascara. `native` e `cudnn` sao suportados;

--- a/documentation/quickstart/MINIMAX_H3.pt-BR.md
+++ b/documentation/quickstart/MINIMAX_H3.pt-BR.md
@@ -75,6 +75,15 @@ Para treino somente de audio, `dataset_type: "audio"` e suficiente. Como o H3 de
 SimpleTuner registra `audio.audio_only: true` na configuracao normalizada, cria o video placeholder e mascara a loss de
 video. A opcao explicita `audio_only` continua aceita, mas nao e obrigatoria.
 
+## Context parallelism
+
+O context parallelism do H3 usa Ulysses com `context_parallel_strategy: "alltoall"`. A sequencia packed pode receber
+padding ate o grau CP, entao o backend de attention local precisa aceitar uma mascara. `native` e `cudnn` sao suportados;
+o SimpleTuner substitui outros backends por `native` quando CP esta ativo.
+
+Com cerca de 8k audio tokens, CP troca comunicacao por menos memoria de activations e checkpointing mais leve. CP nao
+divide os weights sozinho; compare com DDP salvo quando a sequencia for maior ou CP estiver combinado com FSDP.
+
 ## Atenção sparse experimental
 
 A MiniMax informa que o H3 usou atenção sparse 3D estilo MoBA durante a etapa final de treinamento. O release público inicial usa atenção densa, e a MiniMax ainda não publicou o block shape, retention budget, layer schedule ou kernel de produção exatos. Por isso o SimpleTuner deixa esta aproximação experimental desativada por padrão.

--- a/documentation/quickstart/MINIMAX_H3.zh.md
+++ b/documentation/quickstart/MINIMAX_H3.zh.md
@@ -74,6 +74,15 @@ Negative prompting 不属于基础 H3 契约。SimpleTuner 为 de-distilled chec
 仅音频训练只需设置 `dataset_type: "audio"`。H3 声明支持 fake video，因此 SimpleTuner 会在规范化后的 backend
 配置中记录 `audio.audio_only: true`，构建占位视频流，并屏蔽视频 loss。仍可显式设置 `audio_only`，但这不是必需的。
 
+## Context parallelism
+
+H3 context parallelism 使用 Ulysses 和 `context_parallel_strategy: "alltoall"`。packed sequence 可能会 padding 到
+CP degree，因此本地 attention backend 必须支持 mask。`native` 和 `cudnn` 受支持；启用 CP 时，SimpleTuner 会把
+其他 backend 替换为 `native`。
+
+在约 8k audio tokens 时，CP 主要用通信开销换取更低的 activation memory 和更轻的 checkpointing。CP 本身不
+shard weights，因此除非 sequence 更长或与 FSDP 组合使用，否则应与 DDP 做 benchmark。
+
 ## 实验性 Sparse Attention
 
 MiniMax 表示 H3 在最终训练阶段对视频 token 使用了 MoBA 风格的 3D sparse attention。初始公开版本使用 dense attention，MiniMax 还没有发布准确的 block shape、retention budget、layer schedule 或生产 kernel。因此 SimpleTuner 默认关闭这个实验性近似实现。

--- a/documentation/quickstart/MINIMAX_H3.zh.md
+++ b/documentation/quickstart/MINIMAX_H3.zh.md
@@ -74,7 +74,7 @@ Negative prompting 不属于基础 H3 契约。SimpleTuner 为 de-distilled chec
 仅音频训练只需设置 `dataset_type: "audio"`。H3 声明支持 fake video，因此 SimpleTuner 会在规范化后的 backend
 配置中记录 `audio.audio_only: true`，构建占位视频流，并屏蔽视频 loss。仍可显式设置 `audio_only`，但这不是必需的。
 
-## Context parallelism
+## 上下文并行
 
 H3 context parallelism 使用 Ulysses 和 `context_parallel_strategy: "alltoall"`。packed sequence 可能会 padding 到
 CP degree，因此本地 attention backend 必须支持 mask。`native` 和 `cudnn` 受支持；启用 CP 时，SimpleTuner 会把

--- a/simpletuner/helpers/models/minimaxh3/transformer.py
+++ b/simpletuner/helpers/models/minimaxh3/transformer.py
@@ -66,6 +66,7 @@ logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 # MiniMax-H3 tags every row of the packed sequence with the modality it belongs to and keeps one set of AdaLN
 # modulation parameters per (timestep, modality) pair: 0 = video, 1 = text, 2 = audio.
 MINIMAX_H3_MODALITY_NUM = 3
+_H3_MASKED_CONTEXT_PARALLEL_BACKENDS = frozenset({AttentionBackendName.NATIVE, AttentionBackendName._NATIVE_CUDNN})
 
 
 class _MiniMaxH3AllGather(torch.autograd.Function):
@@ -1414,19 +1415,23 @@ class MiniMaxH3Transformer3DModel(ModelMixin, ConfigMixin, AttentionMixin, PeftA
         if context_config is None and hasattr(config, "ring_degree"):
             context_config = config
         if context_config is not None:
+            ring_degree = int(getattr(context_config, "ring_degree", 1) or 1)
+            ulysses_degree = int(getattr(context_config, "ulysses_degree", 1) or 1)
+            if ring_degree != 1 or ulysses_degree <= 1:
+                raise ValueError('MiniMax-H3 context parallelism requires context_parallel_strategy="alltoall".')
             processor = self.transformer_blocks[0].attn.processor
             backend = processor._attention_backend
             if backend is None:
                 backend, _ = _AttentionBackendRegistry.get_active_backend()
             else:
                 backend = AttentionBackendName(backend)
-            if not _AttentionBackendRegistry._is_context_parallel_available(backend):
+            if backend not in _H3_MASKED_CONTEXT_PARALLEL_BACKENDS:
                 logger.warning(
-                    "MiniMax-H3 context parallelism cannot use attention backend %s; "
-                    "falling back to the native FlashAttention backend.",
+                    "MiniMax-H3 context parallelism cannot safely use attention backend %s because packed layouts "
+                    "may require an attention mask; falling back to native SDPA.",
                     backend.value,
                 )
-                self.set_attention_backend("_native_flash")
+                self.set_attention_backend("native")
         return super().enable_parallelism(config=config, cp_plan=cp_plan)
 
     @staticmethod

--- a/tests/test_minimaxh3.py
+++ b/tests/test_minimaxh3.py
@@ -334,8 +334,46 @@ class TestMiniMaxH3SparseAttention(unittest.TestCase):
             result = model.enable_parallelism(config=SimpleNamespace(ring_degree=1, ulysses_degree=2))
 
         self.assertEqual(result, "enabled")
-        set_backend.assert_called_once_with("_native_flash")
+        set_backend.assert_called_once_with("native")
         enable_parallelism.assert_called_once()
+
+    def test_context_parallel_replaces_mask_incompatible_flash_backend(self):
+        model = tiny_h3_transformer(num_layers=1)
+        model.transformer_blocks[0].attn.processor._attention_backend = "_native_flash"
+
+        with (
+            patch.object(model, "set_attention_backend") as set_backend,
+            patch(
+                "diffusers.models.modeling_utils.ModelMixin.enable_parallelism",
+                return_value="enabled",
+            ),
+        ):
+            model.enable_parallelism(config=SimpleNamespace(ring_degree=1, ulysses_degree=2))
+
+        set_backend.assert_called_once_with("native")
+
+    def test_context_parallel_preserves_mask_capable_backend(self):
+        for backend in ("native", "_native_cudnn"):
+            with self.subTest(backend=backend):
+                model = tiny_h3_transformer(num_layers=1)
+                model.transformer_blocks[0].attn.processor._attention_backend = backend
+
+                with (
+                    patch.object(model, "set_attention_backend") as set_backend,
+                    patch("diffusers.models.modeling_utils.ModelMixin.enable_parallelism"),
+                ):
+                    model.enable_parallelism(config=SimpleNamespace(ring_degree=1, ulysses_degree=2))
+
+                set_backend.assert_not_called()
+
+    def test_context_parallel_rejects_ring_strategy(self):
+        model = tiny_h3_transformer(num_layers=1)
+
+        with (
+            patch("diffusers.models.modeling_utils.ModelMixin.enable_parallelism"),
+            self.assertRaisesRegex(ValueError, 'context_parallel_strategy="alltoall"'),
+        ):
+            model.enable_parallelism(config=SimpleNamespace(ring_degree=2, ulysses_degree=1))
 
     @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA FlexAttention")
     def test_full_video_budget_matches_dense_forward_and_backward(self):


### PR DESCRIPTION
This pull request adds support and documentation for context parallelism in MiniMax-H3 models, focusing on ensuring correct backend selection and user guidance for this feature. The main changes include updates to documentation in multiple languages, stricter backend checks and selection logic in the model implementation, and expanded tests to cover these behaviors.

**Documentation updates for context parallelism:**

* Added detailed explanations of context parallelism, its requirements, and backend compatibility to the MiniMax-H3 quickstart guides in English, Chinese, Japanese, Portuguese, Spanish, and Hindi (`documentation/quickstart/MINIMAX_H3.md`, `.zh.md`, `.ja.md`, `.pt-BR.md`, `.es.md`, `.hi.md`). [[1]](diffhunk://#diff-4138c95ed60a8de84709ae0d3ae6923aaa9dfae92e7132c7373f6db183287664R78-R86) [[2]](diffhunk://#diff-c1fccc5d9af098cfebafe2da0a31c82f103b6d98bfb053ade29b41ad1f5bbe0cR77-R85) [[3]](diffhunk://#diff-c1512f8181f8e51966f020566433c0903c40f78df29ea0c8072f26f5bc356aa9R78-R86) [[4]](diffhunk://#diff-fc317a05a0243cb9163537535d7ae3261bd91214c79973c0bc95d63c86116f96R78-R86) [[5]](diffhunk://#diff-306c889b8d9e47b76fbb4b8ab0f557dbd9227ac8cc0f0156a4ceeb7fdd727ef8R78-R86) [[6]](diffhunk://#diff-d2fa9b98d893d11ed20b3ea0507426e3a50bd8155d856488ab4d0bc16cfbf3f9R78-R86)

**Model implementation improvements:**

* Introduced `_H3_MASKED_CONTEXT_PARALLEL_BACKENDS` to define allowed attention backends for context parallelism and updated `enable_parallelism` to strictly enforce the use of mask-capable backends, defaulting to `"native"` if necessary (`simpletuner/helpers/models/minimaxh3/transformer.py`). [[1]](diffhunk://#diff-0e31056fee25c3548ad29942a179564a24bdf95aae593af3f5f9afeeb67e112dR69) [[2]](diffhunk://#diff-0e31056fee25c3548ad29942a179564a24bdf95aae593af3f5f9afeeb67e112dR1418-R1434)

**Testing enhancements:**

* Expanded tests to verify backend replacement logic, ensure mask-capable backends are preserved, and validate that only the `"alltoall"` strategy is accepted for context parallelism (`tests/test_minimaxh3.py`).