### PR TITLE
Test joint AV media extraction priority

### DIFF
--- a/tests/test_validation_pipeline_kwargs.py
+++ b/tests/test_validation_pipeline_kwargs.py
@@ -93,6 +93,14 @@ class ValidationPipelineKwargsTests(unittest.TestCase):
 
         self.assertIs(result, videos)
 
+    def test_pipeline_media_extraction_prefers_video_over_audio(self):
+        videos = [["frame-1", "frame-2"]]
+        audio = torch.zeros(1, 48000)
+
+        result = self.validation._extract_pipeline_media(SimpleNamespace(videos=videos, audios=None, audio=audio))
+
+        self.assertIs(result, videos)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request adds a new unit test to ensure that the pipeline media extraction logic correctly prefers video input over audio when both are present.

**Testing improvements:**

* Added `test_pipeline_media_extraction_prefers_video_over_audio` to verify that the `_extract_pipeline_media` method returns the `videos` field when both `videos` and `audio` are provided, ensuring video takes precedence.