### PR TITLE
Add cubic spline flow timestep sampling

### DIFF
--- a/documentation/OPTIONS.es.md
+++ b/documentation/OPTIONS.es.md
@@ -1291,6 +1291,13 @@ Consulta la guía [DATALOADER.md](DATALOADER.md#automatic-dataset-oversubscripti
 - **Qué**: Entrena un modelo usando un ponderado más gradual en el paisaje de pérdida.
 - **Por qué**: Al entrenar modelos de difusión en píxeles, simplemente se degradarán sin usar una programación específica de ponderación de pérdida. Este es el caso con DeepFloyd, donde se encontró que soft-min-snr-gamma era esencialmente obligatorio para buenos resultados. Puedes tener éxito con entrenamiento de modelos de difusión latente, pero en experimentos pequeños se encontró que potencialmente produce resultados borrosos.
 
+### `--flow_cubic_schedule_weights`
+
+- **Qué**: Muestrea timesteps de flow matching desde una densidad definida por pesos no negativos en puntos equidistantes entre 0 y 1. Acepta un array JSON o valores separados por comas. Cero o un peso selecciona una distribución uniforme, dos definen una densidad lineal y tres o más usan interpolación cúbica Hermite monótona.
+- **Por qué**: Concentra el entrenamiento en regiones de ruido seleccionadas sin reducir el calendario a timesteps discretos. Se siguen aplicando las convenciones nativas de timestep del modelo y el flow schedule shift configurado.
+- **Conflictos**: No se puede combinar con `--flow_use_uniform_schedule`, `--flow_use_beta_schedule`, `--flux_fast_schedule` ni `--flow_custom_timesteps`.
+- **Ejemplo**: `"flow_cubic_schedule_weights": [0.1, 1.0, 0.3, 2.0]`
+
 ### `--diff2flow_enabled`
 
 - **Qué**: Habilita el puente Diffusion-to-Flow para modelos epsilon o v-prediction.
@@ -1975,6 +1982,7 @@ usage: train.py [-h] --model_family
                 [--flow_use_beta_schedule [FLOW_USE_BETA_SCHEDULE]]
                 [--flow_beta_schedule_alpha FLOW_BETA_SCHEDULE_ALPHA]
                 [--flow_beta_schedule_beta FLOW_BETA_SCHEDULE_BETA]
+                [--flow_cubic_schedule_weights FLOW_CUBIC_SCHEDULE_WEIGHTS]
                 [--flow_schedule_shift FLOW_SCHEDULE_SHIFT]
                 [--flow_schedule_auto_shift [FLOW_SCHEDULE_AUTO_SHIFT]]
                 [--audio_flow_schedule_shift AUDIO_FLOW_SCHEDULE_SHIFT]
@@ -2461,6 +2469,11 @@ options:
                         Alpha value for beta schedule (default: 2.0)
   --flow_beta_schedule_beta FLOW_BETA_SCHEDULE_BETA
                         Beta value for beta schedule (default: 2.0)
+  --flow_cubic_schedule_weights FLOW_CUBIC_SCHEDULE_WEIGHTS
+                        Sample flow timesteps from a smooth density through
+                        equally spaced non-negative weights. Use a JSON array
+                        or comma-separated values; zero or one weight produces
+                        a uniform distribution.
   --flow_schedule_shift FLOW_SCHEDULE_SHIFT
                         Shift the noise schedule for flow-matching models
   --flow_schedule_auto_shift [FLOW_SCHEDULE_AUTO_SHIFT]

--- a/documentation/OPTIONS.hi.md
+++ b/documentation/OPTIONS.hi.md
@@ -1289,6 +1289,13 @@ Multi‑GPU training के लिए dataset sizing पर अधिक वि�
 - **What**: loss landscape पर अधिक gradual weighting के साथ मॉडल ट्रेन करता है।
 - **Why**: pixel diffusion models training में विशिष्ट loss weighting schedule के बिना degrade हो सकते हैं। DeepFloyd में soft‑min‑snr‑gamma लगभग अनिवार्य पाया गया। Latent diffusion models में आपको सफलता मिल सकती है, लेकिन छोटे प्रयोगों में इससे blurry results होने की संभावना दिखी।
 
+### `--flow_cubic_schedule_weights`
+
+- **What**: 0 से 1 तक समान दूरी वाले points पर non-negative weights से density बनाकर flow-matching timesteps sample करता है। JSON array या comma-separated values दें। शून्य या एक weight uniform distribution चुनता है, दो weights linear density बनाते हैं, और तीन या अधिक monotone cubic-Hermite interpolation उपयोग करते हैं।
+- **Why**: Schedule को discrete timesteps तक सीमित किए बिना training को चुने हुए noise regions पर केंद्रित करता है। Model की native timestep convention और configured flow schedule shift लागू रहते हैं।
+- **Conflicts**: `--flow_use_uniform_schedule`, `--flow_use_beta_schedule`, `--flux_fast_schedule`, या `--flow_custom_timesteps` के साथ उपयोग नहीं किया जा सकता।
+- **Example**: `"flow_cubic_schedule_weights": [0.1, 1.0, 0.3, 2.0]`
+
 ### `--diff2flow_enabled`
 
 - **What**: epsilon या v‑prediction models के लिए Diffusion‑to‑Flow bridge सक्षम करता है।
@@ -1973,6 +1980,7 @@ usage: train.py [-h] --model_family
                 [--flow_use_beta_schedule [FLOW_USE_BETA_SCHEDULE]]
                 [--flow_beta_schedule_alpha FLOW_BETA_SCHEDULE_ALPHA]
                 [--flow_beta_schedule_beta FLOW_BETA_SCHEDULE_BETA]
+                [--flow_cubic_schedule_weights FLOW_CUBIC_SCHEDULE_WEIGHTS]
                 [--flow_schedule_shift FLOW_SCHEDULE_SHIFT]
                 [--flow_schedule_auto_shift [FLOW_SCHEDULE_AUTO_SHIFT]]
                 [--audio_flow_schedule_shift AUDIO_FLOW_SCHEDULE_SHIFT]
@@ -2459,6 +2467,11 @@ options:
                         Alpha value for beta schedule (default: 2.0)
   --flow_beta_schedule_beta FLOW_BETA_SCHEDULE_BETA
                         Beta value for beta schedule (default: 2.0)
+  --flow_cubic_schedule_weights FLOW_CUBIC_SCHEDULE_WEIGHTS
+                        Sample flow timesteps from a smooth density through
+                        equally spaced non-negative weights. Use a JSON array
+                        or comma-separated values; zero or one weight produces
+                        a uniform distribution.
   --flow_schedule_shift FLOW_SCHEDULE_SHIFT
                         Shift the noise schedule for flow-matching models
   --flow_schedule_auto_shift [FLOW_SCHEDULE_AUTO_SHIFT]

--- a/documentation/OPTIONS.ja.md
+++ b/documentation/OPTIONS.ja.md
@@ -1292,6 +1292,13 @@ Flux Kontext の検証もこのコンディショニングベースの経路を�
 - **内容**: 損失地形に対してより緩やかな重み付けで学習します。
 - **理由**: ピクセル拡散モデルの学習では、特定の損失重み付けがないと劣化することがあります。DeepFloyd では soft-min-snr-gamma が良好な結果にほぼ必須でした。潜在拡散モデルでは成功する場合もありますが、少数の実験ではぼやけた結果になる可能性がありました。
 
+### `--flow_cubic_schedule_weights`
+
+- **内容**: 0 から 1 の等間隔点に置いた非負の重みで密度を定義し、flow-matching の timestep をサンプリングします。JSON 配列またはカンマ区切り値を使用します。重みが 0 個または 1 個なら一様分布、2 個なら線形密度、3 個以上なら単調 cubic-Hermite 補間です。
+- **理由**: schedule を離散 timestep に限定せず、選択したノイズ領域へ学習を集中できます。モデル固有の timestep 規約と設定済みの flow schedule shift は引き続き適用されます。
+- **競合**: `--flow_use_uniform_schedule`、`--flow_use_beta_schedule`、`--flux_fast_schedule`、`--flow_custom_timesteps` とは併用できません。
+- **例**: `"flow_cubic_schedule_weights": [0.1, 1.0, 0.3, 2.0]`
+
 ### `--diff2flow_enabled`
 
 - **内容**: epsilon または v-prediction モデル向けに Diffusion-to-Flow ブリッジを有効化します。
@@ -1976,6 +1983,7 @@ usage: train.py [-h] --model_family
                 [--flow_use_beta_schedule [FLOW_USE_BETA_SCHEDULE]]
                 [--flow_beta_schedule_alpha FLOW_BETA_SCHEDULE_ALPHA]
                 [--flow_beta_schedule_beta FLOW_BETA_SCHEDULE_BETA]
+                [--flow_cubic_schedule_weights FLOW_CUBIC_SCHEDULE_WEIGHTS]
                 [--flow_schedule_shift FLOW_SCHEDULE_SHIFT]
                 [--flow_schedule_auto_shift [FLOW_SCHEDULE_AUTO_SHIFT]]
                 [--audio_flow_schedule_shift AUDIO_FLOW_SCHEDULE_SHIFT]
@@ -2461,6 +2469,11 @@ options:
                         Alpha value for beta schedule (default: 2.0)
   --flow_beta_schedule_beta FLOW_BETA_SCHEDULE_BETA
                         Beta value for beta schedule (default: 2.0)
+  --flow_cubic_schedule_weights FLOW_CUBIC_SCHEDULE_WEIGHTS
+                        Sample flow timesteps from a smooth density through
+                        equally spaced non-negative weights. Use a JSON array
+                        or comma-separated values; zero or one weight produces
+                        a uniform distribution.
   --flow_schedule_shift FLOW_SCHEDULE_SHIFT
                         Shift the noise schedule for flow-matching models
   --flow_schedule_auto_shift [FLOW_SCHEDULE_AUTO_SHIFT]

--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -1295,6 +1295,13 @@ See the [DATALOADER.md](DATALOADER.md#automatic-dataset-oversubscription) guide 
 - **What**: Train a model using a more gradual weighting on the loss landscape.
 - **Why**: When training pixel diffusion models, they will simply degrade without using a specific loss weighting schedule. This is the case with DeepFloyd, where soft-min-snr-gamma was found to essentially be mandatory for good results. You may find success with latent diffusion model training, but in small experiments, it was found to potentially produce blurry results.
 
+### `--flow_cubic_schedule_weights`
+
+- **What**: Samples flow-matching timesteps from a density defined by non-negative weights at equally spaced points from 0 to 1. Use a JSON array or comma-separated values. Zero or one weight selects a uniform distribution, two weights define a linear density, and three or more use monotone cubic-Hermite interpolation.
+- **Why**: Concentrates training on selected noise regions without reducing the schedule to discrete timesteps. Native model timestep conventions and configured flow schedule shifting still apply.
+- **Conflicts**: Cannot be combined with `--flow_use_uniform_schedule`, `--flow_use_beta_schedule`, `--flux_fast_schedule`, or `--flow_custom_timesteps`.
+- **Example**: `"flow_cubic_schedule_weights": [0.1, 1.0, 0.3, 2.0]`
+
 ### `--diff2flow_enabled`
 
 - **What**: Enable the Diffusion-to-Flow bridge for epsilon or v-prediction models.
@@ -1979,6 +1986,7 @@ usage: train.py [-h] --model_family
                 [--flow_use_beta_schedule [FLOW_USE_BETA_SCHEDULE]]
                 [--flow_beta_schedule_alpha FLOW_BETA_SCHEDULE_ALPHA]
                 [--flow_beta_schedule_beta FLOW_BETA_SCHEDULE_BETA]
+                [--flow_cubic_schedule_weights FLOW_CUBIC_SCHEDULE_WEIGHTS]
                 [--flow_schedule_shift FLOW_SCHEDULE_SHIFT]
                 [--flow_schedule_auto_shift [FLOW_SCHEDULE_AUTO_SHIFT]]
                 [--audio_flow_schedule_shift AUDIO_FLOW_SCHEDULE_SHIFT]
@@ -2464,6 +2472,11 @@ options:
                         Alpha value for beta schedule (default: 2.0)
   --flow_beta_schedule_beta FLOW_BETA_SCHEDULE_BETA
                         Beta value for beta schedule (default: 2.0)
+  --flow_cubic_schedule_weights FLOW_CUBIC_SCHEDULE_WEIGHTS
+                        Sample flow timesteps from a smooth density through
+                        equally spaced non-negative weights. Use a JSON array
+                        or comma-separated values; zero or one weight produces
+                        a uniform distribution.
   --flow_schedule_shift FLOW_SCHEDULE_SHIFT
                         Shift the noise schedule for flow-matching models
   --flow_schedule_auto_shift [FLOW_SCHEDULE_AUTO_SHIFT]

--- a/documentation/OPTIONS.pt-BR.md
+++ b/documentation/OPTIONS.pt-BR.md
@@ -1287,6 +1287,13 @@ Veja o guia [DATALOADER.md](DATALOADER.md#automatic-dataset-oversubscription) pa
 - **O que**: Treina usando um peso mais gradual na loss landscape.
 - **Por que**: Em pixel diffusion, modelos degradam sem um agendamento de loss especifico. Isso e o caso do DeepFloyd, onde soft-min-snr-gamma foi quase obrigatorio. Em difusao latente, pode funcionar, mas em experimentos pequenos pode produzir resultados borrados.
 
+### `--flow_cubic_schedule_weights`
+
+- **O que**: Amostra timesteps de flow matching de uma densidade definida por pesos nao negativos em pontos igualmente espacados entre 0 e 1. Aceita um array JSON ou valores separados por virgula. Zero ou um peso seleciona distribuicao uniforme, dois definem densidade linear e tres ou mais usam interpolacao cubica de Hermite monotona.
+- **Por que**: Concentra o treinamento em regioes de ruido escolhidas sem reduzir o schedule a timesteps discretos. As convencoes nativas de timestep do modelo e o flow schedule shift configurado continuam sendo aplicados.
+- **Conflitos**: Nao pode ser combinado com `--flow_use_uniform_schedule`, `--flow_use_beta_schedule`, `--flux_fast_schedule` ou `--flow_custom_timesteps`.
+- **Exemplo**: `"flow_cubic_schedule_weights": [0.1, 1.0, 0.3, 2.0]`
+
 ### `--diff2flow_enabled`
 
 - **O que**: Habilita a ponte Diffusion-to-Flow para modelos epsilon ou v-prediction.
@@ -1971,6 +1978,7 @@ usage: train.py [-h] --model_family
                 [--flow_use_beta_schedule [FLOW_USE_BETA_SCHEDULE]]
                 [--flow_beta_schedule_alpha FLOW_BETA_SCHEDULE_ALPHA]
                 [--flow_beta_schedule_beta FLOW_BETA_SCHEDULE_BETA]
+                [--flow_cubic_schedule_weights FLOW_CUBIC_SCHEDULE_WEIGHTS]
                 [--flow_schedule_shift FLOW_SCHEDULE_SHIFT]
                 [--flow_schedule_auto_shift [FLOW_SCHEDULE_AUTO_SHIFT]]
                 [--audio_flow_schedule_shift AUDIO_FLOW_SCHEDULE_SHIFT]
@@ -2456,6 +2464,11 @@ options:
                         Alpha value for beta schedule (default: 2.0)
   --flow_beta_schedule_beta FLOW_BETA_SCHEDULE_BETA
                         Beta value for beta schedule (default: 2.0)
+  --flow_cubic_schedule_weights FLOW_CUBIC_SCHEDULE_WEIGHTS
+                        Sample flow timesteps from a smooth density through
+                        equally spaced non-negative weights. Use a JSON array
+                        or comma-separated values; zero or one weight produces
+                        a uniform distribution.
   --flow_schedule_shift FLOW_SCHEDULE_SHIFT
                         Shift the noise schedule for flow-matching models
   --flow_schedule_auto_shift [FLOW_SCHEDULE_AUTO_SHIFT]

--- a/documentation/OPTIONS.zh.md
+++ b/documentation/OPTIONS.zh.md
@@ -1294,6 +1294,13 @@ Flux Kontext 的验证也始终走这条基于条件的路径。使用 `--eval_d
 - **内容**：使用更渐进的损失权重进行训练。
 - **原因**：像素扩散模型若不使用特定损失权重会退化。对 DeepFloyd 而言，soft-min-snr-gamma 基本必需。潜在扩散模型可能也有效，但小规模实验中可能产生模糊结果。
 
+### `--flow_cubic_schedule_weights`
+
+- **内容**：根据 0 到 1 之间等距点上的非负权重定义密度，并从中采样流匹配时间步。可使用 JSON 数组或逗号分隔值。零个或一个权重表示均匀分布，两个权重表示线性密度，三个及以上使用单调三次 Hermite 插值。
+- **原因**：无需把调度离散为固定时间步，即可将训练集中在指定噪声区域。模型原生时间步约定和已配置的 flow schedule shift 仍然生效。
+- **冲突**：不能与 `--flow_use_uniform_schedule`、`--flow_use_beta_schedule`、`--flux_fast_schedule` 或 `--flow_custom_timesteps` 同时使用。
+- **示例**：`"flow_cubic_schedule_weights": [0.1, 1.0, 0.3, 2.0]`
+
 ### `--diff2flow_enabled`
 
 - **内容**：为 epsilon 或 v-prediction 模型启用 Diffusion-to-Flow 桥接。
@@ -1978,6 +1985,7 @@ usage: train.py [-h] --model_family
                 [--flow_use_beta_schedule [FLOW_USE_BETA_SCHEDULE]]
                 [--flow_beta_schedule_alpha FLOW_BETA_SCHEDULE_ALPHA]
                 [--flow_beta_schedule_beta FLOW_BETA_SCHEDULE_BETA]
+                [--flow_cubic_schedule_weights FLOW_CUBIC_SCHEDULE_WEIGHTS]
                 [--flow_schedule_shift FLOW_SCHEDULE_SHIFT]
                 [--flow_schedule_auto_shift [FLOW_SCHEDULE_AUTO_SHIFT]]
                 [--audio_flow_schedule_shift AUDIO_FLOW_SCHEDULE_SHIFT]
@@ -2462,6 +2470,11 @@ options:
                         Alpha value for beta schedule (default: 2.0)
   --flow_beta_schedule_beta FLOW_BETA_SCHEDULE_BETA
                         Beta value for beta schedule (default: 2.0)
+  --flow_cubic_schedule_weights FLOW_CUBIC_SCHEDULE_WEIGHTS
+                        Sample flow timesteps from a smooth density through
+                        equally spaced non-negative weights. Use a JSON array
+                        or comma-separated values; zero or one weight produces
+                        a uniform distribution.
   --flow_schedule_shift FLOW_SCHEDULE_SHIFT
                         Shift the noise schedule for flow-matching models
   --flow_schedule_auto_shift [FLOW_SCHEDULE_AUTO_SHIFT]

--- a/simpletuner/helpers/configuration/cmd_args.py
+++ b/simpletuner/helpers/configuration/cmd_args.py
@@ -32,6 +32,7 @@ from simpletuner.helpers.training.optimizer_param import is_optimizer_deprecated
 from simpletuner.helpers.training.quantisation import MANUAL_QUANTIZATION_PRESETS, PIPELINE_QUANTIZATION_PRESETS
 from simpletuner.helpers.training.sdnq_compile import configure_sdnq_compile_mode
 from simpletuner.helpers.training.state_tracker import StateTracker
+from simpletuner.helpers.training.timestep_distribution import parse_cubic_spline_weights
 from simpletuner.simpletuner_sdk.server.services.field_registry.types import (
     ConfigField,
     FieldType,
@@ -1036,6 +1037,23 @@ def parse_cmdline_args(input_args=None, exit_on_error: bool = False):
         info_log(f"{log_msg} {int(args.validation_resolution)}px")
     if args.timestep_bias_portion < 0.0 or args.timestep_bias_portion > 1.0:
         raise ValueError("Timestep bias portion must be between 0.0 and 1.0.")
+
+    cubic_schedule_weights = parse_cubic_spline_weights(getattr(args, "flow_cubic_schedule_weights", None))
+    if cubic_schedule_weights is not None:
+        conflicting_schedules = []
+        if args.flow_use_uniform_schedule:
+            conflicting_schedules.append("--flow_use_uniform_schedule")
+        if args.flow_use_beta_schedule:
+            conflicting_schedules.append("--flow_use_beta_schedule")
+        if args.flux_fast_schedule:
+            conflicting_schedules.append("--flux_fast_schedule")
+        if getattr(args, "flow_custom_timesteps", None) not in (None, "", "None"):
+            conflicting_schedules.append("--flow_custom_timesteps")
+        if conflicting_schedules:
+            raise ValueError(
+                "--flow_cubic_schedule_weights cannot be combined with " + ", ".join(conflicting_schedules) + "."
+            )
+        args.flow_cubic_schedule_weights = list(cubic_schedule_weights)
 
     if args.metadata_update_interval < 60:
         raise ValueError("Metadata update interval must be at least 60 seconds.")

--- a/simpletuner/helpers/models/ace_step/model.py
+++ b/simpletuner/helpers/models/ace_step/model.py
@@ -1682,17 +1682,10 @@ class ACEStep(AudioModelFoundation):
         lyric_token_ids = batch["lyric_token_ids"].to(device=device, dtype=torch.long)
         lyric_mask = batch["lyric_mask"].to(device=device, dtype=torch.long)
 
-        # Sample timesteps via logit-normal to index scheduler sigmas (upstream behavior).
-        timesteps_tensor = self.noise_schedule.timesteps.to(device)
-        sigmas_tensor = self.noise_schedule.sigmas.to(device)
+        sampling_batch = dict(batch)
+        sampling_batch["latents"] = latents
+        sigmas, timesteps = self.sample_flow_sigmas(batch=sampling_batch, state=state)
         bsz = latents.shape[0]
-        mean = getattr(self.config, "logit_mean", 0.0)
-        std = getattr(self.config, "logit_std", 1.0)
-        u = torch.normal(mean=mean, std=std, size=(bsz,), device=device)
-        u = torch.sigmoid(u)
-        indices = (u * (timesteps_tensor.shape[0] - 1)).long().clamp(0, timesteps_tensor.shape[0] - 1)
-        timesteps = timesteps_tensor[indices]
-        sigmas = sigmas_tensor[indices]
         # Expand sigmas to latent shape for mixing/noise and to feed the model
         view_shape = [bsz] + [1] * (latents.ndim - 1)
         sigmas_expanded = sigmas.view(*view_shape).to(dtype=dtype)
@@ -1749,8 +1742,10 @@ class ACEStep(AudioModelFoundation):
 
         mean = getattr(self.config, "logit_mean", 0.0)
         std = getattr(self.config, "logit_std", 1.0)
-        u = torch.normal(mean=mean, std=std, size=(bsz,), device=self.accelerator.device)
-        u = torch.sigmoid(u)
+        if self._uses_flow_cubic_schedule():
+            u = self._sample_flow_cubic_values(bsz, self.accelerator.device)
+        else:
+            u = torch.normal(mean=mean, std=std, size=(bsz,), device=self.accelerator.device).sigmoid()
         indices = (u * (timesteps_tensor.shape[0] - 1)).long().clamp(0, timesteps_tensor.shape[0] - 1)
         timesteps = timesteps_tensor[indices]
         sigmas = sigmas_tensor[indices]

--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -72,6 +72,7 @@ from simpletuner.helpers.training.quantisation import (
     get_pipeline_quantization_builder,
 )
 from simpletuner.helpers.training.state_tracker import StateTracker
+from simpletuner.helpers.training.timestep_distribution import CubicSplineDistribution, parse_cubic_spline_weights
 from simpletuner.helpers.training.wrappers import unwrap_model
 from simpletuner.helpers.utils import ramtorch as ramtorch_utils
 from simpletuner.helpers.utils.hidden_state_buffer import HiddenStateBuffer
@@ -4625,6 +4626,22 @@ class ModelFoundation(ABC):
 
         return tensor
 
+    def _flow_cubic_schedule_weights(self) -> Optional[tuple[float, ...]]:
+        return parse_cubic_spline_weights(getattr(self.config, "flow_cubic_schedule_weights", None))
+
+    def _uses_flow_cubic_schedule(self) -> bool:
+        return self._flow_cubic_schedule_weights() is not None
+
+    def _sample_flow_cubic_values(self, batch_size: int, device: torch.device) -> torch.Tensor:
+        weights = self._flow_cubic_schedule_weights()
+        if weights is None:
+            raise ValueError("flow_cubic_schedule_weights must be configured before sampling its distribution.")
+        cache_key = (weights, device.type, device.index)
+        if getattr(self, "_flow_cubic_distribution_cache_key", None) != cache_key:
+            self._flow_cubic_distribution = CubicSplineDistribution(weights, device=device)
+            self._flow_cubic_distribution_cache_key = cache_key
+        return self._flow_cubic_distribution.sample((batch_size,))
+
     def reset_flow_custom_timestep_cursor(self, global_step: int = 0) -> None:
         if hasattr(self, "_flow_custom_timestep_cursor"):
             delattr(self, "_flow_custom_timestep_cursor")
@@ -4745,7 +4762,11 @@ class ModelFoundation(ABC):
                 timesteps = base_timesteps[indices]
             return sigmas, timesteps
 
-        if not self.config.flux_fast_schedule and not any(
+        cubic_weights = self._flow_cubic_schedule_weights()
+        if cubic_weights is not None:
+            sigmas = self._sample_flow_cubic_values(bsz, self.accelerator.device)
+            sigmas = apply_flow_schedule_shift(self.config, self.noise_schedule, sigmas, batch["noise"])
+        elif not self.config.flux_fast_schedule and not any(
             [
                 self.config.flow_use_beta_schedule,
                 self.config.flow_use_uniform_schedule,

--- a/simpletuner/helpers/models/cosmos3/model.py
+++ b/simpletuner/helpers/models/cosmos3/model.py
@@ -603,8 +603,11 @@ class Cosmos3Image(Cosmos2Image):
         batch["input_noise"] = noise
 
         bsz = latents.shape[0]
-        u = torch.normal(mean=0.0, std=1.0, size=(bsz,), device=latents.device)
-        t = torch.sigmoid(u)
+        if self._uses_flow_cubic_schedule():
+            t = self._sample_flow_cubic_values(bsz, latents.device)
+        else:
+            u = torch.normal(mean=0.0, std=1.0, size=(bsz,), device=latents.device)
+            t = torch.sigmoid(u)
         batch["sigmas"] = t
         batch["timesteps"] = t * 1000.0
         batch["noisy_latents"] = self._interpolate_flow_latents(latents, noise, t)

--- a/simpletuner/helpers/models/ideogram/model.py
+++ b/simpletuner/helpers/models/ideogram/model.py
@@ -774,7 +774,10 @@ class Ideogram4(ImageModelFoundation):
         mu = float(getattr(self.config, "ideogram_schedule_mu", 0.0) or 0.0)
         std = float(getattr(self.config, "ideogram_schedule_std", 1.5) or 1.5)
         schedule = get_schedule_for_resolution((image_height, image_width), known_mean=mu, std=std)
-        schedule_u = torch.rand((bsz,), device=device, dtype=torch.float32)
+        if self._uses_flow_cubic_schedule():
+            schedule_u = self._sample_flow_cubic_values(bsz, device)
+        else:
+            schedule_u = torch.rand((bsz,), device=device, dtype=torch.float32)
         model_t = schedule(schedule_u).to(device=device, dtype=torch.float32)
         sigmas = (1.0 - model_t).clamp(0.0, 1.0)
         timesteps = sigmas * 1000.0

--- a/simpletuner/helpers/models/minimaxmusic/model.py
+++ b/simpletuner/helpers/models/minimaxmusic/model.py
@@ -1265,7 +1265,10 @@ class MiniMaxMusic(AudioModelFoundation):
         dtype = getattr(self.config, "weight_dtype", torch.float32)
         mean = float(getattr(self.config, "logit_mean", 0.0) or 0.0)
         std = float(getattr(self.config, "logit_std", 1.0) or 1.0)
-        u = torch.normal(mean=mean, std=std, size=(bsz,), device=device, dtype=torch.float32).sigmoid()
+        if self._uses_flow_cubic_schedule():
+            u = self._sample_flow_cubic_values(bsz, device)
+        else:
+            u = torch.normal(mean=mean, std=std, size=(bsz,), device=device, dtype=torch.float32).sigmoid()
         data_timesteps = u.to(dtype=dtype)
         noise_sigmas = (1.0 - data_timesteps).clamp(0.0, 1.0)
         return noise_sigmas, data_timesteps

--- a/simpletuner/helpers/models/omnigen/model.py
+++ b/simpletuner/helpers/models/omnigen/model.py
@@ -209,13 +209,7 @@ class OmniGen(ImageModelFoundation):
     def prepare_batch_conditions(self, batch: dict, state: dict) -> dict:
         """OmniGen-specific flow matching preparation"""
         if self.PREDICTION_TYPE is PredictionTypes.FLOW_MATCHING:
-            # Get batch size and device
-            bsz = batch["latents"].shape[0]
-            device = batch["latents"].device
-
-            # Sample t using OmniGen's approach (normal -> sigmoid)
-            u = torch.normal(mean=0.0, std=1.0, size=(bsz,), device=device)
-            t = 1.0 / (1.0 + torch.exp(-u))  # sigmoid transformation
+            _, t = self.sample_flow_sigmas(batch=batch, state=state)
 
             # OmniGen uses timesteps from 0 to 1, NOT scaled by 1000
             batch["timesteps"] = t  # Keep as 0-1 range
@@ -240,8 +234,11 @@ class OmniGen(ImageModelFoundation):
     def sample_flow_sigmas(self, batch: dict, state: dict) -> tuple[torch.Tensor, torch.Tensor]:
         bsz = batch["latents"].shape[0]
         device = batch["latents"].device
-        u = torch.normal(mean=0.0, std=1.0, size=(bsz,), device=device)
-        t = 1.0 / (1.0 + torch.exp(-u))
+        if self._uses_flow_cubic_schedule():
+            t = self._sample_flow_cubic_values(bsz, device)
+        else:
+            u = torch.normal(mean=0.0, std=1.0, size=(bsz,), device=device)
+            t = torch.sigmoid(u)
         return t, t
 
     def _prepare_crepa_self_flow_batch(self, batch: dict, state: dict) -> dict:

--- a/simpletuner/helpers/models/sana/model.py
+++ b/simpletuner/helpers/models/sana/model.py
@@ -286,14 +286,14 @@ class Sana(ImageModelFoundation):
 
     def setup_training_noise_schedule(self):
         """
-        Sana training uses the canonical flow-matching schedule and ignores user-provided shift overrides.
+        Sana training uses its native flow-matching scheduler table and ignores shift overrides.
         """
         self.noise_schedule = FlowMatchEulerDiscreteScheduler.from_pretrained(
             get_model_config_path(self.config.model_family, self.config.pretrained_model_name_or_path),
             subfolder="scheduler",
         )
         fix_flow_match_euler_schedule_bounds(self.noise_schedule)
-        # Lock Sana to the scheduler's built-in shift and distributions; ignore user overrides.
+        # Lock Sana to the scheduler's built-in shift. Its sampler applies custom density before table lookup.
         self.config.flow_schedule_shift = None
         self.config.flow_schedule_auto_shift = False
         self.config.flow_use_beta_schedule = False
@@ -302,11 +302,14 @@ class Sana(ImageModelFoundation):
 
     def sample_flow_sigmas(self, batch: dict, state: dict):
         """
-        Sample sigmas uniformly from the scheduler tables (stateless) to mirror the reference Sana trainer.
+        Sample positions from the configured density, then look them up in Sana's scheduler table.
         """
         bsz = batch["latents"].shape[0]
         num_train_timesteps = self.noise_schedule.config.num_train_timesteps
-        u = torch.rand((bsz,), device=self.accelerator.device)
+        if self._uses_flow_cubic_schedule():
+            u = self._sample_flow_cubic_values(bsz, self.accelerator.device)
+        else:
+            u = torch.rand((bsz,), device=self.accelerator.device)
         indices = torch.clamp((u * num_train_timesteps).long(), max=num_train_timesteps - 1)
         scheduler_sigmas = self.noise_schedule.sigmas.to(device=self.accelerator.device, dtype=batch["latents"].dtype)
         scheduler_timesteps = self.noise_schedule.timesteps.to(device=self.accelerator.device)

--- a/simpletuner/helpers/models/sanavideo/model.py
+++ b/simpletuner/helpers/models/sanavideo/model.py
@@ -467,14 +467,14 @@ class SanaVideo(VideoModelFoundation):
 
     def setup_training_noise_schedule(self):
         """
-        Sana training uses the canonical flow-matching schedule and ignores user-provided shift overrides.
+        Sana Video training uses its native flow-matching scheduler table and ignores shift overrides.
         """
         self.noise_schedule = FlowMatchEulerDiscreteScheduler.from_pretrained(
             get_model_config_path(self.config.model_family, self.config.pretrained_model_name_or_path),
             subfolder="scheduler",
         )
         fix_flow_match_euler_schedule_bounds(self.noise_schedule)
-        # Lock Sana to the scheduler's built-in shift and distributions; ignore user overrides.
+        # Lock Sana Video to the scheduler's built-in shift. Its sampler applies custom density before table lookup.
         self.config.flow_schedule_shift = None
         self.config.flow_schedule_auto_shift = False
         self.config.flow_use_beta_schedule = False
@@ -483,11 +483,14 @@ class SanaVideo(VideoModelFoundation):
 
     def sample_flow_sigmas(self, batch: dict, state: dict):
         """
-        Sample sigmas uniformly from the scheduler tables (stateless) to mirror the reference Sana trainer.
+        Sample positions from the configured density, then look them up in Sana Video's scheduler table.
         """
         bsz = batch["latents"].shape[0]
         num_train_timesteps = self.noise_schedule.config.num_train_timesteps
-        u = torch.rand((bsz,), device=self.accelerator.device)
+        if self._uses_flow_cubic_schedule():
+            u = self._sample_flow_cubic_values(bsz, self.accelerator.device)
+        else:
+            u = torch.rand((bsz,), device=self.accelerator.device)
         indices = torch.clamp((u * num_train_timesteps).long(), max=num_train_timesteps - 1)
         scheduler_sigmas = self.noise_schedule.sigmas.to(device=self.accelerator.device, dtype=batch["latents"].dtype)
         scheduler_timesteps = self.noise_schedule.timesteps.to(device=self.accelerator.device)

--- a/simpletuner/helpers/training/timestep_distribution.py
+++ b/simpletuner/helpers/training/timestep_distribution.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Sequence
+from numbers import Real
+from typing import Optional
+
+import torch
+from torch.distributions import Distribution, constraints
+
+
+def parse_cubic_spline_weights(raw_value) -> Optional[tuple[float, ...]]:
+    """Parse configured density knots while preserving None versus an empty uniform schedule."""
+    if raw_value is None:
+        return None
+    if isinstance(raw_value, str):
+        stripped = raw_value.strip()
+        if not stripped or stripped.lower() == "none":
+            return None
+        try:
+            raw_value = json.loads(stripped)
+        except json.JSONDecodeError:
+            segments = [segment.strip() for segment in stripped.replace(";", ",").split(",")]
+            if any(not segment for segment in segments):
+                raise ValueError("flow_cubic_schedule_weights contains an empty value.")
+            raw_value = segments
+
+    if torch.is_tensor(raw_value):
+        raw_value = raw_value.detach().cpu().flatten().tolist()
+    elif hasattr(raw_value, "tolist") and not isinstance(raw_value, (str, bytes)):
+        raw_value = raw_value.tolist()
+    if isinstance(raw_value, Real):
+        raw_value = [raw_value]
+    if not isinstance(raw_value, Sequence) or isinstance(raw_value, (str, bytes)):
+        raise ValueError("flow_cubic_schedule_weights must be a JSON array or comma-separated list of numbers.")
+
+    weights = []
+    for index, raw_weight in enumerate(raw_value):
+        try:
+            weight = float(raw_weight)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"flow_cubic_schedule_weights[{index}] must be numeric.") from exc
+        if not math.isfinite(weight):
+            raise ValueError(f"flow_cubic_schedule_weights[{index}] must be finite.")
+        if weight < 0:
+            raise ValueError(f"flow_cubic_schedule_weights[{index}] must be non-negative.")
+        weights.append(weight)
+
+    if len(weights) > 1 and not any(weight > 0 for weight in weights):
+        raise ValueError("flow_cubic_schedule_weights must contain a positive value when two or more knots are used.")
+    return tuple(weights)
+
+
+class CubicSplineDistribution(Distribution):
+    """A normalized PDF through equally spaced non-negative density knots."""
+
+    arg_constraints = {}
+    support = constraints.unit_interval
+    has_rsample = False
+
+    def __init__(
+        self,
+        weights: Sequence[float],
+        *,
+        device: torch.device | str = "cpu",
+        resolution: int = 4097,
+        validate_args: Optional[bool] = None,
+    ):
+        parsed = parse_cubic_spline_weights(weights)
+        if parsed is None:
+            raise ValueError("CubicSplineDistribution requires an explicit weight sequence.")
+        if resolution < 257:
+            raise ValueError("CubicSplineDistribution resolution must be at least 257.")
+
+        self.weights = parsed
+        self.resolution = int(resolution)
+        self.device = torch.device(device)
+        self.is_uniform = len(parsed) <= 1
+        self.grid_x: Optional[torch.Tensor] = None
+        self.pdf_grid: Optional[torch.Tensor] = None
+        self.cdf_grid: Optional[torch.Tensor] = None
+        if not self.is_uniform:
+            self._build_grid()
+        super().__init__(batch_shape=torch.Size(), event_shape=torch.Size(), validate_args=validate_args)
+
+    @staticmethod
+    def _pchip_slopes(values: torch.Tensor, spacing: float) -> torch.Tensor:
+        deltas = (values[1:] - values[:-1]) / spacing
+        slopes = torch.zeros_like(values)
+        if values.numel() == 2:
+            slopes[:] = deltas[0]
+            return slopes
+
+        previous = deltas[:-1]
+        following = deltas[1:]
+        same_direction = previous * following > 0
+        denominator = torch.where(same_direction, previous + following, torch.ones_like(previous))
+        slopes[1:-1] = torch.where(
+            same_direction,
+            2.0 * previous * following / denominator,
+            torch.zeros_like(previous),
+        )
+
+        first = (3.0 * deltas[0] - deltas[1]) / 2.0
+        first = torch.where(torch.sign(first) != torch.sign(deltas[0]), torch.zeros_like(first), first)
+        first = torch.where(
+            (torch.sign(deltas[0]) != torch.sign(deltas[1])) & (first.abs() > 3.0 * deltas[0].abs()),
+            3.0 * deltas[0],
+            first,
+        )
+        last = (3.0 * deltas[-1] - deltas[-2]) / 2.0
+        last = torch.where(torch.sign(last) != torch.sign(deltas[-1]), torch.zeros_like(last), last)
+        last = torch.where(
+            (torch.sign(deltas[-1]) != torch.sign(deltas[-2])) & (last.abs() > 3.0 * deltas[-1].abs()),
+            3.0 * deltas[-1],
+            last,
+        )
+        slopes[0] = first
+        slopes[-1] = last
+        return slopes
+
+    def _build_grid(self) -> None:
+        values = torch.tensor(self.weights, device=self.device, dtype=torch.float32)
+        knot_count = values.numel()
+        spacing = 1.0 / (knot_count - 1)
+        positions = torch.linspace(0.0, knot_count - 1, self.resolution, device=self.device, dtype=torch.float32)
+        segment = positions.floor().long().clamp(max=knot_count - 2)
+        local = positions - segment
+
+        if knot_count == 2:
+            pdf = torch.lerp(values[0].expand_as(local), values[1].expand_as(local), local)
+        else:
+            slopes = self._pchip_slopes(values, spacing)
+            local_squared = local.square()
+            local_cubed = local_squared * local
+            h00 = 2.0 * local_cubed - 3.0 * local_squared + 1.0
+            h10 = local_cubed - 2.0 * local_squared + local
+            h01 = -2.0 * local_cubed + 3.0 * local_squared
+            h11 = local_cubed - local_squared
+            pdf = (
+                h00 * values[segment]
+                + h10 * spacing * slopes[segment]
+                + h01 * values[segment + 1]
+                + h11 * spacing * slopes[segment + 1]
+            )
+
+        pdf = pdf.clamp_min(0.0)
+        grid_x = torch.linspace(0.0, 1.0, self.resolution, device=self.device, dtype=torch.float32)
+        dx = 1.0 / (self.resolution - 1)
+        interval_areas = (pdf[:-1] + pdf[1:]) * (0.5 * dx)
+        total_area = interval_areas.sum()
+        if not torch.isfinite(total_area) or total_area <= 0:
+            raise ValueError("Cubic spline density has zero or non-finite area.")
+
+        self.grid_x = grid_x
+        self.pdf_grid = pdf / total_area
+        self.cdf_grid = torch.cat([torch.zeros(1, device=self.device), torch.cumsum(interval_areas, dim=0)])
+        self.cdf_grid = self.cdf_grid / self.cdf_grid[-1]
+
+    @torch.no_grad()
+    def sample(self, sample_shape: torch.Size = torch.Size()) -> torch.Tensor:
+        shape = torch.Size(sample_shape)
+        uniform = torch.rand(shape, device=self.device, dtype=torch.float32)
+        if self.is_uniform:
+            return uniform
+
+        indices = torch.searchsorted(self.cdf_grid, uniform).clamp(1, self.resolution - 1)
+        lower = indices - 1
+        cdf_lower = self.cdf_grid[lower]
+        cdf_upper = self.cdf_grid[indices]
+        denominator = (cdf_upper - cdf_lower).clamp_min(torch.finfo(torch.float32).eps)
+        fraction = (uniform - cdf_lower) / denominator
+        return torch.lerp(self.grid_x[lower], self.grid_x[indices], fraction)
+
+    def log_prob(self, value: torch.Tensor) -> torch.Tensor:
+        value = torch.as_tensor(value, device=self.device, dtype=torch.float32)
+        if self.is_uniform:
+            result = torch.zeros_like(value)
+        else:
+            scaled = value.clamp(0.0, 1.0) * (self.resolution - 1)
+            lower = scaled.floor().long().clamp(0, self.resolution - 1)
+            upper = (lower + 1).clamp(max=self.resolution - 1)
+            density = torch.lerp(self.pdf_grid[lower], self.pdf_grid[upper], scaled - lower)
+            result = density.log()
+        outside = (value < 0.0) | (value > 1.0)
+        return torch.where(outside, torch.full_like(result, -torch.inf), result)

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/advanced.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/advanced.py
@@ -484,6 +484,27 @@ def register_advanced_fields(registry: "FieldRegistry") -> None:
 
     registry._add_field(
         ConfigField(
+            name="flow_cubic_schedule_weights",
+            arg_name="--flow_cubic_schedule_weights",
+            ui_label="Cubic Schedule Weights",
+            field_type=FieldType.TEXT_JSON,
+            tab="training",
+            section="loss_functions",
+            subsection="advanced",
+            default_value=None,
+            help_text=(
+                "Sample flow timesteps from a smooth density through equally spaced non-negative weights. "
+                "Use a JSON array or comma-separated values; zero or one weight produces a uniform distribution."
+            ),
+            tooltip="Defines a custom cubic-Hermite timestep density over the normalized interval [0,1].",
+            documentation="OPTIONS.md#--flow_cubic_schedule_weights",
+            importance=ImportanceLevel.ADVANCED,
+            order=24.5,
+        )
+    )
+
+    registry._add_field(
+        ConfigField(
             name="flow_schedule_shift",
             arg_name="--flow_schedule_shift",
             ui_label="Schedule Shift",

--- a/simpletuner/simpletuner_sdk/server/services/field_service.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_service.py
@@ -80,6 +80,7 @@ class FieldService:
         "flow_use_beta_schedule",
         "flow_beta_schedule_alpha",
         "flow_beta_schedule_beta",
+        "flow_cubic_schedule_weights",
         "flow_schedule_shift",
         "flow_schedule_auto_shift",
         "audio_flow_schedule_shift",

--- a/tests/test_ace_step_model.py
+++ b/tests/test_ace_step_model.py
@@ -20,6 +20,7 @@ class TestACEStepModel(unittest.TestCase):
         self.config.logit_mean = 0.0
         self.config.logit_std = 1.0
         self.config.flow_schedule_shift = 3.0
+        self.config.flow_cubic_schedule_weights = None
         self.config.model_family = "ace_step"
         self.config.pretrained_model_name_or_path = "dummy_path"
         self.config.pretrained_transformer_model_name_or_path = None

--- a/tests/test_flow_cubic_schedule.py
+++ b/tests/test_flow_cubic_schedule.py
@@ -1,0 +1,235 @@
+import math
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+import tests.test_stubs  # noqa: F401
+from simpletuner.helpers.configuration.cli_utils import mapping_to_cli_args
+from simpletuner.helpers.configuration.cmd_args import parse_cmdline_args
+from simpletuner.helpers.models.ace_step.model import ACEStep
+from simpletuner.helpers.models.common import ImageModelFoundation
+from simpletuner.helpers.models.cosmos3.model import Cosmos3Image
+from simpletuner.helpers.models.ideogram.model import Ideogram4, get_schedule_for_resolution
+from simpletuner.helpers.models.minimaxmusic.model import MiniMaxMusic
+from simpletuner.helpers.models.omnigen.model import OmniGen
+from simpletuner.helpers.models.sana.model import Sana
+from simpletuner.helpers.models.sanavideo.model import SanaVideo
+from simpletuner.helpers.training.timestep_distribution import CubicSplineDistribution, parse_cubic_spline_weights
+from simpletuner.simpletuner_sdk.server.services.field_registry.registry import FieldRegistry
+from simpletuner.simpletuner_sdk.server.services.field_registry.types import FieldType
+
+
+def _base_args():
+    return [
+        "--model_family=pixart",
+        "--output_dir=/tmp/output",
+        "--model_type=lora",
+        "--optimizer=adamw_bf16",
+        "--data_backend_config=/tmp/config.json",
+    ]
+
+
+def _flow_model(weights, shift=None):
+    model = SimpleNamespace(
+        config=SimpleNamespace(
+            flow_cubic_schedule_weights=weights,
+            flow_custom_timesteps=None,
+            flow_timesteps_mode="fixed-list",
+            flow_schedule_shift=shift,
+            flow_schedule_auto_shift=False,
+        ),
+        accelerator=SimpleNamespace(device=torch.device("cpu")),
+        noise_schedule=SimpleNamespace(config=SimpleNamespace()),
+    )
+    model._normalize_flow_custom_timesteps = ImageModelFoundation._normalize_flow_custom_timesteps.__get__(model)
+    model._flow_cubic_schedule_weights = ImageModelFoundation._flow_cubic_schedule_weights.__get__(model)
+    model._uses_flow_cubic_schedule = ImageModelFoundation._uses_flow_cubic_schedule.__get__(model)
+    model._sample_flow_cubic_values = ImageModelFoundation._sample_flow_cubic_values.__get__(model)
+    model.sample_flow_sigmas = ImageModelFoundation.sample_flow_sigmas.__get__(model)
+    return model
+
+
+class CubicSplineDistributionTests(unittest.TestCase):
+    def test_empty_and_single_weight_schedules_are_uniform(self):
+        for weights in ([], [0.0], [4.0]):
+            torch.manual_seed(17)
+            expected = torch.rand(64)
+            torch.manual_seed(17)
+            actual = CubicSplineDistribution(weights).sample((64,))
+            self.assertTrue(torch.equal(actual, expected))
+
+    def test_two_weights_define_linear_density(self):
+        distribution = CubicSplineDistribution([0.0, 1.0])
+        density = distribution.log_prob(torch.tensor([0.25, 0.75])).exp()
+        self.assertTrue(torch.allclose(density, torch.tensor([0.5, 1.5]), atol=1e-3))
+
+        torch.manual_seed(11)
+        samples = distribution.sample((100_000,))
+        self.assertAlmostEqual(samples.mean().item(), 2.0 / 3.0, places=2)
+
+    def test_cubic_density_is_bounded_and_finite(self):
+        distribution = CubicSplineDistribution([0.0, 1.0, 0.1, 2.0, 0.0])
+        samples = distribution.sample((10_000,))
+
+        self.assertGreaterEqual(samples.min().item(), 0.0)
+        self.assertLessEqual(samples.max().item(), 1.0)
+        self.assertTrue(torch.isfinite(distribution.log_prob(samples)).all())
+        self.assertEqual(distribution.log_prob(torch.tensor([-0.1, 1.1])).tolist(), [-math.inf, -math.inf])
+
+    def test_invalid_weights_raise(self):
+        invalid_values = ([1.0, -1.0], [0.0, 0.0], [1.0, math.inf], "1,,2", {"weight": 1})
+        for value in invalid_values:
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                parse_cubic_spline_weights(value)
+
+
+class FlowCubicScheduleIntegrationTests(unittest.TestCase):
+    def test_common_flow_sampler_uses_distribution_and_shift(self):
+        model = _flow_model([0.0, 1.0], shift=2.0)
+        batch = {
+            "latents": torch.zeros(32, 1, 2, 2),
+            "noise": torch.zeros(32, 1, 2, 2),
+        }
+
+        torch.manual_seed(7)
+        raw = CubicSplineDistribution([0.0, 1.0]).sample((32,))
+        expected = (raw * 2.0) / (1.0 + raw)
+        torch.manual_seed(7)
+        sigmas, timesteps = model.sample_flow_sigmas(batch=batch, state={})
+
+        self.assertTrue(torch.allclose(sigmas, expected))
+        self.assertTrue(torch.allclose(timesteps, expected * 1000.0))
+
+    def test_json_config_remains_one_cli_argument(self):
+        cli_args = mapping_to_cli_args({"flow_cubic_schedule_weights": [0.0, 1.0, 0.25]})
+        matching = [value for value in cli_args if value.startswith("--flow_cubic_schedule_weights")]
+
+        self.assertEqual(matching, ["--flow_cubic_schedule_weights=[0.0, 1.0, 0.25]"])
+
+    def test_command_line_parses_json_and_comma_separated_weights(self):
+        json_args = parse_cmdline_args(
+            input_args=_base_args() + ["--flow_cubic_schedule_weights=[0, 1, 0.5]"],
+            exit_on_error=False,
+        )
+        comma_args = parse_cmdline_args(
+            input_args=_base_args() + ["--flow_cubic_schedule_weights=0,1,0.5"],
+            exit_on_error=False,
+        )
+
+        self.assertEqual(json_args.flow_cubic_schedule_weights, [0.0, 1.0, 0.5])
+        self.assertEqual(comma_args.flow_cubic_schedule_weights, [0.0, 1.0, 0.5])
+
+    def test_command_line_rejects_competing_schedule(self):
+        with self.assertRaisesRegex(ValueError, "cannot be combined"):
+            parse_cmdline_args(
+                input_args=_base_args() + ["--flow_cubic_schedule_weights=[0, 1]", "--flow_use_uniform_schedule"],
+                exit_on_error=False,
+            )
+
+    def test_webui_field_is_registered_as_json(self):
+        field = FieldRegistry().get_field("flow_cubic_schedule_weights")
+
+        self.assertIsNotNone(field)
+        self.assertEqual(field.field_type, FieldType.TEXT_JSON)
+        self.assertEqual(field.arg_name, "--flow_cubic_schedule_weights")
+
+
+class ModelSpecificCubicScheduleTests(unittest.TestCase):
+    def test_ace_step_uses_density_before_scheduler_lookup(self):
+        model = ACEStep.__new__(ACEStep)
+        model.accelerator = SimpleNamespace(device=torch.device("cpu"))
+        model.config = SimpleNamespace(flow_cubic_schedule_weights=[0.0, 1.0], logit_mean=0.0, logit_std=1.0)
+        model.noise_schedule = SimpleNamespace(
+            sigmas=torch.tensor([1.0, 0.75, 0.5, 0.25, 0.0]),
+            timesteps=torch.tensor([1000.0, 750.0, 500.0, 250.0, 0.0]),
+        )
+        model._sample_flow_cubic_values = MagicMock(return_value=torch.tensor([0.0, 0.99]))
+
+        sigmas, timesteps = model.sample_flow_sigmas({"latents": torch.zeros(2, 1, 2, 2)}, {})
+
+        self.assertTrue(torch.equal(sigmas, torch.tensor([1.0, 0.25])))
+        self.assertTrue(torch.equal(timesteps, torch.tensor([1000.0, 250.0])))
+
+    def test_cosmos3_uses_density_as_native_timestep(self):
+        model = Cosmos3Image.__new__(Cosmos3Image)
+        model.accelerator = SimpleNamespace(device=torch.device("cpu"))
+        model.config = SimpleNamespace(
+            flow_cubic_schedule_weights=[0.0, 1.0],
+            weight_dtype=torch.float32,
+            model_flavour="nano",
+        )
+        model._sample_flow_cubic_values = MagicMock(return_value=torch.tensor([0.2, 0.8]))
+        model.prepare_batch_conditions = lambda batch, state: batch
+
+        result = model.prepare_batch({"latent_batch": torch.ones(2, 1, 1, 1)}, {})
+
+        self.assertTrue(torch.equal(result["sigmas"], torch.tensor([0.2, 0.8])))
+        self.assertTrue(torch.equal(result["timesteps"], torch.tensor([200.0, 800.0])))
+
+    def test_ideogram_uses_density_before_resolution_schedule(self):
+        model = Ideogram4.__new__(Ideogram4)
+        model.accelerator = SimpleNamespace(device=torch.device("cpu"))
+        model.config = SimpleNamespace(
+            flow_cubic_schedule_weights=[0.0, 1.0],
+            ideogram_schedule_mu=0.0,
+            ideogram_schedule_std=1.5,
+        )
+        schedule_u = torch.tensor([0.25, 0.75])
+        model._sample_flow_cubic_values = MagicMock(return_value=schedule_u)
+        batch = {"latents": torch.zeros(2, 128, 64, 64)}
+
+        sigmas, timesteps = model.sample_flow_sigmas(batch, {})
+
+        model_t = get_schedule_for_resolution((1024, 1024), known_mean=0.0, std=1.5)(schedule_u)
+        self.assertTrue(torch.allclose(sigmas, 1.0 - model_t))
+        self.assertTrue(torch.allclose(timesteps, (1.0 - model_t) * 1000.0))
+
+    def test_minimax_music_preserves_data_ward_timestep_convention(self):
+        model = MiniMaxMusic.__new__(MiniMaxMusic)
+        model.accelerator = SimpleNamespace(device=torch.device("cpu"))
+        model.config = SimpleNamespace(
+            flow_cubic_schedule_weights=[0.0, 1.0],
+            weight_dtype=torch.float32,
+            logit_mean=0.0,
+            logit_std=1.0,
+        )
+        model._sample_flow_cubic_values = MagicMock(return_value=torch.tensor([0.2, 0.8]))
+
+        sigmas, timesteps = model.sample_flow_sigmas({"latents": torch.zeros(2, 1, 2)}, {})
+
+        self.assertTrue(torch.allclose(sigmas, torch.tensor([0.8, 0.2])))
+        self.assertTrue(torch.equal(timesteps, torch.tensor([0.2, 0.8])))
+
+    def test_omnigen_uses_density_as_unscaled_timestep(self):
+        model = OmniGen.__new__(OmniGen)
+        model.config = SimpleNamespace(flow_cubic_schedule_weights=[0.0, 1.0])
+        model._sample_flow_cubic_values = MagicMock(return_value=torch.tensor([0.2, 0.8]))
+
+        sigmas, timesteps = model.sample_flow_sigmas({"latents": torch.zeros(2, 1, 2, 2)}, {})
+
+        self.assertTrue(torch.equal(sigmas, torch.tensor([0.2, 0.8])))
+        self.assertTrue(torch.equal(timesteps, torch.tensor([0.2, 0.8])))
+
+    def test_sana_families_use_density_before_scheduler_lookup(self):
+        for model_class in (Sana, SanaVideo):
+            with self.subTest(model_class=model_class.__name__):
+                model = model_class.__new__(model_class)
+                model.accelerator = SimpleNamespace(device=torch.device("cpu"))
+                model.config = SimpleNamespace(flow_cubic_schedule_weights=[0.0, 1.0])
+                model.noise_schedule = SimpleNamespace(
+                    config=SimpleNamespace(num_train_timesteps=5),
+                    sigmas=torch.tensor([1.0, 0.75, 0.5, 0.25, 0.0]),
+                    timesteps=torch.tensor([1000.0, 750.0, 500.0, 250.0, 0.0]),
+                )
+                model._sample_flow_cubic_values = MagicMock(return_value=torch.tensor([0.0, 0.99]))
+
+                sigmas, timesteps = model.sample_flow_sigmas({"latents": torch.zeros(2, 1, 2, 2)}, {})
+
+                self.assertTrue(torch.equal(sigmas, torch.tensor([1.0, 0.0])))
+                self.assertTrue(torch.equal(timesteps, torch.tensor([1000.0, 0.0])))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sanavideo_model.py
+++ b/tests/test_sanavideo_model.py
@@ -22,6 +22,7 @@ class TestSanaVideoModel(unittest.TestCase):
         self.config.sana_complex_human_instruction = True
         self.config.validation_num_video_frames = 81
         self.config.flow_schedule_shift = 1.0
+        self.config.flow_cubic_schedule_weights = None
         self.config.tracker_run_name = "test_run"
 
         # Mock the pipeline classes so they don't try to load real models


### PR DESCRIPTION
## Summary
- add validated cubic-Hermite flow timestep density sampling from user-defined knots
- apply the schedule across shared and model-specific image, video, and audio flow samplers
- add WebUI configuration, tests, and multilingual option documentation

## Validation
- `.venv/bin/python -m unittest -v -f`
- `.venv/bin/mkdocs build --strict`
- single-H200 Anima v1.0 LoRA smoke training with adapter export

Closes #2561