### PR TITLE
Add iREPA spatial representation alignment

### DIFF
--- a/documentation/OPTIONS.es.md
+++ b/documentation/OPTIONS.es.md
@@ -1385,6 +1385,33 @@ Consulta la guía [DATALOADER.md](DATALOADER.md#automatic-dataset-oversubscripti
 
 ---
 
+## 🎯 iREPA (Alineacion de Representaciones Mejorada)
+
+iREPA conserva la estructura espacial mediante un proyector convolucional y normalizacion espacial por frame. Mejora CREPA para Transformers y U-REPA para UNets. Consulta la [guia de iREPA](experimental/IREPA.es.md).
+
+### `--irepa_enabled`
+
+- **Tipo**: Flag booleana
+- **Predeterminado**: `false`
+- **Qué hace**: Mejora una ruta CREPA o U-REPA activa con las operaciones espaciales de iREPA.
+- **Nota**: Activa tambien `crepa_enabled` para Transformer o `urepa_enabled` para UNet.
+- **Modo de entrenamiento**: Modelo completo o LoRA PEFT estandar. LyCORIS no puede guardar el proyector auxiliar y no es compatible.
+
+### `--irepa_spatial_norm_alpha`
+
+- **Tipo**: Float
+- **Predeterminado**: `0.6`
+- **Qué hace**: Escala la resta de la media de las features del teacher antes de dividir por la desviacion estandar espacial.
+- **Nota**: `0.6` es la configuracion de referencia para latent diffusion; `1.0` centra por completo cada canal.
+
+### `--irepa_projector_kernel_size`
+
+- **Tipo**: Entero (`1`, `3`, `5` o `7`)
+- **Predeterminado**: `3`
+- **Qué hace**: Define el kernel de la convolucion espacial del proyector.
+
+---
+
 ## 🎯 CREPA (Cross-frame Representation Alignment)
 
 CREPA es una técnica de regularización para fine-tuning de modelos de difusión de video que mejora la consistencia temporal al alinear estados ocultos con características visuales preentrenadas de fotogramas adyacentes. Basado en el paper ["Cross-Frame Representation Alignment for Fine-Tuning Video Diffusion Models"](https://arxiv.org/abs/2506.09229).

--- a/documentation/OPTIONS.hi.md
+++ b/documentation/OPTIONS.hi.md
@@ -1383,6 +1383,33 @@ Multi‑GPU training के लिए dataset sizing पर अधिक वि�
 
 ---
 
+## 🎯 iREPA (Improved Representation Alignment)
+
+iREPA convolution projector और per-frame spatial normalization से representation alignment में spatial structure बनाए रखता है। यह Transformers के CREPA और UNets के U-REPA को बेहतर बनाता है। [iREPA guide](experimental/IREPA.hi.md) देखें।
+
+### `--irepa_enabled`
+
+- **Type**: Boolean flag
+- **Default**: `false`
+- **What**: चालू CREPA या U-REPA path में iREPA spatial operations जोड़ता है।
+- **Note**: Transformer के लिए `crepa_enabled` या UNet के लिए `urepa_enabled` भी चालू करें।
+- **Training mode**: Full-model या standard PEFT LoRA। Auxiliary projector save न कर पाने के कारण LyCORIS supported नहीं है।
+
+### `--irepa_spatial_norm_alpha`
+
+- **Type**: Float
+- **Default**: `0.6`
+- **What**: Spatial standard deviation से divide करने से पहले teacher-feature mean subtraction को scale करता है।
+- **Note**: `0.6` latent-diffusion reference setting है; `1.0` हर channel को पूरी तरह center करता है।
+
+### `--irepa_projector_kernel_size`
+
+- **Type**: Integer (`1`, `3`, `5`, या `7`)
+- **Default**: `3`
+- **What**: Alignment projector का spatial convolution kernel सेट करता है।
+
+---
+
 ## 🎯 CREPA (Cross-frame Representation Alignment)
 
 CREPA एक regularization तकनीक है जो video diffusion models की fine‑tuning में temporal consistency सुधारती है, adjacent frames से pretrained visual features के साथ hidden states align करके। यह पेपर ["Cross-Frame Representation Alignment for Fine-Tuning Video Diffusion Models"](https://arxiv.org/abs/2506.09229) पर आधारित है।

--- a/documentation/OPTIONS.ja.md
+++ b/documentation/OPTIONS.ja.md
@@ -1386,6 +1386,33 @@ Flux Kontext の検証もこのコンディショニングベースの経路を�
 
 ---
 
+## 🎯 iREPA（Improved Representation Alignment）
+
+iREPA は convolution projector と frame ごとの spatial normalization により、representation alignment の空間構造を保持します。Transformer の CREPA と UNet の U-REPA を改善します。[iREPA ガイド](experimental/IREPA.ja.md)を参照してください。
+
+### `--irepa_enabled`
+
+- **型**: Boolean flag
+- **既定値**: `false`
+- **内容**: 有効な CREPA または U-REPA path に iREPA spatial operations を追加します。
+- **注記**: Transformer では `crepa_enabled`、UNet では `urepa_enabled` も有効にします。
+- **Training mode**: Full-model または standard PEFT LoRA。LyCORIS は補助 projector を保存できないため未対応です。
+
+### `--irepa_spatial_norm_alpha`
+
+- **型**: Float
+- **既定値**: `0.6`
+- **内容**: spatial standard deviation で割る前の teacher-feature mean subtraction を調整します。
+- **注記**: `0.6` は latent-diffusion reference setting、`1.0` は完全な channel centering です。
+
+### `--irepa_projector_kernel_size`
+
+- **型**: Integer（`1`、`3`、`5`、`7`）
+- **既定値**: `3`
+- **内容**: alignment projector の spatial convolution kernel を設定します。
+
+---
+
 ## 🎯 CREPA（Cross-frame Representation Alignment）
 
 CREPA は動画拡散モデルのファインチューニング向け正則化手法で、隣接フレームの事前学習済み視覚特徴と隠れ状態を整合させることで時間的一貫性を向上させます。論文は ["Cross-Frame Representation Alignment for Fine-Tuning Video Diffusion Models"](https://arxiv.org/abs/2506.09229) を参照してください。

--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -1389,6 +1389,34 @@ See the [DATALOADER.md](DATALOADER.md#automatic-dataset-oversubscription) guide 
 
 ---
 
+## 🎯 iREPA (Improved Representation Alignment)
+
+iREPA preserves spatial structure during representation alignment with a convolutional projector and per-frame spatial normalization. It upgrades CREPA for transformers and U-REPA for UNets. See [the iREPA guide](experimental/IREPA.md).
+
+### `--irepa_enabled`
+
+- **Type**: Boolean flag
+- **Default**: `false`
+- **What**: Upgrades an enabled CREPA or U-REPA path with iREPA spatial operations.
+- **Note**: Also enable `crepa_enabled` for transformer models or `urepa_enabled` for UNet models.
+- **Training mode**: Full-model or standard PEFT LoRA. LyCORIS is not supported because it cannot save the auxiliary projector.
+
+### `--irepa_spatial_norm_alpha`
+
+- **Type**: Float
+- **Default**: `0.6`
+- **What**: Scales teacher-feature mean subtraction before division by the spatial standard deviation.
+- **Note**: `0.6` is the latent-diffusion reference setting; `1.0` fully centers every channel.
+
+### `--irepa_projector_kernel_size`
+
+- **Type**: Integer (`1`, `3`, `5`, or `7`)
+- **Default**: `3`
+- **What**: Sets the spatial convolution kernel used by the alignment projector.
+- **Note**: `3` matches the published iREPA architecture.
+
+---
+
 ## 🎯 CREPA (Cross-frame Representation Alignment)
 
 CREPA is a regularization technique for fine-tuning video diffusion models that improves temporal consistency by aligning hidden states with pretrained visual features from adjacent frames. Based on the paper ["Cross-Frame Representation Alignment for Fine-Tuning Video Diffusion Models"](https://arxiv.org/abs/2506.09229).

--- a/documentation/OPTIONS.pt-BR.md
+++ b/documentation/OPTIONS.pt-BR.md
@@ -1381,6 +1381,33 @@ Veja o guia [DATALOADER.md](DATALOADER.md#automatic-dataset-oversubscription) pa
 
 ---
 
+## 🎯 iREPA (Alinhamento de Representacoes Melhorado)
+
+iREPA preserva a estrutura espacial com um projetor convolucional e normalizacao espacial por frame. Ele melhora CREPA para Transformers e U-REPA para UNets. Veja o [guia iREPA](experimental/IREPA.pt-BR.md).
+
+### `--irepa_enabled`
+
+- **Tipo**: Flag booleana
+- **Padrao**: `false`
+- **O que**: Melhora um caminho CREPA ou U-REPA ativo com as operacoes espaciais do iREPA.
+- **Nota**: Habilite tambem `crepa_enabled` para Transformer ou `urepa_enabled` para UNet.
+- **Modo de treinamento**: Modelo completo ou LoRA PEFT padrao. LyCORIS nao consegue salvar o projetor auxiliar e nao e suportado.
+
+### `--irepa_spatial_norm_alpha`
+
+- **Tipo**: Float
+- **Padrao**: `0.6`
+- **O que**: Escala a subtracao da media das features do teacher antes da divisao pelo desvio padrao espacial.
+- **Nota**: `0.6` e a configuracao de referencia para latent diffusion; `1.0` centraliza totalmente cada canal.
+
+### `--irepa_projector_kernel_size`
+
+- **Tipo**: Inteiro (`1`, `3`, `5` ou `7`)
+- **Padrao**: `3`
+- **O que**: Define o kernel da convolucao espacial do projetor.
+
+---
+
 ## 🎯 CREPA (Cross-frame Representation Alignment)
 
 CREPA e uma tecnica de regularizacao para fine-tuning de modelos de difusao de video que melhora a consistencia temporal alinhando hidden states com features visuais pre-treinadas de frames adjacentes. Baseada no paper ["Cross-Frame Representation Alignment for Fine-Tuning Video Diffusion Models"](https://arxiv.org/abs/2506.09229).

--- a/documentation/OPTIONS.zh.md
+++ b/documentation/OPTIONS.zh.md
@@ -1388,6 +1388,33 @@ Flux Kontext 的验证也始终走这条基于条件的路径。使用 `--eval_d
 
 ---
 
+## 🎯 iREPA（改进的表示对齐）
+
+iREPA 使用卷积投影器和逐帧空间归一化，在表示对齐中保留空间结构。它改进 Transformer 的 CREPA 和 UNet 的 U-REPA。参见 [iREPA 指南](experimental/IREPA.zh.md)。
+
+### `--irepa_enabled`
+
+- **类型**：布尔标志
+- **默认值**：`false`
+- **作用**：使用 iREPA 空间操作升级已启用的 CREPA 或 U-REPA 路径。
+- **说明**：Transformer 还需启用 `crepa_enabled`，UNet 还需启用 `urepa_enabled`。
+- **训练模式**：完整模型或标准 PEFT LoRA。LyCORIS 无法保存辅助投影器，因此不受支持。
+
+### `--irepa_spatial_norm_alpha`
+
+- **类型**：浮点数
+- **默认值**：`0.6`
+- **作用**：在除以空间标准差之前，缩放教师特征的均值减法。
+- **说明**：`0.6` 是 latent-diffusion 参考设置；`1.0` 会完全中心化每个通道。
+
+### `--irepa_projector_kernel_size`
+
+- **类型**：整数（`1`、`3`、`5` 或 `7`）
+- **默认值**：`3`
+- **作用**：设置对齐投影器的空间卷积核。
+
+---
+
 ## 🎯 CREPA（Cross-frame Representation Alignment）
 
 CREPA 是一种用于视频扩散模型微调的正则化技术，通过将隐藏状态与相邻帧的预训练视觉特征对齐来提升时间一致性。基于论文 ["Cross-Frame Representation Alignment for Fine-Tuning Video Diffusion Models"](https://arxiv.org/abs/2506.09229)。

--- a/documentation/experimental/IMAGE_REPA.es.md
+++ b/documentation/experimental/IMAGE_REPA.es.md
@@ -9,7 +9,7 @@ SimpleTuner soporta dos variantes:
 
 > **¿Buscas modelos de video?** Consulta [VIDEO_CREPA.es.md](VIDEO_CREPA.es.md) para soporte CREPA en modelos de video con alineamiento temporal.
 
-> **Alineacion espacial mejorada:** [iREPA](IREPA.es.md) agrega un proyector convolucional y normalizacion espacial del teacher a ambas rutas REPA.
+> **Alineación espacial mejorada:** [iREPA](IREPA.es.md) agrega un proyector convolucional y normalización espacial del teacher a ambas rutas REPA.
 
 ## Cuándo usarlo
 

--- a/documentation/experimental/IMAGE_REPA.es.md
+++ b/documentation/experimental/IMAGE_REPA.es.md
@@ -9,6 +9,8 @@ SimpleTuner soporta dos variantes:
 
 > **¿Buscas modelos de video?** Consulta [VIDEO_CREPA.es.md](VIDEO_CREPA.es.md) para soporte CREPA en modelos de video con alineamiento temporal.
 
+> **Alineacion espacial mejorada:** [iREPA](IREPA.es.md) agrega un proyector convolucional y normalizacion espacial del teacher a ambas rutas REPA.
+
 ## Cuándo usarlo
 
 ### REPA (modelos DiT)

--- a/documentation/experimental/IMAGE_REPA.hi.md
+++ b/documentation/experimental/IMAGE_REPA.hi.md
@@ -9,6 +9,8 @@ SimpleTuner दो वेरिएंट को सपोर्ट करता 
 
 > **वीडियो मॉडल्स की तलाश है?** टेम्पोरल अलाइनमेंट वाले वीडियो मॉडल्स पर CREPA सपोर्ट के लिए [VIDEO_CREPA.hi.md](VIDEO_CREPA.hi.md) देखें।
 
+> **बेहतर spatial alignment:** [iREPA](IREPA.hi.md) दोनों REPA paths में convolution projector और teacher spatial normalization जोड़ता है।
+
 ## कब उपयोग करें
 
 ### REPA (DiT मॉडल्स)

--- a/documentation/experimental/IMAGE_REPA.ja.md
+++ b/documentation/experimental/IMAGE_REPA.ja.md
@@ -9,6 +9,8 @@ SimpleTunerは2つのバリアントをサポートしています：
 
 > **動画モデルをお探しですか？** 時間的アラインメント付きの動画モデルCREPAサポートについては [VIDEO_CREPA.ja.md](VIDEO_CREPA.ja.md) をご覧ください。
 
+> **空間 alignment の改善:** [iREPA](IREPA.ja.md) は両方の REPA path に convolution projector と teacher spatial normalization を追加します。
+
 ## 使用するタイミング
 
 ### REPA（DiTモデル）

--- a/documentation/experimental/IMAGE_REPA.md
+++ b/documentation/experimental/IMAGE_REPA.md
@@ -9,6 +9,8 @@ SimpleTuner supports two variants:
 
 > **Looking for video models?** See [VIDEO_CREPA.md](VIDEO_CREPA.md) for CREPA support on video models with temporal alignment.
 
+> **Improved spatial alignment:** [iREPA](IREPA.md) adds a convolutional projector and spatial teacher normalization to both REPA variants.
+
 ## When to use it
 
 ### REPA (DiT models)

--- a/documentation/experimental/IMAGE_REPA.pt-BR.md
+++ b/documentation/experimental/IMAGE_REPA.pt-BR.md
@@ -9,6 +9,8 @@ O SimpleTuner suporta duas variantes:
 
 > **Procurando modelos de vídeo?** Veja [VIDEO_CREPA.pt-BR.md](VIDEO_CREPA.pt-BR.md) para suporte CREPA em modelos de vídeo com alinhamento temporal.
 
+> **Alinhamento espacial melhorado:** [iREPA](IREPA.pt-BR.md) adiciona um projetor convolucional e normalizacao espacial do teacher aos dois caminhos REPA.
+
 ## Quando usar
 
 ### REPA (modelos DiT)

--- a/documentation/experimental/IMAGE_REPA.zh.md
+++ b/documentation/experimental/IMAGE_REPA.zh.md
@@ -9,6 +9,8 @@ SimpleTuner 支持两种变体：
 
 > **寻找视频模型？** 请参阅 [VIDEO_CREPA.zh.md](VIDEO_CREPA.zh.md) 了解带时间对齐的视频模型 CREPA 支持。
 
+> **改进空间对齐：** [iREPA](IREPA.zh.md) 为两种 REPA 路径加入卷积投影器和教师空间归一化。
+
 ## 何时使用
 
 ### REPA（DiT 模型）

--- a/documentation/experimental/IREPA.es.md
+++ b/documentation/experimental/IREPA.es.md
@@ -1,0 +1,24 @@
+# iREPA
+
+iREPA mejora la alineacion de representaciones al conservar la estructura espacial en la ruta de alineacion. Sustituye el proyector lineal por token por una convolucion espacial y normaliza cada canal de las features del teacher con z-score sobre los patches de la imagen.
+
+SimpleTuner usa el motor existente segun el backbone: los modelos Transformer de imagen usan REPA/CREPA; los modelos Transformer de video aplican iREPA por frame y conservan la loss temporal de CREPA; los modelos UNet usan el mid-block y la manifold loss de U-REPA. La cuadricula rectangular se deriva de la forma de los latents limpios.
+
+```json
+{
+  "irepa_enabled": true,
+  "irepa_spatial_norm_alpha": 0.6,
+  "irepa_projector_kernel_size": 3,
+  "crepa_enabled": true,
+  "crepa_block_index": 8,
+  "crepa_lambda": 1.0
+}
+```
+
+Activa `crepa_enabled` con iREPA para Transformer o `urepa_enabled` con iREPA para UNet. Las opciones `crepa_*` o `urepa_*` controlan teacher, peso, capa y schedule. `0.6` corresponde a la receta de latent diffusion; kernel `3` es la arquitectura publicada.
+
+iREPA requiere hidden states con patch tokens espaciales y latents limpios para recuperar la cuadricula. En video, la convolucion no mezcla frames.
+
+Usa entrenamiento de modelo completo o LoRA PEFT estandar. LyCORIS no puede guardar el proyector auxiliar y no es compatible.
+
+Referencia: [What Matters for Representation Alignment: Global Information or Spatial Structure?](https://arxiv.org/abs/2512.10794)

--- a/documentation/experimental/IREPA.es.md
+++ b/documentation/experimental/IREPA.es.md
@@ -1,8 +1,8 @@
 # iREPA
 
-iREPA mejora la alineacion de representaciones al conservar la estructura espacial en la ruta de alineacion. Sustituye el proyector lineal por token por una convolucion espacial y normaliza cada canal de las features del teacher con z-score sobre los patches de la imagen.
+iREPA mejora la alineación de representaciones al conservar la estructura espacial en la ruta de alineación. Sustituye el proyector lineal por token por una convolución espacial y normaliza cada canal de las features del teacher con z-score sobre los patches de la imagen.
 
-SimpleTuner usa el motor existente segun el backbone: los modelos Transformer de imagen usan REPA/CREPA; los modelos Transformer de video aplican iREPA por frame y conservan la loss temporal de CREPA; los modelos UNet usan el mid-block y la manifold loss de U-REPA. La cuadricula rectangular se deriva de la forma de los latents limpios.
+SimpleTuner usa el motor existente según el backbone: los modelos Transformer de imagen usan REPA/CREPA; los modelos Transformer de video aplican iREPA por frame y conservan la loss temporal de CREPA; los modelos UNet usan el mid-block y la manifold loss de U-REPA. La cuadrícula rectangular se deriva de la forma de los latents limpios.
 
 ```json
 {
@@ -17,8 +17,8 @@ SimpleTuner usa el motor existente segun el backbone: los modelos Transformer de
 
 Activa `crepa_enabled` con iREPA para Transformer o `urepa_enabled` con iREPA para UNet. Las opciones `crepa_*` o `urepa_*` controlan teacher, peso, capa y schedule. `0.6` corresponde a la receta de latent diffusion; kernel `3` es la arquitectura publicada.
 
-iREPA requiere hidden states con patch tokens espaciales y latents limpios para recuperar la cuadricula. En video, la convolucion no mezcla frames.
+iREPA requiere hidden states con patch tokens espaciales y latents limpios para recuperar la cuadrícula. En video, la convolución no mezcla frames.
 
-Usa entrenamiento de modelo completo o LoRA PEFT estandar. LyCORIS no puede guardar el proyector auxiliar y no es compatible.
+Usa entrenamiento de modelo completo o LoRA PEFT estándar. LyCORIS no puede guardar el proyector auxiliar y no es compatible.
 
 Referencia: [What Matters for Representation Alignment: Global Information or Spatial Structure?](https://arxiv.org/abs/2512.10794)

--- a/documentation/experimental/IREPA.hi.md
+++ b/documentation/experimental/IREPA.hi.md
@@ -1,0 +1,24 @@
+# iREPA
+
+iREPA alignment path में spatial structure को बनाए रखकर representation alignment सुधारता है। यह per-token linear projector को spatial convolution से बदलता है और हर image के patch dimension पर teacher feature channels को z-score normalize करता है।
+
+SimpleTuner backbone के अनुसार मौजूदा alignment engine चुनता है: Transformer image models REPA/CREPA उपयोग करते हैं; Transformer video models हर frame पर iREPA लगाकर CREPA temporal-neighbour loss रखते हैं; UNet image models U-REPA mid-block और manifold loss उपयोग करते हैं। Rectangular token grid clean latent shape से निकाली जाती है।
+
+```json
+{
+  "irepa_enabled": true,
+  "irepa_spatial_norm_alpha": 0.6,
+  "irepa_projector_kernel_size": 3,
+  "crepa_enabled": true,
+  "crepa_block_index": 8,
+  "crepa_lambda": 1.0
+}
+```
+
+Transformer के लिए iREPA के साथ `crepa_enabled` या UNet के लिए `urepa_enabled` भी चालू करें। संबंधित `crepa_*` या `urepa_*` settings teacher, weight, capture layer और schedule नियंत्रित करती हैं। `0.6` latent-diffusion reference recipe है; kernel `3` paper architecture है।
+
+iREPA को spatial patch tokens वाले hidden states और grid recovery के लिए clean latents चाहिए। Video convolution frames को आपस में mix नहीं करता।
+
+Full-model या standard PEFT LoRA training उपयोग करें। Auxiliary projector save न कर पाने के कारण LyCORIS supported नहीं है।
+
+संदर्भ: [What Matters for Representation Alignment: Global Information or Spatial Structure?](https://arxiv.org/abs/2512.10794)

--- a/documentation/experimental/IREPA.ja.md
+++ b/documentation/experimental/IREPA.ja.md
@@ -1,0 +1,24 @@
+# iREPA
+
+iREPA は alignment path の空間構造を保持して representation alignment を改善します。token ごとの linear projector を spatial convolution に置き換え、各画像の patch 次元で teacher feature を channel ごとに z-score 正規化します。
+
+SimpleTuner は backbone に応じて既存の alignment engine を使います。Transformer image model は REPA/CREPA、Transformer video model は各 frame に iREPA を独立適用した上で CREPA の temporal-neighbour loss、UNet image model は U-REPA の mid-block と manifold loss を使います。矩形 token grid は clean latent shape から復元され、square bucket は不要です。
+
+```json
+{
+  "irepa_enabled": true,
+  "irepa_spatial_norm_alpha": 0.6,
+  "irepa_projector_kernel_size": 3,
+  "crepa_enabled": true,
+  "crepa_block_index": 8,
+  "crepa_lambda": 1.0
+}
+```
+
+Transformer では iREPA と `crepa_enabled`、UNet では iREPA と `urepa_enabled` を有効にします。対応する `crepa_*` / `urepa_*` options が teacher、weight、capture layer、schedule を制御します。`0.6` は latent-diffusion reference recipe、kernel size `3` は paper の構成です。
+
+iREPA には spatial patch token を持つ hidden state と grid 復元用の clean latent が必要です。video convolution は frame 間を混合しません。
+
+Full-model または standard PEFT LoRA training を使用します。LyCORIS は補助 projector を保存できないため未対応です。
+
+参照: [What Matters for Representation Alignment: Global Information or Spatial Structure?](https://arxiv.org/abs/2512.10794)

--- a/documentation/experimental/IREPA.md
+++ b/documentation/experimental/IREPA.md
@@ -1,0 +1,40 @@
+# iREPA
+
+iREPA improves representation alignment by preserving spatial structure in the alignment path. It replaces the tokenwise linear projector with a spatial convolution and z-score normalizes each teacher feature channel over the image patches.
+
+SimpleTuner applies iREPA through the existing alignment engine for the loaded backbone:
+
+- Transformer image models use REPA/CREPA hidden-state capture.
+- Transformer video models apply the convolution and normalization independently to each frame, then retain CREPA's temporal-neighbour loss.
+- UNet image models use the U-REPA mid-block capture and manifold loss.
+
+The implementation derives rectangular token grids from the clean latent shape. It does not assume square training buckets.
+
+## Configuration
+
+```json
+{
+  "irepa_enabled": true,
+  "irepa_spatial_norm_alpha": 0.6,
+  "irepa_projector_kernel_size": 3,
+  "crepa_enabled": true,
+  "crepa_block_index": 8,
+  "crepa_lambda": 1.0
+}
+```
+
+Enable `crepa_enabled` with iREPA for transformer backbones. Enable `urepa_enabled` with iREPA for UNet backbones. The corresponding `crepa_*` or `urepa_*` settings control the teacher, loss weight, capture point, and schedule.
+
+- `irepa_spatial_norm_alpha=0.6` matches the latent-diffusion reference recipe. `1.0` fully removes the spatial mean.
+- `irepa_projector_kernel_size=3` is the published architecture.
+- Use an early transformer block for spatial alignment. The best block remains model-dependent.
+
+## Requirements
+
+iREPA requires a captured hidden state with spatial patch tokens and clean latents for grid recovery. The selected vision encoder must expose patch tokens. The convolution projector is attached to the trained backbone and optimized with it; it is used only by the training loss.
+
+Use full-model training or standard PEFT LoRA. PEFT stores the projector as a trainable module in the adapter checkpoint. LyCORIS does not support the auxiliary projector and is rejected.
+
+For video, the convolution never mixes adjacent frames. Temporal mixing remains controlled by `crepa_adjacent_distance` and `crepa_adjacent_tau`.
+
+Reference: [What Matters for Representation Alignment: Global Information or Spatial Structure?](https://arxiv.org/abs/2512.10794)

--- a/documentation/experimental/IREPA.pt-BR.md
+++ b/documentation/experimental/IREPA.pt-BR.md
@@ -1,0 +1,24 @@
+# iREPA
+
+iREPA melhora o alinhamento de representacoes preservando a estrutura espacial no caminho de alinhamento. Ele troca o projetor linear por token por uma convolucao espacial e normaliza cada canal das features do teacher com z-score sobre os patches da imagem.
+
+O SimpleTuner usa o mecanismo existente conforme o backbone: modelos Transformer de imagem usam REPA/CREPA; modelos Transformer de video aplicam iREPA por frame e mantem a loss temporal do CREPA; modelos UNet usam o mid-block e a manifold loss do U-REPA. A grade retangular de tokens e derivada do shape dos latents limpos.
+
+```json
+{
+  "irepa_enabled": true,
+  "irepa_spatial_norm_alpha": 0.6,
+  "irepa_projector_kernel_size": 3,
+  "crepa_enabled": true,
+  "crepa_block_index": 8,
+  "crepa_lambda": 1.0
+}
+```
+
+Habilite `crepa_enabled` com iREPA para Transformer ou `urepa_enabled` com iREPA para UNet. As opcoes `crepa_*` ou `urepa_*` controlam teacher, peso, camada e schedule. `0.6` corresponde a receita de latent diffusion; kernel `3` e a arquitetura publicada.
+
+iREPA requer hidden states com patch tokens espaciais e latents limpos para recuperar a grade. Em video, a convolucao nao mistura frames.
+
+Use treinamento de modelo completo ou LoRA PEFT padrao. LyCORIS nao consegue salvar o projetor auxiliar e nao e suportado.
+
+Referencia: [What Matters for Representation Alignment: Global Information or Spatial Structure?](https://arxiv.org/abs/2512.10794)

--- a/documentation/experimental/IREPA.zh.md
+++ b/documentation/experimental/IREPA.zh.md
@@ -1,0 +1,24 @@
+# iREPA
+
+iREPA 通过保留对齐路径中的空间结构来改进表示对齐。它用空间卷积替代逐 token 线性投影，并在每张图像的 patch 维度上对教师特征逐通道进行 z-score 归一化。
+
+SimpleTuner 会根据骨干类型使用现有对齐引擎：Transformer 图像模型使用 REPA/CREPA；Transformer 视频模型逐帧应用 iREPA，并保留 CREPA 的时间邻帧损失；UNet 图像模型使用 U-REPA 的 mid-block 与 manifold loss。矩形 token 网格从干净 latent 的形状推导，不要求方形 bucket。
+
+```json
+{
+  "irepa_enabled": true,
+  "irepa_spatial_norm_alpha": 0.6,
+  "irepa_projector_kernel_size": 3,
+  "crepa_enabled": true,
+  "crepa_block_index": 8,
+  "crepa_lambda": 1.0
+}
+```
+
+Transformer 需同时启用 iREPA 和 `crepa_enabled`，UNet 需同时启用 iREPA 和 `urepa_enabled`。对应的 `crepa_*` 或 `urepa_*` 设置控制教师、权重、捕获层和调度。`0.6` 对应 latent-diffusion 参考配置；`3` 是论文中的卷积核大小。
+
+iREPA 需要带空间 patch token 的隐藏状态和用于恢复网格的干净 latent。视频卷积不会跨帧混合；时间对齐仍由 CREPA 参数控制。
+
+请使用完整模型训练或标准 PEFT LoRA。LyCORIS 无法保存辅助投影器，因此不受支持。
+
+参考：[What Matters for Representation Alignment: Global Information or Spatial Structure?](https://arxiv.org/abs/2512.10794)

--- a/documentation/experimental/VIDEO_CREPA.es.md
+++ b/documentation/experimental/VIDEO_CREPA.es.md
@@ -4,11 +4,13 @@ Cross-frame Representation Alignment (CREPA) es un regularizador ligero para mod
 
 > **¿Buscas modelos de imagen?** Consulta [IMAGE_REPA.es.md](IMAGE_REPA.es.md) para soporte REPA en modelos DiT de imagen (Flux, SD3, etc.) y U-REPA para modelos UNet (SDXL, SD1.5, Kolors).
 
+> **Alineacion espacial mejorada:** [iREPA](IREPA.es.md) aplica el proyector convolucional y la normalizacion del teacher de forma independiente a cada frame.
+
 ## Cuándo usarlo
 
 - Estás entrenando con videos con movimiento complejo, cambios de escena u oclusiones.
 - Estás afinando un DiT de video (LoRA o completo) y ves parpadeo o deriva de identidad entre frames.
-- Familias de modelos compatibles: `kandinsky5_video`, `ltxvideo`, `sanavideo` y `wan` (otras familias no exponen los hooks de CREPA).
+- Familias compatibles: Transformers de video que exponen captura de hidden states CREPA, incluidos Kandinsky 5 Video, LTXVideo/LTX-2, HunyuanVideo, LongCat Video, MiniMax H3, SanaVideo, Wan/Wan S2V y Cosmos.
 - Tienes VRAM extra (CREPA añade ~1–2 GB según la configuración) para el encoder DINO y el VAE, que deben permanecer en memoria durante el entrenamiento para decodificar latentes a píxeles.
 
 ## Configuración rápida (WebUI)
@@ -162,7 +164,7 @@ El corte temprano previene artefactos de franjas en fondos uniformes.
 
 ## Errores comunes
 
-- Habilitar CREPA en familias no soportadas causa estados ocultos faltantes; usa `kandinsky5_video`, `ltxvideo`, `sanavideo` o `wan`.
+- Activar CREPA en una familia sin captura de hidden states produce un error de hidden state faltante.
 - **Índice de bloque demasiado alto** → “hidden states not returned”. Baja el índice; es de base cero en los bloques transformer.
 - **Picos de VRAM** → prueba `crepa_spatial_align=false`, un encoder más pequeño (`dinov2_vits14` + `224`) o un índice de bloque más bajo.
 - **Errores en modo backbone** → configura tanto `crepa_block_index` (estudiante) como `crepa_teacher_block_index` (maestro) con capas existentes.

--- a/documentation/experimental/VIDEO_CREPA.es.md
+++ b/documentation/experimental/VIDEO_CREPA.es.md
@@ -4,7 +4,7 @@ Cross-frame Representation Alignment (CREPA) es un regularizador ligero para mod
 
 > **¿Buscas modelos de imagen?** Consulta [IMAGE_REPA.es.md](IMAGE_REPA.es.md) para soporte REPA en modelos DiT de imagen (Flux, SD3, etc.) y U-REPA para modelos UNet (SDXL, SD1.5, Kolors).
 
-> **Alineacion espacial mejorada:** [iREPA](IREPA.es.md) aplica el proyector convolucional y la normalizacion del teacher de forma independiente a cada frame.
+> **Alineación espacial mejorada:** [iREPA](IREPA.es.md) aplica el proyector convolucional y la normalización del teacher de forma independiente a cada frame.
 
 ## Cuándo usarlo
 

--- a/documentation/experimental/VIDEO_CREPA.hi.md
+++ b/documentation/experimental/VIDEO_CREPA.hi.md
@@ -4,11 +4,13 @@ Cross-frame Representation Alignment (CREPA) वीडियो मॉडल्�
 
 > **इमेज मॉडल्स की तलाश है?** इमेज DiT मॉडल्स (Flux, SD3, आदि) पर REPA सपोर्ट और UNet मॉडल्स (SDXL, SD1.5, Kolors) के लिए U-REPA के बारे में [IMAGE_REPA.hi.md](IMAGE_REPA.hi.md) देखें।
 
+> **बेहतर spatial alignment:** [iREPA](IREPA.hi.md) हर video frame पर convolution projector और teacher normalization अलग से लगाता है।
+
 ## कब उपयोग करें
 
 - आप जटिल motion, scene changes, या occlusions वाले वीडियो पर ट्रेन कर रहे हैं।
 - आप वीडियो DiT (LoRA या full) fine-tune कर रहे हैं और फ्रेम्स के बीच flicker/identity drift देख रहे हैं।
-- समर्थित मॉडल फैमिलीज़: `kandinsky5_video`, `ltxvideo`, `sanavideo`, और `wan` (अन्य फैमिलीज़ CREPA hooks एक्सपोज़ नहीं करतीं)।
+- समर्थित मॉडल फैमिलीज़: CREPA hidden-state capture वाले video Transformers, जिनमें Kandinsky 5 Video, LTXVideo/LTX-2, HunyuanVideo, LongCat Video, MiniMax H3, SanaVideo, Wan/Wan S2V और Cosmos शामिल हैं।
 - आपके पास अतिरिक्त VRAM है (CREPA सेटिंग्स के अनुसार ~1–2GB जोड़ता है) DINO encoder और VAE के लिए, जिन्हें ट्रेनिंग के दौरान latents को pixels में decode करने हेतु मेमोरी में रहना पड़ता है।
 
 ## क्विक सेटअप (WebUI)
@@ -162,7 +164,7 @@ Early cutoff uniform backgrounds पर stripe artifacts को रोकता 
 
 ## सामान्य pitfalls
 
-- unsupported families पर CREPA सक्षम करने से hidden states गायब होंगे; `kandinsky5_video`, `ltxvideo`, `sanavideo`, या `wan` तक सीमित रहें।
+- CREPA hidden-state capture के बिना किसी family पर इसे चालू करने से missing hidden state error मिलता है।
 - **Block index बहुत ऊँचा** → “hidden states not returned”। index कम करें; यह transformer blocks पर zero-based है।
 - **VRAM spikes** → `crepa_spatial_align=false` आज़माएँ, छोटा encoder (`dinov2_vits14` + `224`) या कम block index चुनें।
 - **Backbone mode errors** → `crepa_block_index` (student) और `crepa_teacher_block_index` (teacher) दोनों को मौजूदा लेयर्स पर सेट करें।

--- a/documentation/experimental/VIDEO_CREPA.ja.md
+++ b/documentation/experimental/VIDEO_CREPA.ja.md
@@ -4,11 +4,13 @@ Cross-frame Representation Alignment（CREPA）は動画モデル向けの軽量
 
 > **画像モデルをお探しですか？** 画像DiTモデル（Flux、SD3など）のREPAサポートとUNetモデル（SDXL、SD1.5、Kolors）のU-REPAサポートについては [IMAGE_REPA.ja.md](IMAGE_REPA.ja.md) をご覧ください。
 
+> **空間 alignment の改善:** [iREPA](IREPA.ja.md) は各 video frame に convolution projector と teacher normalization を独立適用します。
+
 ## 使いどき
 
 - 複雑な動き、シーン変化、オクルージョンを含む動画を学習している。
 - 動画 DiT（LoRA またはフル）を微調整していてフリッカー/アイデンティティドリフトが見える。
-- 対応モデルファミリー: `kandinsky5_video`, `ltxvideo`, `sanavideo`, `wan`（他は CREPA フックがありません）。
+- 対応モデルファミリー: CREPA hidden-state capture を公開する video Transformer。Kandinsky 5 Video、LTXVideo/LTX-2、HunyuanVideo、LongCat Video、MiniMax H3、SanaVideo、Wan/Wan S2V、Cosmos を含みます。
 - 追加の VRAM（設定により約 1〜2GB）があり、DINO エンコーダと VAE を訓練中にメモリ保持できる。
 
 ## クイック設定（WebUI）
@@ -162,7 +164,7 @@ CREPA は訓練中に係数（`crepa_lambda`）をスケジュールする機能
 
 ## よくある落とし穴
 
-- 未対応ファミリーで CREPA を有効化すると隠れ状態が取れません。`kandinsky5_video`, `ltxvideo`, `sanavideo`, `wan` に限定してください。
+- CREPA hidden-state capture がないファミリーでは missing hidden state error になります。
 - **ブロックインデックスが高すぎる** → “hidden states not returned”。インデックスを下げてください。Transformer ブロックは 0 始まりです。
 - **VRAM スパイク** → `crepa_spatial_align=false`、小さいエンコーダ（`dinov2_vits14` + `224`）、またはブロックインデックスを下げる。
 - **バックボーンモードのエラー** → `crepa_block_index`（学生）と `crepa_teacher_block_index`（教師）を実在するレイヤーに設定。

--- a/documentation/experimental/VIDEO_CREPA.md
+++ b/documentation/experimental/VIDEO_CREPA.md
@@ -4,11 +4,13 @@ Cross-frame Representation Alignment (CREPA) is a light regularizer for video mo
 
 > **Looking for image models?** See [IMAGE_REPA.md](IMAGE_REPA.md) for REPA support on image DiT models (Flux, SD3, etc.) and U-REPA for UNet models (SDXL, SD1.5, Kolors).
 
+> **Improved spatial alignment:** [iREPA](IREPA.md) applies its convolutional projector and teacher normalization independently to every video frame.
+
 ## When to use it
 
 - You are training on videos with complex motion, scene changes, or occlusions.
 - You are fine-tuning a video DiT (LoRA or full) and see flicker/identity drift between frames.
-- Supported model families: `kandinsky5_video`, `ltxvideo`, `sanavideo`, and `wan` (other families do not expose the CREPA hooks).
+- Supported model families: video transformers that expose CREPA hidden-state capture, including Kandinsky 5 Video, LTXVideo/LTX-2, HunyuanVideo, LongCat Video, MiniMax H3, SanaVideo, Wan/Wan S2V, and Cosmos.
 - You have extra VRAM (CREPA adds ~1–2GB depending on settings) for the DINO encoder and VAE, which must remain in memory during training for decoding latents to pixels.
 
 ## Quick setup (WebUI)
@@ -162,7 +164,7 @@ Early cutoff prevents stripe artifacts on uniform backgrounds.
 
 ## Common pitfalls
 
-- Enabling CREPA on unsupported families leads to missing hidden states; stick to `kandinsky5_video`, `ltxvideo`, `sanavideo`, or `wan`.
+- Enabling CREPA on a family without hidden-state capture leads to a missing-hidden-state error.
 - **Block index too high** → “hidden states not returned”. Lower the index; it is zero-based on the transformer blocks.
 - **VRAM spikes** → try `crepa_spatial_align=false`, a smaller encoder (`dinov2_vits14` + `224`), or a lower block index.
 - **Backbone mode errors** → set both `crepa_block_index` (student) and `crepa_teacher_block_index` (teacher) to layers that exist.

--- a/documentation/experimental/VIDEO_CREPA.pt-BR.md
+++ b/documentation/experimental/VIDEO_CREPA.pt-BR.md
@@ -4,11 +4,13 @@ Cross-frame Representation Alignment (CREPA) e um regularizador leve para modelo
 
 > **Procurando modelos de imagem?** Veja [IMAGE_REPA.pt-BR.md](IMAGE_REPA.pt-BR.md) para suporte REPA em modelos DiT de imagem (Flux, SD3, etc.) e U-REPA para modelos UNet (SDXL, SD1.5, Kolors).
 
+> **Alinhamento espacial melhorado:** [iREPA](IREPA.pt-BR.md) aplica o projetor convolucional e a normalizacao do teacher separadamente em cada frame.
+
 ## Quando usar
 
 - Voce treina videos com movimento complexo, mudancas de cena ou oclusoes.
 - Voce esta fazendo fine-tuning de um video DiT (LoRA ou full) e ve flicker/deriva de identidade entre frames.
-- Familias suportadas: `kandinsky5_video`, `ltxvideo`, `sanavideo` e `wan` (outras familias nao expoem hooks CREPA).
+- Familias suportadas: Transformers de video que expoem captura de hidden states CREPA, incluindo Kandinsky 5 Video, LTXVideo/LTX-2, HunyuanVideo, LongCat Video, MiniMax H3, SanaVideo, Wan/Wan S2V e Cosmos.
 - Voce tem VRAM extra (CREPA adiciona ~1-2GB dependendo das configuracoes) para o encoder DINO e o VAE, que precisam ficar em memoria durante o treino para decodificar latentes em pixels.
 
 ## Config rapida (WebUI)
@@ -162,7 +164,7 @@ Corte antecipado previne artefatos de listras em fundos uniformes.
 
 ## Armadilhas comuns
 
-- Habilitar CREPA em familias nao suportadas leva a hidden states ausentes; use `kandinsky5_video`, `ltxvideo`, `sanavideo` ou `wan`.
+- Habilitar CREPA em uma familia sem captura de hidden states produz um erro de hidden state ausente.
 - **Indice de bloco alto demais** -> “hidden states not returned”. Reduza o indice; ele e baseado em zero nos blocos transformer.
 - **Picos de VRAM** -> tente `crepa_spatial_align=false`, um encoder menor (`dinov2_vits14` + `224`), ou um indice de bloco menor.
 - **Erros no modo backbone** -> defina `crepa_block_index` (student) e `crepa_teacher_block_index` (teacher) para camadas que existam.

--- a/documentation/experimental/VIDEO_CREPA.zh.md
+++ b/documentation/experimental/VIDEO_CREPA.zh.md
@@ -4,11 +4,13 @@ Cross-frame Representation Alignment（CREPA）是视频模型的轻量正则项
 
 > **寻找图像模型？** 请参阅 [IMAGE_REPA.zh.md](IMAGE_REPA.zh.md) 了解图像 DiT 模型（Flux、SD3 等）的 REPA 支持以及 UNet 模型（SDXL、SD1.5、Kolors）的 U-REPA 支持。
 
+> **改进空间对齐：** [iREPA](IREPA.zh.md) 会对每个视频帧独立应用卷积投影器和教师归一化。
+
 ## 适用场景
 
 - 训练包含复杂运动、场景变化或遮挡的视频。
 - 微调视频 DiT（LoRA 或全量）时出现帧间闪烁/身份漂移。
-- 支持的模型家族：`kandinsky5_video`、`ltxvideo`、`sanavideo`、`wan`（其他家族未暴露 CREPA 钩子）。
+- 支持的模型家族：所有暴露 CREPA 隐藏状态捕获的视频 Transformer，包括 Kandinsky 5 Video、LTXVideo/LTX-2、HunyuanVideo、LongCat Video、MiniMax H3、SanaVideo、Wan/Wan S2V 和 Cosmos。
 - 有额外 VRAM（根据设置约 1–2GB）用于 DINO 编码器与 VAE，并需在训练时保持内存驻留以将 latent 解码为像素。
 
 ## 快速设置（WebUI）
@@ -162,7 +164,7 @@ CREPA 支持在训练过程中对系数（`crepa_lambda`）进行调度，包括
 
 ## 常见问题
 
-- 在不支持的家族上启用 CREPA 会导致缺失隐藏状态；仅限 `kandinsky5_video`、`ltxvideo`、`sanavideo`、`wan`。
+- 在没有 CREPA 隐藏状态捕获的家族上启用 CREPA 会导致缺失隐藏状态错误。
 - **Block index 太高** → “hidden states not returned”。降低索引；Transformer 块为 0-based。
 - **显存峰值** → 尝试 `crepa_spatial_align=false`、更小编码器（`dinov2_vits14` + `224`）或更低 block index。
 - **主干模式报错** → 同时设置 `crepa_block_index`（学生）与 `crepa_teacher_block_index`（教师）为存在的层。

--- a/documentation/index.es.md
+++ b/documentation/index.es.md
@@ -72,9 +72,9 @@
 
     ---
 
-    Funciones de investigación como AnyFlow, cuantización SDNQ Hadamard estilo ConvRot, checkpointing segmentado, checkpointing estilo Unsloth, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention y Video CREPA
+    Funciones de investigación como AnyFlow, cuantización SDNQ Hadamard estilo ConvRot, checkpointing segmentado, checkpointing estilo Unsloth, Prompt2Effect, Self-Flow, Flow-DPO, iREPA, LayerSync, Diff2Flow, Metal Flash Attention y Video CREPA
 
-    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Segmented Checkpointing](experimental/SEGMENTED_CHECKPOINTING.md) · [:octicons-arrow-right-24: Unsloth Checkpointing](experimental/UNSLOTH_CHECKPOINTING.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
+    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: iREPA](experimental/IREPA.es.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Segmented Checkpointing](experimental/SEGMENTED_CHECKPOINTING.md) · [:octicons-arrow-right-24: Unsloth Checkpointing](experimental/UNSLOTH_CHECKPOINTING.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
 
 </div>
 

--- a/documentation/index.hi.md
+++ b/documentation/index.hi.md
@@ -72,9 +72,9 @@
 
     ---
 
-    AnyFlow, ConvRot-style SDNQ Hadamard quantization, segmented checkpointing, Unsloth-style checkpointing, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention और Video CREPA जैसी research features
+    AnyFlow, ConvRot-style SDNQ Hadamard quantization, segmented checkpointing, Unsloth-style checkpointing, Prompt2Effect, Self-Flow, Flow-DPO, iREPA, LayerSync, Diff2Flow, Metal Flash Attention और Video CREPA जैसी research features
 
-    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Segmented Checkpointing](experimental/SEGMENTED_CHECKPOINTING.md) · [:octicons-arrow-right-24: Unsloth Checkpointing](experimental/UNSLOTH_CHECKPOINTING.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
+    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: iREPA](experimental/IREPA.hi.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Segmented Checkpointing](experimental/SEGMENTED_CHECKPOINTING.md) · [:octicons-arrow-right-24: Unsloth Checkpointing](experimental/UNSLOTH_CHECKPOINTING.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
 
 </div>
 

--- a/documentation/index.ja.md
+++ b/documentation/index.ja.md
@@ -72,9 +72,9 @@
 
     ---
 
-    AnyFlow、ConvRot 形式の SDNQ Hadamard 量子化、segmented checkpointing、Unsloth 形式 checkpointing、Prompt2Effect、Self-Flow、Flow-DPO、LayerSync、Diff2Flow、Metal Flash Attention、Video CREPA などの研究向け機能
+    AnyFlow、ConvRot 形式の SDNQ Hadamard 量子化、segmented checkpointing、Unsloth 形式 checkpointing、Prompt2Effect、Self-Flow、Flow-DPO、iREPA、LayerSync、Diff2Flow、Metal Flash Attention、Video CREPA などの研究向け機能
 
-    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Segmented Checkpointing](experimental/SEGMENTED_CHECKPOINTING.md) · [:octicons-arrow-right-24: Unsloth Checkpointing](experimental/UNSLOTH_CHECKPOINTING.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
+    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: iREPA](experimental/IREPA.ja.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Segmented Checkpointing](experimental/SEGMENTED_CHECKPOINTING.md) · [:octicons-arrow-right-24: Unsloth Checkpointing](experimental/UNSLOTH_CHECKPOINTING.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
 
 </div>
 

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -72,9 +72,9 @@
 
     ---
 
-    Research features such as AnyFlow, ConvRot-style SDNQ Hadamard quantization, segmented checkpointing, Unsloth-style checkpointing, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention, and Video CREPA
+    Research features such as AnyFlow, ConvRot-style SDNQ Hadamard quantization, segmented checkpointing, Unsloth-style checkpointing, Prompt2Effect, Self-Flow, Flow-DPO, iREPA, LayerSync, Diff2Flow, Metal Flash Attention, and Video CREPA
 
-    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Segmented Checkpointing](experimental/SEGMENTED_CHECKPOINTING.md) · [:octicons-arrow-right-24: Unsloth Checkpointing](experimental/UNSLOTH_CHECKPOINTING.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
+    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: iREPA](experimental/IREPA.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Segmented Checkpointing](experimental/SEGMENTED_CHECKPOINTING.md) · [:octicons-arrow-right-24: Unsloth Checkpointing](experimental/UNSLOTH_CHECKPOINTING.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
 
 </div>
 

--- a/documentation/index.pt-BR.md
+++ b/documentation/index.pt-BR.md
@@ -72,9 +72,9 @@
 
     ---
 
-    Recursos de pesquisa como AnyFlow, quantização SDNQ Hadamard no estilo ConvRot, checkpointing segmentado, checkpointing estilo Unsloth, Prompt2Effect, Self-Flow, Flow-DPO, LayerSync, Diff2Flow, Metal Flash Attention e Video CREPA
+    Recursos de pesquisa como AnyFlow, quantização SDNQ Hadamard no estilo ConvRot, checkpointing segmentado, checkpointing estilo Unsloth, Prompt2Effect, Self-Flow, Flow-DPO, iREPA, LayerSync, Diff2Flow, Metal Flash Attention e Video CREPA
 
-    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Segmented Checkpointing](experimental/SEGMENTED_CHECKPOINTING.md) · [:octicons-arrow-right-24: Unsloth Checkpointing](experimental/UNSLOTH_CHECKPOINTING.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
+    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: iREPA](experimental/IREPA.pt-BR.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Segmented Checkpointing](experimental/SEGMENTED_CHECKPOINTING.md) · [:octicons-arrow-right-24: Unsloth Checkpointing](experimental/UNSLOTH_CHECKPOINTING.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
 
 </div>
 

--- a/documentation/index.zh.md
+++ b/documentation/index.zh.md
@@ -72,9 +72,9 @@
 
     ---
 
-    AnyFlow、ConvRot 风格的 SDNQ Hadamard 量化、segmented checkpointing、Unsloth 风格 checkpointing、Prompt2Effect、Self-Flow、Flow-DPO、LayerSync、Diff2Flow、Metal Flash Attention、Video CREPA 等研究功能
+    AnyFlow、ConvRot 风格的 SDNQ Hadamard 量化、segmented checkpointing、Unsloth 风格 checkpointing、Prompt2Effect、Self-Flow、Flow-DPO、iREPA、LayerSync、Diff2Flow、Metal Flash Attention、Video CREPA 等研究功能
 
-    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Segmented Checkpointing](experimental/SEGMENTED_CHECKPOINTING.md) · [:octicons-arrow-right-24: Unsloth Checkpointing](experimental/UNSLOTH_CHECKPOINTING.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
+    [:octicons-arrow-right-24: AnyFlow](experimental/ANYFLOW.md) · [:octicons-arrow-right-24: iREPA](experimental/IREPA.zh.md) · [:octicons-arrow-right-24: ConvRot / Hadamard SDNQ](experimental/CONVROT.md) · [:octicons-arrow-right-24: Segmented Checkpointing](experimental/SEGMENTED_CHECKPOINTING.md) · [:octicons-arrow-right-24: Unsloth Checkpointing](experimental/UNSLOTH_CHECKPOINTING.md) · [:octicons-arrow-right-24: Metal Flash Attention](experimental/METAL_FLASH_ATTENTION.md)
 
 </div>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -356,6 +356,7 @@ nav:
       - ConvRot / Hadamard SDNQ: experimental/CONVROT.md
       - Diff2Flow: experimental/DIFF2FLOW.md
       - Flow-DPO: experimental/FLOW_DPO.md
+      - iREPA: experimental/IREPA.md
       - LayerSync: experimental/LAYERSYNC.md
       - Metal Flash Attention: experimental/METAL_FLASH_ATTENTION.md
       - Prompt2Effect: experimental/PROMPT2EFFECT.md

--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -902,7 +902,24 @@ class ModelFoundation(ABC):
     # LoRA/PEFT helpers (shared across model families)
     # -------------------------------------------------------------------------
     def get_lora_save_layers(self):
-        return None
+        model = self.get_trained_component(unwrap_model=False)
+        if model is None:
+            return None
+        modules = [name for name in ("crepa_projector", "urepa_projector") if hasattr(model, name)]
+        return modules or None
+
+    def refresh_representation_alignment_projectors(self):
+        model = self.get_trained_component(unwrap_model=False)
+        if model is None:
+            return
+        for regularizer_name, module_name in (
+            ("crepa_regularizer", "crepa_projector"),
+            ("urepa_regularizer", "urepa_projector"),
+        ):
+            regularizer = getattr(self, regularizer_name, None)
+            projector = getattr(model, module_name, None)
+            if regularizer is not None and projector is not None:
+                regularizer.projector = projector
 
     def _get_peft_lora_target_modules(self):
         if str(getattr(self.config, "lora_type", "standard")).lower() != "standard":
@@ -6255,11 +6272,36 @@ class ImageModelFoundation(PipelineSupportMixin, VaeLatentScalingMixin, ModelFou
 
     def post_model_load_setup(self):
         super().post_model_load_setup()
+        self._validate_irepa_adapter_support()
         self._init_crepa_regularizer()
         self._init_urepa_regularizer()
 
+    def post_quantization_setup(self):
+        super().post_quantization_setup()
+        if not getattr(self.config, "irepa_enabled", False):
+            return
+        model_component = self.get_trained_component(unwrap_model=False)
+        if model_component is None:
+            return
+        for regularizer in (self.crepa_regularizer, self.urepa_regularizer):
+            if regularizer is not None:
+                regularizer.reinitialize_projector(model_component)
+
+    def _validate_irepa_adapter_support(self):
+        if not getattr(self.config, "irepa_enabled", False):
+            return
+        if (
+            "lora" in str(getattr(self.config, "model_type", ""))
+            and str(getattr(self.config, "lora_type", "standard")).lower() == "lycoris"
+        ):
+            raise ValueError("iREPA supports full-model and standard PEFT LoRA training; LyCORIS is not supported.")
+
     def _init_crepa_regularizer(self):
-        if not getattr(self.config, "crepa_enabled", False):
+        crepa_enabled = bool(getattr(self.config, "crepa_enabled", False))
+        irepa_enabled = bool(getattr(self.config, "irepa_enabled", False))
+        if irepa_enabled and getattr(self, "MODEL_TYPE", None) == ModelTypes.TRANSFORMER and not crepa_enabled:
+            raise ValueError("iREPA requires crepa_enabled=true for transformer models.")
+        if not crepa_enabled:
             self.crepa_regularizer = None
             return
 
@@ -6317,7 +6359,11 @@ class ImageModelFoundation(PipelineSupportMixin, VaeLatentScalingMixin, ModelFou
 
     def _init_urepa_regularizer(self):
         """Initialize U-REPA regularizer for UNet-based models (SDXL, SD1.5, Kolors)."""
-        if not getattr(self.config, "urepa_enabled", False):
+        urepa_enabled = bool(getattr(self.config, "urepa_enabled", False))
+        irepa_enabled = bool(getattr(self.config, "irepa_enabled", False))
+        if irepa_enabled and getattr(self, "MODEL_TYPE", None) == ModelTypes.UNET and not urepa_enabled:
+            raise ValueError("iREPA requires urepa_enabled=true for UNet models.")
+        if not urepa_enabled:
             self.urepa_regularizer = None
             return
 

--- a/simpletuner/helpers/models/minimaxh3/model.py
+++ b/simpletuner/helpers/models/minimaxh3/model.py
@@ -295,14 +295,15 @@ class MiniMaxH3(VideoModelFoundation):
         return list(dict.fromkeys(targets))
 
     def get_lora_save_layers(self):
+        save_layers = list(super().get_lora_save_layers() or [])
         if not self._configured_anyflow():
-            return super().get_lora_save_layers()
+            return save_layers or None
         if not bool(self._anyflow_distillation_config().get("train_delta_embedder", True)):
-            return super().get_lora_save_layers()
+            return save_layers or None
         transformer = self.unwrap_model(self.model) if getattr(self, "model", None) is not None else None
         if transformer is not None and getattr(transformer, "delta_adaln_embedder", None) is not None:
-            return ["delta_adaln_embedder"]
-        return super().get_lora_save_layers()
+            save_layers.append("delta_adaln_embedder")
+        return list(dict.fromkeys(save_layers)) or None
 
     def _assert_anyflow_endpoint_parameters_trainable(self) -> None:
         if not self._configured_anyflow():

--- a/simpletuner/helpers/training/crepa.py
+++ b/simpletuner/helpers/training/crepa.py
@@ -13,6 +13,45 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def spatial_zscore(features: torch.Tensor, alpha: float = 1.0, eps: float = 1e-6) -> torch.Tensor:
+    """Normalize each feature channel over the spatial token dimension."""
+    if features.ndim not in (3, 4):
+        raise ValueError(f"iREPA spatial normalization expects 3D or 4D features, got {features.shape}")
+    spatial_dim = features.ndim - 2
+    mean = features.mean(dim=spatial_dim, keepdim=True)
+    correction = 1 if features.shape[spatial_dim] > 1 else 0
+    std = features.std(dim=spatial_dim, keepdim=True, correction=correction)
+    return (features - alpha * mean) / (std + eps)
+
+
+class SpatialConvProjector(nn.Module):
+    """Project frame tokens with an iREPA spatial convolution."""
+
+    def __init__(self, input_dim: int, output_dim: int, *, kernel_size: int = 3):
+        super().__init__()
+        if kernel_size <= 0 or kernel_size % 2 == 0:
+            raise ValueError("irepa_projector_kernel_size must be a positive odd integer.")
+        self.projection = nn.Conv2d(
+            input_dim,
+            output_dim,
+            kernel_size=kernel_size,
+            padding=kernel_size // 2,
+        )
+
+    def forward(self, hidden_states: torch.Tensor, *, spatial_shape: tuple[int, int]) -> torch.Tensor:
+        if hidden_states.ndim != 4:
+            raise ValueError(f"iREPA projector expects (B, T, N, D), got {hidden_states.shape}")
+        batch_size, frame_count, token_count, hidden_dim = hidden_states.shape
+        height, width = spatial_shape
+        if height * width != token_count:
+            raise ValueError(f"iREPA spatial shape {spatial_shape} does not match the {token_count} tokens in each frame.")
+        spatial = hidden_states.reshape(batch_size * frame_count, height, width, hidden_dim)
+        spatial = spatial.permute(0, 3, 1, 2).contiguous()
+        projected = self.projection(spatial)
+        projected = projected.permute(0, 2, 3, 1).contiguous()
+        return projected.reshape(batch_size, frame_count, token_count, -1)
+
+
 class QwenVLVisionEncoder(nn.Module):
     """Adapter exposing Qwen-VL visual features through the same shape as DINO."""
 
@@ -283,7 +322,14 @@ class CrepaRegularizer:
         self.hidden_size = hidden_size
         self.model_foundation = model_foundation
 
+        self.irepa_enabled = bool(getattr(config, "irepa_enabled", False))
         self.enabled = bool(getattr(config, "crepa_enabled", False))
+        spatial_norm_alpha = getattr(config, "irepa_spatial_norm_alpha", 0.6)
+        projector_kernel_size = getattr(config, "irepa_projector_kernel_size", 3)
+        self.irepa_spatial_norm_alpha = 0.6 if spatial_norm_alpha is None else float(spatial_norm_alpha)
+        self.irepa_projector_kernel_size = 3 if projector_kernel_size is None else int(projector_kernel_size)
+        if self.irepa_spatial_norm_alpha < 0:
+            raise ValueError("irepa_spatial_norm_alpha must be non-negative.")
         self.block_index = getattr(config, "crepa_block_index", None)
         raw_distance = getattr(config, "crepa_adjacent_distance", 1)
         self.distance = 1 if raw_distance is None else int(raw_distance)
@@ -356,15 +402,29 @@ class CrepaRegularizer:
                 raise RuntimeError("CREPA failed to determine encoder output dimension.")
 
         if self.projector is None:
-            self.projector = nn.Sequential(
-                nn.LayerNorm(self.hidden_size),
-                nn.Linear(self.hidden_size, target_dim),
-            )
+            if self.irepa_enabled:
+                self.projector = SpatialConvProjector(
+                    self.hidden_size,
+                    target_dim,
+                    kernel_size=self.irepa_projector_kernel_size,
+                )
+            else:
+                self.projector = nn.Sequential(
+                    nn.LayerNorm(self.hidden_size),
+                    nn.Linear(self.hidden_size, target_dim),
+                )
             # Register as part of the model to ensure optimizer coverage.
             setattr(model, "crepa_projector", self.projector)
 
         # Ensure the projector lives on the correct device/dtype.
         self.projector.to(device=self.device, dtype=torch.float32)
+
+    def reinitialize_projector(self, model: nn.Module):
+        """Recreate the training-owned projector after recursive model quantization."""
+        if not self.irepa_enabled:
+            return
+        self.projector = None
+        self.attach_to_model(model)
 
     def wants_hidden_states(self) -> bool:
         return self.enabled
@@ -391,6 +451,8 @@ class CrepaRegularizer:
         else:
             if frame_features is None:
                 raise ValueError(f"CREPA {self.feature_source.value} feature mode requires teacher features from the model.")
+        if self.irepa_enabled and latents is None:
+            raise ValueError("iREPA requires clean latents to recover the spatial token grid.")
         if self.projector is None:
             raise RuntimeError("CREPA projector was not initialised on the diffusion model.")
         if self.base_weight == 0:
@@ -404,13 +466,31 @@ class CrepaRegularizer:
             # Treat backbone features as a frozen teacher to avoid over-regularization.
             frame_features = frame_features.detach()
 
-        projected = self._project_hidden_states(hidden_states)  # (B, T_dit, N_dit, D_enc)
+        projected_spatial_shape = None
+        if self.irepa_enabled:
+            projected, projected_spatial_shape = self._project_irepa_hidden_states(hidden_states, latents)
+        else:
+            projected = self._project_hidden_states(hidden_states, latents=latents)
+
+        if self.irepa_enabled:
+            frame_features = spatial_zscore(frame_features, alpha=self.irepa_spatial_norm_alpha)
 
         # Temporal alignment: match frame count between projected and frame_features
         projected, frame_features = self._maybe_align_temporal(projected, frame_features)
 
         # Spatial alignment: match token count per frame
-        projected, frame_features = self._maybe_align_tokens(projected, frame_features)
+        feature_spatial_shape = None
+        if self.irepa_enabled:
+            feature_reference_shape = (
+                latents.shape[-2:] if self.uses_internal_teacher_features else (self.encoder_image_size,) * 2
+            )
+            feature_spatial_shape = self._infer_spatial_shape(frame_features.shape[2], feature_reference_shape)
+        projected, frame_features = self._maybe_align_tokens(
+            projected,
+            frame_features,
+            projected_spatial_shape=projected_spatial_shape,
+            feature_spatial_shape=feature_spatial_shape,
+        )
 
         projected = F.normalize(projected, dim=-1)
         frame_features = F.normalize(frame_features, dim=-1)
@@ -530,10 +610,14 @@ class CrepaRegularizer:
 
         return projected, frame_features
 
-    def _project_hidden_states(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def _project_hidden_states(self, hidden_states: torch.Tensor, latents: Optional[torch.Tensor] = None) -> torch.Tensor:
         # Expected shapes depend on mode:
         # VIDEO mode: (B, T, D) -> (B, T, 1, D) or already (B, T, P, D)
         # IMAGE mode: (B, S, D) -> (B, 1, S, D) or already (B, 1, S, D)
+        if self.irepa_enabled:
+            projected, _ = self._project_irepa_hidden_states(hidden_states, latents)
+            return projected
+
         if hidden_states.ndim == 3:
             if self.mode == CrepaMode.VIDEO:
                 # Video: (B, T, D) -> (B, T, 1, D) - T frames, 1 global token each
@@ -551,13 +635,116 @@ class CrepaRegularizer:
         projected = projected.view(b, t, p, -1)
         return projected
 
+    def _project_irepa_hidden_states(
+        self, hidden_states: torch.Tensor, latents: torch.Tensor
+    ) -> Tuple[torch.Tensor, tuple[int, int]]:
+        hidden_states, spatial_shape = self._reshape_irepa_hidden_states(hidden_states, latents)
+        projector_dtype = next(self.projector.parameters()).dtype
+        projected = self.projector(hidden_states.to(dtype=projector_dtype), spatial_shape=spatial_shape)
+        return projected, spatial_shape
+
+    def _reshape_irepa_hidden_states(
+        self, hidden_states: torch.Tensor, latents: Optional[torch.Tensor]
+    ) -> Tuple[torch.Tensor, tuple[int, int]]:
+        if latents is None:
+            raise ValueError("iREPA requires clean latents to recover the spatial token grid.")
+        if self.mode is CrepaMode.IMAGE:
+            if hidden_states.ndim == 3:
+                hidden_states = hidden_states.unsqueeze(1)
+            if hidden_states.ndim != 4:
+                raise ValueError(f"iREPA image features must have 3 or 4 dimensions, got {hidden_states.shape}")
+            spatial_shape = self._infer_spatial_shape(hidden_states.shape[2], latents.shape[-2:])
+            return hidden_states, spatial_shape
+
+        if hidden_states.ndim == 4:
+            spatial_shape = self._infer_spatial_shape(hidden_states.shape[2], latents.shape[-2:])
+            return hidden_states, spatial_shape
+        if hidden_states.ndim != 3:
+            raise ValueError(f"iREPA video features must have 3 or 4 dimensions, got {hidden_states.shape}")
+        if latents.ndim != 5:
+            raise ValueError(f"iREPA video alignment expects 5D clean latents, got {latents.shape}")
+
+        frame_count, spatial_shape = self._infer_video_layout(hidden_states.shape[1], latents.shape[-3:])
+        return hidden_states.reshape(hidden_states.shape[0], frame_count, -1, hidden_states.shape[-1]), spatial_shape
+
+    def _infer_video_layout(
+        self, token_count: int, latent_shape: torch.Size | tuple[int, ...]
+    ) -> Tuple[int, tuple[int, int]]:
+        latent_frames, latent_height, latent_width = (int(value) for value in latent_shape)
+        expected_frames, expected_height, expected_width = self._expected_patch_grid(
+            latent_frames, latent_height, latent_width
+        )
+        if expected_frames * expected_height * expected_width == token_count:
+            return expected_frames, (expected_height, expected_width)
+
+        candidates = []
+        for frame_count in range(1, min(token_count, latent_frames) + 1):
+            if token_count % frame_count:
+                continue
+            spatial_shape = self._infer_spatial_shape(token_count // frame_count, (latent_height, latent_width))
+            temporal_error = abs(math.log(frame_count / max(expected_frames, 1)))
+            candidates.append((temporal_error, -frame_count, frame_count, spatial_shape))
+        if not candidates:
+            raise ValueError(f"Unable to infer an iREPA video grid for {token_count} tokens and latents {latent_shape}.")
+        _, _, frame_count, spatial_shape = min(candidates)
+        return frame_count, spatial_shape
+
+    def _expected_patch_grid(self, frames: int, height: int, width: int) -> tuple[int, int, int]:
+        patch_t, patch_h, patch_w = 1, 1, 1
+        foundation = self.model_foundation
+        if foundation is not None:
+            model = foundation.get_trained_component()
+            model_config = getattr(model, "config", None)
+            raw_patch = getattr(model_config, "patch_size", 1)
+            raw_patch_t = getattr(model_config, "patch_size_t", None)
+            if isinstance(raw_patch, (tuple, list)):
+                if len(raw_patch) == 3:
+                    patch_t, patch_h, patch_w = (int(value) for value in raw_patch)
+                elif len(raw_patch) == 2:
+                    patch_h, patch_w = (int(value) for value in raw_patch)
+            else:
+                patch_h = patch_w = int(raw_patch)
+            patch_t = int(raw_patch_t) if raw_patch_t is not None else patch_t
+        return (
+            math.ceil(frames / max(patch_t, 1)),
+            math.ceil(height / max(patch_h, 1)),
+            math.ceil(width / max(patch_w, 1)),
+        )
+
+    @staticmethod
+    def _infer_spatial_shape(token_count: int, reference_shape: torch.Size | tuple[int, ...]) -> tuple[int, int]:
+        reference_height, reference_width = (int(value) for value in reference_shape)
+        reference_ratio = reference_width / max(reference_height, 1)
+        candidates = []
+        for height in range(1, math.isqrt(token_count) + 1):
+            if token_count % height:
+                continue
+            width = token_count // height
+            for candidate_height, candidate_width in ((height, width), (width, height)):
+                ratio_error = abs(math.log((candidate_width / candidate_height) / reference_ratio))
+                candidates.append((ratio_error, candidate_height, candidate_width))
+        if not candidates:
+            raise ValueError(f"Unable to infer an iREPA spatial grid for {token_count} tokens.")
+        _, height, width = min(candidates)
+        return height, width
+
     def _maybe_align_tokens(
-        self, projected: torch.Tensor, frame_features: torch.Tensor
+        self,
+        projected: torch.Tensor,
+        frame_features: torch.Tensor,
+        *,
+        projected_spatial_shape: Optional[tuple[int, int]] = None,
+        feature_spatial_shape: Optional[tuple[int, int]] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         # Align spatial token counts. If disabled, fall back to global pooling.
         proj_tokens = projected.shape[2]
         enc_tokens = frame_features.shape[2]
-        if proj_tokens == enc_tokens:
+        matching_layout = (
+            projected_spatial_shape is None
+            or feature_spatial_shape is None
+            or projected_spatial_shape == feature_spatial_shape
+        )
+        if proj_tokens == enc_tokens and matching_layout:
             return projected, frame_features
 
         if not self.spatial_align:
@@ -565,22 +752,58 @@ class CrepaRegularizer:
             frame_features = frame_features.mean(dim=2, keepdim=True)
             return projected, frame_features
 
-        target_tokens = min(proj_tokens, enc_tokens)
-        projected = self._interpolate_tokens(projected, target_tokens)
-        frame_features = self._interpolate_tokens(frame_features, target_tokens)
+        if projected_spatial_shape is not None and feature_spatial_shape is not None:
+            target_shape = projected_spatial_shape if proj_tokens <= enc_tokens else feature_spatial_shape
+            target_tokens = target_shape[0] * target_shape[1]
+        else:
+            target_shape = None
+            target_tokens = min(proj_tokens, enc_tokens)
+        projected = self._interpolate_tokens(
+            projected,
+            target_tokens,
+            source_shape=projected_spatial_shape,
+            target_shape=target_shape,
+        )
+        frame_features = self._interpolate_tokens(
+            frame_features,
+            target_tokens,
+            source_shape=feature_spatial_shape,
+            target_shape=target_shape,
+        )
         return projected, frame_features
 
-    def _interpolate_tokens(self, tokens: torch.Tensor, target_tokens: int) -> torch.Tensor:
+    def _interpolate_tokens(
+        self,
+        tokens: torch.Tensor,
+        target_tokens: int,
+        *,
+        source_shape: Optional[tuple[int, int]] = None,
+        target_shape: Optional[tuple[int, int]] = None,
+    ) -> torch.Tensor:
         if tokens.shape[2] == target_tokens:
-            return tokens
+            if source_shape is None or target_shape is None or source_shape == target_shape:
+                return tokens
         b, t, n, d = tokens.shape
         flat = tokens.reshape(b * t, n, d).permute(0, 2, 1)  # (BT, D, N)
 
-        src_size = int(math.sqrt(n))
-        tgt_size = int(math.sqrt(target_tokens))
-        if src_size * src_size == n and tgt_size * tgt_size == target_tokens:
-            flat = flat.view(b * t, d, src_size, src_size)
-            interpolated = F.interpolate(flat, size=(tgt_size, tgt_size), mode="bilinear", align_corners=False)
+        if source_shape is None and target_shape is None:
+            src_size = math.isqrt(n)
+            tgt_size = math.isqrt(target_tokens)
+            if src_size * src_size == n and tgt_size * tgt_size == target_tokens:
+                flat = flat.view(b * t, d, src_size, src_size)
+                interpolated = F.interpolate(flat, size=(tgt_size, tgt_size), mode="bilinear", align_corners=False)
+                interpolated = interpolated.view(b * t, d, target_tokens)
+            else:
+                interpolated = F.interpolate(flat, size=target_tokens, mode="linear", align_corners=False)
+            return interpolated.permute(0, 2, 1).reshape(b, t, target_tokens, d)
+
+        if source_shape is None:
+            source_shape = self._infer_spatial_shape(n, (1, 1))
+        if target_shape is None:
+            target_shape = self._infer_spatial_shape(target_tokens, source_shape)
+        if source_shape[0] * source_shape[1] == n and target_shape[0] * target_shape[1] == target_tokens:
+            flat = flat.view(b * t, d, *source_shape)
+            interpolated = F.interpolate(flat, size=target_shape, mode="bilinear", align_corners=False)
             interpolated = interpolated.view(b * t, d, target_tokens)
         else:
             interpolated = F.interpolate(flat, size=target_tokens, mode="linear", align_corners=False)
@@ -773,7 +996,14 @@ class UrepaRegularizer:
         self.hidden_size = hidden_size
         self.model_foundation = model_foundation
 
+        self.irepa_enabled = bool(getattr(config, "irepa_enabled", False))
         self.enabled = bool(getattr(config, "urepa_enabled", False))
+        spatial_norm_alpha = getattr(config, "irepa_spatial_norm_alpha", 0.6)
+        projector_kernel_size = getattr(config, "irepa_projector_kernel_size", 3)
+        self.irepa_spatial_norm_alpha = 0.6 if spatial_norm_alpha is None else float(spatial_norm_alpha)
+        self.irepa_projector_kernel_size = 3 if projector_kernel_size is None else int(projector_kernel_size)
+        if self.irepa_spatial_norm_alpha < 0:
+            raise ValueError("irepa_spatial_norm_alpha must be non-negative.")
         self.base_weight = float(getattr(config, "urepa_lambda", 0.5) or 0.5)
         self.manifold_weight = float(getattr(config, "urepa_manifold_weight", 3.0) or 3.0)
 
@@ -834,13 +1064,27 @@ class UrepaRegularizer:
             raise RuntimeError("U-REPA failed to determine encoder output dimension.")
 
         if self.projector is None:
-            self.projector = nn.Sequential(
-                nn.LayerNorm(self.hidden_size),
-                nn.Linear(self.hidden_size, target_dim),
-            )
+            if self.irepa_enabled:
+                self.projector = SpatialConvProjector(
+                    self.hidden_size,
+                    target_dim,
+                    kernel_size=self.irepa_projector_kernel_size,
+                )
+            else:
+                self.projector = nn.Sequential(
+                    nn.LayerNorm(self.hidden_size),
+                    nn.Linear(self.hidden_size, target_dim),
+                )
             setattr(model, "urepa_projector", self.projector)
 
         self.projector.to(device=self.device, dtype=torch.float32)
+
+    def reinitialize_projector(self, model: nn.Module):
+        """Recreate the training-owned projector after recursive model quantization."""
+        if not self.irepa_enabled:
+            return
+        self.projector = None
+        self.attach_to_model(model)
 
     def wants_hidden_states(self) -> bool:
         return self.enabled
@@ -882,11 +1126,28 @@ class UrepaRegularizer:
         pixels = self._decode_latents(latents, vae)
         encoder_features = self._encode_pixels(pixels)  # (B, N_enc, D_enc)
 
+        if self.irepa_enabled:
+            encoder_features = spatial_zscore(encoder_features, alpha=self.irepa_spatial_norm_alpha)
+
         # Project hidden states from (B, C, H, W) to (B, N_proj, D_enc)
         projected = self._project_hidden_states(hidden_states)
 
         # Align spatial dimensions
-        projected, encoder_features = self._align_spatial(projected, encoder_features)
+        projected_spatial_shape = tuple(int(value) for value in hidden_states.shape[-2:]) if self.irepa_enabled else None
+        encoder_spatial_shape = (
+            CrepaRegularizer._infer_spatial_shape(
+                encoder_features.shape[1],
+                (self.encoder_image_size, self.encoder_image_size),
+            )
+            if self.irepa_enabled
+            else None
+        )
+        projected, encoder_features = self._align_spatial(
+            projected,
+            encoder_features,
+            projected_spatial_shape=projected_spatial_shape,
+            encoder_spatial_shape=encoder_spatial_shape,
+        )
 
         # Normalize for cosine similarity
         projected_norm = F.normalize(projected, dim=-1)
@@ -943,16 +1204,23 @@ class UrepaRegularizer:
             raise ValueError(f"U-REPA expected 4D hidden states (B, C, H, W), got {hidden_states.shape}")
 
         b, c, h, w = hidden_states.shape
-        # Reshape: (B, C, H, W) -> (B, H*W, C)
-        hidden_states = hidden_states.permute(0, 2, 3, 1).reshape(b, h * w, c)
-
-        # Project to encoder dimension
         projector_dtype = next(self.projector.parameters()).dtype
         hidden_states = hidden_states.to(dtype=projector_dtype)
-        projected = self.projector(hidden_states)
-        return projected
+        if self.irepa_enabled:
+            sequence = hidden_states.permute(0, 2, 3, 1).reshape(b, 1, h * w, c)
+            return self.projector(sequence, spatial_shape=(h, w)).squeeze(1)
 
-    def _align_spatial(self, projected: torch.Tensor, encoder_features: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        sequence = hidden_states.permute(0, 2, 3, 1).reshape(b, h * w, c)
+        return self.projector(sequence)
+
+    def _align_spatial(
+        self,
+        projected: torch.Tensor,
+        encoder_features: torch.Tensor,
+        *,
+        projected_spatial_shape: Optional[tuple[int, int]] = None,
+        encoder_spatial_shape: Optional[tuple[int, int]] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Align spatial token counts between projected features and encoder features.
 
@@ -961,19 +1229,52 @@ class UrepaRegularizer:
         n_proj = projected.shape[1]
         n_enc = encoder_features.shape[1]
 
-        if n_proj == n_enc:
+        matching_layout = (
+            projected_spatial_shape is None
+            or encoder_spatial_shape is None
+            or projected_spatial_shape == encoder_spatial_shape
+        )
+        if n_proj == n_enc and matching_layout:
             return projected, encoder_features
 
-        target_tokens = min(n_proj, n_enc)
-        projected = self._interpolate_tokens(projected, target_tokens)
-        encoder_features = self._interpolate_tokens(encoder_features, target_tokens)
+        if projected_spatial_shape is not None and encoder_spatial_shape is not None:
+            target_shape = projected_spatial_shape if n_proj <= n_enc else encoder_spatial_shape
+            target_tokens = target_shape[0] * target_shape[1]
+        else:
+            target_shape = None
+            target_tokens = min(n_proj, n_enc)
+        projected = self._interpolate_tokens(
+            projected,
+            target_tokens,
+            source_shape=projected_spatial_shape,
+            target_shape=target_shape,
+        )
+        encoder_features = self._interpolate_tokens(
+            encoder_features,
+            target_tokens,
+            source_shape=encoder_spatial_shape,
+            target_shape=target_shape,
+        )
         return projected, encoder_features
 
-    def _interpolate_tokens(self, tokens: torch.Tensor, target_tokens: int) -> torch.Tensor:
+    def _interpolate_tokens(
+        self,
+        tokens: torch.Tensor,
+        target_tokens: int,
+        *,
+        source_shape: Optional[tuple[int, int]] = None,
+        target_shape: Optional[tuple[int, int]] = None,
+    ) -> torch.Tensor:
         """Interpolate token sequence to target length using bilinear interpolation."""
         if tokens.shape[1] == target_tokens:
-            return tokens
+            if source_shape is None or target_shape is None or source_shape == target_shape:
+                return tokens
         b, n, d = tokens.shape
+
+        if source_shape is not None and target_shape is not None:
+            tokens = tokens.permute(0, 2, 1).reshape(b, d, *source_shape)
+            tokens = F.interpolate(tokens, size=target_shape, mode="bilinear", align_corners=False)
+            return tokens.reshape(b, d, target_tokens).permute(0, 2, 1)
 
         # Try 2D interpolation if tokens form a square grid
         src_size = int(math.sqrt(n))

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -3304,6 +3304,7 @@ class Trainer:
             logger.info(lora_info_msg)
             self._send_webhook_msg(message=lora_info_msg)
             addkeys, misskeys = self.model.add_lora_adapter()
+            self.model.refresh_representation_alignment_projectors()
             if addkeys:
                 logger.warning(
                     "The following keys were found in %s, but are not part of the model and are ignored:\n %s.\nThis is most likely an error"

--- a/simpletuner/helpers/utils/hidden_state_buffer.py
+++ b/simpletuner/helpers/utils/hidden_state_buffer.py
@@ -54,7 +54,7 @@ class UNetMidBlockCapture:
             raise ValueError("UNet does not have a mid_block to capture from")
 
         def hook_fn(module, input, output):
-            self._captured = output.detach()
+            self._captured = output
 
         self._hook_handle = self.unet.mid_block.register_forward_hook(hook_fn)
 

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/loss.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/loss.py
@@ -119,6 +119,66 @@ def register_loss_fields(registry: "FieldRegistry") -> None:
 
     registry._add_field(
         ConfigField(
+            name="irepa_enabled",
+            arg_name="--irepa_enabled",
+            ui_label="Enable iREPA",
+            field_type=FieldType.CHECKBOX,
+            tab="training",
+            section="loss_functions",
+            default_value=False,
+            help_text="Upgrade enabled CREPA or U-REPA alignment with iREPA spatial operations.",
+            tooltip="Also enable CREPA for transformer models or U-REPA for UNet models.",
+            importance=ImportanceLevel.EXPERIMENTAL,
+            order=6,
+            documentation="OPTIONS.md#--irepa_enabled",
+        )
+    )
+
+    registry._add_field(
+        ConfigField(
+            name="irepa_spatial_norm_alpha",
+            arg_name="--irepa_spatial_norm_alpha",
+            ui_label="iREPA Spatial Norm Alpha",
+            field_type=FieldType.NUMBER,
+            tab="training",
+            section="loss_functions",
+            default_value=0.6,
+            validation_rules=[ValidationRule(ValidationRuleType.MIN, value=0.0, message="Must be non-negative")],
+            dependencies=[FieldDependency(field="irepa_enabled", operator="equals", value=True)],
+            help_text="Mean-subtraction strength for iREPA teacher-feature spatial normalization.",
+            tooltip="0.6 matches the latent-diffusion reference recipe; 1.0 fully centers each feature channel.",
+            importance=ImportanceLevel.EXPERIMENTAL,
+            order=7,
+            documentation="OPTIONS.md#--irepa_spatial_norm_alpha",
+        )
+    )
+
+    registry._add_field(
+        ConfigField(
+            name="irepa_projector_kernel_size",
+            arg_name="--irepa_projector_kernel_size",
+            ui_label="iREPA Projector Kernel",
+            field_type=FieldType.SELECT,
+            tab="training",
+            section="loss_functions",
+            default_value=3,
+            choices=[
+                {"value": 1, "label": "1 x 1"},
+                {"value": 3, "label": "3 x 3 (Paper)"},
+                {"value": 5, "label": "5 x 5"},
+                {"value": 7, "label": "7 x 7"},
+            ],
+            dependencies=[FieldDependency(field="irepa_enabled", operator="equals", value=True)],
+            help_text="Spatial convolution kernel used by the iREPA projector.",
+            tooltip="Use 3 for the published iREPA architecture.",
+            importance=ImportanceLevel.EXPERIMENTAL,
+            order=8,
+            documentation="OPTIONS.md#--irepa_projector_kernel_size",
+        )
+    )
+
+    registry._add_field(
+        ConfigField(
             name="crepa_enabled",
             arg_name="--crepa_enabled",
             ui_label="Enable CREPA",

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/loss.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/loss.py
@@ -172,7 +172,7 @@ def register_loss_fields(registry: "FieldRegistry") -> None:
             help_text="Spatial convolution kernel used by the iREPA projector.",
             tooltip="Use 3 for the published iREPA architecture.",
             importance=ImportanceLevel.EXPERIMENTAL,
-            order=8,
+            order=7.1,
             documentation="OPTIONS.md#--irepa_projector_kernel_size",
         )
     )

--- a/tests/test_config_field_validation.py
+++ b/tests/test_config_field_validation.py
@@ -205,6 +205,8 @@ class TestIrepaFields(unittest.TestCase):
         self.assertIsNone(enabled.model_specific)
         self.assertEqual(alpha.default_value, 0.6)
         self.assertEqual(kernel.default_value, 3)
+        crepa_enabled = registry.get_field("crepa_enabled")
+        self.assertEqual(len({enabled.order, alpha.order, kernel.order, crepa_enabled.order}), 4)
 
 
 if __name__ == "__main__":

--- a/tests/test_config_field_validation.py
+++ b/tests/test_config_field_validation.py
@@ -190,5 +190,22 @@ class TestValidationStartFields(unittest.TestCase):
                 self.assertEqual(min_rules[0].value, 0)
 
 
+class TestIrepaFields(unittest.TestCase):
+    def test_irepa_fields_are_model_neutral(self):
+        from simpletuner.simpletuner_sdk.server.services.field_registry.registry import FieldRegistry
+        from simpletuner.simpletuner_sdk.server.services.field_registry.types import FieldType
+
+        registry = FieldRegistry()
+        enabled = registry.get_field("irepa_enabled")
+        alpha = registry.get_field("irepa_spatial_norm_alpha")
+        kernel = registry.get_field("irepa_projector_kernel_size")
+
+        self.assertEqual(enabled.field_type, FieldType.CHECKBOX)
+        self.assertFalse(enabled.default_value)
+        self.assertIsNone(enabled.model_specific)
+        self.assertEqual(alpha.default_value, 0.6)
+        self.assertEqual(kernel.default_value, 3)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_crepa.py
+++ b/tests/test_crepa.py
@@ -5,13 +5,15 @@ from unittest.mock import patch
 
 import torch
 
-from simpletuner.helpers.models.common import ModelFoundation
+from simpletuner.helpers.models.common import ImageModelFoundation, ModelFoundation, ModelTypes
 from simpletuner.helpers.training.crepa import (
     CrepaFeatureSource,
     CrepaMode,
     CrepaRegularizer,
     CrepaScheduler,
+    SpatialConvProjector,
     UrepaRegularizer,
+    spatial_zscore,
 )
 from simpletuner.helpers.training.ema import EMAModel
 from simpletuner.helpers.utils.hidden_state_buffer import UNetMidBlockCapture
@@ -88,6 +90,223 @@ class _DummyQwenVLModel(torch.nn.Module):
             for index in range(image_grid_thw.shape[0])
         )
         return SimpleNamespace(pooler_output=features)
+
+
+class IrepaTests(unittest.TestCase):
+    def test_transformer_irepa_requires_crepa(self):
+        foundation = SimpleNamespace(
+            config=SimpleNamespace(irepa_enabled=True, crepa_enabled=False),
+            MODEL_TYPE=ModelTypes.TRANSFORMER,
+        )
+
+        with self.assertRaisesRegex(ValueError, "requires crepa_enabled"):
+            ImageModelFoundation._init_crepa_regularizer(foundation)
+
+    def test_unet_irepa_requires_urepa(self):
+        foundation = SimpleNamespace(
+            config=SimpleNamespace(irepa_enabled=True, urepa_enabled=False),
+            MODEL_TYPE=ModelTypes.UNET,
+        )
+
+        with self.assertRaisesRegex(ValueError, "requires urepa_enabled"):
+            ImageModelFoundation._init_urepa_regularizer(foundation)
+
+    def test_irepa_rejects_lycoris(self):
+        foundation = SimpleNamespace(
+            config=SimpleNamespace(irepa_enabled=True, model_type="lora", lora_type="lycoris"),
+        )
+
+        with self.assertRaisesRegex(ValueError, "LyCORIS is not supported"):
+            ImageModelFoundation._validate_irepa_adapter_support(foundation)
+
+    def test_peft_saves_alignment_projectors(self):
+        model = torch.nn.Module()
+        model.crepa_projector = SpatialConvProjector(4, 8)
+        foundation = SimpleNamespace(get_trained_component=lambda unwrap_model=False: model)
+
+        self.assertEqual(ModelFoundation.get_lora_save_layers(foundation), ["crepa_projector"])
+
+    def test_peft_refreshes_and_trains_wrapped_alignment_projector(self):
+        from peft import LoraConfig, get_peft_model_state_dict, inject_adapter_in_model
+
+        model = torch.nn.Module()
+        model.linear = torch.nn.Linear(4, 4)
+        original = SpatialConvProjector(4, 8)
+        model.crepa_projector = original
+        foundation = SimpleNamespace(
+            crepa_regularizer=SimpleNamespace(projector=original),
+            urepa_regularizer=None,
+            get_trained_component=lambda unwrap_model=False: model,
+        )
+        inject_adapter_in_model(
+            LoraConfig(r=2, target_modules=["linear"], modules_to_save=["crepa_projector"]),
+            model,
+        )
+
+        ModelFoundation.refresh_representation_alignment_projectors(foundation)
+        hidden = torch.randn(1, 1, 4, 4)
+        foundation.crepa_regularizer.projector(hidden, spatial_shape=(2, 2)).sum().backward()
+        projector_grads = [parameter.grad for parameter in model.crepa_projector.parameters() if parameter.requires_grad]
+        saved_keys = get_peft_model_state_dict(model)
+
+        self.assertIs(foundation.crepa_regularizer.projector, model.crepa_projector)
+        self.assertTrue(projector_grads)
+        self.assertTrue(all(gradient is not None for gradient in projector_grads))
+        self.assertTrue(any("crepa_projector" in key for key in saved_keys))
+
+    def test_irepa_reinitializes_projector_after_quantization(self):
+        config = SimpleNamespace(
+            crepa_enabled=True,
+            crepa_block_index=1,
+            crepa_feature_source="backbone",
+            irepa_enabled=True,
+            irepa_projector_kernel_size=3,
+        )
+        regularizer = CrepaRegularizer(
+            config,
+            SimpleNamespace(device=torch.device("cpu")),
+            hidden_size=4,
+        )
+        model = torch.nn.Module()
+        regularizer.attach_to_model(model)
+        original = model.crepa_projector
+
+        regularizer.reinitialize_projector(model)
+
+        self.assertIs(model.crepa_projector, regularizer.projector)
+        self.assertIsNot(model.crepa_projector, original)
+        self.assertEqual(next(model.crepa_projector.parameters()).dtype, torch.float32)
+
+    def test_spatial_conv_projector_rejects_invalid_kernel(self):
+        with self.assertRaisesRegex(ValueError, "positive odd integer"):
+            SpatialConvProjector(8, 8, kernel_size=0)
+
+        with self.assertRaisesRegex(ValueError, "positive odd integer"):
+            SpatialConvProjector(8, 8, kernel_size=2)
+
+    def test_spatial_zscore_normalizes_each_frame(self):
+        features = torch.tensor(
+            [
+                [
+                    [[1.0, 10.0], [2.0, 20.0], [3.0, 30.0], [4.0, 40.0]],
+                    [[10.0, 1.0], [20.0, 2.0], [30.0, 3.0], [40.0, 4.0]],
+                ]
+            ]
+        )
+
+        normalized = spatial_zscore(features, alpha=1.0)
+
+        torch.testing.assert_close(normalized.mean(dim=2), torch.zeros(1, 2, 2), atol=1e-6, rtol=0)
+        torch.testing.assert_close(normalized.std(dim=2), torch.ones(1, 2, 2), atol=1e-6, rtol=0)
+
+    def test_spatial_conv_projector_preserves_rectangular_frame_layout(self):
+        projector = SpatialConvProjector(1, 1, kernel_size=3)
+        projector.projection.weight.data.fill_(1.0)
+        projector.projection.bias.data.zero_()
+        hidden = torch.cat(
+            [
+                torch.ones(1, 1, 6, 1),
+                torch.full((1, 1, 6, 1), 10.0),
+            ],
+            dim=1,
+        )
+
+        projected = projector(hidden, spatial_shape=(2, 3))
+
+        self.assertEqual(projected.shape, (1, 2, 6, 1))
+        torch.testing.assert_close(projected[0, 0, :, 0], torch.tensor([4.0, 6.0, 4.0, 4.0, 6.0, 4.0]))
+        torch.testing.assert_close(projected[0, 1, :, 0], torch.tensor([40.0, 60.0, 40.0, 40.0, 60.0, 40.0]))
+
+    def test_irepa_uses_framewise_video_geometry(self):
+        config = SimpleNamespace(
+            irepa_enabled=True,
+            irepa_spatial_norm_alpha=0.6,
+            irepa_projector_kernel_size=3,
+            crepa_enabled=True,
+            crepa_block_index=0,
+            crepa_feature_source="backbone",
+            crepa_adjacent_distance=1,
+            crepa_adjacent_tau=1.0,
+            crepa_lambda=0.5,
+        )
+        accelerator = SimpleNamespace(device=torch.device("cpu"))
+        reg = CrepaRegularizer(config, accelerator, hidden_size=4)
+        model = torch.nn.Module()
+
+        reg.attach_to_model(model)
+        hidden = torch.randn(1, 12, 4)
+        latents = torch.randn(1, 4, 2, 2, 3)
+        projected = reg._project_hidden_states(hidden, latents=latents)
+
+        self.assertTrue(reg.enabled)
+        self.assertIsInstance(model.crepa_projector, SpatialConvProjector)
+        self.assertEqual(projected.shape, (1, 2, 6, 4))
+
+    def test_irepa_resamples_equal_token_counts_with_different_layouts(self):
+        config = SimpleNamespace(
+            irepa_enabled=True,
+            crepa_enabled=True,
+            crepa_block_index=0,
+            crepa_feature_source="backbone",
+            crepa_adjacent_distance=1,
+            crepa_adjacent_tau=1.0,
+            crepa_lambda=0.5,
+        )
+        accelerator = SimpleNamespace(device=torch.device("cpu"))
+        reg = CrepaRegularizer(config, accelerator, hidden_size=1)
+        projected = torch.zeros(1, 1, 16, 1)
+        teacher = torch.arange(16, dtype=torch.float32).reshape(1, 1, 16, 1)
+
+        _, aligned_teacher = reg._maybe_align_tokens(
+            projected,
+            teacher,
+            projected_spatial_shape=(2, 8),
+            feature_spatial_shape=(4, 4),
+        )
+
+        self.assertFalse(torch.equal(aligned_teacher, teacher))
+
+    def test_irepa_uses_conv_projector_for_urepa(self):
+        config = SimpleNamespace(
+            irepa_enabled=True,
+            irepa_spatial_norm_alpha=0.6,
+            irepa_projector_kernel_size=3,
+            urepa_enabled=True,
+            urepa_lambda=0.5,
+            urepa_manifold_weight=3.0,
+        )
+        accelerator = SimpleNamespace(device=torch.device("cpu"))
+        reg = UrepaRegularizer(config, accelerator, hidden_size=4)
+        reg.encoder_dim = 8
+        reg._load_encoder = lambda: None
+        model = torch.nn.Module()
+
+        reg.attach_to_model(model)
+        projected = reg._project_hidden_states(torch.randn(1, 4, 2, 3))
+
+        self.assertTrue(reg.enabled)
+        self.assertIsInstance(model.urepa_projector, SpatialConvProjector)
+        self.assertEqual(projected.shape, (1, 6, 8))
+
+    def test_legacy_crepa_projector_is_unchanged(self):
+        config = SimpleNamespace(
+            irepa_enabled=False,
+            crepa_enabled=True,
+            crepa_block_index=0,
+            crepa_feature_source="backbone",
+            crepa_adjacent_distance=1,
+            crepa_adjacent_tau=1.0,
+            crepa_lambda=0.5,
+        )
+        accelerator = SimpleNamespace(device=torch.device("cpu"))
+        reg = CrepaRegularizer(config, accelerator, hidden_size=4)
+        model = torch.nn.Module()
+
+        reg.attach_to_model(model)
+
+        self.assertIsInstance(model.crepa_projector, torch.nn.Sequential)
+        self.assertIsInstance(model.crepa_projector[0], torch.nn.LayerNorm)
+        self.assertIsInstance(model.crepa_projector[1], torch.nn.Linear)
 
 
 class CrepaDecodeTests(unittest.TestCase):
@@ -1113,6 +1332,18 @@ class UNetMidBlockCaptureTests(unittest.TestCase):
         # Should have captured the mid_block output
         self.assertIsNotNone(captured)
         self.assertEqual(captured.shape, (2, 4, 8, 8))
+
+    def test_capture_preserves_gradient_graph(self):
+        unet = self._make_dummy_unet()
+        x = torch.randn(2, 4, 8, 8, requires_grad=True)
+
+        with UNetMidBlockCapture(unet) as capture:
+            _ = unet(x)
+            captured = capture.get_captured()
+            captured.sum().backward()
+
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(unet.mid_block.conv.weight.grad)
 
     def test_context_manager_usage(self):
         """UNetMidBlockCapture should work as context manager."""


### PR DESCRIPTION
## Summary
- add iREPA spatial normalization and convolution projectors to transformer CREPA and UNet U-REPA
- preserve rectangular image grids and per-frame video grids across existing REPA-capable model families
- keep trainable projectors in full precision and serialize them in standard PEFT adapters
- expose WebUI controls and document the feature in all maintained translations

## Validation
- `.venv/bin/python -m unittest -v -f` (6205 passed, 195 skipped)
- `.venv/bin/mkdocs build --strict`
- Black, isort, flake8, and pre-commit hooks
- two-step single-H200 Flux PEFT LoRA smoke with an int8-Quanto base; both checkpoints contain finite, updated iREPA projector tensors

Closes #2566