### PR TITLE
Fix H3 audio validation target mode

### DIFF
--- a/documentation/OPTIONS.es.md
+++ b/documentation/OPTIONS.es.md
@@ -104,7 +104,7 @@ Donde `foo` es tu entorno de configuración; o simplemente usa `config/config.js
 - **Opciones**: `auto`, `video`, `av`
 - **Predeterminado**: `auto`
 - **Notas**:
-  - `auto` se resuelve como solo video, omitiendo caché VAE de audio, colación y filas de audio objetivo para H3.
+  - `auto` se resuelve como `av` cuando se detectan datos de audio habilitados y como `video` en caso contrario. La validación usa el mismo valor predeterminado detectado en los datos.
   - Define `minimax_h3_target_mode` o `h3_target_mode` como `av` en una entrada de data backend para activar entrenamiento conjunto audio-video en un backend de audio auto-split o explícito.
 
 ### `--minimax_h3_sparse_attention`

--- a/documentation/OPTIONS.hi.md
+++ b/documentation/OPTIONS.hi.md
@@ -104,7 +104,7 @@ simpletuner configure config/foo/config.json
 - **Choices**: `auto`, `video`, `av`
 - **Default**: `auto`
 - **Notes**:
-  - `auto` video-only में resolve होता है, जिससे H3 के लिए audio VAE cache, collate, और target audio rows skip होते हैं।
+  - `auto` enabled audio data मिलने पर `av`, अन्यथा `video` में resolve होता है। Validation भी इसी detected-data default का उपयोग करता है।
   - auto-split या explicit audio backend को joint audio-video training में opt in करने के लिए data backend entry में `minimax_h3_target_mode` या `h3_target_mode` को `av` सेट करें।
 
 ### `--minimax_h3_sparse_attention`

--- a/documentation/OPTIONS.ja.md
+++ b/documentation/OPTIONS.ja.md
@@ -104,7 +104,7 @@ simpletuner configure config/foo/config.json
 - **選択肢**: `auto`, `video`, `av`
 - **既定**: `auto`
 - **注記**:
-  - `auto` は video-only として扱われ、H3 の audio VAE cache、collate、ターゲット音声行を省略します。
+  - `auto` は有効な audio data が検出された場合は `av`、それ以外は `video` になります。Validation も同じ detected-data default を使います。
   - auto-split または明示的な audio backend で joint audio-video training を使う場合は、data backend entry に `minimax_h3_target_mode` または `h3_target_mode` を `av` として設定します。
 
 ### `--minimax_h3_sparse_attention`

--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -104,7 +104,7 @@ Where `foo` is your config environment - or just use `config/config.json` if you
 - **Choices**: `auto`, `video`, `av`
 - **Default**: `auto`
 - **Notes**:
-  - `auto` resolves to video-only, skipping audio VAE caching, collation, and target audio rows for H3.
+  - `auto` resolves to `av` when enabled audio data is detected and to `video` otherwise. Validation uses the same detected-data default.
   - Set `minimax_h3_target_mode` or `h3_target_mode` to `av` in a data backend entry to opt an auto-split or explicit audio backend into joint audio-video training.
 
 ### `--minimax_h3_sparse_attention`

--- a/documentation/OPTIONS.pt-BR.md
+++ b/documentation/OPTIONS.pt-BR.md
@@ -104,7 +104,7 @@ Onde `foo` e seu ambiente de config — ou use `config/config.json` se nao estiv
 - **Opcoes**: `auto`, `video`, `av`
 - **Padrao**: `auto`
 - **Notas**:
-  - `auto` resolve para `av` quando dados de audio habilitados sao detectados e para `video` caso contrario. A validacao usa o mesmo padrao detectado nos dados.
+  - `auto` resolve para `av` quando dados de áudio habilitados são detectados e para `video` caso contrário. A validação usa o mesmo padrão detectado nos dados.
   - Defina `minimax_h3_target_mode` ou `h3_target_mode` como `av` em uma entrada de data backend para ativar treino conjunto audio-video em um backend de audio auto-split ou explicito.
 
 ### `--minimax_h3_sparse_attention`

--- a/documentation/OPTIONS.pt-BR.md
+++ b/documentation/OPTIONS.pt-BR.md
@@ -104,7 +104,7 @@ Onde `foo` e seu ambiente de config — ou use `config/config.json` se nao estiv
 - **Opcoes**: `auto`, `video`, `av`
 - **Padrao**: `auto`
 - **Notas**:
-  - `auto` resolve para somente video, pulando cache de audio VAE, collate e linhas de audio alvo para H3.
+  - `auto` resolve para `av` quando dados de audio habilitados sao detectados e para `video` caso contrario. A validacao usa o mesmo padrao detectado nos dados.
   - Defina `minimax_h3_target_mode` ou `h3_target_mode` como `av` em uma entrada de data backend para ativar treino conjunto audio-video em um backend de audio auto-split ou explicito.
 
 ### `--minimax_h3_sparse_attention`

--- a/documentation/OPTIONS.zh.md
+++ b/documentation/OPTIONS.zh.md
@@ -104,7 +104,7 @@ simpletuner configure config/foo/config.json
 - **选项**：`auto`, `video`, `av`
 - **默认**：`auto`
 - **说明**：
-  - `auto` 会解析为仅视频，跳过 H3 的音频 VAE 缓存、collate 和目标音频行。
+  - `auto` 在检测到已启用的音频数据时解析为 `av`，否则解析为 `video`。验证使用相同的数据检测默认值。
   - 如需让 auto-split 或显式音频 backend 进行联合音视频训练，请在 data backend 条目中将 `minimax_h3_target_mode` 或 `h3_target_mode` 设为 `av`。
 
 ### `--minimax_h3_sparse_attention`

--- a/documentation/quickstart/MINIMAX_H3.es.md
+++ b/documentation/quickstart/MINIMAX_H3.es.md
@@ -61,7 +61,7 @@ Negative prompting no forma parte del contrato base de H3. SimpleTuner mantiene 
 
 ## Modo de audio
 
-`minimax_h3_target_mode: "auto"` se resuelve como video-only y evita trabajo de audio VAE:
+`minimax_h3_target_mode: "auto"` se resuelve como `av` cuando se detectan datos de audio habilitados y como `video` en caso contrario. La validación usa el mismo valor predeterminado detectado en los datos, por lo que los entrenamientos solo de audio y audio/video conjunto generan audio sin una configuración de validación separada. Define `video` explícitamente para evitar trabajo de audio VAE:
 
 ```json
 {
@@ -69,7 +69,7 @@ Negative prompting no forma parte del contrato base de H3. SimpleTuner mantiene 
 }
 ```
 
-Usa `"av"` solo si el dataset tiene latentes de audio y quieres training conjunto audio/video. También puedes configurarlo por data backend con `h3_target_mode` o `minimax_h3_target_mode`.
+Usa `"av"` explícitamente si el dataset tiene latentes de audio y quieres training conjunto audio/video. También puedes configurarlo por data backend con `h3_target_mode` o `minimax_h3_target_mode`.
 
 Para training solo de audio, `dataset_type: "audio"` es suficiente. Como H3 declara soporte para fake video,
 SimpleTuner registra `audio.audio_only: true` en la configuración normalizada, construye el video placeholder y excluye

--- a/documentation/quickstart/MINIMAX_H3.hi.md
+++ b/documentation/quickstart/MINIMAX_H3.hi.md
@@ -61,7 +61,7 @@ Negative prompting base H3 contract का हिस्सा नहीं ह�
 
 ## Audio Target Mode
 
-`minimax_h3_target_mode: "auto"` video-only बनता है और audio VAE work बचाता है:
+`minimax_h3_target_mode: "auto"` enabled audio data मिलने पर `av`, अन्यथा `video` में resolve होता है। Validation भी इसी detected-data default का उपयोग करता है, इसलिए audio-only और joint audio/video runs अलग validation override के बिना audio बनाते हैं। Audio VAE work से बचने के लिए `video` explicitly set करें:
 
 ```json
 {
@@ -69,7 +69,7 @@ Negative prompting base H3 contract का हिस्सा नहीं ह�
 }
 ```
 
-`"av"` तभी use करें जब dataset में target audio latents हों और joint audio/video training चाहिए। Per-backend `h3_target_mode` या `minimax_h3_target_mode` भी set कर सकते हैं।
+जब dataset में target audio latents हों और joint audio/video training चाहिए, तब `"av"` explicitly use कर सकते हैं। Per-backend `h3_target_mode` या `minimax_h3_target_mode` भी set कर सकते हैं।
 
 Audio-only training के लिए `dataset_type: "audio"` पर्याप्त है। H3 fake-video support advertise करता है, इसलिए
 SimpleTuner normalized backend config में `audio.audio_only: true` record करता है, placeholder video stream बनाता है,

--- a/documentation/quickstart/MINIMAX_H3.ja.md
+++ b/documentation/quickstart/MINIMAX_H3.ja.md
@@ -61,7 +61,7 @@ Negative prompting は base H3 contract の一部ではありません。SimpleT
 
 ## Audio Target Mode
 
-`minimax_h3_target_mode: "auto"` は video-only になり、audio VAE work を避けます。
+`minimax_h3_target_mode: "auto"` は、有効な audio data が検出された場合は `av`、それ以外は `video` になります。Validation も同じ検出結果を使うため、audio-only および joint audio/video run では別の validation override なしで audio を生成します。Audio VAE work を避けるには `video` を明示します。
 
 ```json
 {
@@ -69,7 +69,7 @@ Negative prompting は base H3 contract の一部ではありません。SimpleT
 }
 ```
 
-dataset に target audio latents があり joint audio/video training したい場合だけ `"av"` を使います。data backend ごとに `h3_target_mode` または `minimax_h3_target_mode` でも設定できます。
+dataset に target audio latents があり joint audio/video training したい場合は `"av"` を明示できます。data backend ごとに `h3_target_mode` または `minimax_h3_target_mode` でも設定できます。
 
 Audio-only training では `dataset_type: "audio"` だけで十分です。H3 は fake-video support を提供するため、
 SimpleTuner は normalized backend config に `audio.audio_only: true` を記録し、placeholder video stream を作成して

--- a/documentation/quickstart/MINIMAX_H3.md
+++ b/documentation/quickstart/MINIMAX_H3.md
@@ -61,7 +61,7 @@ Negative prompting is not part of the base H3 contract. SimpleTuner keeps real C
 
 ## Audio Target Mode
 
-By default, `minimax_h3_target_mode: "auto"` resolves to video-only and avoids audio VAE work:
+By default, `minimax_h3_target_mode: "auto"` resolves to `av` when enabled audio data is detected and to `video` otherwise. Validation uses the same detected-data default, so audio-only and joint audio/video runs render audio without a separate validation override. Set `video` explicitly to avoid audio VAE work:
 
 ```json
 {
@@ -69,7 +69,7 @@ By default, `minimax_h3_target_mode: "auto"` resolves to video-only and avoids a
 }
 ```
 
-Use `"av"` only when the dataset has target audio latents and you want joint audio/video training. You can set `h3_target_mode` or `minimax_h3_target_mode` inside a data backend entry to opt only selected backends into audio.
+Use `"av"` explicitly when the dataset has target audio latents and you want joint audio/video training. You can set `h3_target_mode` or `minimax_h3_target_mode` inside a data backend entry to opt only selected backends into audio.
 
 For audio-only training, `dataset_type: "audio"` is sufficient. Because H3 advertises fake-video support, SimpleTuner
 records `audio.audio_only: true` in the normalized backend config, builds the placeholder video stream, and masks video

--- a/documentation/quickstart/MINIMAX_H3.pt-BR.md
+++ b/documentation/quickstart/MINIMAX_H3.pt-BR.md
@@ -61,7 +61,7 @@ Negative prompting não faz parte do contrato base do H3. SimpleTuner mantém re
 
 ## Modo de audio
 
-`minimax_h3_target_mode: "auto"` resolve para `av` quando dados de audio habilitados sao detectados e para `video` caso contrario. A validacao usa o mesmo padrao detectado nos dados, portanto execucoes somente de audio e audio-video conjunto geram audio sem uma substituicao separada de validacao. Defina `video` explicitamente para evitar trabalho de audio VAE:
+`minimax_h3_target_mode: "auto"` resolve para `av` quando dados de áudio habilitados são detectados e para `video` caso contrário. A validação usa o mesmo padrão detectado nos dados, portanto execuções somente de áudio e áudio-vídeo conjunto geram áudio sem uma substituição separada de validação. Defina `video` explicitamente para evitar trabalho de áudio VAE:
 
 ```json
 {
@@ -69,7 +69,7 @@ Negative prompting não faz parte do contrato base do H3. SimpleTuner mantém re
 }
 ```
 
-Use `"av"` explicitamente quando o dataset tiver target audio latents e voce quiser joint audio/video training. Tambem pode configurar por backend com `h3_target_mode` ou `minimax_h3_target_mode`.
+Use `"av"` explicitamente quando o dataset tiver target audio latents e você quiser joint audio/video training. Também pode configurar por backend com `h3_target_mode` ou `minimax_h3_target_mode`.
 
 Para treino somente de audio, `dataset_type: "audio"` e suficiente. Como o H3 declara suporte a fake video, o
 SimpleTuner registra `audio.audio_only: true` na configuracao normalizada, cria o video placeholder e mascara a loss de

--- a/documentation/quickstart/MINIMAX_H3.pt-BR.md
+++ b/documentation/quickstart/MINIMAX_H3.pt-BR.md
@@ -61,7 +61,7 @@ Negative prompting não faz parte do contrato base do H3. SimpleTuner mantém re
 
 ## Modo de audio
 
-`minimax_h3_target_mode: "auto"` vira video-only e evita trabalho de audio VAE:
+`minimax_h3_target_mode: "auto"` resolve para `av` quando dados de audio habilitados sao detectados e para `video` caso contrario. A validacao usa o mesmo padrao detectado nos dados, portanto execucoes somente de audio e audio-video conjunto geram audio sem uma substituicao separada de validacao. Defina `video` explicitamente para evitar trabalho de audio VAE:
 
 ```json
 {
@@ -69,7 +69,7 @@ Negative prompting não faz parte do contrato base do H3. SimpleTuner mantém re
 }
 ```
 
-Use `"av"` só quando o dataset tiver target audio latents e você quiser joint audio/video training. Também pode configurar por backend com `h3_target_mode` ou `minimax_h3_target_mode`.
+Use `"av"` explicitamente quando o dataset tiver target audio latents e voce quiser joint audio/video training. Tambem pode configurar por backend com `h3_target_mode` ou `minimax_h3_target_mode`.
 
 Para treino somente de audio, `dataset_type: "audio"` e suficiente. Como o H3 declara suporte a fake video, o
 SimpleTuner registra `audio.audio_only: true` na configuracao normalizada, cria o video placeholder e mascara a loss de

--- a/documentation/quickstart/MINIMAX_H3.zh.md
+++ b/documentation/quickstart/MINIMAX_H3.zh.md
@@ -61,7 +61,7 @@ Negative prompting 不属于基础 H3 契约。SimpleTuner 为 de-distilled chec
 
 ## 音频目标模式
 
-`minimax_h3_target_mode: "auto"` 会解析为 video-only，并避免 audio VAE 工作：
+`minimax_h3_target_mode: "auto"` 在检测到已启用的音频数据时解析为 `av`，否则解析为 `video`。验证使用相同的数据检测默认值，因此仅音频和联合音视频训练无需单独覆盖验证设置即可生成音频。要避免 audio VAE 工作，请显式设置 `video`：
 
 ```json
 {
@@ -69,7 +69,7 @@ Negative prompting 不属于基础 H3 契约。SimpleTuner 为 de-distilled chec
 }
 ```
 
-只有当 dataset 有 target audio latents 并需要联合音视频训练时才使用 `"av"`。也可以在 data backend 中设置 `h3_target_mode` 或 `minimax_h3_target_mode`。
+当 dataset 有 target audio latents 并需要联合音视频训练时，可以显式设置 `"av"`。也可以在 data backend 中设置 `h3_target_mode` 或 `minimax_h3_target_mode`。
 
 仅音频训练只需设置 `dataset_type: "audio"`。H3 声明支持 fake video，因此 SimpleTuner 会在规范化后的 backend
 配置中记录 `audio.audio_only: true`，构建占位视频流，并屏蔽视频 loss。仍可显式设置 `audio_only`，但这不是必需的。

--- a/simpletuner/helpers/models/minimaxh3/model.py
+++ b/simpletuner/helpers/models/minimaxh3/model.py
@@ -1213,8 +1213,14 @@ class MiniMaxH3(VideoModelFoundation):
         sampling_rate = getattr(getattr(self.audio_vae, "config", None), "sampling_rate", None)
         return int(sampling_rate) if sampling_rate else None
 
+    def _h3_target_mode_for_validation(self) -> str:
+        mode = self._configured_h3_target_mode()
+        if mode == "auto":
+            return "av" if getattr(self, "_data_has_audio", False) else "video"
+        return mode
+
     def update_pipeline_call_kwargs(self, pipeline_kwargs):
-        pipeline_kwargs.setdefault("minimax_h3_target_mode", self._configured_h3_target_mode())
+        pipeline_kwargs.setdefault("minimax_h3_target_mode", self._h3_target_mode_for_validation())
         num_frames = getattr(self.config, "validation_num_video_frames", None)
         if num_frames:
             pipeline_kwargs.setdefault("num_frames", int(num_frames))

--- a/tests/test_minimaxh3.py
+++ b/tests/test_minimaxh3.py
@@ -1180,6 +1180,50 @@ class MiniMaxH3Tests(unittest.TestCase):
         ):
             self.assertTrue(wrapper.uses_audio_latents_for_data_backend("audio"))
 
+    def test_minimax_h3_validation_auto_target_mode_uses_detected_audio_data(self):
+        wrapper = MiniMaxH3.__new__(MiniMaxH3)
+        wrapper.config = SimpleNamespace(minimax_h3_target_mode="auto")
+        wrapper.configure_data_signals(has_audio=True)
+
+        pipeline_kwargs = wrapper.update_pipeline_call_kwargs({})
+
+        self.assertEqual(pipeline_kwargs["minimax_h3_target_mode"], "av")
+
+    def test_minimax_h3_validation_auto_target_mode_uses_video_without_audio_data(self):
+        wrapper = MiniMaxH3.__new__(MiniMaxH3)
+        wrapper.config = SimpleNamespace(minimax_h3_target_mode="auto")
+        wrapper.configure_data_signals(has_video=True)
+
+        pipeline_kwargs = wrapper.update_pipeline_call_kwargs({})
+
+        self.assertEqual(pipeline_kwargs["minimax_h3_target_mode"], "video")
+
+    def test_minimax_h3_validation_preserves_explicit_pipeline_target_mode(self):
+        wrapper = MiniMaxH3.__new__(MiniMaxH3)
+        wrapper.config = SimpleNamespace(minimax_h3_target_mode="auto")
+        wrapper.configure_data_signals(has_audio=True)
+
+        pipeline_kwargs = wrapper.update_pipeline_call_kwargs({"minimax_h3_target_mode": "video"})
+
+        self.assertEqual(pipeline_kwargs["minimax_h3_target_mode"], "video")
+
+    def test_minimax_h3_validation_uses_audio_vae_sample_rate(self):
+        wrapper = MiniMaxH3.__new__(MiniMaxH3)
+        wrapper.audio_vae = SimpleNamespace(config=SimpleNamespace(sampling_rate=48000))
+
+        self.assertEqual(wrapper.validation_audio_sample_rate(), 48000)
+
+    def test_minimax_h3_validation_forwards_configured_frame_count(self):
+        wrapper = MiniMaxH3.__new__(MiniMaxH3)
+        wrapper.config = SimpleNamespace(
+            minimax_h3_target_mode="video",
+            validation_num_video_frames=345,
+        )
+
+        pipeline_kwargs = wrapper.update_pipeline_call_kwargs({})
+
+        self.assertEqual(pipeline_kwargs["num_frames"], 345)
+
     def test_transformer_cached_reference_mode_reuses_static_kv(self):
         model = tiny_h3_transformer(num_layers=1)
         model.eval()


### PR DESCRIPTION
This pull request updates the documentation and implementation for the `minimax_h3_target_mode` configuration, clarifying and aligning its behavior across code and docs. The main change is that `"auto"` now resolves to `"av"` if enabled audio data is detected, and to `"video"` otherwise, both in training and validation. This logic is now consistently documented in all supported languages, and the implementation and tests have been updated to match.

**Documentation updates:**

* Clarified that `"auto"` for `minimax_h3_target_mode` resolves to `"av"` when enabled audio data is detected, and to `"video"` otherwise, in all relevant documentation files (`OPTIONS.md`, `OPTIONS.*.md`, and quickstart guides). This includes specifying that validation uses the same detected-data default and providing explicit guidance for when to use `"av"` or `"video"`. [[1]](diffhunk://#diff-45e063db3ebcffb55dde68f083e92399a74f4cefbb464e8cd36911971c50933fL107-R107) [[2]](diffhunk://#diff-3f0cd39e3a7f176d81408ae40dc4f8c6271347f75b1cee5cf71c4e701d7db561L107-R107) [[3]](diffhunk://#diff-39b5789a705b2e70400106934436b619d10413ca5e37bd7a2b5fa7aa0c0fb8cfL107-R107) [[4]](diffhunk://#diff-fd629904ab3e1ecdd5b568c3ef6ac61e71e3d7741700e360820849938158a1d9L107-R107) [[5]](diffhunk://#diff-2c007ae9176f9f69b3ae16558be55b46d524f460a626f4e5c31e1e9a1d1b14b8L107-R107) [[6]](diffhunk://#diff-cddcc50c252e719be92644d65ea8542cc51d08f15e67d918bfae737904142b1fL107-R107) [[7]](diffhunk://#diff-4138c95ed60a8de84709ae0d3ae6923aaa9dfae92e7132c7373f6db183287664L64-R72) [[8]](diffhunk://#diff-306c889b8d9e47b76fbb4b8ab0f557dbd9227ac8cc0f0156a4ceeb7fdd727ef8L64-R72) [[9]](diffhunk://#diff-d2fa9b98d893d11ed20b3ea0507426e3a50bd8155d856488ab4d0bc16cfbf3f9L64-R72) [[10]](diffhunk://#diff-c1512f8181f8e51966f020566433c0903c40f78df29ea0c8072f26f5bc356aa9L64-R72) [[11]](diffhunk://#diff-fc317a05a0243cb9163537535d7ae3261bd91214c79973c0bc95d63c86116f96L64-R72) [[12]](diffhunk://#diff-c1fccc5d9af098cfebafe2da0a31c82f103b6d98bfb053ade29b41ad1f5bbe0cL64-R72)

**Implementation updates:**

* Added a helper method `_h3_target_mode_for_validation` in `simpletuner/helpers/models/minimaxh3/model.py` to resolve `"auto"` based on detected audio data, and updated `update_pipeline_call_kwargs` to use this logic for validation.

**Testing improvements:**

* Added and expanded tests in `tests/test_minimaxh3.py` to verify the new `"auto"` resolution logic, including cases for audio data present, absent, explicit overrides, and validation of related parameters.