### PR TITLE
Batch variable-duration audio VAE caching

### DIFF
--- a/simpletuner/helpers/caching/vae.py
+++ b/simpletuner/helpers/caching/vae.py
@@ -805,9 +805,9 @@ class VAECache(WebhookMixin):
             return self._clone_metadata_value(value)
         return value
 
-    def _gather_sample_metadata(self, filepaths):
+    def _gather_sample_metadata(self, filepaths, samples: torch.Tensor | None = None):
         metadata_entries = []
-        for filepath in filepaths:
+        for index, filepath in enumerate(filepaths):
             resolved_metadata = None
             try:
                 resolved_metadata = StateTracker.get_metadata_by_filepath(
@@ -821,11 +821,14 @@ class VAECache(WebhookMixin):
                 except Exception as exc:
                     logger.debug(f"Metadata backend lookup failed for {filepath}: {exc}")
                     resolved_metadata = None
+            resolved_metadata = dict(resolved_metadata or {})
+            if self.dataset_type_enum is DatasetType.AUDIO and torch.is_tensor(samples):
+                resolved_metadata["num_samples"] = int(samples[index].shape[-1])
             metadata_entries.append(
                 {
                     "filepath": filepath,
                     "data_backend_id": self.id,
-                    "metadata": resolved_metadata or {},
+                    "metadata": resolved_metadata,
                 }
             )
         return metadata_entries
@@ -1300,7 +1303,10 @@ class VAECache(WebhookMixin):
                     for idx, fp in enumerate(debug_filepaths):
                         self._log_audio_tensor_stats("audio_waveform_batch", processed_images[idx], fp)
                 processed_images = self.model.pre_vae_encode_transform_sample(processed_images)
-                metadata_for_batch = self._gather_sample_metadata([filepaths[i] for i in uncached_image_indices])
+                metadata_for_batch = self._gather_sample_metadata(
+                    [filepaths[i] for i in uncached_image_indices],
+                    samples=processed_images,
+                )
                 latents_uncached = self.model.encode_cache_batch(
                     self.vae,
                     processed_images,
@@ -1638,7 +1644,7 @@ class VAECache(WebhookMixin):
         waveform, sample_rate = self._coerce_audio_waveform(raw_sample, metadata, filepath)
         if waveform is None:
             return None
-        waveform, metadata = self._truncate_audio_waveform_to_max_duration(
+        waveform, metadata = self._truncate_audio_waveform_to_target_duration(
             waveform=waveform,
             sample_rate=sample_rate,
             metadata=metadata,
@@ -1702,22 +1708,27 @@ class VAECache(WebhookMixin):
         metadata["duration_seconds"] = float(waveform.shape[-1]) / float(sample_rate)
         return waveform, metadata
 
-    def _truncate_audio_waveform_to_max_duration(self, waveform, sample_rate, metadata: dict, filepath: str):
+    def _truncate_audio_waveform_to_target_duration(self, waveform, sample_rate, metadata: dict, filepath: str):
         if sample_rate is None:
             return waveform, metadata
         backend_config = StateTracker.get_data_backend_config(data_backend_id=self.id) or {}
         audio_config = backend_config.get("audio") or {}
-        max_duration = audio_config.get("max_duration_seconds")
-        if max_duration is None:
-            return waveform, metadata
-        try:
-            max_duration = float(max_duration)
-        except (TypeError, ValueError):
-            return waveform, metadata
-        if max_duration <= 0:
+        duration_limits = [audio_config.get("max_duration_seconds")]
+        if not audio_config.get("source_from_video", False):
+            duration_limits.append(metadata.get("bucket_duration_seconds"))
+        resolved_limits = []
+        for duration_limit in duration_limits:
+            try:
+                duration_limit = float(duration_limit)
+            except (TypeError, ValueError):
+                continue
+            if duration_limit > 0:
+                resolved_limits.append(duration_limit)
+        if not resolved_limits:
             return waveform, metadata
 
-        target_samples = int(round(max_duration * float(sample_rate)))
+        target_duration = min(resolved_limits)
+        target_samples = int(round(target_duration * float(sample_rate)))
         if target_samples <= 0 or waveform.shape[-1] <= target_samples:
             return waveform, metadata
 
@@ -1734,7 +1745,7 @@ class VAECache(WebhookMixin):
         metadata["duration_seconds"] = float(waveform.shape[-1]) / float(sample_rate)
         metadata["truncated_duration_seconds"] = metadata["duration_seconds"]
         logger.debug(
-            "Truncated audio sample %s to %.2fs for audio.max_duration_seconds.",
+            "Truncated audio sample %s to %.2fs for its configured duration limit.",
             filepath,
             metadata["duration_seconds"],
         )
@@ -1826,26 +1837,23 @@ class VAECache(WebhookMixin):
             output_values = []
             while qlen > 0:
                 vae_input_images, vae_input_filepaths, vae_output_filepaths = [], [], []
-                batch_aspect_bucket = None
                 count_to_process = min(qlen, self.vae_batch_size)
                 for _ in range(0, count_to_process):
                     if image_pixel_values:
                         (
                             pixel_values,
                             filepath,
-                            aspect_bucket,
+                            _aspect_bucket,
                             is_final_sample,
                         ) = image_pixel_values.pop()
                     else:
                         (
                             pixel_values,
                             filepath,
-                            aspect_bucket,
+                            _aspect_bucket,
                             is_final_sample,
                         ) = self.vae_input_queue.get()
 
-                    if batch_aspect_bucket is None:
-                        batch_aspect_bucket = aspect_bucket
                     vae_input_images.append(pixel_values)
                     vae_input_filepaths.append(filepath)
                     vae_output_filepaths.append(self.generate_vae_cache_filename(filepath)[0])
@@ -1854,17 +1862,32 @@ class VAECache(WebhookMixin):
                         # we need to respect is_final_sample value and not retrieve the *next* element yet.
                         break
 
-                latents = self.encode_images(
-                    [sample.to(dtype=self._cache_vae_dtype()) for sample in vae_input_images],
-                    vae_input_filepaths,
-                    load_from_cache=False,
-                )
-                if latents is None:
-                    raise ValueError("Received None from encode_images")
-                for output_file, latent_vector, filepath in zip(vae_output_filepaths, latents, vae_input_filepaths):
-                    if latent_vector is None:
-                        raise ValueError(f"Latent vector is None for filepath {filepath}")
-                    output_value = (output_file, filepath, latent_vector)
+                indexed_batch = list(enumerate(zip(vae_input_images, vae_input_filepaths, vae_output_filepaths)))
+                if self.dataset_type_enum is DatasetType.AUDIO:
+                    grouped_batch = {}
+                    for index, entry in indexed_batch:
+                        grouped_batch.setdefault(tuple(entry[0].shape), []).append((index, entry))
+                    encode_groups = grouped_batch.values()
+                else:
+                    encode_groups = (indexed_batch,)
+
+                encoded_batch = []
+                for encode_group in encode_groups:
+                    group_images = [entry[0] for _, entry in encode_group]
+                    group_filepaths = [entry[1] for _, entry in encode_group]
+                    latents = self.encode_images(
+                        [sample.to(dtype=self._cache_vae_dtype()) for sample in group_images],
+                        group_filepaths,
+                        load_from_cache=False,
+                    )
+                    if latents is None:
+                        raise ValueError("Received None from encode_images")
+                    for (index, (_, filepath, output_file)), latent_vector in zip(encode_group, latents):
+                        if latent_vector is None:
+                            raise ValueError(f"Latent vector is None for filepath {filepath}")
+                        encoded_batch.append((index, (output_file, filepath, latent_vector)))
+
+                for _, output_value in sorted(encoded_batch):
                     output_values.append(output_value)
                     if not disable_queue:
                         logger.debug("Adding outputs to write queue")

--- a/tests/test_vae.py
+++ b/tests/test_vae.py
@@ -3,6 +3,7 @@ import sys
 import types
 import unittest
 from hashlib import sha256
+from queue import Queue
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -235,6 +236,108 @@ class MiniAudioModel(AudioModelFoundation):
 
 
 class TestVaeCacheAudio(unittest.TestCase):
+    def test_audio_batch_metadata_uses_encoded_waveform_length(self):
+        vae_cache = VAECache.__new__(VAECache)
+        vae_cache.id = "audio-cache"
+        vae_cache.dataset_type_enum = DatasetType.AUDIO
+        vae_cache._metadata_search_types = ["image", "video", "conditioning", "audio"]
+        vae_cache.metadata_backend = DummyMetadataBackend(metadata={"track.wav": {"num_samples": 350}})
+
+        with patch.object(StateTracker, "get_metadata_by_filepath", return_value=None):
+            entries = vae_cache._gather_sample_metadata(["track.wav"], samples=torch.zeros(1, 2, 300))
+
+        self.assertEqual(entries[0]["metadata"]["num_samples"], 300)
+        self.assertEqual(vae_cache.metadata_backend._metadata["track.wav"]["num_samples"], 350)
+
+    def test_audio_preparation_truncates_to_duration_bucket(self):
+        vae_cache = VAECache.__new__(VAECache)
+        vae_cache.id = "audio-cache"
+        vae_cache.metadata_backend = DummyMetadataBackend(
+            metadata={
+                "track.wav": {
+                    "bucket_duration_seconds": 3.0,
+                    "truncation_mode": "beginning",
+                }
+            }
+        )
+        vae_cache._log_audio_tensor_stats = MagicMock()
+
+        with patch.object(
+            StateTracker,
+            "get_data_backend_config",
+            return_value={"audio": {"source_from_video": False}},
+        ):
+            prepared = vae_cache._prepare_audio_sample(
+                "track.wav",
+                {"waveform": torch.arange(700, dtype=torch.float32).reshape(2, 350), "sample_rate": 100},
+            )
+
+        self.assertEqual(prepared["waveform"].shape, (2, 300))
+        self.assertEqual(prepared["metadata"]["duration_seconds"], 3.0)
+
+    def test_audio_preparation_preserves_max_duration_limit(self):
+        vae_cache = VAECache.__new__(VAECache)
+        vae_cache.id = "audio-cache"
+        vae_cache.metadata_backend = DummyMetadataBackend(metadata={"track.wav": {}})
+        vae_cache._log_audio_tensor_stats = MagicMock()
+
+        with patch.object(
+            StateTracker,
+            "get_data_backend_config",
+            return_value={"audio": {"max_duration_seconds": 3.0}},
+        ):
+            prepared = vae_cache._prepare_audio_sample(
+                "track.wav",
+                {"waveform": torch.zeros(2, 350), "sample_rate": 100},
+            )
+
+        self.assertEqual(prepared["waveform"].shape, (2, 300))
+
+    def test_video_audio_preparation_does_not_truncate_to_duration_bucket(self):
+        vae_cache = VAECache.__new__(VAECache)
+        vae_cache.id = "audio-cache"
+        vae_cache.metadata_backend = DummyMetadataBackend(
+            metadata={"track.mp4": {"bucket_duration_seconds": 3.0, "truncation_mode": "beginning"}}
+        )
+        vae_cache._log_audio_tensor_stats = MagicMock()
+
+        with patch.object(
+            StateTracker,
+            "get_data_backend_config",
+            return_value={"audio": {"source_from_video": True}},
+        ):
+            prepared = vae_cache._prepare_audio_sample(
+                "track.mp4",
+                {"waveform": torch.zeros(2, 350), "sample_rate": 100},
+            )
+
+        self.assertEqual(prepared["waveform"].shape, (2, 350))
+
+    def test_audio_vae_queue_partitions_variable_length_waveforms(self):
+        vae_cache = VAECache.__new__(VAECache)
+        vae_cache.dataset_type_enum = DatasetType.AUDIO
+        vae_cache.vae_batch_size = 4
+        vae_cache.vae_input_queue = Queue()
+        vae_cache._cache_vae_dtype = MagicMock(return_value=torch.float32)
+        vae_cache.generate_vae_cache_filename = MagicMock(side_effect=lambda filepath: (f"{filepath}.pt", f"{filepath}.pt"))
+        vae_cache.encode_images = MagicMock(
+            side_effect=lambda images, filepaths, load_from_cache: [torch.zeros(1) for _ in images]
+        )
+        vae_cache._handle_metadata_filtered_sample = MagicMock()
+        vae_cache.debug_log = MagicMock()
+        vae_cache.vae_input_queue.put((torch.zeros(2, 100), "short.wav", "3s", False))
+        vae_cache.vae_input_queue.put((torch.zeros(2, 120), "long.wav", "3s", False))
+        vae_cache.vae_input_queue.put((torch.zeros(2, 100), "short-2.wav", "3s", True))
+
+        output = vae_cache._encode_images_in_batch(disable_queue=True)
+
+        self.assertEqual([entry[1] for entry in output], ["short.wav", "long.wav", "short-2.wav"])
+        self.assertEqual(vae_cache.encode_images.call_count, 2)
+        encoded_shapes = [
+            [tuple(sample.shape) for sample in call.args[0]] for call in vae_cache.encode_images.call_args_list
+        ]
+        self.assertEqual(encoded_shapes, [[(2, 100), (2, 100)], [(2, 120)]])
+
     @patch("simpletuner.helpers.caching.vae.StateTracker.set_vae_cache_files")
     @patch("simpletuner.helpers.caching.vae.StateTracker.get_vae_cache_files", return_value=[])
     @patch("simpletuner.helpers.caching.vae.StateTracker.set_image_files", return_value={})


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the audio handling and batching logic in the VAE caching system, with a focus on more accurate metadata management, flexible audio truncation, and robust batch processing for variable-length audio waveforms. Additionally, new tests have been added to ensure correctness of these behaviors.

**Audio metadata and truncation improvements:**

* The `_gather_sample_metadata` method now accepts an optional `samples` argument, and for audio datasets, it sets the `"num_samples"` field in the metadata to the actual encoded waveform length. This ensures that the metadata accurately reflects the processed data. [[1]](diffhunk://#diff-614668871ca0c481a8427daef01930a4dbbf640cd7c1b15e3fba9d8d2cbe4f4eL808-R810) [[2]](diffhunk://#diff-614668871ca0c481a8427daef01930a4dbbf640cd7c1b15e3fba9d8d2cbe4f4eR824-R831) [[3]](diffhunk://#diff-614668871ca0c481a8427daef01930a4dbbf640cd7c1b15e3fba9d8d2cbe4f4eL1303-R1309)
* The audio waveform truncation logic has been refactored: `_truncate_audio_waveform_to_max_duration` is now `_truncate_audio_waveform_to_target_duration`, and it considers both `max_duration_seconds` and `bucket_duration_seconds` (when not sourced from video) to determine the appropriate truncation length. The minimum of the valid duration limits is used, allowing for more flexible and correct truncation. [[1]](diffhunk://#diff-614668871ca0c481a8427daef01930a4dbbf640cd7c1b15e3fba9d8d2cbe4f4eL1641-R1647) [[2]](diffhunk://#diff-614668871ca0c481a8427daef01930a4dbbf640cd7c1b15e3fba9d8d2cbe4f4eL1705-R1731) [[3]](diffhunk://#diff-614668871ca0c481a8427daef01930a4dbbf640cd7c1b15e3fba9d8d2cbe4f4eL1737-R1748)

**Batch processing and queue handling:**

* The `_encode_images_in_batch` method now groups audio samples by their waveform shape before batching, ensuring that only samples of the same shape are processed together. This supports variable-length audio batching and prevents shape mismatches during encoding. The output order is preserved by sorting the results by their original indices. [[1]](diffhunk://#diff-614668871ca0c481a8427daef01930a4dbbf640cd7c1b15e3fba9d8d2cbe4f4eL1829-L1848) [[2]](diffhunk://#diff-614668871ca0c481a8427daef01930a4dbbf640cd7c1b15e3fba9d8d2cbe4f4eR1865-R1890)

**Testing and validation:**

* Several new tests have been added to `tests/test_vae.py` to verify that:
  - Audio batch metadata uses the encoded waveform length.
  - Audio preparation truncates to the bucket duration or max duration as configured.
  - Video-sourced audio is not truncated to the bucket duration.
  - The VAE queue correctly partitions variable-length waveforms for batching.

**Minor cleanup:**

* Unused variables related to aspect buckets have been removed from the batching logic for clarity.

These changes collectively improve the accuracy, flexibility, and robustness of audio processing in the VAE caching system.