### PR TITLE
Add built-in local training metrics dashboard

### DIFF
--- a/documentation/OPTIONS.es.md
+++ b/documentation/OPTIONS.es.md
@@ -1821,8 +1821,19 @@ Mapeo de opciones upstream (LayerSync → SimpleTuner):
 ### `--report_to`
 
 - **Qué**: Especifica la plataforma para reportar resultados y logs.
-- **Por qué**: Habilita integración con plataformas como TensorBoard, wandb o comet_ml para monitoreo. Usa múltiples valores separados por comas para reportar a múltiples trackers;
-- **Opciones**: wandb, tensorboard, comet_ml
+- **Por qué**: Habilita monitoreo local o externo. `simpletuner` escribe JSONL, un manifiesto, metadatos de validación y un informe HTML autónomo en `output_dir`. `all` incluye el tracker local.
+- **Opciones**: simpletuner, wandb, tensorboard, swanlab, comet_ml, custom-tracker, all, none
+
+### `--validation_image_format`
+
+- **Qué**: Formato de imágenes guardadas en `output_dir/validation_images`.
+- **Opciones**: png, webp, jpeg
+- **Predeterminado**: png
+
+### `--validation_image_quality`
+
+- **Qué**: Calidad de WebP y JPEG, de 1 a 100.
+- **Predeterminado**: 90. Se ignora para PNG.
 
 ## Variables de configuración del entorno
 

--- a/documentation/OPTIONS.hi.md
+++ b/documentation/OPTIONS.hi.md
@@ -1819,8 +1819,19 @@ Upstream option mapping (LayerSync → SimpleTuner):
 ### `--report_to`
 
 - **What**: results और logs रिपोर्ट करने के लिए platform निर्दिष्ट करता है।
-- **Why**: TensorBoard, wandb, या comet_ml जैसी platforms के साथ integration सक्षम करता है। multiple trackers पर रिपोर्ट करने के लिए comma से अलग values उपयोग करें;
-- **Choices**: wandb, tensorboard, comet_ml
+- **Why**: स्थानीय या external monitoring चालू करता है। `simpletuner`, `output_dir` में JSONL, manifest, validation media metadata और self-contained HTML report लिखता है। `all` में local tracker शामिल है।
+- **Choices**: simpletuner, wandb, tensorboard, swanlab, comet_ml, custom-tracker, all, none
+
+### `--validation_image_format`
+
+- **What**: `output_dir/validation_images` में save होने वाली images का format।
+- **Choices**: png, webp, jpeg
+- **Default**: png
+
+### `--validation_image_quality`
+
+- **What**: WebP और JPEG quality, 1 से 100।
+- **Default**: 90। PNG के लिए ignored है।
 
 ## Environment configuration variables
 

--- a/documentation/OPTIONS.ja.md
+++ b/documentation/OPTIONS.ja.md
@@ -1822,8 +1822,19 @@ LayerSync は同一 Transformer 内の「学生」レイヤーを、より強い
 ### `--report_to`
 
 - **内容**: 結果とログの報告先プラットフォーム。
-- **理由**: TensorBoard、wandb、comet_ml などと連携して監視できます。複数指定はカンマ区切りです。
-- **選択肢**: wandb, tensorboard, comet_ml
+- **理由**: ローカルまたは外部監視を有効にします。`simpletuner` は JSONL、マニフェスト、検証メディア情報、自己完結 HTML を `output_dir` に保存します。`all` にはローカルトラッカーも含まれます。
+- **選択肢**: simpletuner, wandb, tensorboard, swanlab, comet_ml, custom-tracker, all, none
+
+### `--validation_image_format`
+
+- **内容**: `output_dir/validation_images` に保存する画像形式。
+- **選択肢**: png, webp, jpeg
+- **デフォルト**: png
+
+### `--validation_image_quality`
+
+- **内容**: WebP と JPEG の品質（1 から 100）。
+- **デフォルト**: 90。PNG では無視されます。
 
 ## 環境設定変数
 

--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -1825,8 +1825,20 @@ Upstream option mapping (LayerSync → SimpleTuner):
 ### `--report_to`
 
 - **What**: Specifies the platform for reporting results and logs.
-- **Why**: Enables integration with platforms like TensorBoard, wandb, or comet_ml for monitoring. Use multiple values separated by a comma to report to multiple trackers;
-- **Choices**: wandb, tensorboard, comet_ml
+- **Why**: Enables local or external monitoring. `simpletuner` writes raw JSONL, a manifest, validation media metadata, and a self-contained HTML report to `output_dir`. Use comma-separated values for multiple trackers. `all` includes the local tracker.
+- **Choices**: simpletuner, wandb, tensorboard, swanlab, comet_ml, custom-tracker, all, none
+
+### `--validation_image_format`
+
+- **What**: Format for validation images saved in `output_dir/validation_images`.
+- **Choices**: png, webp, jpeg
+- **Default**: png
+
+### `--validation_image_quality`
+
+- **What**: Encoding quality for WebP and JPEG validation images.
+- **Range**: 1 to 100
+- **Default**: 90. Ignored for PNG.
 
 ## Environment configuration variables
 

--- a/documentation/OPTIONS.pt-BR.md
+++ b/documentation/OPTIONS.pt-BR.md
@@ -1817,8 +1817,19 @@ Mapeamento de opcoes upstream (LayerSync → SimpleTuner):
 ### `--report_to`
 
 - **O que**: Especifica a plataforma para reportar resultados e logs.
-- **Por que**: Habilita integracao com TensorBoard, wandb ou comet_ml para monitoramento. Use multiplos valores separados por virgula para reportar a varios trackers.
-- **Opcoes**: wandb, tensorboard, comet_ml
+- **Por que**: Habilita monitoramento local ou externo. `simpletuner` grava JSONL, manifesto, metadados de validacao e um relatorio HTML autonomo em `output_dir`. `all` inclui o tracker local.
+- **Opcoes**: simpletuner, wandb, tensorboard, swanlab, comet_ml, custom-tracker, all, none
+
+### `--validation_image_format`
+
+- **O que**: Formato das imagens salvas em `output_dir/validation_images`.
+- **Opcoes**: png, webp, jpeg
+- **Padrao**: png
+
+### `--validation_image_quality`
+
+- **O que**: Qualidade de WebP e JPEG, de 1 a 100.
+- **Padrao**: 90. Ignorado para PNG.
 
 ## Variaveis de configuracao do ambiente
 

--- a/documentation/OPTIONS.zh.md
+++ b/documentation/OPTIONS.zh.md
@@ -1824,8 +1824,19 @@ LayerSync 通过在同一 Transformer 内让“学生”层对齐更强的“教
 ### `--report_to`
 
 - **内容**：指定结果与日志的上报平台。
-- **原因**：可与 TensorBoard、wandb、comet_ml 集成监控。多个值用逗号分隔；
-- **选项**：wandb, tensorboard, comet_ml
+- **原因**：启用本地或外部监控。`simpletuner` 会在 `output_dir` 中写入 JSONL、运行清单、验证媒体元数据和独立 HTML 报告。`all` 包含本地 tracker。
+- **选项**：simpletuner, wandb, tensorboard, swanlab, comet_ml, custom-tracker, all, none
+
+### `--validation_image_format`
+
+- **内容**：保存到 `output_dir/validation_images` 的图像格式。
+- **选项**：png, webp, jpeg
+- **默认值**：png
+
+### `--validation_image_quality`
+
+- **内容**：WebP 和 JPEG 的质量，范围 1 到 100。
+- **默认值**：90。PNG 会忽略此项。
 
 ## 环境配置变量
 

--- a/documentation/api/TUTORIAL.es.md
+++ b/documentation/api/TUTORIAL.es.md
@@ -110,10 +110,10 @@ After=network.target
 [Service]
 Type=simple
 User=trainer
-WorkingDirectory=/home/trainer/simpletuner-workspace
+WorkingDirectory=/opt/simpletuner
 Environment="SIMPLETUNER_HOST=127.0.0.1"
 Environment="SIMPLETUNER_PORT=8001"
-ExecStart=/home/trainer/simpletuner-workspace/.venv/bin/simpletuner server
+ExecStart=/opt/simpletuner/.venv/bin/simpletuner server
 Restart=on-failure
 
 [Install]
@@ -916,3 +916,7 @@ Las etiquetas soportan patrones glob (`*` coincide con cualquier caracter).
 - **Ejecuta entrenamiento en GPUs en la nube** vía Replicate—ver el [Tutorial de entrenamiento en la nube](../experimental/cloud/TUTORIAL.md)
 
 Con estos patrones puedes automatizar por completo el entrenamiento de SimpleTuner sin tocar la WebUI, mientras sigues apoyándote en el proceso de configuración CLI probado en batalla.
+
+### Endpoints de métricas locales
+
+Con `report_to=simpletuner`, lista ejecuciones con `GET /api/metrics/training/runs` y lee una con `GET /api/metrics/training/runs/{environment}`. Admite filtros `start_step`, `end_step`, `max_points` y `metric`. Consulta [Métricas locales](../webui/LOCAL_METRICS.md).

--- a/documentation/api/TUTORIAL.hi.md
+++ b/documentation/api/TUTORIAL.hi.md
@@ -110,10 +110,10 @@ After=network.target
 [Service]
 Type=simple
 User=trainer
-WorkingDirectory=/home/trainer/simpletuner-workspace
+WorkingDirectory=/opt/simpletuner
 Environment="SIMPLETUNER_HOST=127.0.0.1"
 Environment="SIMPLETUNER_PORT=8001"
-ExecStart=/home/trainer/simpletuner-workspace/.venv/bin/simpletuner server
+ExecStart=/opt/simpletuner/.venv/bin/simpletuner server
 Restart=on-failure
 
 [Install]
@@ -908,3 +908,7 @@ Labels glob patterns सपोर्ट करते हैं (`*` किसी
 - Replicate के जरिए **cloud GPUs पर training चलाएं**—देखें [Cloud Training Tutorial](../experimental/cloud/TUTORIAL.md)
 
 इन पैटर्न्स के साथ आप WebUI छुए बिना SimpleTuner training पूरी तरह स्क्रिप्ट कर सकते हैं, जबकि setup process के लिए भरोसेमंद CLI का सहारा बना रहता है।
+
+### स्थानीय मेट्रिक्स API
+
+`report_to=simpletuner` के साथ `GET /api/metrics/training/runs` से runs की सूची और `GET /api/metrics/training/runs/{environment}` से एक run पढ़ें। `start_step`, `end_step`, `max_points` और `metric` filters उपलब्ध हैं। [स्थानीय मेट्रिक्स](../webui/LOCAL_METRICS.md) देखें।

--- a/documentation/api/TUTORIAL.ja.md
+++ b/documentation/api/TUTORIAL.ja.md
@@ -110,10 +110,10 @@ After=network.target
 [Service]
 Type=simple
 User=trainer
-WorkingDirectory=/home/trainer/simpletuner-workspace
+WorkingDirectory=/opt/simpletuner
 Environment="SIMPLETUNER_HOST=127.0.0.1"
 Environment="SIMPLETUNER_PORT=8001"
-ExecStart=/home/trainer/simpletuner-workspace/.venv/bin/simpletuner server
+ExecStart=/opt/simpletuner/.venv/bin/simpletuner server
 Restart=on-failure
 
 [Install]
@@ -912,3 +912,7 @@ curl -s -X POST http://localhost:8001/api/queue/submit \
 - **クラウドGPUでトレーニングを実行**するにはReplicateを使用—[クラウドトレーニングチュートリアル](../experimental/cloud/TUTORIAL.md)を参照
 
 これらのパターンを使用すると、実証済みのCLIセットアッププロセスに依存しながら、WebUIに触れることなくSimpleTunerトレーニングを完全にスクリプト化できます。
+
+### ローカルメトリクス API
+
+`report_to=simpletuner` の場合、`GET /api/metrics/training/runs` で一覧を取得し、`GET /api/metrics/training/runs/{environment}` で読み込みます。`start_step`、`end_step`、`max_points`、`metric` が使えます。詳細は [ローカルメトリクス](../webui/LOCAL_METRICS.md) を参照してください。

--- a/documentation/api/TUTORIAL.md
+++ b/documentation/api/TUTORIAL.md
@@ -110,10 +110,10 @@ After=network.target
 [Service]
 Type=simple
 User=trainer
-WorkingDirectory=/home/trainer/simpletuner-workspace
+WorkingDirectory=/opt/simpletuner
 Environment="SIMPLETUNER_HOST=127.0.0.1"
 Environment="SIMPLETUNER_PORT=8001"
-ExecStart=/home/trainer/simpletuner-workspace/.venv/bin/simpletuner server
+ExecStart=/opt/simpletuner/.venv/bin/simpletuner server
 Restart=on-failure
 
 [Install]
@@ -912,3 +912,7 @@ Labels support glob patterns (`*` matches any characters).
 - **Run training on cloud GPUs** via Replicate—see the [Cloud Training Tutorial](../experimental/cloud/TUTORIAL.md)
 
 With these patterns you can fully script SimpleTuner training without touching the WebUI, while still relying on the battle-tested CLI setup process.
+
+### Local metric endpoints
+
+With `report_to=simpletuner`, list runs at `GET /api/metrics/training/runs` and read one at `GET /api/metrics/training/runs/{environment}`. The latter accepts `start_step`, `end_step`, `max_points`, and repeated `metric` filters. See [Local training metrics](../webui/LOCAL_METRICS.md).

--- a/documentation/api/TUTORIAL.pt-BR.md
+++ b/documentation/api/TUTORIAL.pt-BR.md
@@ -110,10 +110,10 @@ After=network.target
 [Service]
 Type=simple
 User=trainer
-WorkingDirectory=/home/trainer/simpletuner-workspace
+WorkingDirectory=/opt/simpletuner
 Environment="SIMPLETUNER_HOST=127.0.0.1"
 Environment="SIMPLETUNER_PORT=8001"
-ExecStart=/home/trainer/simpletuner-workspace/.venv/bin/simpletuner server
+ExecStart=/opt/simpletuner/.venv/bin/simpletuner server
 Restart=on-failure
 
 [Install]
@@ -914,3 +914,7 @@ Labels suportam glob patterns (`*` corresponde a qualquer conjunto de caracteres
 - **Rode treinamento em GPUs de nuvem** via Replicate—veja o [Cloud Training Tutorial](../experimental/cloud/TUTORIAL.md)
 
 Com esses padroes voce consegue automatizar totalmente o treinamento do SimpleTuner sem tocar na WebUI, enquanto ainda depende do processo CLI consolidado.
+
+### Endpoints de métricas locais
+
+Com `report_to=simpletuner`, liste execuções em `GET /api/metrics/training/runs` e leia uma em `GET /api/metrics/training/runs/{environment}`. Há filtros `start_step`, `end_step`, `max_points` e `metric`. Consulte [Métricas locais](../webui/LOCAL_METRICS.md).

--- a/documentation/api/TUTORIAL.zh.md
+++ b/documentation/api/TUTORIAL.zh.md
@@ -110,10 +110,10 @@ After=network.target
 [Service]
 Type=simple
 User=trainer
-WorkingDirectory=/home/trainer/simpletuner-workspace
+WorkingDirectory=/opt/simpletuner
 Environment="SIMPLETUNER_HOST=127.0.0.1"
 Environment="SIMPLETUNER_PORT=8001"
-ExecStart=/home/trainer/simpletuner-workspace/.venv/bin/simpletuner server
+ExecStart=/opt/simpletuner/.venv/bin/simpletuner server
 Restart=on-failure
 
 [Install]
@@ -914,3 +914,7 @@ curl -s -X POST http://localhost:8001/api/queue/submit \
 - **在云端 GPU 上运行训练**，通过 Replicate——参见[云端训练教程](../experimental/cloud/TUTORIAL.md)
 
 通过这些模式，您可以完全脚本化 SimpleTuner 训练而无需接触 WebUI，同时仍然依赖久经考验的 CLI 设置流程。
+
+### 本地指标 API
+
+设置 `report_to=simpletuner` 后，使用 `GET /api/metrics/training/runs` 获取列表，使用 `GET /api/metrics/training/runs/{environment}` 读取运行。支持 `start_step`、`end_step`、`max_points` 和 `metric`。参阅[本地训练指标](../webui/LOCAL_METRICS.md)。

--- a/documentation/index.es.md
+++ b/documentation/index.es.md
@@ -20,6 +20,14 @@
 
     [:octicons-arrow-right-24: Tutorial de Web UI](webui/TUTORIAL.md)
 
+-   :material-chart-line:{ .lg .middle } __Métricas locales__
+
+    ---
+
+    Guarda gráficas y comparaciones de validación con cada entrenamiento
+
+    [:octicons-arrow-right-24: Métricas locales](webui/LOCAL_METRICS.md)
+
 -   :material-closed-caption:{ .lg .middle } __CaptionFlow__
 
     ---

--- a/documentation/index.hi.md
+++ b/documentation/index.hi.md
@@ -20,6 +20,14 @@
 
     [:octicons-arrow-right-24: वेब UI ट्यूटोरियल](webui/TUTORIAL.md)
 
+-   :material-chart-line:{ .lg .middle } __स्थानीय मेट्रिक्स__
+
+    ---
+
+    हर training run के साथ scalar charts और validation comparisons रखें
+
+    [:octicons-arrow-right-24: स्थानीय प्रशिक्षण मेट्रिक्स](webui/LOCAL_METRICS.md)
+
 -   :material-closed-caption:{ .lg .middle } __CaptionFlow__
 
     ---

--- a/documentation/index.ja.md
+++ b/documentation/index.ja.md
@@ -20,6 +20,14 @@
 
     [:octicons-arrow-right-24: Web UI チュートリアル](webui/TUTORIAL.md)
 
+-   :material-chart-line:{ .lg .middle } __ローカルメトリクス__
+
+    ---
+
+    学習ごとにスカラーチャートと検証比較を保存
+
+    [:octicons-arrow-right-24: ローカル学習メトリクス](webui/LOCAL_METRICS.md)
+
 -   :material-closed-caption:{ .lg .middle } __CaptionFlow__
 
     ---

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -20,6 +20,14 @@
 
     [:octicons-arrow-right-24: Web UI Tutorial](webui/TUTORIAL.md)
 
+-   :material-chart-line:{ .lg .middle } __Local Metrics__
+
+    ---
+
+    Store scalar charts and validation comparisons with each training run
+
+    [:octicons-arrow-right-24: Local Training Metrics](webui/LOCAL_METRICS.md)
+
 -   :material-closed-caption:{ .lg .middle } __CaptionFlow__
 
     ---

--- a/documentation/index.pt-BR.md
+++ b/documentation/index.pt-BR.md
@@ -20,6 +20,14 @@
 
     [:octicons-arrow-right-24: Tutorial da Web UI](webui/TUTORIAL.md)
 
+-   :material-chart-line:{ .lg .middle } __Métricas locais__
+
+    ---
+
+    Salve gráficos e comparações de validação em cada treinamento
+
+    [:octicons-arrow-right-24: Métricas locais](webui/LOCAL_METRICS.md)
+
 -   :material-closed-caption:{ .lg .middle } __CaptionFlow__
 
     ---

--- a/documentation/index.zh.md
+++ b/documentation/index.zh.md
@@ -20,6 +20,14 @@
 
     [:octicons-arrow-right-24: Web 界面教程](webui/TUTORIAL.md)
 
+-   :material-chart-line:{ .lg .middle } __本地指标__
+
+    ---
+
+    为每次训练保存标量图表和验证对比
+
+    [:octicons-arrow-right-24: 本地训练指标](webui/LOCAL_METRICS.md)
+
 -   :material-closed-caption:{ .lg .middle } __CaptionFlow__
 
     ---

--- a/documentation/webui/LOCAL_METRICS.es.md
+++ b/documentation/webui/LOCAL_METRICS.es.md
@@ -1,0 +1,33 @@
+# Métricas locales de entrenamiento
+
+SimpleTuner puede registrar métricas sin un servicio externo. Configura:
+
+```json
+{"report_to": "simpletuner"}
+```
+
+`report_to=all` también activa el tracker local. Funciona con todas las familias de modelos y, con DDP, solo escribe el proceso principal.
+
+## Archivos de salida
+
+El directorio de salida contiene:
+
+- `training_metrics.jsonl`: escalares por paso, en formato append-only.
+- `training_metrics.json`: manifiesto atómico, estado y nombres de métricas.
+- `validation_media.jsonl`: índice de imágenes, vídeo y audio de validación.
+- `training_report.html`: informe autónomo que abre sin servidor.
+
+Una reanudación añade registros. Archiva el informe HTML junto con el directorio de salida porque usa rutas relativas para los medios.
+
+## WebUI y API
+
+Abre **Metrics** y **Training Runs** para elegir escalares, comparar validaciones por prompt/paso y abrir el informe. **System** conserva salud de GPU y Prometheus.
+
+```text
+GET /api/metrics/training/runs
+GET /api/metrics/training/runs/{environment}?max_points=2000&metric=train_loss
+GET /api/metrics/training/runs/{environment}/media/{path}
+GET /api/metrics/training/runs/{environment}/report
+```
+
+La API solo resuelve directorios de entornos configurados. Para ahorrar espacio usa `validation_image_format=webp` y `validation_image_quality=90`; PNG sigue siendo el valor predeterminado.

--- a/documentation/webui/LOCAL_METRICS.hi.md
+++ b/documentation/webui/LOCAL_METRICS.hi.md
@@ -1,0 +1,31 @@
+# स्थानीय प्रशिक्षण मेट्रिक्स
+
+SimpleTuner बाहरी सेवा के बिना प्रशिक्षण मेट्रिक्स लिख सकता है:
+
+```json
+{"report_to": "simpletuner"}
+```
+
+`report_to=all` भी स्थानीय tracker को चालू करता है। यह सभी model families पर लागू है; DDP में केवल main process फाइलें लिखता है।
+
+## आउटपुट फाइलें
+
+- `training_metrics.jsonl`: हर step के append-only scalar records।
+- `training_metrics.json`: atomic run manifest, status और metric names।
+- `validation_media.jsonl`: validation image, video और audio index।
+- `training_report.html`: बिना server के खुलने वाली self-contained report।
+
+Resume पर records जोड़े जाते हैं। HTML relative media paths उपयोग करता है, इसलिए इसे output directory के साथ archive करें।
+
+## WebUI और API
+
+**Metrics** में **Training Runs** खोलें। यहाँ scalar चुन सकते हैं, prompt/step के अनुसार validation तुलना कर सकते हैं और offline report खोल सकते हैं। **System** में GPU health और Prometheus configuration रहती है।
+
+```text
+GET /api/metrics/training/runs
+GET /api/metrics/training/runs/{environment}?max_points=2000&metric=train_loss
+GET /api/metrics/training/runs/{environment}/media/{path}
+GET /api/metrics/training/runs/{environment}/report
+```
+
+API केवल configured environments के output directories पढ़ती है। छोटी archive के लिए `validation_image_format=webp` और `validation_image_quality=90` उपयोग करें; default PNG है।

--- a/documentation/webui/LOCAL_METRICS.ja.md
+++ b/documentation/webui/LOCAL_METRICS.ja.md
@@ -1,0 +1,31 @@
+# ローカル学習メトリクス
+
+外部サービスなしでメトリクスを保存できます。
+
+```json
+{"report_to": "simpletuner"}
+```
+
+`report_to=all` でもローカルトラッカーが有効になります。全モデルファミリーで共通に動作し、DDP ではメインプロセスだけが書き込みます。
+
+## 出力ファイル
+
+- `training_metrics.jsonl`: step ごとの追記専用スカラー記録
+- `training_metrics.json`: 状態、メトリクス名、設定を含むアトミックなマニフェスト
+- `validation_media.jsonl`: 検証画像・動画・音声のインデックス
+- `training_report.html`: サーバーなしで開ける自己完結レポート
+
+再開時は既存履歴へ追記します。HTML は相対メディアパスを使うため、出力ディレクトリと一緒に保存してください。
+
+## WebUI と API
+
+**Metrics** の **Training Runs** でスカラーを選択し、prompt と step ごとに検証結果を比較できます。**System** には GPU health と Prometheus 設定があります。
+
+```text
+GET /api/metrics/training/runs
+GET /api/metrics/training/runs/{environment}?max_points=2000&metric=train_loss
+GET /api/metrics/training/runs/{environment}/media/{path}
+GET /api/metrics/training/runs/{environment}/report
+```
+
+API は設定済み environment の出力だけを参照します。容量を減らすには `validation_image_format=webp` と `validation_image_quality=90` を使います。既定値は PNG です。

--- a/documentation/webui/LOCAL_METRICS.md
+++ b/documentation/webui/LOCAL_METRICS.md
@@ -1,0 +1,63 @@
+# Local training metrics
+
+SimpleTuner can record training metrics without an external tracking service. Set:
+
+```json
+{
+  "report_to": "simpletuner"
+}
+```
+
+`report_to=all` also enables the local tracker. The tracker is model-independent and receives the same scalar calls used by the other Accelerate trackers.
+
+## Output contract
+
+The training output directory contains:
+
+| File | Purpose |
+| --- | --- |
+| `training_metrics.jsonl` | Append-only scalar records with step and UTC timestamp |
+| `training_metrics.json` | Atomic run manifest, metric names, status, and selected configuration values |
+| `validation_media.jsonl` | Indexed validation image, video, and audio paths |
+| `training_report.html` | Self-contained report that opens without a server |
+
+The JSONL files are the raw interface for analysis tools. A resumed run appends records instead of replacing them. Under DDP, only the main process writes these files.
+
+The HTML report embeds a bounded copy of the scalar history and uses relative paths for validation media. Archive it with the output directory.
+
+## WebUI
+
+Open **Metrics**, then **Training Runs**. Runs are discovered from saved WebUI environments. The page provides:
+
+- dynamic scalar selection, up to eight series
+- latest values and step history
+- validation comparison by prompt and training step
+- a link to the offline report
+
+The **System** section retains GPU health and Prometheus configuration.
+
+## Validation image storage
+
+PNG remains the default. For smaller archives, set:
+
+```json
+{
+  "validation_image_format": "webp",
+  "validation_image_quality": 90
+}
+```
+
+`validation_image_quality` applies to WebP and JPEG. Audio and video keep their existing formats.
+
+## API
+
+All endpoints require normal WebUI authentication:
+
+```text
+GET /api/metrics/training/runs
+GET /api/metrics/training/runs/{environment}?max_points=2000&metric=train_loss
+GET /api/metrics/training/runs/{environment}/media/{path}
+GET /api/metrics/training/runs/{environment}/report
+```
+
+The API resolves output directories from configured environments. It does not accept arbitrary filesystem paths. Scalar reads can be bounded by `start_step`, `end_step`, `max_points`, and repeated `metric` parameters.

--- a/documentation/webui/LOCAL_METRICS.pt-BR.md
+++ b/documentation/webui/LOCAL_METRICS.pt-BR.md
@@ -1,0 +1,31 @@
+# Métricas locais de treinamento
+
+O SimpleTuner pode registrar métricas sem um serviço externo. Configure:
+
+```json
+{"report_to": "simpletuner"}
+```
+
+`report_to=all` também ativa o tracker local. Ele funciona com todas as famílias de modelos e, em DDP, somente o processo principal grava os arquivos.
+
+## Arquivos de saída
+
+- `training_metrics.jsonl`: escalares por etapa, somente anexados.
+- `training_metrics.json`: manifesto atômico, status e nomes das métricas.
+- `validation_media.jsonl`: índice de imagens, vídeos e áudios de validação.
+- `training_report.html`: relatório autônomo que abre sem servidor.
+
+Ao retomar, novos registros são anexados. Arquive o HTML com o diretório de saída, pois os caminhos de mídia são relativos.
+
+## WebUI e API
+
+Abra **Metrics** e **Training Runs** para selecionar escalares, comparar validações por prompt/etapa e abrir o relatório. **System** mantém a saúde das GPUs e a configuração do Prometheus.
+
+```text
+GET /api/metrics/training/runs
+GET /api/metrics/training/runs/{environment}?max_points=2000&metric=train_loss
+GET /api/metrics/training/runs/{environment}/media/{path}
+GET /api/metrics/training/runs/{environment}/report
+```
+
+A API resolve apenas diretórios de ambientes configurados. Para reduzir o arquivo, use `validation_image_format=webp` e `validation_image_quality=90`; PNG continua sendo o padrão.

--- a/documentation/webui/LOCAL_METRICS.zh.md
+++ b/documentation/webui/LOCAL_METRICS.zh.md
@@ -1,0 +1,31 @@
+# 本地训练指标
+
+SimpleTuner 可以在不使用外部服务的情况下记录训练指标：
+
+```json
+{"report_to": "simpletuner"}
+```
+
+`report_to=all` 也会启用本地 tracker。它适用于所有模型系列；在 DDP 下仅主进程写入文件。
+
+## 输出文件
+
+- `training_metrics.jsonl`：按 step 追加的标量记录。
+- `training_metrics.json`：原子写入的运行清单、状态和指标名称。
+- `validation_media.jsonl`：验证图像、视频和音频索引。
+- `training_report.html`：无需服务器即可打开的独立报告。
+
+恢复训练时会追加记录。HTML 使用相对媒体路径，因此应与输出目录一起归档。
+
+## WebUI 与 API
+
+打开 **Metrics** 和 **Training Runs**，可选择标量、按 prompt/step 比较验证结果并打开离线报告。**System** 保留 GPU 健康和 Prometheus 设置。
+
+```text
+GET /api/metrics/training/runs
+GET /api/metrics/training/runs/{environment}?max_points=2000&metric=train_loss
+GET /api/metrics/training/runs/{environment}/media/{path}
+GET /api/metrics/training/runs/{environment}/report
+```
+
+API 只解析已配置 environment 的输出目录。若要减小归档大小，可设置 `validation_image_format=webp` 和 `validation_image_quality=90`；默认仍为 PNG。

--- a/documentation/webui/TUTORIAL.es.md
+++ b/documentation/webui/TUTORIAL.es.md
@@ -358,3 +358,7 @@ En la página **Environment**, verás el trabajo de entrenamiento recién config
 **NOTA**: El entorno **Default** es especial y no se recomienda usarlo como entorno de entrenamiento general; su configuración puede combinarse automáticamente en cualquier entorno que habilite la opción **Use environment defaults**:
 
 <img width="1521" height="991" alt="image" src="https://github.com/user-attachments/assets/9d18b0c1-608e-4ab2-be14-65b98907ec69" />
+
+## Métricas locales de entrenamiento
+
+Elige **SimpleTuner (Local)** como plataforma de logging y abre **Metrics → Training Runs**. Consulta [Métricas locales](LOCAL_METRICS.md) para conocer los archivos, el informe offline, la compresión y la API.

--- a/documentation/webui/TUTORIAL.hi.md
+++ b/documentation/webui/TUTORIAL.hi.md
@@ -358,3 +358,7 @@ consumer हार्डवेयर पर सेटअप आसान बन�
 **नोट**: **Default** environment विशेष है, और इसे सामान्य training environment के रूप में उपयोग करने की सलाह नहीं है; इसकी settings को किसी भी environment में स्वचालित रूप से merge किया जा सकता है जो **Use environment defaults** विकल्प सक्षम करता है:
 
 <img width="1521" height="991" alt="image" src="https://github.com/user-attachments/assets/9d18b0c1-608e-4ab2-be14-65b98907ec69" />
+
+## स्थानीय प्रशिक्षण मेट्रिक्स
+
+Logging platform में **SimpleTuner (Local)** चुनें और **Metrics → Training Runs** खोलें। Files, offline report, compression और API के लिए [स्थानीय मेट्रिक्स](LOCAL_METRICS.md) देखें।

--- a/documentation/webui/TUTORIAL.ja.md
+++ b/documentation/webui/TUTORIAL.ja.md
@@ -358,3 +358,7 @@ effective_batch_size = train_batch_size × num_gpus × gradient_accumulation_ste
 **注意**: **デフォルト**環境は特別であり、一般的なトレーニング環境として使用することは推奨されません。その設定は、そのオプションを有効にする任意の環境に自動的にマージできます、**環境のデフォルトを使用**:
 
 <img width="1521" height="991" alt="image" src="https://github.com/user-attachments/assets/9d18b0c1-608e-4ab2-be14-65b98907ec69" />
+
+## ローカル学習メトリクス
+
+logging platform に **SimpleTuner (Local)** を選び、**Metrics → Training Runs** を開きます。ファイル、offline report、圧縮、API は [ローカル学習メトリクス](LOCAL_METRICS.md) を参照してください。

--- a/documentation/webui/TUTORIAL.md
+++ b/documentation/webui/TUTORIAL.md
@@ -359,3 +359,7 @@ On the **Environment** page, you'll see the newly-configured training job, and b
 **NOTE**: The **Default** environment is special, and not recommended for use as a general training environment; its settings can be automatically merged into any environment that enables the option to do so, **Use environment defaults**:
 
 <img width="1521" height="991" alt="image" src="https://github.com/user-attachments/assets/9d18b0c1-608e-4ab2-be14-65b98907ec69" />
+
+## Local training metrics
+
+Choose **SimpleTuner (Local)** as the logging platform to record scalar charts and validation media in the output directory. Open **Metrics → Training Runs** to inspect them. See [Local training metrics](LOCAL_METRICS.md) for the file contract, offline report, compression options, and API.

--- a/documentation/webui/TUTORIAL.pt-BR.md
+++ b/documentation/webui/TUTORIAL.pt-BR.md
@@ -357,3 +357,7 @@ Na pagina **Environment**, voce vera o job configurado e botoes para baixar ou d
 **NOTA**: O ambiente **Default** e especial e nao e recomendado como ambiente de treinamento geral; suas configuracoes podem ser mescladas automaticamente a qualquer ambiente que habilite a opcao **Use environment defaults**:
 
 <img width="1521" height="991" alt="image" src="https://github.com/user-attachments/assets/9d18b0c1-608e-4ab2-be14-65b98907ec69" />
+
+## Métricas locais de treinamento
+
+Escolha **SimpleTuner (Local)** como plataforma de logging e abra **Metrics → Training Runs**. Consulte [Métricas locais](LOCAL_METRICS.md) para ver os arquivos, relatório offline, compressão e API.

--- a/documentation/webui/TUTORIAL.zh.md
+++ b/documentation/webui/TUTORIAL.zh.md
@@ -358,3 +358,7 @@ effective_batch_size = train_batch_size × num_gpus × gradient_accumulation_ste
 **注意**：**默认**环境是特殊的，不建议用作通用训练环境；它的设置可以自动合并到任何启用了**使用环境默认值**选项的环境中：
 
 <img width="1521" height="991" alt="image" src="https://github.com/user-attachments/assets/9d18b0c1-608e-4ab2-be14-65b98907ec69" />
+
+## 本地训练指标
+
+选择 **SimpleTuner (Local)** 作为 logging platform，然后打开 **Metrics → Training Runs**。文件格式、离线报告、压缩和 API 请参阅[本地训练指标](LOCAL_METRICS.md)。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ plugins:
             Getting Started: 入门指南
             Installation: 安装
             Quick Start: 快速开始
+            Local Training Metrics: 本地训练指标
             Tutorials: 教程
             Model Guides: 模型指南
             Image Models: 图像模型
@@ -87,6 +88,7 @@ plugins:
             Getting Started: はじめに
             Installation: インストール
             Quick Start: クイックスタート
+            Local Training Metrics: ローカル学習メトリクス
             Tutorials: チュートリアル
             Model Guides: モデルガイド
             Image Models: 画像モデル
@@ -105,6 +107,7 @@ plugins:
             Getting Started: शुरुआत
             Installation: स्थापना
             Quick Start: त्वरित शुरुआत
+            Local Training Metrics: स्थानीय प्रशिक्षण मेट्रिक्स
             Tutorials: ट्यूटोरियल
             Model Guides: मॉडल गाइड
             Image Models: इमेज मॉडल
@@ -142,6 +145,7 @@ plugins:
             Getting Started: Primeiros passos
             Installation: Instalacao
             Quick Start: Inicio rapido
+            Local Training Metrics: Metricas locais de treinamento
             Tutorials: Tutoriais
             Model Guides: Guias de modelos
             Image Models: Modelos de imagem
@@ -164,6 +168,7 @@ plugins:
             Getting Started: Primeros pasos
             Installation: Instalación
             Quick Start: Inicio rápido
+            Local Training Metrics: Métricas locales de entrenamiento
             Tutorials: Tutoriales
             Model Guides: Guías de modelos
             Image Models: Modelos de imagen
@@ -237,6 +242,7 @@ nav:
     - Quick Start: QUICKSTART.md
     - Tutorials:
       - Web UI Tutorial: webui/TUTORIAL.md
+      - Local Training Metrics: webui/LOCAL_METRICS.md
       - CLI Tutorial: TUTORIAL.md
       - API Tutorial: api/TUTORIAL.md
 

--- a/simpletuner/helpers/training/local_metrics.py
+++ b/simpletuner/helpers/training/local_metrics.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from accelerate.tracking import GeneralTracker
+
+SCHEMA_VERSION = 1
+METRICS_FILENAME = "training_metrics.jsonl"
+MANIFEST_FILENAME = "training_metrics.json"
+MEDIA_FILENAME = "validation_media.jsonl"
+REPORT_FILENAME = "training_report.html"
+REPORT_REFRESH_INTERVAL = 100
+
+_CONFIG_KEYS = (
+    "model_family",
+    "model_flavour",
+    "model_type",
+    "pretrained_model_name_or_path",
+    "optimizer",
+    "learning_rate",
+    "lr_scheduler",
+    "lr_warmup_steps",
+    "train_batch_size",
+    "gradient_accumulation_steps",
+    "max_train_steps",
+    "num_train_epochs",
+    "seed",
+    "resolution",
+    "validation_resolution",
+)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(f"{path.suffix}.tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def _append_json_line(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n")
+        handle.flush()
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+
+    content = path.read_text(encoding="utf-8")
+    records = []
+    lines = content.splitlines()
+    for index, line in enumerate(lines):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            is_torn_final_write = index == len(lines) - 1 and not content.endswith("\n")
+            if is_torn_final_write:
+                break
+            raise
+        if not isinstance(record, dict):
+            raise ValueError(f"Expected an object in {path.name} at line {index + 1}.")
+        records.append(record)
+    return records
+
+
+def read_manifest(output_dir: str | os.PathLike[str]) -> dict[str, Any]:
+    path = Path(output_dir) / MANIFEST_FILENAME
+    if not path.is_file():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{MANIFEST_FILENAME} must contain a JSON object.")
+    return payload
+
+
+def read_metric_records(output_dir: str | os.PathLike[str]) -> list[dict[str, Any]]:
+    return read_jsonl(Path(output_dir) / METRICS_FILENAME)
+
+
+def read_media_records(output_dir: str | os.PathLike[str]) -> list[dict[str, Any]]:
+    return read_jsonl(Path(output_dir) / MEDIA_FILENAME)
+
+
+def downsample_records(records: list[dict[str, Any]], max_points: int) -> list[dict[str, Any]]:
+    if max_points < 2:
+        raise ValueError("max_points must be at least 2.")
+    if len(records) <= max_points:
+        return records
+
+    last_index = len(records) - 1
+    selected = {round(index * last_index / (max_points - 1)) for index in range(max_points)}
+    return [records[index] for index in sorted(selected)]
+
+
+def is_local_metrics_enabled(report_to: Any) -> bool:
+    if isinstance(report_to, str):
+        values = [part.strip().lower() for part in report_to.split(",")]
+    elif isinstance(report_to, (list, tuple, set)):
+        values = [str(part).strip().lower() for part in report_to]
+    else:
+        return False
+    return "simpletuner" in values or "all" in values
+
+
+def _coerce_scalar(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        result = float(value)
+    elif hasattr(value, "numel") and callable(value.numel) and value.numel() == 1:
+        result = float(value.detach().item()) if hasattr(value, "detach") else float(value.item())
+    elif hasattr(value, "item") and callable(value.item):
+        try:
+            result = float(value.item())
+        except (TypeError, ValueError):
+            return None
+    else:
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _filtered_config(values: dict[str, Any]) -> dict[str, Any]:
+    return {key: values[key] for key in _CONFIG_KEYS if values.get(key) is not None}
+
+
+def _media_for_report(output_dir: Path) -> list[dict[str, Any]]:
+    media = []
+    for record in read_media_records(output_dir):
+        relative_path = record.get("path")
+        if not isinstance(relative_path, str):
+            continue
+        path = (output_dir / relative_path).resolve()
+        if path.is_file() and path.is_relative_to(output_dir.resolve()):
+            media.append(record)
+    return media
+
+
+def _json_for_html(payload: Any) -> str:
+    return (
+        json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+    )
+
+
+def render_static_report(output_dir: str | os.PathLike[str], max_points: int = 5000) -> Path:
+    output_path = Path(output_dir).resolve()
+    package_root = Path(__file__).resolve().parents[2]
+    template_path = package_root / "templates" / "training_metrics_report.html"
+    chart_script_path = package_root / "static" / "js" / "training_metrics_chart.js"
+    chart_style_path = package_root / "static" / "css" / "training_metrics_report.css"
+
+    records = downsample_records(read_metric_records(output_path), max_points=max_points)
+    payload = {
+        "run": read_manifest(output_path),
+        "records": records,
+        "media": _media_for_report(output_path),
+    }
+    html = template_path.read_text(encoding="utf-8")
+    html = html.replace("__SIMPLETUNER_REPORT_CSS__", chart_style_path.read_text(encoding="utf-8"))
+    html = html.replace("__SIMPLETUNER_REPORT_DATA__", _json_for_html(payload))
+    html = html.replace("__SIMPLETUNER_CHART_JS__", chart_script_path.read_text(encoding="utf-8"))
+    report_path = output_path / REPORT_FILENAME
+    temporary = report_path.with_suffix(".html.tmp")
+    temporary.write_text(html, encoding="utf-8")
+    os.replace(temporary, report_path)
+    return report_path
+
+
+def record_validation_media(
+    config: Any,
+    media_path: str | os.PathLike[str],
+    *,
+    media_type: str,
+    label: str,
+    index: int,
+    resolution: Optional[str] = None,
+) -> None:
+    if config is None or not is_local_metrics_enabled(getattr(config, "report_to", None)):
+        return
+
+    output_dir = Path(getattr(config, "output_dir")).expanduser().resolve()
+    path = Path(media_path).resolve()
+    if not path.is_relative_to(output_dir):
+        raise ValueError("Validation media for local metrics must be inside output_dir.")
+    _append_json_line(
+        output_dir / MEDIA_FILENAME,
+        {
+            "schema_version": SCHEMA_VERSION,
+            "timestamp": _utc_now(),
+            "step": int(_state_tracker_step()),
+            "type": media_type,
+            "label": str(label),
+            "index": int(index),
+            "resolution": resolution,
+            "path": path.relative_to(output_dir).as_posix(),
+        },
+    )
+
+
+def _state_tracker_step() -> int:
+    from simpletuner.helpers.training.state_tracker import StateTracker
+
+    return StateTracker.get_global_step()
+
+
+class LocalMetricsTracker(GeneralTracker):
+    name = "simpletuner"
+    requires_logging_directory = False
+    main_process_only = True
+
+    def __init__(self, run_name: str, output_dir: str, project_name: str):
+        super().__init__()
+        self.run_name = run_name
+        self.project_name = project_name
+        self.output_dir = Path(output_dir).expanduser().resolve()
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.metrics_path = self.output_dir / METRICS_FILENAME
+        self.manifest_path = self.output_dir / MANIFEST_FILENAME
+        self._manifest = read_manifest(self.output_dir)
+        self._metric_names = set(self._manifest.get("metric_names", []))
+        self._record_count = int(self._manifest.get("record_count", 0) or 0)
+
+    @property
+    def tracker(self):
+        return self
+
+    def store_init_configuration(self, values: dict[str, Any]) -> None:
+        now = _utc_now()
+        self._manifest = {
+            "schema_version": SCHEMA_VERSION,
+            "run_name": self.run_name,
+            "project_name": self.project_name,
+            "status": "running",
+            "created_at": self._manifest.get("created_at", now),
+            "updated_at": now,
+            "last_step": self._manifest.get("last_step"),
+            "record_count": self._record_count,
+            "metric_names": sorted(self._metric_names),
+            "config": _filtered_config(values),
+        }
+        self._write_manifest()
+        render_static_report(self.output_dir)
+
+    def log(self, values: dict[str, Any], step: Optional[int] = None, **kwargs) -> None:
+        metrics = {}
+        for key, value in values.items():
+            scalar = _coerce_scalar(value)
+            if scalar is not None:
+                metrics[str(key)] = scalar
+        if not metrics:
+            return
+
+        resolved_step = int(step) if step is not None else self._record_count
+        _append_json_line(
+            self.metrics_path,
+            {
+                "schema_version": SCHEMA_VERSION,
+                "timestamp": _utc_now(),
+                "step": resolved_step,
+                "metrics": metrics,
+            },
+        )
+        self._record_count += 1
+        self._metric_names.update(metrics)
+        self._manifest.update(
+            {
+                "status": "running",
+                "updated_at": _utc_now(),
+                "last_step": resolved_step,
+                "record_count": self._record_count,
+                "metric_names": sorted(self._metric_names),
+            }
+        )
+        self._write_manifest()
+        if self._record_count == 1 or self._record_count % REPORT_REFRESH_INTERVAL == 0:
+            render_static_report(self.output_dir)
+
+    def finish(self) -> None:
+        self._manifest.update({"status": "completed", "updated_at": _utc_now()})
+        self._write_manifest()
+        render_static_report(self.output_dir)
+
+    def _write_manifest(self) -> None:
+        _atomic_write_json(self.manifest_path, self._manifest)

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -74,6 +74,7 @@ from simpletuner.helpers.training.evaluation import ModelEvaluator
 from simpletuner.helpers.training.exceptions import GPUHealthError
 from simpletuner.helpers.training.gpu_circuit_breaker import get_current_gpu_index, get_gpu_circuit_breaker, is_cuda_error
 from simpletuner.helpers.training.iteration_tracker import IterationTracker
+from simpletuner.helpers.training.local_metrics import LocalMetricsTracker
 from simpletuner.helpers.training.min_snr_gamma import compute_snr
 from simpletuner.helpers.training.multi_process import _get_rank as get_rank
 from simpletuner.helpers.training.multi_process import broadcast_object_from_main, should_log
@@ -914,10 +915,11 @@ class Trainer:
             custom_tracker_name = None
         setattr(self.config, "custom_tracker", custom_tracker_name)
 
-        _, tracker_run_name = self._resolve_tracker_identifiers()
+        tracker_project_name, tracker_run_name = self._resolve_tracker_identifiers()
         logging_dir_value = getattr(self.config, "logging_dir", None)
 
         custom_tracker_instance: Optional[GeneralTracker] = None
+        local_metrics_tracker: Optional[LocalMetricsTracker] = None
 
         def _ensure_custom_tracker() -> GeneralTracker:
             nonlocal custom_tracker_instance
@@ -928,6 +930,17 @@ class Trainer:
             custom_tracker_instance = self._load_custom_tracker(custom_tracker_name, tracker_run_name, logging_dir_value)
             self.custom_tracker = custom_tracker_instance
             return custom_tracker_instance
+
+        def _ensure_local_metrics_tracker() -> LocalMetricsTracker:
+            nonlocal local_metrics_tracker
+            if local_metrics_tracker is None:
+                local_metrics_tracker = LocalMetricsTracker(
+                    run_name=tracker_run_name,
+                    project_name=tracker_project_name,
+                    output_dir=self.config.output_dir,
+                )
+                self.local_metrics_tracker = local_metrics_tracker
+            return local_metrics_tracker
 
         checkpoint_step_interval_value = getattr(self.config, "checkpoint_step_interval", None)
         if checkpoint_step_interval_value in (None, "", "None", 0):
@@ -950,15 +963,28 @@ class Trainer:
                 report_to = None
             elif normalized_report == "custom-tracker":
                 report_to = _ensure_custom_tracker()
+            elif normalized_report == "simpletuner":
+                report_to = _ensure_local_metrics_tracker()
+            elif normalized_report == "all":
+                report_to = [_ensure_local_metrics_tracker(), "all"]
             else:
                 report_to = report_to_value.strip()
         elif isinstance(report_to_value, (list, tuple)):
             resolved_trackers: List[object] = []
             for entry in report_to_value:
-                if isinstance(entry, str) and entry.strip().lower() == "custom-tracker":
-                    resolved_trackers.append(_ensure_custom_tracker())
+                normalized_entry = entry.strip().lower() if isinstance(entry, str) else None
+                if normalized_entry == "custom-tracker":
+                    tracker = _ensure_custom_tracker()
+                elif normalized_entry == "simpletuner":
+                    tracker = _ensure_local_metrics_tracker()
                 else:
-                    resolved_trackers.append(entry)
+                    tracker = entry
+                if tracker not in resolved_trackers:
+                    resolved_trackers.append(tracker)
+            if any(isinstance(entry, str) and entry.strip().lower() == "all" for entry in report_to_value):
+                tracker = _ensure_local_metrics_tracker()
+                if tracker not in resolved_trackers:
+                    resolved_trackers.insert(0, tracker)
             report_to = resolved_trackers
         else:
             report_to = report_to_value

--- a/simpletuner/helpers/training/validation.py
+++ b/simpletuner/helpers/training/validation.py
@@ -4034,6 +4034,7 @@ class Validation:
                     self.save_dir,
                     validation_audios,
                     decorated_shortname,
+                    config=self.config,
                 )
                 validation_audio.log_audio_to_webhook(
                     validation_audios,
@@ -4046,6 +4047,7 @@ class Validation:
                     validation_audios,
                     decorated_shortname,
                     sample_rate=sample_rate,
+                    config=self.config,
                 )
                 validation_audio.log_audio_to_webhook(
                     validation_audios,
@@ -5129,60 +5131,6 @@ class Validation:
             ema_validation_images,
             validation_audio_results,
         )
-
-    def _save_videos(self, validation_images, validation_shortname, validation_prompt):
-        validation_img_idx = 0
-        from diffusers.utils.export_utils import export_to_video
-
-        video_paths: list[str] = []
-        for validation_image in validation_images[validation_shortname]:
-            # Get the validation resolution for this index
-            if validation_img_idx < len(self.validation_resolutions):
-                resolution = self.validation_resolutions[validation_img_idx]
-                if isinstance(resolution, str):
-                    if "x" in resolution:
-                        res_label = resolution
-                    else:
-                        res_label = f"{resolution}x{resolution}"
-                elif isinstance(resolution, tuple):
-                    res_label = f"{resolution[0]}x{resolution[1]}"
-                else:
-                    res_label = f"{resolution}x{resolution}"
-            else:
-                # Fallback to actual size if somehow out of bounds
-                logger.warning(f"Image index {validation_img_idx} exceeds validation resolutions list")
-                if type(validation_image) is list:
-                    size_x, size_y = validation_image[0].size
-                else:
-                    size_x, size_y = validation_image.size
-                res_label = f"{size_x}x{size_y}"
-
-            # convert array of numpy to array of pil:
-            validation_image = MultiaspectImage.numpy_list_to_pil(validation_image)
-            if type(validation_image) is not list:
-                # save as single image instead
-                validation_image.save(
-                    os.path.join(
-                        self.save_dir,
-                        f"step_{StateTracker.get_global_step()}_{validation_shortname}_{validation_img_idx}_{res_label}.png",
-                    )
-                )
-                validation_img_idx += 1
-                continue
-
-            video_path = os.path.join(
-                self.save_dir,
-                f"step_{StateTracker.get_global_step()}_{validation_shortname}_{validation_img_idx}_{res_label}.mp4",
-            )
-            export_to_video(
-                validation_image,
-                video_path,
-                fps=int(getattr(self.config, "framerate", None) or 16),
-            )
-            video_paths.append(video_path)
-            validation_img_idx += 1
-        if video_paths:
-            self.validation_video_paths[validation_shortname] = video_paths
 
     def _log_validations_to_trackers(self, validation_images, validation_audios=None):
         if isinstance(self.model, AudioModelFoundation):

--- a/simpletuner/helpers/training/validation_audio.py
+++ b/simpletuner/helpers/training/validation_audio.py
@@ -9,12 +9,13 @@ import scipy.io.wavfile
 import torch
 import wandb
 
+from simpletuner.helpers.training.local_metrics import record_validation_media
 from simpletuner.helpers.training.state_tracker import StateTracker
 
 logger = logging.getLogger(__name__)
 
 
-def save_audio(save_dir, validation_audios, validation_shortname, sample_rate=44100):
+def save_audio(save_dir, validation_audios, validation_shortname, sample_rate=44100, config=None):
     """
     Save validation audio to disk using scipy (no torchcodec dependency).
     validation_audios: dict where key is shortname, value is list of audio tensors (C, T) or (T,)
@@ -49,6 +50,13 @@ def save_audio(save_dir, validation_audios, validation_shortname, sample_rate=44
                 f"min={audio_np.min()}, max={audio_np.max()}"
             )
             scipy.io.wavfile.write(save_path, sample_rate, audio_np)
+            record_validation_media(
+                config,
+                save_path,
+                media_type="audio",
+                label=validation_shortname,
+                index=idx,
+            )
             saved_paths.append(save_path)
         except Exception as e:
             logger.error(f"Failed to save validation audio to {save_path}: {e}")

--- a/simpletuner/helpers/training/validation_images.py
+++ b/simpletuner/helpers/training/validation_images.py
@@ -5,9 +5,46 @@ import numpy as np
 import wandb
 from PIL import Image
 
+from simpletuner.helpers.training.local_metrics import record_validation_media
 from simpletuner.helpers.training.state_tracker import StateTracker
 
 logger = logging.getLogger(__name__)
+
+
+def save_validation_image(
+    image,
+    save_dir,
+    filename_stem,
+    config,
+    *,
+    label,
+    index,
+    resolution,
+):
+    image_format = str(getattr(config, "validation_image_format", "png") or "png").lower()
+    if image_format not in {"png", "webp", "jpeg"}:
+        raise ValueError("validation_image_format must be one of: png, webp, jpeg.")
+    configured_quality = getattr(config, "validation_image_quality", 90)
+    quality = 90 if configured_quality is None else int(configured_quality)
+    if not 1 <= quality <= 100:
+        raise ValueError("validation_image_quality must be within [1, 100].")
+
+    extension = "jpg" if image_format == "jpeg" else image_format
+    save_path = os.path.join(save_dir, f"{filename_stem}.{extension}")
+    save_image = image.convert("RGB") if image_format == "jpeg" and getattr(image, "mode", None) != "RGB" else image
+    save_kwargs = {"format": image_format.upper()}
+    if image_format in {"webp", "jpeg"}:
+        save_kwargs["quality"] = quality
+    save_image.save(save_path, **save_kwargs)
+    record_validation_media(
+        config,
+        save_path,
+        media_type="image",
+        label=label,
+        index=index,
+        resolution=resolution,
+    )
+    return save_path
 
 
 def save_images(save_dir, validation_images, validation_shortname, validation_resolutions, config):
@@ -33,13 +70,20 @@ def save_images(save_dir, validation_images, validation_shortname, validation_re
             else:
                 res_label = f"{res}x{res}"
 
-        filename = f"step_{StateTracker.get_global_step()}_{validation_shortname}_{validation_img_idx}_{res_label}.png"
-        save_path = os.path.join(save_dir, filename)
+        filename_stem = f"step_{StateTracker.get_global_step()}_{validation_shortname}_{validation_img_idx}_{res_label}"
 
         try:
-            validation_image.save(save_path)
+            save_validation_image(
+                validation_image,
+                save_dir,
+                filename_stem,
+                config,
+                label=validation_shortname,
+                index=validation_img_idx,
+                resolution=res_label,
+            )
         except Exception as e:
-            logger.error(f"Failed to save validation image to {save_path}: {e}")
+            logger.error(f"Failed to save validation image {filename_stem}: {e}")
 
         validation_img_idx += 1
 

--- a/simpletuner/helpers/training/validation_video.py
+++ b/simpletuner/helpers/training/validation_video.py
@@ -15,6 +15,8 @@ from PIL import Image
 
 from simpletuner.helpers.multiaspect.image import MultiaspectImage
 from simpletuner.helpers.training import validation_audio
+from simpletuner.helpers.training import validation_images as validation_images_utils
+from simpletuner.helpers.training.local_metrics import record_validation_media
 from simpletuner.helpers.training.state_tracker import StateTracker
 
 logger = logging.getLogger(__name__)
@@ -108,6 +110,7 @@ def save_videos(
             validation_audios,
             validation_shortname,
             sample_rate=audio_sample_rate,
+            config=config,
         )
         return audio_paths
 
@@ -146,12 +149,19 @@ def save_videos(
 
         if not isinstance(validation_image, list):
             # save as single image instead
-            filename = f"step_{StateTracker.get_global_step()}_{validation_shortname}_{validation_img_idx}_{res_label}.png"
-            save_path = os.path.join(save_dir, filename)
+            filename_stem = f"step_{StateTracker.get_global_step()}_{validation_shortname}_{validation_img_idx}_{res_label}"
             try:
-                validation_image.save(save_path)
+                validation_images_utils.save_validation_image(
+                    validation_image,
+                    save_dir,
+                    filename_stem,
+                    config,
+                    label=validation_shortname,
+                    index=validation_img_idx,
+                    resolution=res_label,
+                )
             except Exception as e:
-                logger.error(f"Failed to save validation image to {save_path}: {e}")
+                logger.error(f"Failed to save validation image {filename_stem}: {e}")
             validation_img_idx += 1
             continue
 
@@ -167,6 +177,14 @@ def save_videos(
             video_paths.append(video_path)
             if audio_list is not None:
                 _mux_audio_into_video(video_path, audio_list[validation_img_idx], audio_sample_rate)
+            record_validation_media(
+                config,
+                video_path,
+                media_type="video",
+                label=validation_shortname,
+                index=validation_img_idx,
+                resolution=res_label,
+            )
         except Exception as e:
             logger.error(f"Failed to save validation video to {video_path}: {e}")
 

--- a/simpletuner/simpletuner_sdk/server/routes/metrics.py
+++ b/simpletuner/simpletuner_sdk/server/routes/metrics.py
@@ -10,11 +10,16 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
 from simpletuner.simpletuner_sdk.server.services.cloud.auth.middleware import get_current_user
 from simpletuner.simpletuner_sdk.server.services.cloud.auth.models import User
+from simpletuner.simpletuner_sdk.server.services.training_metrics_service import (
+    TRAINING_METRICS_SERVICE,
+    TrainingMetricsServiceError,
+)
 
 from .cloud._shared import (
     BillingResponse,
@@ -35,6 +40,62 @@ router = APIRouter(prefix="/api/metrics", tags=["metrics"])
 from .cloud.metrics_config import router as metrics_config_router
 
 router.include_router(metrics_config_router, prefix="/config")
+
+
+def _call_training_metrics_service(func, *args, **kwargs):
+    try:
+        return func(*args, **kwargs)
+    except TrainingMetricsServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+
+
+@router.get("/training/runs")
+async def list_training_runs(
+    _user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """List saved environments containing SimpleTuner local metrics."""
+    return _call_training_metrics_service(TRAINING_METRICS_SERVICE.list_runs)
+
+
+@router.get("/training/runs/{environment}")
+async def get_training_run(
+    environment: str,
+    start_step: Optional[int] = Query(None, ge=0),
+    end_step: Optional[int] = Query(None, ge=0),
+    max_points: int = Query(2000, ge=2, le=10000),
+    metric: Optional[List[str]] = Query(None),
+    _user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """Read bounded scalar history and validation media for one environment."""
+    if start_step is not None and end_step is not None and start_step > end_step:
+        raise HTTPException(status_code=400, detail="start_step must be less than or equal to end_step.")
+    return _call_training_metrics_service(
+        TRAINING_METRICS_SERVICE.get_run,
+        environment,
+        start_step=start_step,
+        end_step=end_step,
+        max_points=max_points,
+        metric_names=metric,
+    )
+
+
+@router.get("/training/runs/{environment}/media/{relative_path:path}")
+async def get_training_run_media(
+    environment: str,
+    relative_path: str,
+    _user: User = Depends(get_current_user),
+):
+    path = _call_training_metrics_service(TRAINING_METRICS_SERVICE.media_path, environment, relative_path)
+    return FileResponse(path)
+
+
+@router.get("/training/runs/{environment}/report")
+async def get_training_run_report(
+    environment: str,
+    _user: User = Depends(get_current_user),
+):
+    path = _call_training_metrics_service(TRAINING_METRICS_SERVICE.report_path, environment)
+    return FileResponse(path, media_type="text/html")
 
 
 async def check_cost_limit(store, provider: str) -> CostLimitStatusResponse:

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/logging_fields.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/logging_fields.py
@@ -23,6 +23,7 @@ def register_logging_fields(registry: "FieldRegistry") -> None:
             section="project_settings",
             default_value="none",
             choices=[
+                {"value": "simpletuner", "label": "SimpleTuner (Local)"},
                 {"value": "tensorboard", "label": "TensorBoard"},
                 {"value": "wandb", "label": "Weights & Biases"},
                 {"value": "swanlab", "label": "SwanLab"},
@@ -32,7 +33,7 @@ def register_logging_fields(registry: "FieldRegistry") -> None:
                 {"value": "none", "label": "None"},
             ],
             help_text="Where to log training metrics",
-            tooltip="WandB provides cloud logging. TensorBoard is local. 'All' logs to all configured platforms.",
+            tooltip="SimpleTuner writes local charts and an offline report. 'All' includes the local report and available external platforms.",
             importance=ImportanceLevel.IMPORTANT,
             order=1,
             documentation="OPTIONS.md#--report_to",

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/validation.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/validation.py
@@ -205,6 +205,54 @@ def register_validation_fields(registry: "FieldRegistry") -> None:
         )
     )
 
+    registry._add_field(
+        ConfigField(
+            name="validation_image_format",
+            arg_name="--validation_image_format",
+            ui_label="Validation Image Format",
+            field_type=FieldType.SELECT,
+            tab="validation",
+            section="validation_schedule",
+            default_value="png",
+            choices=[
+                {"value": "png", "label": "PNG"},
+                {"value": "webp", "label": "WebP"},
+                {"value": "jpeg", "label": "JPEG"},
+            ],
+            help_text="Image format used for validation files saved in the output directory",
+            tooltip="WebP and JPEG reduce archive size. PNG preserves the existing lossless output.",
+            importance=ImportanceLevel.ADVANCED,
+            order=3.1,
+            subsection="advanced",
+            documentation="OPTIONS.md#--validation_image_format",
+        )
+    )
+
+    registry._add_field(
+        ConfigField(
+            name="validation_image_quality",
+            arg_name="--validation_image_quality",
+            ui_label="Validation Image Quality",
+            field_type=FieldType.NUMBER,
+            tab="validation",
+            section="validation_schedule",
+            default_value=90,
+            validation_rules=[
+                ValidationRule(ValidationRuleType.MIN, value=1, message="Must be at least 1"),
+                ValidationRule(ValidationRuleType.MAX, value=100, message="Must be at most 100"),
+            ],
+            dependencies=[
+                FieldDependency(field="validation_image_format", operator="in", values=["webp", "jpeg"], action="show")
+            ],
+            help_text="Encoding quality for WebP and JPEG validation images",
+            tooltip="Higher values retain more detail and use more disk space.",
+            importance=ImportanceLevel.ADVANCED,
+            order=3.2,
+            subsection="advanced",
+            documentation="OPTIONS.md#--validation_image_quality",
+        )
+    )
+
     # Number of Eval Images
     registry._add_field(
         ConfigField(

--- a/simpletuner/simpletuner_sdk/server/services/training_metrics_service.py
+++ b/simpletuner/simpletuner_sdk/server/services/training_metrics_service.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import quote
+
+from fastapi import status
+
+from simpletuner.helpers.training.local_metrics import (
+    MANIFEST_FILENAME,
+    MEDIA_FILENAME,
+    METRICS_FILENAME,
+    REPORT_FILENAME,
+    downsample_records,
+    read_manifest,
+    read_media_records,
+    read_metric_records,
+)
+from simpletuner.simpletuner_sdk.server.services.config_store import ConfigStore
+from simpletuner.simpletuner_sdk.server.services.webui_state import WebUIStateStore
+
+SUPPORTED_MEDIA_SUFFIXES = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".mp4", ".webm", ".mov", ".wav"}
+
+
+class TrainingMetricsServiceError(Exception):
+    def __init__(self, message: str, status_code: int = status.HTTP_500_INTERNAL_SERVER_ERROR):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+class TrainingMetricsService:
+    def _get_config_store(self) -> ConfigStore:
+        defaults = WebUIStateStore().load_defaults()
+        if defaults.configs_dir:
+            return ConfigStore(config_dir=Path(defaults.configs_dir).expanduser(), config_type="model")
+        return ConfigStore(config_type="model")
+
+    def _environment(self, environment: str) -> tuple[dict[str, Any], Path]:
+        store = self._get_config_store()
+        try:
+            config, _metadata = store.load_config(environment)
+        except FileNotFoundError as exc:
+            raise TrainingMetricsServiceError(f"Environment '{environment}' not found.", status.HTTP_404_NOT_FOUND) from exc
+        output_dir = config.get("--output_dir") or config.get("output_dir")
+        if not output_dir:
+            raise TrainingMetricsServiceError(
+                f"Environment '{environment}' does not have an output_dir configured.",
+                status.HTTP_400_BAD_REQUEST,
+            )
+        return config, Path(os.path.expanduser(str(output_dir))).resolve()
+
+    def list_runs(self) -> dict[str, Any]:
+        store = self._get_config_store()
+        runs = []
+        for metadata in store.list_configs():
+            environment = metadata.get("name")
+            if not environment:
+                continue
+            try:
+                config, output_dir = self._environment(environment)
+                manifest = read_manifest(output_dir)
+            except TrainingMetricsServiceError:
+                continue
+            if not manifest:
+                continue
+            runs.append(
+                {
+                    "environment": environment,
+                    "run_name": manifest.get("run_name") or environment,
+                    "project_name": manifest.get("project_name"),
+                    "status": manifest.get("status", "unknown"),
+                    "model_family": config.get("--model_family") or config.get("model_family"),
+                    "last_step": manifest.get("last_step"),
+                    "record_count": int(manifest.get("record_count", 0) or 0),
+                    "metric_count": len(manifest.get("metric_names", [])),
+                    "updated_at": manifest.get("updated_at"),
+                    "has_report": (output_dir / REPORT_FILENAME).is_file(),
+                }
+            )
+        runs.sort(key=lambda run: run.get("updated_at") or "", reverse=True)
+        return {"runs": runs, "count": len(runs)}
+
+    def get_run(
+        self,
+        environment: str,
+        *,
+        start_step: Optional[int] = None,
+        end_step: Optional[int] = None,
+        max_points: int = 2000,
+        metric_names: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        config, output_dir = self._environment(environment)
+        manifest = read_manifest(output_dir)
+        if not manifest:
+            raise TrainingMetricsServiceError(
+                f"Environment '{environment}' has no SimpleTuner training metrics.",
+                status.HTTP_404_NOT_FOUND,
+            )
+
+        requested_metrics = set(metric_names or [])
+        records = []
+        for record in read_metric_records(output_dir):
+            step = int(record.get("step", 0))
+            if start_step is not None and step < start_step:
+                continue
+            if end_step is not None and step > end_step:
+                continue
+            if requested_metrics:
+                record = dict(record)
+                record["metrics"] = {
+                    name: value for name, value in record.get("metrics", {}).items() if name in requested_metrics
+                }
+            records.append(record)
+        records = downsample_records(records, max_points=max_points) if records else []
+
+        media = []
+        for record in read_media_records(output_dir):
+            relative_path = record.get("path")
+            if not isinstance(relative_path, str):
+                continue
+            path = (output_dir / relative_path).resolve()
+            validation_root = (output_dir / "validation_images").resolve()
+            if not path.is_file() or not path.is_relative_to(validation_root):
+                continue
+            enriched = dict(record)
+            enriched["url"] = (
+                f"/api/metrics/training/runs/{quote(environment, safe='')}/media/{quote(relative_path, safe='/')}"
+            )
+            media.append(enriched)
+
+        return {
+            "run": {
+                **manifest,
+                "environment": environment,
+                "model_family": config.get("--model_family") or config.get("model_family"),
+                "has_report": (output_dir / REPORT_FILENAME).is_file(),
+            },
+            "records": records,
+            "media": media,
+            "available_metrics": sorted(manifest.get("metric_names", [])),
+            "raw_files": {
+                "metrics": METRICS_FILENAME,
+                "manifest": MANIFEST_FILENAME,
+                "media": MEDIA_FILENAME,
+                "report": REPORT_FILENAME,
+            },
+        }
+
+    def media_path(self, environment: str, relative_path: str) -> Path:
+        _config, output_dir = self._environment(environment)
+        path = (output_dir / relative_path).resolve()
+        validation_root = (output_dir / "validation_images").resolve()
+        if not path.is_file() or not path.is_relative_to(validation_root):
+            raise TrainingMetricsServiceError("Validation media not found.", status.HTTP_404_NOT_FOUND)
+        if path.suffix.lower() not in SUPPORTED_MEDIA_SUFFIXES:
+            raise TrainingMetricsServiceError("Unsupported validation media type.", status.HTTP_400_BAD_REQUEST)
+        indexed_paths = {record.get("path") for record in read_media_records(output_dir)}
+        if path.relative_to(output_dir).as_posix() not in indexed_paths:
+            raise TrainingMetricsServiceError("Validation media is not indexed for this run.", status.HTTP_404_NOT_FOUND)
+        return path
+
+    def report_path(self, environment: str) -> Path:
+        _config, output_dir = self._environment(environment)
+        path = output_dir / REPORT_FILENAME
+        if not path.is_file():
+            raise TrainingMetricsServiceError("Training report not found.", status.HTTP_404_NOT_FOUND)
+        return path
+
+
+TRAINING_METRICS_SERVICE = TrainingMetricsService()

--- a/simpletuner/static/css/metrics.css
+++ b/simpletuner/static/css/metrics.css
@@ -869,8 +869,358 @@
     flex: 0 0 auto;
 }
 
+.metrics-section-tabs {
+    display: inline-flex;
+    gap: 0.25rem;
+    margin-bottom: 1rem;
+    padding: 0.25rem;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 0.5rem;
+    background: rgba(15, 23, 42, 0.45);
+}
+
+.metrics-section-tab {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    min-height: 2.25rem;
+    padding: 0.4rem 0.75rem;
+    border: 0;
+    border-radius: 0.375rem;
+    color: #94a3b8;
+    background: transparent;
+    font-size: 0.875rem;
+    font-weight: 600;
+}
+
+.metrics-section-tab:hover,
+.metrics-section-tab.active {
+    color: #f8fafc;
+    background: rgba(99, 102, 241, 0.2);
+}
+
+.training-metrics-workspace {
+    min-width: 0;
+}
+
+.training-metrics-toolbar,
+.training-tool-header,
+.training-run-actions,
+.training-latest-values,
+.training-media-steps {
+    display: flex;
+    align-items: center;
+}
+
+.training-metrics-toolbar {
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.training-metrics-toolbar h2,
+.training-tool-header h3 {
+    margin: 0;
+    color: #f8fafc;
+    letter-spacing: 0;
+}
+
+.training-metrics-toolbar h2 {
+    font-size: 1.25rem;
+}
+
+.training-metrics-toolbar p,
+.training-tool-header span {
+    margin: 0.2rem 0 0;
+    color: #94a3b8;
+    font-size: 0.8rem;
+}
+
+.training-run-actions {
+    justify-content: flex-end;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.training-run-actions .form-select {
+    width: min(22rem, 55vw);
+}
+
+.training-metrics-empty {
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+    min-height: 9rem;
+    padding: 1.25rem;
+    border: 1px dashed rgba(148, 163, 184, 0.35);
+    border-radius: 0.5rem;
+    color: #94a3b8;
+}
+
+.training-metrics-empty > i {
+    font-size: 1.5rem;
+}
+
+.training-metrics-empty strong,
+.training-metrics-empty span {
+    display: block;
+}
+
+.training-metrics-empty strong {
+    color: #e2e8f0;
+}
+
+.training-run-summary {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    margin-bottom: 1rem;
+    border-block: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.training-run-summary > div {
+    padding: 0.8rem 1rem;
+    border-right: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.training-run-summary > div:last-child {
+    border-right: 0;
+}
+
+.training-run-summary span,
+.training-run-summary strong {
+    display: block;
+}
+
+.training-run-summary span {
+    margin-bottom: 0.2rem;
+    color: #94a3b8;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+}
+
+.training-run-summary strong {
+    overflow: hidden;
+    color: #f8fafc;
+    font-size: 0.95rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.training-metrics-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 3fr) minmax(18rem, 2fr);
+    gap: 1rem;
+}
+
+.training-chart-tool,
+.training-media-tool {
+    min-width: 0;
+    padding: 1rem;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 0.5rem;
+    background: rgba(15, 23, 42, 0.38);
+}
+
+.training-tool-header {
+    justify-content: space-between;
+    gap: 0.75rem;
+    align-items: flex-start;
+}
+
+.training-tool-header h3 {
+    font-size: 0.95rem;
+}
+
+.training-tool-header .form-select {
+    max-width: 13rem;
+}
+
+.training-metric-picker {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.35rem;
+    max-width: 70%;
+    flex-wrap: wrap;
+}
+
+.training-metric-picker label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    max-width: 14rem;
+    padding: 0.25rem 0.45rem;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 0.25rem;
+    color: #94a3b8;
+    font-size: 0.7rem;
+    cursor: pointer;
+}
+
+.training-metric-picker label.selected {
+    border-color: rgba(56, 189, 248, 0.6);
+    color: #e0f2fe;
+    background: rgba(14, 165, 233, 0.12);
+}
+
+.training-metric-picker input {
+    width: 0.8rem;
+    height: 0.8rem;
+}
+
+.training-metric-picker span {
+    overflow: hidden;
+    margin: 0;
+    color: inherit;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.training-latest-values {
+    gap: 0.75rem;
+    min-height: 3.4rem;
+    margin: 0.75rem 0;
+    overflow-x: auto;
+}
+
+.training-latest-values > div {
+    min-width: 7rem;
+}
+
+.training-latest-values span,
+.training-latest-values strong {
+    display: block;
+}
+
+.training-latest-values span {
+    overflow: hidden;
+    color: #94a3b8;
+    font-size: 0.7rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.training-latest-values strong {
+    color: #e2e8f0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.85rem;
+}
+
+.training-chart-canvas-wrap {
+    position: relative;
+    height: 24rem;
+}
+
+.training-chart-canvas-wrap canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
+.training-media-steps {
+    gap: 0.25rem;
+    margin: 0.8rem 0;
+    overflow-x: auto;
+}
+
+.training-media-steps button {
+    min-width: 2.5rem;
+    padding: 0.25rem 0.45rem;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 0.25rem;
+    color: #94a3b8;
+    background: transparent;
+    font-size: 0.7rem;
+}
+
+.training-media-steps button.active {
+    border-color: #38bdf8;
+    color: #e0f2fe;
+    background: rgba(14, 165, 233, 0.14);
+}
+
+.training-media-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.6rem;
+}
+
+.training-media-grid figure {
+    min-width: 0;
+    margin: 0;
+}
+
+.training-media-grid img,
+.training-media-grid video {
+    display: block;
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    border-radius: 0.25rem;
+    background: #020617;
+    object-fit: contain;
+}
+
+.training-media-grid audio {
+    display: block;
+    width: 100%;
+    min-height: 3rem;
+}
+
+.training-media-grid figcaption {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-top: 0.3rem;
+    color: #94a3b8;
+    font-size: 0.7rem;
+}
+
+.training-media-empty {
+    padding: 3rem 1rem;
+    color: #94a3b8;
+    text-align: center;
+}
+
+@media (max-width: 1100px) {
+    .training-metrics-layout {
+        grid-template-columns: 1fr;
+    }
+}
+
 /* Responsive */
 @media (max-width: 576px) {
+    .training-metrics-toolbar,
+    .training-tool-header {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .training-run-actions {
+        justify-content: flex-start;
+    }
+
+    .training-run-actions .form-select,
+    .training-tool-header .form-select,
+    .training-metric-picker {
+        width: 100%;
+        max-width: none;
+    }
+
+    .training-run-summary {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .training-run-summary > div:nth-child(2) {
+        border-right: 0;
+    }
+
+    .training-metrics-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .training-chart-canvas-wrap {
+        height: 18rem;
+    }
+
     .gpu-stats-grid {
         grid-template-columns: repeat(2, 1fr);
     }

--- a/simpletuner/static/css/training_metrics_report.css
+++ b/simpletuner/static/css/training_metrics_report.css
@@ -1,0 +1,265 @@
+:root {
+    color-scheme: dark;
+    --report-bg: #090d14;
+    --report-panel: #111827;
+    --report-border: #263244;
+    --report-text: #e5e7eb;
+    --report-muted: #94a3b8;
+    --report-accent: #38bdf8;
+}
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    background: var(--report-bg);
+    color: var(--report-text);
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+button,
+select,
+input {
+    font: inherit;
+}
+
+.report-shell {
+    width: min(1440px, calc(100% - 32px));
+    margin: 0 auto;
+    padding: 28px 0 48px;
+}
+
+.report-header {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 20px;
+    padding-bottom: 18px;
+    border-bottom: 1px solid var(--report-border);
+}
+
+.report-header h1,
+.report-section h2 {
+    margin: 0;
+    letter-spacing: 0;
+}
+
+.report-header h1 {
+    font-size: 24px;
+}
+
+.report-kicker,
+.report-meta,
+.report-empty {
+    color: var(--report-muted);
+    font-size: 13px;
+}
+
+.report-kicker {
+    margin-bottom: 6px;
+    text-transform: uppercase;
+}
+
+.report-summary {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1px;
+    margin: 22px 0;
+    background: var(--report-border);
+    border: 1px solid var(--report-border);
+}
+
+.report-stat {
+    min-width: 0;
+    padding: 14px 16px;
+    background: var(--report-panel);
+}
+
+.report-stat-label {
+    color: var(--report-muted);
+    font-size: 11px;
+    text-transform: uppercase;
+}
+
+.report-stat-value {
+    margin-top: 5px;
+    overflow: hidden;
+    font-size: 18px;
+    font-weight: 650;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.report-section {
+    margin-top: 28px;
+}
+
+.report-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 12px;
+}
+
+.report-section h2 {
+    font-size: 17px;
+}
+
+.metric-picker {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 7px;
+    margin-bottom: 12px;
+}
+
+.metric-picker label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 30px;
+    padding: 4px 9px;
+    border: 1px solid var(--report-border);
+    background: var(--report-panel);
+    color: var(--report-muted);
+    cursor: pointer;
+    font-size: 12px;
+}
+
+.metric-picker label.active {
+    border-color: var(--metric-color, var(--report-accent));
+    color: var(--report-text);
+}
+
+.metric-picker input {
+    width: 13px;
+    height: 13px;
+    margin: 0;
+}
+
+.chart-frame {
+    position: relative;
+    height: 390px;
+    border: 1px solid var(--report-border);
+    background: var(--report-panel);
+}
+
+.chart-frame canvas {
+    width: 100%;
+    height: 100%;
+}
+
+.chart-tooltip {
+    position: absolute;
+    z-index: 2;
+    min-width: 180px;
+    padding: 9px 10px;
+    border: 1px solid var(--report-border);
+    background: rgba(9, 13, 20, 0.96);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.28);
+    pointer-events: none;
+    font-size: 12px;
+}
+
+.chart-tooltip[hidden] {
+    display: none;
+}
+
+.chart-tooltip-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    margin-top: 4px;
+}
+
+.media-controls {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.media-controls select {
+    min-width: 180px;
+    padding: 7px 28px 7px 9px;
+    border: 1px solid var(--report-border);
+    background: var(--report-panel);
+    color: var(--report-text);
+}
+
+.media-timeline {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 12px;
+    overflow-x: auto;
+    padding-bottom: 4px;
+}
+
+.media-step {
+    flex: 0 0 auto;
+    padding: 6px 9px;
+    border: 1px solid var(--report-border);
+    background: transparent;
+    color: var(--report-muted);
+    cursor: pointer;
+}
+
+.media-step.active {
+    border-color: var(--report-accent);
+    background: rgba(56, 189, 248, 0.1);
+    color: var(--report-text);
+}
+
+.media-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 12px;
+}
+
+.media-item {
+    min-width: 0;
+    border: 1px solid var(--report-border);
+    background: var(--report-panel);
+}
+
+.media-item img,
+.media-item video {
+    display: block;
+    width: 100%;
+    max-height: 520px;
+    object-fit: contain;
+    background: #05070b;
+}
+
+.media-item audio {
+    display: block;
+    width: calc(100% - 20px);
+    margin: 20px 10px;
+}
+
+.media-caption {
+    padding: 8px 10px;
+    color: var(--report-muted);
+    font-size: 12px;
+}
+
+@media (max-width: 720px) {
+    .report-shell {
+        width: min(100% - 20px, 1440px);
+        padding-top: 18px;
+    }
+
+    .report-header,
+    .report-section-header {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .report-summary {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .chart-frame {
+        height: 310px;
+    }
+}

--- a/simpletuner/static/js/metrics_component.js
+++ b/simpletuner/static/js/metrics_component.js
@@ -6,6 +6,7 @@
 
 function metricsComponent(initialSettings = {}) {
     return {
+        ...window.trainingMetricsState(),
         // Configuration state
         prometheusEnabled: initialSettings.prometheus_enabled || false,
         selectedCategories: initialSettings.prometheus_categories || ['jobs', 'http'],
@@ -68,6 +69,7 @@ function metricsComponent(initialSettings = {}) {
 
             // Load categories, templates, circuit breaker status, and GPU health
             await Promise.all([
+                this.loadTrainingRuns(),
                 this.loadCategoriesAndTemplates(),
                 this.loadCircuitBreakers(),
                 this.loadGpuHealth(),
@@ -79,6 +81,14 @@ function metricsComponent(initialSettings = {}) {
             }
 
             this.startGpuHealthPolling();
+        },
+
+        destroy() {
+            if (this._gpuHealthTimer) {
+                window.clearInterval(this._gpuHealthTimer);
+                this._gpuHealthTimer = null;
+            }
+            this.destroyTrainingMetrics();
         },
 
         async loadCircuitBreakers() {

--- a/simpletuner/static/js/training-wizard.js
+++ b/simpletuner/static/js/training-wizard.js
@@ -1163,6 +1163,7 @@ function trainingWizardComponent() {
                     // Fallback to hardcoded options
                     this.loggingProviders = [
                         { value: 'none', label: 'None' },
+                        { value: 'simpletuner', label: 'SimpleTuner (Local)' },
                         { value: 'wandb', label: 'Weights & Biases' },
                         { value: 'tensorboard', label: 'TensorBoard' },
                         { value: 'comet_ml', label: 'Comet ML' },
@@ -1186,6 +1187,7 @@ function trainingWizardComponent() {
                     // Fallback
                     this.loggingProviders = [
                         { value: 'none', label: 'None' },
+                        { value: 'simpletuner', label: 'SimpleTuner (Local)' },
                         { value: 'wandb', label: 'Weights & Biases' },
                         { value: 'tensorboard', label: 'TensorBoard' },
                         { value: 'comet_ml', label: 'Comet ML' },

--- a/simpletuner/static/js/training_metrics_chart.js
+++ b/simpletuner/static/js/training_metrics_chart.js
@@ -1,0 +1,253 @@
+(function (global) {
+    'use strict';
+
+    const COLORS = ['#38bdf8', '#f59e0b', '#22c55e', '#f472b6', '#a78bfa', '#fb7185', '#2dd4bf', '#eab308'];
+    const PREFERRED_METRICS = [
+        'train_loss',
+        'optimization_loss',
+        'diffusion_loss',
+        'eval_loss',
+        'learning_rate',
+    ];
+
+    function metricNames(records) {
+        const names = new Set();
+        (records || []).forEach((record) => {
+            Object.keys(record.metrics || {}).forEach((name) => names.add(name));
+        });
+        return Array.from(names).sort((left, right) => left.localeCompare(right));
+    }
+
+    function defaultMetricNames(names, limit = 4) {
+        const selected = PREFERRED_METRICS.filter((name) => names.includes(name));
+        for (const name of names) {
+            if (selected.length >= limit) break;
+            if (!selected.includes(name) && !name.includes('learning_rate')) selected.push(name);
+        }
+        return selected.slice(0, limit);
+    }
+
+    function latestMetricValues(records) {
+        const latest = {};
+        (records || []).forEach((record) => {
+            Object.entries(record.metrics || {}).forEach(([name, value]) => {
+                if (typeof value === 'number' && Number.isFinite(value)) latest[name] = value;
+            });
+        });
+        return latest;
+    }
+
+    function formatMetricValue(value) {
+        if (typeof value !== 'number' || !Number.isFinite(value)) return '—';
+        const absolute = Math.abs(value);
+        if (absolute !== 0 && (absolute >= 10000 || absolute < 0.001)) return value.toExponential(3);
+        return value.toLocaleString(undefined, { maximumFractionDigits: 6 });
+    }
+
+    class TrainingMetricsChart {
+        constructor(canvas, options = {}) {
+            this.canvas = canvas;
+            this.records = [];
+            this.metrics = [];
+            this.options = options;
+            this.geometry = null;
+            this.hoverIndex = null;
+            this._resizeHandler = () => this.draw();
+            this._moveHandler = (event) => this._handlePointer(event);
+            this._leaveHandler = () => {
+                this.hoverIndex = null;
+                this.draw();
+                if (this.options.onHover) this.options.onHover(null);
+            };
+            global.addEventListener('resize', this._resizeHandler);
+            canvas.addEventListener('pointermove', this._moveHandler);
+            canvas.addEventListener('pointerleave', this._leaveHandler);
+        }
+
+        setData(records, metrics) {
+            this.records = Array.isArray(records) ? records : [];
+            this.metrics = Array.isArray(metrics) ? metrics.slice(0, COLORS.length) : [];
+            this.hoverIndex = null;
+            this.draw();
+        }
+
+        destroy() {
+            global.removeEventListener('resize', this._resizeHandler);
+            this.canvas.removeEventListener('pointermove', this._moveHandler);
+            this.canvas.removeEventListener('pointerleave', this._leaveHandler);
+        }
+
+        draw() {
+            const canvas = this.canvas;
+            const context = canvas.getContext('2d');
+            if (!context) return;
+
+            const width = Math.max(320, canvas.clientWidth || 800);
+            const height = Math.max(220, canvas.clientHeight || 360);
+            const dpr = global.devicePixelRatio || 1;
+            if (canvas.width !== Math.round(width * dpr) || canvas.height !== Math.round(height * dpr)) {
+                canvas.width = Math.round(width * dpr);
+                canvas.height = Math.round(height * dpr);
+            }
+            context.setTransform(dpr, 0, 0, dpr, 0, 0);
+            context.clearRect(0, 0, width, height);
+
+            const points = this.records.filter((record) => Number.isFinite(Number(record.step)));
+            const values = [];
+            points.forEach((record) => {
+                this.metrics.forEach((name) => {
+                    const value = record.metrics && record.metrics[name];
+                    if (typeof value === 'number' && Number.isFinite(value)) values.push(value);
+                });
+            });
+            if (!points.length || !values.length || !this.metrics.length) {
+                this._drawEmpty(context, width, height);
+                this.geometry = null;
+                return;
+            }
+
+            const padding = { left: 64, right: 20, top: 20, bottom: 42 };
+            const plotWidth = width - padding.left - padding.right;
+            const plotHeight = height - padding.top - padding.bottom;
+            const steps = points.map((record) => Number(record.step));
+            let minStep = Math.min(...steps);
+            let maxStep = Math.max(...steps);
+            let minValue = Math.min(...values);
+            let maxValue = Math.max(...values);
+            if (minStep === maxStep) maxStep = minStep + 1;
+            if (minValue === maxValue) {
+                const offset = Math.abs(minValue) * 0.05 || 1;
+                minValue -= offset;
+                maxValue += offset;
+            }
+            const valuePadding = (maxValue - minValue) * 0.08;
+            minValue -= valuePadding;
+            maxValue += valuePadding;
+
+            const xForStep = (step) => padding.left + ((step - minStep) / (maxStep - minStep)) * plotWidth;
+            const yForValue = (value) => padding.top + (1 - (value - minValue) / (maxValue - minValue)) * plotHeight;
+            this.geometry = { points, padding, plotWidth, plotHeight, minStep, maxStep, minValue, maxValue, xForStep, yForValue };
+
+            this._drawGrid(context, width, height, this.geometry);
+            this.metrics.forEach((name, metricIndex) => {
+                context.strokeStyle = COLORS[metricIndex % COLORS.length];
+                context.lineWidth = 2;
+                context.lineJoin = 'round';
+                context.beginPath();
+                let started = false;
+                points.forEach((record) => {
+                    const value = record.metrics && record.metrics[name];
+                    if (typeof value !== 'number' || !Number.isFinite(value)) {
+                        started = false;
+                        return;
+                    }
+                    const x = xForStep(Number(record.step));
+                    const y = yForValue(value);
+                    if (!started) {
+                        context.moveTo(x, y);
+                        started = true;
+                    } else {
+                        context.lineTo(x, y);
+                    }
+                });
+                context.stroke();
+            });
+
+            if (this.hoverIndex !== null && points[this.hoverIndex]) {
+                const record = points[this.hoverIndex];
+                const x = xForStep(Number(record.step));
+                context.strokeStyle = 'rgba(148, 163, 184, 0.65)';
+                context.lineWidth = 1;
+                context.beginPath();
+                context.moveTo(x, padding.top);
+                context.lineTo(x, padding.top + plotHeight);
+                context.stroke();
+                this.metrics.forEach((name, metricIndex) => {
+                    const value = record.metrics && record.metrics[name];
+                    if (typeof value !== 'number' || !Number.isFinite(value)) return;
+                    context.fillStyle = COLORS[metricIndex % COLORS.length];
+                    context.beginPath();
+                    context.arc(x, yForValue(value), 4, 0, Math.PI * 2);
+                    context.fill();
+                });
+            }
+        }
+
+        _drawEmpty(context, width, height) {
+            context.fillStyle = '#94a3b8';
+            context.font = '14px system-ui, sans-serif';
+            context.textAlign = 'center';
+            context.fillText('No scalar metrics selected', width / 2, height / 2);
+        }
+
+        _drawGrid(context, width, height, geometry) {
+            const { padding, plotWidth, plotHeight, minStep, maxStep, minValue, maxValue } = geometry;
+            context.font = '12px system-ui, sans-serif';
+            context.fillStyle = '#94a3b8';
+            context.strokeStyle = 'rgba(148, 163, 184, 0.18)';
+            context.lineWidth = 1;
+            context.textAlign = 'right';
+            context.textBaseline = 'middle';
+            for (let index = 0; index <= 4; index += 1) {
+                const ratio = index / 4;
+                const y = padding.top + ratio * plotHeight;
+                const value = maxValue - ratio * (maxValue - minValue);
+                context.beginPath();
+                context.moveTo(padding.left, y);
+                context.lineTo(padding.left + plotWidth, y);
+                context.stroke();
+                context.fillText(formatMetricValue(value), padding.left - 10, y);
+            }
+
+            context.textAlign = 'center';
+            context.textBaseline = 'top';
+            for (let index = 0; index <= 4; index += 1) {
+                const ratio = index / 4;
+                const x = padding.left + ratio * plotWidth;
+                const step = Math.round(minStep + ratio * (maxStep - minStep));
+                context.fillText(step.toLocaleString(), x, height - padding.bottom + 12);
+            }
+        }
+
+        _handlePointer(event) {
+            if (!this.geometry) return;
+            const rect = this.canvas.getBoundingClientRect();
+            const x = event.clientX - rect.left;
+            const { points, xForStep } = this.geometry;
+            let nearestIndex = 0;
+            let nearestDistance = Number.POSITIVE_INFINITY;
+            points.forEach((record, index) => {
+                const distance = Math.abs(xForStep(Number(record.step)) - x);
+                if (distance < nearestDistance) {
+                    nearestDistance = distance;
+                    nearestIndex = index;
+                }
+            });
+            if (this.hoverIndex !== nearestIndex) {
+                this.hoverIndex = nearestIndex;
+                this.draw();
+            }
+            if (this.options.onHover) {
+                const record = points[nearestIndex];
+                this.options.onHover({
+                    record,
+                    x: xForStep(Number(record.step)),
+                    metrics: this.metrics.map((name, index) => ({
+                        name,
+                        value: record.metrics ? record.metrics[name] : undefined,
+                        color: COLORS[index % COLORS.length],
+                    })),
+                });
+            }
+        }
+    }
+
+    global.TrainingMetricsCharts = {
+        COLORS,
+        TrainingMetricsChart,
+        defaultMetricNames,
+        formatMetricValue,
+        latestMetricValues,
+        metricNames,
+    };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/simpletuner/static/js/training_metrics_component.js
+++ b/simpletuner/static/js/training_metrics_component.js
@@ -1,0 +1,166 @@
+(function (global) {
+    'use strict';
+
+    function trainingMetricsState() {
+        return {
+            activeMetricsSection: 'training',
+            trainingRuns: [],
+            selectedTrainingEnvironment: '',
+            trainingRunData: null,
+            trainingMetricsLoading: false,
+            trainingMetricsError: null,
+            selectedTrainingMetrics: [],
+            selectedTrainingMediaLabel: '',
+            selectedTrainingMediaStep: null,
+            trainingChartHover: null,
+            _trainingMetricsChart: null,
+
+            async loadTrainingRuns() {
+                this.trainingMetricsLoading = true;
+                this.trainingMetricsError = null;
+                try {
+                    const response = await fetch('/api/metrics/training/runs');
+                    if (!response.ok) throw new Error(`Unable to load training runs (HTTP ${response.status})`);
+                    const data = await response.json();
+                    this.trainingRuns = Array.isArray(data.runs) ? data.runs : [];
+                    if (!this.trainingRuns.length) {
+                        this.selectedTrainingEnvironment = '';
+                        this.trainingRunData = null;
+                        return;
+                    }
+                    const selectedStillExists = this.trainingRuns.some(
+                        (run) => run.environment === this.selectedTrainingEnvironment,
+                    );
+                    if (!selectedStillExists) this.selectedTrainingEnvironment = this.trainingRuns[0].environment;
+                    await this.loadTrainingRun();
+                } catch (error) {
+                    this.trainingMetricsError = error.message || 'Unable to load training runs';
+                } finally {
+                    this.trainingMetricsLoading = false;
+                }
+            },
+
+            async selectTrainingRun(environment) {
+                if (!environment || environment === this.selectedTrainingEnvironment) return;
+                this.selectedTrainingEnvironment = environment;
+                await this.loadTrainingRun();
+            },
+
+            async loadTrainingRun() {
+                if (!this.selectedTrainingEnvironment) return;
+                this.trainingMetricsLoading = true;
+                this.trainingMetricsError = null;
+                try {
+                    const environment = encodeURIComponent(this.selectedTrainingEnvironment);
+                    const response = await fetch(`/api/metrics/training/runs/${environment}?max_points=4000`);
+                    if (!response.ok) throw new Error(`Unable to load run metrics (HTTP ${response.status})`);
+                    this.trainingRunData = await response.json();
+                    const available = this.trainingRunData.available_metrics || [];
+                    this.selectedTrainingMetrics = global.TrainingMetricsCharts.defaultMetricNames(available);
+                    this.selectDefaultTrainingMedia();
+                    this.$nextTick(() => this.renderTrainingMetricsChart());
+                } catch (error) {
+                    this.trainingMetricsError = error.message || 'Unable to load run metrics';
+                    this.trainingRunData = null;
+                } finally {
+                    this.trainingMetricsLoading = false;
+                }
+            },
+
+            setMetricsSection(section) {
+                this.activeMetricsSection = section;
+                if (section === 'training') this.$nextTick(() => this.renderTrainingMetricsChart());
+                if (section === 'system') this.$nextTick(() => this.renderActiveGpuCharts());
+            },
+
+            toggleTrainingMetric(metric) {
+                const index = this.selectedTrainingMetrics.indexOf(metric);
+                if (index >= 0) {
+                    this.selectedTrainingMetrics.splice(index, 1);
+                } else if (this.selectedTrainingMetrics.length < 8) {
+                    this.selectedTrainingMetrics.push(metric);
+                }
+                this.renderTrainingMetricsChart();
+            },
+
+            renderTrainingMetricsChart() {
+                const canvas = this.$refs.trainingMetricsCanvas;
+                if (!canvas || !this.trainingRunData || !global.TrainingMetricsCharts) return;
+                if (!this._trainingMetricsChart) {
+                    this._trainingMetricsChart = new global.TrainingMetricsCharts.TrainingMetricsChart(canvas, {
+                        onHover: (value) => {
+                            this.trainingChartHover = value;
+                        },
+                    });
+                }
+                this._trainingMetricsChart.setData(
+                    this.trainingRunData.records || [],
+                    this.selectedTrainingMetrics,
+                );
+            },
+
+            latestTrainingMetrics() {
+                if (!this.trainingRunData) return [];
+                const latest = global.TrainingMetricsCharts.latestMetricValues(this.trainingRunData.records || []);
+                return this.selectedTrainingMetrics.map((name) => ({ name, value: latest[name] }));
+            },
+
+            formatTrainingMetric(value) {
+                return global.TrainingMetricsCharts.formatMetricValue(value);
+            },
+
+            trainingMediaLabels() {
+                if (!this.trainingRunData) return [];
+                return Array.from(new Set((this.trainingRunData.media || []).map((item) => item.label))).sort();
+            },
+
+            trainingMediaSteps() {
+                if (!this.trainingRunData || !this.selectedTrainingMediaLabel) return [];
+                return Array.from(
+                    new Set(
+                        (this.trainingRunData.media || [])
+                            .filter((item) => item.label === this.selectedTrainingMediaLabel)
+                            .map((item) => item.step),
+                    ),
+                ).sort((left, right) => left - right);
+            },
+
+            selectDefaultTrainingMedia() {
+                const labels = this.trainingMediaLabels();
+                this.selectedTrainingMediaLabel = labels[0] || '';
+                const steps = this.trainingMediaSteps();
+                this.selectedTrainingMediaStep = steps.length ? steps[steps.length - 1] : null;
+            },
+
+            selectTrainingMediaLabel(label) {
+                this.selectedTrainingMediaLabel = label;
+                const steps = this.trainingMediaSteps();
+                this.selectedTrainingMediaStep = steps.length ? steps[steps.length - 1] : null;
+            },
+
+            selectedTrainingMedia() {
+                if (!this.trainingRunData) return [];
+                return (this.trainingRunData.media || [])
+                    .filter(
+                        (item) =>
+                            item.label === this.selectedTrainingMediaLabel && item.step === this.selectedTrainingMediaStep,
+                    )
+                    .sort((left, right) => left.index - right.index);
+            },
+
+            trainingReportUrl() {
+                if (!this.selectedTrainingEnvironment) return '#';
+                return `/api/metrics/training/runs/${encodeURIComponent(this.selectedTrainingEnvironment)}/report`;
+            },
+
+            destroyTrainingMetrics() {
+                if (this._trainingMetricsChart) {
+                    this._trainingMetricsChart.destroy();
+                    this._trainingMetricsChart = null;
+                }
+            },
+        };
+    }
+
+    global.trainingMetricsState = trainingMetricsState;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/simpletuner/templates/base_htmx.html
+++ b/simpletuner/templates/base_htmx.html
@@ -219,7 +219,9 @@
     <script src="/static/js/modules/admin/index.js?v={{ asset_version }}"></script>
     <!-- Audit log component (registers Alpine component) -->
     <script src="/static/js/audit_component.js?v={{ asset_version }}"></script>
-    <!-- Metrics component (registers Alpine component) -->
+    <!-- Metrics components (register Alpine component and shared chart renderer) -->
+    <script src="/static/js/training_metrics_chart.js?v={{ asset_version }}"></script>
+    <script src="/static/js/training_metrics_component.js?v={{ asset_version }}"></script>
     <script src="/static/js/metrics_component.js?v={{ asset_version }}"></script>
     <!-- Notifications component (registers Alpine component) -->
     <script src="/static/js/notifications_component.js?v={{ asset_version }}"></script>

--- a/simpletuner/templates/metrics_tab.html
+++ b/simpletuner/templates/metrics_tab.html
@@ -12,6 +12,189 @@
      x-data='metricsComponent({{ metrics_ctx | tojson | safe }})'
      x-init="init()">
 
+    <div class="metrics-section-tabs" role="tablist" aria-label="Metrics sections">
+        <button type="button"
+                class="metrics-section-tab"
+                :class="{ 'active': activeMetricsSection === 'training' }"
+                @click="setMetricsSection('training')"
+                data-testid="training-runs-tab">
+            <i class="fas fa-chart-line"></i>
+            Training Runs
+        </button>
+        <button type="button"
+                class="metrics-section-tab"
+                :class="{ 'active': activeMetricsSection === 'system' }"
+                @click="setMetricsSection('system')"
+                data-testid="system-metrics-tab">
+            <i class="fas fa-server"></i>
+            System
+        </button>
+    </div>
+
+    <section class="training-metrics-workspace"
+             x-show="activeMetricsSection === 'training'"
+             x-cloak
+             aria-label="Training run metrics">
+        <div class="training-metrics-toolbar">
+            <div>
+                <h2>Training Runs</h2>
+                <p>Scalar history and validation outputs saved with each environment.</p>
+            </div>
+            <div class="training-run-actions">
+                <label class="visually-hidden" for="training-run-select">Training environment</label>
+                <select id="training-run-select"
+                        class="form-select form-select-sm"
+                        :value="selectedTrainingEnvironment"
+                        @change="selectTrainingRun($event.target.value)"
+                        :disabled="trainingMetricsLoading || !trainingRuns.length"
+                        data-testid="training-run-select">
+                    <template x-for="run in trainingRuns" :key="run.environment">
+                        <option :value="run.environment" x-text="run.run_name + ' · ' + run.environment"></option>
+                    </template>
+                </select>
+                <button type="button"
+                        class="btn btn-sm btn-outline-secondary"
+                        @click="loadTrainingRuns()"
+                        :disabled="trainingMetricsLoading"
+                        title="Refresh training metrics">
+                    <i class="fas" :class="trainingMetricsLoading ? 'fa-spinner fa-spin' : 'fa-sync-alt'"></i>
+                </button>
+                <a class="btn btn-sm btn-outline-info"
+                   :href="trainingReportUrl()"
+                   target="_blank"
+                   rel="noopener"
+                   x-show="trainingRunData && trainingRunData.run.has_report">
+                    <i class="fas fa-file-code me-1"></i>Offline report
+                </a>
+            </div>
+        </div>
+
+        <template x-if="trainingMetricsError">
+            <div class="alert alert-danger" role="alert" data-testid="training-metrics-error">
+                <i class="fas fa-exclamation-circle me-2"></i><span x-text="trainingMetricsError"></span>
+            </div>
+        </template>
+
+        <template x-if="!trainingMetricsLoading && !trainingRuns.length && !trainingMetricsError">
+            <div class="training-metrics-empty">
+                <i class="fas fa-chart-line"></i>
+                <div>
+                    <strong>No local training runs</strong>
+                    <span>Set <code>report_to=simpletuner</code> in a training environment to record one.</span>
+                </div>
+            </div>
+        </template>
+
+        <template x-if="trainingRunData">
+            <div>
+                <div class="training-run-summary">
+                    <div>
+                        <span>Status</span>
+                        <strong x-text="trainingRunData.run.status"></strong>
+                    </div>
+                    <div>
+                        <span>Model family</span>
+                        <strong x-text="trainingRunData.run.model_family || 'Unknown'"></strong>
+                    </div>
+                    <div>
+                        <span>Latest step</span>
+                        <strong x-text="(trainingRunData.run.last_step ?? 0).toLocaleString()"></strong>
+                    </div>
+                    <div>
+                        <span>Samples</span>
+                        <strong x-text="(trainingRunData.run.record_count || 0).toLocaleString()"></strong>
+                    </div>
+                </div>
+
+                <div class="training-metrics-layout">
+                    <section class="training-chart-tool" aria-label="Scalar chart">
+                        <div class="training-tool-header">
+                            <div>
+                                <h3>Scalars</h3>
+                                <span x-show="trainingChartHover"
+                                      x-text="trainingChartHover ? 'Step ' + trainingChartHover.record.step.toLocaleString() : ''"></span>
+                            </div>
+                            <div class="training-metric-picker" aria-label="Chart metrics">
+                                <template x-for="metric in trainingRunData.available_metrics" :key="metric">
+                                    <label :class="{ 'selected': selectedTrainingMetrics.includes(metric) }">
+                                        <input type="checkbox"
+                                               :checked="selectedTrainingMetrics.includes(metric)"
+                                               @change="toggleTrainingMetric(metric)"
+                                               :disabled="!selectedTrainingMetrics.includes(metric) && selectedTrainingMetrics.length >= 8">
+                                        <span x-text="metric"></span>
+                                    </label>
+                                </template>
+                            </div>
+                        </div>
+                        <div class="training-latest-values">
+                            <template x-for="metric in latestTrainingMetrics()" :key="metric.name">
+                                <div>
+                                    <span x-text="metric.name"></span>
+                                    <strong x-text="formatTrainingMetric(metric.value)"></strong>
+                                </div>
+                            </template>
+                        </div>
+                        <div class="training-chart-canvas-wrap">
+                            <canvas x-ref="trainingMetricsCanvas" data-testid="training-metrics-canvas"></canvas>
+                        </div>
+                    </section>
+
+                    <section class="training-media-tool" aria-label="Validation media">
+                        <div class="training-tool-header">
+                            <div>
+                                <h3>Validation</h3>
+                                <span>Compare saved outputs by prompt and step.</span>
+                            </div>
+                            <select class="form-select form-select-sm"
+                                    :value="selectedTrainingMediaLabel"
+                                    @change="selectTrainingMediaLabel($event.target.value)"
+                                    :disabled="!trainingMediaLabels().length"
+                                    aria-label="Validation prompt">
+                                <template x-for="label in trainingMediaLabels()" :key="label">
+                                    <option :value="label" x-text="label"></option>
+                                </template>
+                            </select>
+                        </div>
+                        <div class="training-media-steps" role="tablist" aria-label="Validation steps">
+                            <template x-for="step in trainingMediaSteps()" :key="step">
+                                <button type="button"
+                                        :class="{ 'active': selectedTrainingMediaStep === step }"
+                                        @click="selectedTrainingMediaStep = step"
+                                        x-text="step.toLocaleString()"></button>
+                            </template>
+                        </div>
+                        <template x-if="!selectedTrainingMedia().length">
+                            <div class="training-media-empty">No validation media was recorded for this run.</div>
+                        </template>
+                        <div class="training-media-grid">
+                            <template x-for="item in selectedTrainingMedia()" :key="item.path">
+                                <figure>
+                                    <img x-show="item.type === 'image'"
+                                         :src="item.type === 'image' ? item.url : null"
+                                         :alt="item.label + ' at step ' + item.step">
+                                    <video x-show="item.type === 'video'"
+                                           :src="item.type === 'video' ? item.url : null"
+                                           controls
+                                           preload="metadata"></video>
+                                    <audio x-show="item.type === 'audio'"
+                                           :src="item.type === 'audio' ? item.url : null"
+                                           controls
+                                           preload="metadata"></audio>
+                                    <figcaption>
+                                        <span x-text="'Output ' + (item.index + 1)"></span>
+                                        <span x-text="item.resolution || item.type"></span>
+                                    </figcaption>
+                                </figure>
+                            </template>
+                        </div>
+                    </section>
+                </div>
+            </div>
+        </template>
+    </section>
+
+    <div x-show="activeMetricsSection === 'system'" x-cloak>
+
     <!-- Hero CTA (shown when Prometheus not configured) -->
     <template x-if="!prometheusEnabled && !heroDismissed">
         {% call hero_cta(
@@ -448,25 +631,6 @@
                     </div><!-- /collapse -->
                 </div>
 
-                <!-- Tensorboard Placeholder -->
-                <div class="metrics-card mt-3 disabled-card">
-                    <div class="metrics-card-header">
-                        <h5 class="mb-0">
-                            <i class="fas fa-chart-area me-2"></i>Tensorboard
-                            <span class="badge bg-secondary ms-2">Coming Soon</span>
-                        </h5>
-                    </div>
-                    <div class="metrics-card-body text-muted">
-                        <p class="mb-2 small">
-                            Real-time training metrics from running jobs will be available here in a future update.
-                        </p>
-                        <ul class="small mb-0">
-                            <li>Loss curves and learning rate schedules</li>
-                            <li>Validation metrics and sample images</li>
-                            <li>GPU utilization and memory usage</li>
-                        </ul>
-                    </div>
-                </div>
             </div>
 
             <!-- Preview Panel -->
@@ -527,6 +691,7 @@
                 </div>
             </div>
         </div>
+    </div>
     </div>
 
     <!-- Toast for copy feedback -->

--- a/simpletuner/templates/metrics_tab.html
+++ b/simpletuner/templates/metrics_tab.html
@@ -12,7 +12,7 @@
      x-data='metricsComponent({{ metrics_ctx | tojson | safe }})'
      x-init="init()">
 
-    <div class="metrics-section-tabs" role="tablist" aria-label="Metrics sections">
+    <div class="metrics-section-tabs" role="group" aria-label="Metrics sections">
         <button type="button"
                 class="metrics-section-tab"
                 :class="{ 'active': activeMetricsSection === 'training' }"
@@ -155,7 +155,7 @@
                                 </template>
                             </select>
                         </div>
-                        <div class="training-media-steps" role="tablist" aria-label="Validation steps">
+                        <div class="training-media-steps" role="group" aria-label="Validation steps">
                             <template x-for="step in trainingMediaSteps()" :key="step">
                                 <button type="button"
                                         :class="{ 'active': selectedTrainingMediaStep === step }"

--- a/simpletuner/templates/training_metrics_report.html
+++ b/simpletuner/templates/training_metrics_report.html
@@ -1,0 +1,197 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>SimpleTuner Training Report</title>
+    <style>__SIMPLETUNER_REPORT_CSS__</style>
+</head>
+<body>
+    <main class="report-shell">
+        <header class="report-header">
+            <div>
+                <div class="report-kicker">SimpleTuner training report</div>
+                <h1 id="run-name">Training run</h1>
+            </div>
+            <div class="report-meta" id="run-meta"></div>
+        </header>
+
+        <section class="report-summary" id="run-summary"></section>
+
+        <section class="report-section">
+            <div class="report-section-header">
+                <h2>Scalar metrics</h2>
+                <div class="report-meta" id="chart-step"></div>
+            </div>
+            <div class="metric-picker" id="metric-picker"></div>
+            <div class="chart-frame">
+                <canvas id="metrics-chart"></canvas>
+                <div class="chart-tooltip" id="chart-tooltip" hidden></div>
+            </div>
+        </section>
+
+        <section class="report-section">
+            <div class="report-section-header">
+                <h2>Validation media</h2>
+                <div class="media-controls">
+                    <label class="report-meta" for="media-label">Prompt</label>
+                    <select id="media-label"></select>
+                </div>
+            </div>
+            <div class="media-timeline" id="media-timeline"></div>
+            <div class="media-grid" id="media-grid"></div>
+        </section>
+    </main>
+
+    <script id="training-metrics-data" type="application/json">__SIMPLETUNER_REPORT_DATA__</script>
+    <script>__SIMPLETUNER_CHART_JS__</script>
+    <script>
+        (function () {
+            const payload = JSON.parse(document.getElementById('training-metrics-data').textContent);
+            const charts = window.TrainingMetricsCharts;
+            const run = payload.run || {};
+            const records = payload.records || [];
+            const media = payload.media || [];
+            const names = charts.metricNames(records);
+            let selectedMetrics = charts.defaultMetricNames(names);
+            let selectedLabel = null;
+            let selectedStep = null;
+
+            function escapeHtml(value) {
+                return String(value)
+                    .replaceAll('&', '&amp;')
+                    .replaceAll('<', '&lt;')
+                    .replaceAll('>', '&gt;')
+                    .replaceAll('"', '&quot;')
+                    .replaceAll("'", '&#039;');
+            }
+
+            document.getElementById('run-name').textContent = run.run_name || 'Training run';
+            document.getElementById('run-meta').textContent = [run.project_name, run.status].filter(Boolean).join(' · ');
+
+            const summary = [
+                ['Last step', run.last_step ?? '—'],
+                ['Metric records', run.record_count ?? records.length],
+                ['Scalar series', names.length],
+                ['Validation items', media.length],
+            ];
+            document.getElementById('run-summary').innerHTML = summary.map(([label, value]) =>
+                `<div class="report-stat"><div class="report-stat-label">${escapeHtml(label)}</div><div class="report-stat-value">${escapeHtml(value)}</div></div>`
+            ).join('');
+
+            const tooltip = document.getElementById('chart-tooltip');
+            const chart = new charts.TrainingMetricsChart(document.getElementById('metrics-chart'), {
+                onHover(info) {
+                    if (!info) {
+                        tooltip.hidden = true;
+                        return;
+                    }
+                    const rows = info.metrics.filter((metric) => typeof metric.value === 'number').map((metric) =>
+                        `<div class="chart-tooltip-row"><span style="color:${metric.color}">${escapeHtml(metric.name)}</span><strong>${escapeHtml(charts.formatMetricValue(metric.value))}</strong></div>`
+                    ).join('');
+                    tooltip.innerHTML = `<strong>Step ${escapeHtml(info.record.step)}</strong>${rows}`;
+                    tooltip.style.left = `${Math.min(info.x + 12, tooltip.parentElement.clientWidth - 200)}px`;
+                    tooltip.style.top = '12px';
+                    tooltip.hidden = false;
+                },
+            });
+
+            function renderMetricPicker() {
+                const picker = document.getElementById('metric-picker');
+                picker.innerHTML = '';
+                names.forEach((name) => {
+                    const index = selectedMetrics.indexOf(name);
+                    const label = document.createElement('label');
+                    label.className = index >= 0 ? 'active' : '';
+                    label.style.setProperty('--metric-color', charts.COLORS[Math.max(0, index) % charts.COLORS.length]);
+                    const input = document.createElement('input');
+                    input.type = 'checkbox';
+                    input.checked = index >= 0;
+                    input.addEventListener('change', () => {
+                        if (input.checked && !selectedMetrics.includes(name)) selectedMetrics.push(name);
+                        if (!input.checked) selectedMetrics = selectedMetrics.filter((entry) => entry !== name);
+                        selectedMetrics = selectedMetrics.slice(-charts.COLORS.length);
+                        renderMetricPicker();
+                        chart.setData(records, selectedMetrics);
+                    });
+                    label.append(input, document.createTextNode(name));
+                    picker.appendChild(label);
+                });
+            }
+
+            function mediaForSelection() {
+                return media.filter((item) => item.label === selectedLabel && Number(item.step) === Number(selectedStep));
+            }
+
+            function renderMedia() {
+                const labels = Array.from(new Set(media.map((item) => item.label))).sort();
+                const select = document.getElementById('media-label');
+                select.innerHTML = '';
+                labels.forEach((label) => {
+                    const option = document.createElement('option');
+                    option.value = label;
+                    option.textContent = label;
+                    select.appendChild(option);
+                });
+                if (!selectedLabel || !labels.includes(selectedLabel)) selectedLabel = labels[0] || null;
+                select.value = selectedLabel || '';
+                select.onchange = () => {
+                    selectedLabel = select.value;
+                    selectedStep = null;
+                    renderMedia();
+                };
+
+                const steps = Array.from(new Set(media.filter((item) => item.label === selectedLabel).map((item) => Number(item.step)))).sort((a, b) => a - b);
+                if (selectedStep === null || !steps.includes(selectedStep)) selectedStep = steps[steps.length - 1] ?? null;
+                const timeline = document.getElementById('media-timeline');
+                timeline.innerHTML = '';
+                steps.forEach((step) => {
+                    const button = document.createElement('button');
+                    button.type = 'button';
+                    button.className = `media-step${step === selectedStep ? ' active' : ''}`;
+                    button.textContent = `Step ${step}`;
+                    button.onclick = () => {
+                        selectedStep = step;
+                        renderMedia();
+                    };
+                    timeline.appendChild(button);
+                });
+
+                const grid = document.getElementById('media-grid');
+                grid.innerHTML = '';
+                const selected = mediaForSelection();
+                if (!selected.length) {
+                    grid.innerHTML = '<div class="report-empty">No validation media</div>';
+                    return;
+                }
+                selected.forEach((item) => {
+                    const wrapper = document.createElement('article');
+                    wrapper.className = 'media-item';
+                    let element;
+                    if (item.type === 'video') {
+                        element = document.createElement('video');
+                        element.controls = true;
+                    } else if (item.type === 'audio') {
+                        element = document.createElement('audio');
+                        element.controls = true;
+                    } else {
+                        element = document.createElement('img');
+                        element.loading = 'lazy';
+                        element.alt = `${item.label} at step ${item.step}`;
+                    }
+                    element.src = item.path;
+                    const caption = document.createElement('div');
+                    caption.className = 'media-caption';
+                    caption.textContent = [item.resolution, `sample ${Number(item.index) + 1}`].filter(Boolean).join(' · ');
+                    wrapper.append(element, caption);
+                    grid.appendChild(wrapper);
+                });
+            }
+
+            renderMetricPicker();
+            chart.setData(records, selectedMetrics);
+            renderMedia();
+        })();
+    </script>
+</body>
+</html>

--- a/tests/js/training_metrics_component.test.js
+++ b/tests/js/training_metrics_component.test.js
@@ -1,0 +1,88 @@
+global.fetch = jest.fn();
+
+require('../../simpletuner/static/js/training_metrics_chart.js');
+require('../../simpletuner/static/js/training_metrics_component.js');
+
+describe('training metrics component', () => {
+    let state;
+
+    beforeEach(() => {
+        fetch.mockReset();
+        state = window.trainingMetricsState();
+        state.$nextTick = (callback) => callback();
+        state.renderTrainingMetricsChart = jest.fn();
+    });
+
+    test('loads run summaries and selects the newest run', async () => {
+        fetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    runs: [
+                        { environment: 'anima', run_name: 'Anima smoke' },
+                        { environment: 'flux', run_name: 'Flux run' },
+                    ],
+                }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    run: { environment: 'anima', last_step: 20 },
+                    available_metrics: ['loss', 'learning_rate'],
+                    records: [{ step: 20, metrics: { loss: 0.5, learning_rate: 0.0001 } }],
+                    media: [],
+                }),
+            });
+
+        await state.loadTrainingRuns();
+
+        expect(state.selectedTrainingEnvironment).toBe('anima');
+        expect(state.trainingRunData.run.last_step).toBe(20);
+        expect(state.selectedTrainingMetrics).toEqual(['learning_rate', 'loss']);
+        expect(fetch).toHaveBeenNthCalledWith(1, '/api/metrics/training/runs');
+        expect(fetch).toHaveBeenNthCalledWith(2, '/api/metrics/training/runs/anima?max_points=4000');
+    });
+
+    test('filters validation media by prompt and step', () => {
+        state.trainingRunData = {
+            media: [
+                { label: 'portrait', step: 10, index: 0, path: 'a.webp' },
+                { label: 'portrait', step: 20, index: 1, path: 'c.webp' },
+                { label: 'portrait', step: 20, index: 0, path: 'b.webp' },
+                { label: 'landscape', step: 20, index: 0, path: 'd.webp' },
+            ],
+        };
+
+        state.selectDefaultTrainingMedia();
+
+        expect(state.selectedTrainingMediaLabel).toBe('landscape');
+        expect(state.selectedTrainingMediaStep).toBe(20);
+        state.selectTrainingMediaLabel('portrait');
+        expect(state.trainingMediaSteps()).toEqual([10, 20]);
+        expect(state.selectedTrainingMedia().map((item) => item.path)).toEqual(['b.webp', 'c.webp']);
+    });
+
+    test('limits the chart to eight selected metrics', () => {
+        state.selectedTrainingMetrics = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+
+        state.toggleTrainingMetric('i');
+        expect(state.selectedTrainingMetrics).toHaveLength(8);
+
+        state.toggleTrainingMetric('a');
+        state.toggleTrainingMetric('i');
+        expect(state.selectedTrainingMetrics).toContain('i');
+        expect(state.renderTrainingMetricsChart).toHaveBeenCalledTimes(3);
+    });
+
+    test('surfaces API failures without retaining stale run data', async () => {
+        state.selectedTrainingEnvironment = 'anima';
+        state.trainingRunData = { run: { environment: 'old' } };
+        fetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+        await state.loadTrainingRun();
+
+        expect(state.trainingRunData).toBeNull();
+        expect(state.trainingMetricsError).toContain('HTTP 500');
+        expect(state.trainingMetricsLoading).toBe(false);
+    });
+});

--- a/tests/test_local_metrics.py
+++ b/tests/test_local_metrics.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+from PIL import Image
+
+from simpletuner.helpers.training.local_metrics import (
+    MANIFEST_FILENAME,
+    MEDIA_FILENAME,
+    METRICS_FILENAME,
+    REPORT_FILENAME,
+    LocalMetricsTracker,
+    downsample_records,
+    is_local_metrics_enabled,
+    read_media_records,
+    read_metric_records,
+)
+from simpletuner.helpers.training.state_tracker import StateTracker
+from simpletuner.helpers.training.validation_images import save_validation_image
+
+
+class LocalMetricsTrackerTests(unittest.TestCase):
+    def test_tracker_writes_scalars_manifest_and_self_contained_report(self):
+        with tempfile.TemporaryDirectory() as directory:
+            tracker = LocalMetricsTracker("anima-smoke", directory, "local-tests")
+            tracker.store_init_configuration(
+                {
+                    "model_family": "anima",
+                    "learning_rate": 1e-4,
+                    "output_dir": "/private/output",
+                }
+            )
+            tracker.log(
+                {
+                    "train_loss": torch.tensor(1.25),
+                    "learning_rate": 1e-4,
+                    "table": {"not": "scalar"},
+                    "invalid": float("nan"),
+                },
+                step=4,
+            )
+            tracker.finish()
+
+            output_dir = Path(directory)
+            records = read_metric_records(output_dir)
+            self.assertEqual(records[0]["step"], 4)
+            self.assertEqual(records[0]["metrics"], {"learning_rate": 1e-4, "train_loss": 1.25})
+
+            manifest = json.loads((output_dir / MANIFEST_FILENAME).read_text(encoding="utf-8"))
+            self.assertEqual(manifest["status"], "completed")
+            self.assertEqual(manifest["record_count"], 1)
+            self.assertNotIn("output_dir", manifest["config"])
+
+            report = (output_dir / REPORT_FILENAME).read_text(encoding="utf-8")
+            self.assertIn("anima-smoke", report)
+            self.assertIn('"train_loss":1.25', report)
+            self.assertNotIn("fetch(", report)
+            self.assertTrue((output_dir / METRICS_FILENAME).is_file())
+
+    def test_resume_appends_to_existing_run(self):
+        with tempfile.TemporaryDirectory() as directory:
+            first = LocalMetricsTracker("resume", directory, "tests")
+            first.store_init_configuration({"model_family": "anima"})
+            first.log({"train_loss": 2.0}, step=1)
+
+            resumed = LocalMetricsTracker("resume", directory, "tests")
+            resumed.store_init_configuration({"model_family": "anima"})
+            resumed.log({"train_loss": 1.0}, step=2)
+            resumed.finish()
+
+            records = read_metric_records(directory)
+            self.assertEqual([record["step"] for record in records], [1, 2])
+            manifest = json.loads((Path(directory) / MANIFEST_FILENAME).read_text(encoding="utf-8"))
+            self.assertEqual(manifest["record_count"], 2)
+
+    def test_downsampling_preserves_first_and_last_records(self):
+        records = [{"step": index, "metrics": {"loss": float(index)}} for index in range(100)]
+
+        sampled = downsample_records(records, max_points=10)
+
+        self.assertEqual(len(sampled), 10)
+        self.assertEqual(sampled[0]["step"], 0)
+        self.assertEqual(sampled[-1]["step"], 99)
+
+    def test_local_metrics_enablement_supports_explicit_and_all_modes(self):
+        self.assertTrue(is_local_metrics_enabled("simpletuner"))
+        self.assertTrue(is_local_metrics_enabled("all"))
+        self.assertTrue(is_local_metrics_enabled(["wandb", "simpletuner"]))
+        self.assertFalse(is_local_metrics_enabled("wandb"))
+
+
+class ValidationMediaManifestTests(unittest.TestCase):
+    def setUp(self):
+        StateTracker.set_global_step(12)
+
+    def test_webp_image_is_saved_and_recorded(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output_dir = Path(directory)
+            validation_dir = output_dir / "validation_images"
+            validation_dir.mkdir()
+            config = SimpleNamespace(
+                output_dir=str(output_dir),
+                report_to="simpletuner",
+                validation_image_format="webp",
+                validation_image_quality=82,
+            )
+
+            saved_path = save_validation_image(
+                Image.new("RGB", (16, 12), color="red"),
+                validation_dir,
+                "step_12_sample_0_16x12",
+                config,
+                label="sample",
+                index=0,
+                resolution="16x12",
+            )
+
+            self.assertTrue(saved_path.endswith(".webp"))
+            self.assertTrue(Path(saved_path).is_file())
+            media = read_media_records(output_dir)
+            self.assertEqual(media[0]["path"], "validation_images/step_12_sample_0_16x12.webp")
+            self.assertEqual(media[0]["step"], 12)
+            self.assertEqual(media[0]["type"], "image")
+            self.assertTrue((output_dir / MEDIA_FILENAME).is_file())
+
+    def test_png_remains_default_and_external_trackers_do_not_create_manifest(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output_dir = Path(directory)
+            validation_dir = output_dir / "validation_images"
+            validation_dir.mkdir()
+            config = SimpleNamespace(output_dir=str(output_dir), report_to="wandb")
+
+            saved_path = save_validation_image(
+                Image.new("RGBA", (8, 8), color=(0, 0, 0, 0)),
+                validation_dir,
+                "step_12_sample_0_8x8",
+                config,
+                label="sample",
+                index=0,
+                resolution="8x8",
+            )
+
+            self.assertTrue(saved_path.endswith(".png"))
+            self.assertFalse((output_dir / MEDIA_FILENAME).exists())
+
+    def test_invalid_validation_image_quality_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config = SimpleNamespace(
+                output_dir=directory,
+                report_to="simpletuner",
+                validation_image_format="webp",
+                validation_image_quality=0,
+            )
+
+            with self.assertRaisesRegex(ValueError, "within"):
+                save_validation_image(
+                    Image.new("RGB", (8, 8)),
+                    directory,
+                    "invalid-quality",
+                    config,
+                    label="sample",
+                    index=0,
+                    resolution="8x8",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_training_metrics_routes.py
+++ b/tests/test_training_metrics_routes.py
@@ -1,0 +1,69 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from simpletuner.simpletuner_sdk.server import ServerMode
+from simpletuner.simpletuner_sdk.server.services.training_metrics_service import TRAINING_METRICS_SERVICE
+from tests.unittest_support import APITestCase
+
+
+class TrainingMetricsRoutesTests(APITestCase, unittest.TestCase):
+    def test_training_run_routes(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            report = root / "training_report.html"
+            report.write_text("<html>report</html>", encoding="utf-8")
+            media = root / "validation.webp"
+            media.write_bytes(b"RIFF")
+            run_payload = {
+                "run": {"environment": "anima", "last_step": 2},
+                "records": [{"step": 2, "metrics": {"loss": 0.5}}],
+                "media": [],
+                "available_metrics": ["loss"],
+            }
+
+            with (
+                patch.object(TRAINING_METRICS_SERVICE, "list_runs", return_value={"runs": [], "count": 0}),
+                patch.object(TRAINING_METRICS_SERVICE, "get_run", return_value=run_payload) as get_run,
+                patch.object(TRAINING_METRICS_SERVICE, "report_path", return_value=report),
+                patch.object(TRAINING_METRICS_SERVICE, "media_path", return_value=media),
+                self.client_session(ServerMode.UNIFIED) as client,
+            ):
+                self.assertEqual(client.get("/api/metrics/training/runs").json(), {"runs": [], "count": 0})
+
+                response = client.get(
+                    "/api/metrics/training/runs/anima",
+                    params={"start_step": 1, "end_step": 2, "max_points": 25, "metric": ["loss"]},
+                )
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json()["run"]["environment"], "anima")
+                get_run.assert_called_once_with(
+                    "anima",
+                    start_step=1,
+                    end_step=2,
+                    max_points=25,
+                    metric_names=["loss"],
+                )
+
+                report_response = client.get("/api/metrics/training/runs/anima/report")
+                self.assertEqual(report_response.status_code, 200)
+                self.assertEqual(report_response.headers["content-type"], "text/html; charset=utf-8")
+                self.assertNotIn("attachment", report_response.headers.get("content-disposition", ""))
+
+                media_response = client.get("/api/metrics/training/runs/anima/media/validation_images/validation.webp")
+                self.assertEqual(media_response.status_code, 200)
+                self.assertEqual(media_response.content, b"RIFF")
+
+    def test_training_run_rejects_reversed_step_range(self):
+        with self.client_session(ServerMode.UNIFIED) as client:
+            response = client.get(
+                "/api/metrics/training/runs/anima",
+                params={"start_step": 10, "end_step": 1},
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("start_step", response.json()["detail"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_training_metrics_service.py
+++ b/tests/test_training_metrics_service.py
@@ -1,0 +1,133 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from simpletuner.helpers.training.local_metrics import MANIFEST_FILENAME, MEDIA_FILENAME, METRICS_FILENAME, REPORT_FILENAME
+from simpletuner.simpletuner_sdk.server.services.training_metrics_service import (
+    TrainingMetricsService,
+    TrainingMetricsServiceError,
+)
+
+
+class _ConfigStore:
+    def __init__(self, configs):
+        self.configs = configs
+
+    def list_configs(self):
+        return [{"name": name} for name in self.configs]
+
+    def load_config(self, name):
+        if name not in self.configs:
+            raise FileNotFoundError(name)
+        return self.configs[name], object()
+
+
+class TrainingMetricsServiceTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.output_dir = self.root / "output"
+        self.output_dir.mkdir()
+        self.store = _ConfigStore(
+            {
+                "anima": {
+                    "--output_dir": str(self.output_dir),
+                    "--model_family": "anima",
+                },
+                "untracked": {"--output_dir": str(self.root / "untracked")},
+            }
+        )
+        self.service = TrainingMetricsService()
+        self.service._get_config_store = lambda: self.store
+
+        self._write_json(
+            MANIFEST_FILENAME,
+            {
+                "run_name": "anima-local",
+                "project_name": "local-metrics",
+                "status": "completed",
+                "last_step": 9,
+                "record_count": 10,
+                "metric_names": ["loss", "lr"],
+                "updated_at": "2026-08-21T12:00:00+00:00",
+            },
+        )
+        self._write_jsonl(
+            METRICS_FILENAME,
+            [{"step": step, "metrics": {"loss": 10.0 - step, "lr": step / 1000, "epoch": step / 10}} for step in range(10)],
+        )
+        validation_dir = self.output_dir / "validation_images"
+        validation_dir.mkdir()
+        (validation_dir / "step_9_prompt_0.webp").write_bytes(b"RIFF")
+        self._write_jsonl(
+            MEDIA_FILENAME,
+            [
+                {
+                    "step": 9,
+                    "type": "image",
+                    "label": "prompt",
+                    "index": 0,
+                    "path": "validation_images/step_9_prompt_0.webp",
+                }
+            ],
+        )
+        (self.output_dir / REPORT_FILENAME).write_text("<html>report</html>", encoding="utf-8")
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def _write_json(self, filename, payload):
+        (self.output_dir / filename).write_text(json.dumps(payload), encoding="utf-8")
+
+    def _write_jsonl(self, filename, records):
+        content = "".join(f"{json.dumps(record)}\n" for record in records)
+        (self.output_dir / filename).write_text(content, encoding="utf-8")
+
+    def test_list_runs_only_returns_environments_with_metrics(self):
+        result = self.service.list_runs()
+
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["runs"][0]["environment"], "anima")
+        self.assertEqual(result["runs"][0]["model_family"], "anima")
+        self.assertTrue(result["runs"][0]["has_report"])
+
+    def test_get_run_filters_metrics_steps_and_downsamples(self):
+        result = self.service.get_run(
+            "anima",
+            start_step=2,
+            end_step=8,
+            max_points=3,
+            metric_names=["loss"],
+        )
+
+        self.assertEqual([record["step"] for record in result["records"]], [2, 5, 8])
+        self.assertEqual([set(record["metrics"]) for record in result["records"]], [{"loss"}] * 3)
+        self.assertEqual(result["available_metrics"], ["loss", "lr"])
+        self.assertEqual(len(result["media"]), 1)
+        self.assertIn("/api/metrics/training/runs/anima/media/validation_images/", result["media"][0]["url"])
+
+    def test_media_path_requires_manifest_entry_and_validation_directory(self):
+        indexed = self.service.media_path("anima", "validation_images/step_9_prompt_0.webp")
+        self.assertEqual(indexed.name, "step_9_prompt_0.webp")
+
+        unindexed = self.output_dir / "validation_images" / "unindexed.webp"
+        unindexed.write_bytes(b"RIFF")
+        with self.assertRaises(TrainingMetricsServiceError) as context:
+            self.service.media_path("anima", "validation_images/unindexed.webp")
+        self.assertEqual(context.exception.status_code, 404)
+
+        outside = self.root / "outside.webp"
+        outside.write_bytes(b"RIFF")
+        with self.assertRaises(TrainingMetricsServiceError):
+            self.service.media_path("anima", "../outside.webp")
+
+    def test_report_path_and_missing_run(self):
+        self.assertEqual(self.service.report_path("anima").name, REPORT_FILENAME)
+        with self.assertRaises(TrainingMetricsServiceError) as context:
+            self.service.get_run("missing")
+        self.assertEqual(context.exception.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_webui_e2e.py
+++ b/tests/test_webui_e2e.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import json
 import time
 import unittest
+from io import BytesIO
 
 import requests
+from PIL import Image
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -700,6 +702,15 @@ class MetricsGpuHealthDashboardTestCase(_TrainerPageMixin, WebUITestCase):
             trainer_page.switch_to_metrics_tab()
             trainer_page.wait_for_tab("metrics")
 
+            system_tab = WebDriverWait(driver, 10).until(
+                EC.element_to_be_clickable((By.CSS_SELECTOR, "[data-testid='system-metrics-tab']"))
+            )
+            system_tab.click()
+            driver.execute_script(
+                "const comp = Alpine.$data(document.getElementById('metrics-tab-content')); comp.heroDismissed = true;"
+                "const root = Alpine.$data(document.querySelector('.dashboard-wrapper')); root.eventDockCollapsed = true;"
+            )
+
             WebDriverWait(driver, 10).until(
                 EC.presence_of_element_located((By.CSS_SELECTOR, "#metrics-tab-content .gpu-dashboard"))
             )
@@ -728,6 +739,102 @@ class MetricsGpuHealthDashboardTestCase(_TrainerPageMixin, WebUITestCase):
             WebDriverWait(driver, 5).until(lambda d: history_container.get_attribute("data-history-series") == "Temp")
 
         self.for_each_browser("test_gpu_history_toggle_series", scenario)
+
+
+class TrainingMetricsDashboardTestCase(_TrainerPageMixin, WebUITestCase):
+    """Test local training run charts and validation media wiring."""
+
+    MAX_BROWSERS = 1
+
+    def test_training_run_metrics_and_validation_media(self) -> None:
+        self.with_sample_environment()
+        output_dir = self.home_path / "training-output"
+        validation_dir = output_dir / "validation_images"
+        validation_dir.mkdir(parents=True)
+
+        config_path = self.config_dir / "test-config" / "config.json"
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        config["--output_dir"] = str(output_dir)
+        config["--report_to"] = "simpletuner"
+        config_path.write_text(json.dumps(config), encoding="utf-8")
+        self.seed_defaults(active_config="test-config", output_dir=str(output_dir))
+
+        manifest = {
+            "schema_version": 1,
+            "run_name": "Anima local metrics",
+            "project_name": "metrics-e2e",
+            "status": "completed",
+            "last_step": 20,
+            "record_count": 3,
+            "metric_names": ["learning_rate", "train_loss"],
+            "updated_at": "2026-08-21T12:00:00+00:00",
+        }
+        (output_dir / "training_metrics.json").write_text(json.dumps(manifest), encoding="utf-8")
+        records = [
+            {"step": step, "metrics": {"train_loss": loss, "learning_rate": step / 100000}}
+            for step, loss in ((0, 1.0), (10, 0.7), (20, 0.4))
+        ]
+        (output_dir / "training_metrics.jsonl").write_text(
+            "".join(f"{json.dumps(record)}\n" for record in records),
+            encoding="utf-8",
+        )
+        image_path = validation_dir / "step_20_prompt_0_64x64.png"
+        Image.new("RGB", (64, 64), color=(32, 160, 120)).save(image_path, format="PNG")
+        media = {
+            "step": 20,
+            "type": "image",
+            "label": "A green square",
+            "index": 0,
+            "resolution": "64x64",
+            "path": image_path.relative_to(output_dir).as_posix(),
+        }
+        (output_dir / "validation_media.jsonl").write_text(f"{json.dumps(media)}\n", encoding="utf-8")
+        (output_dir / "training_report.html").write_text("<html>report</html>", encoding="utf-8")
+
+        def scenario(driver, _browser):
+            trainer_page = self._trainer_page(driver)
+            trainer_page.navigate_to_trainer()
+            self.dismiss_onboarding(driver)
+            trainer_page.switch_to_metrics_tab()
+            trainer_page.wait_for_tab("metrics")
+
+            run_select = WebDriverWait(driver, 10).until(
+                EC.presence_of_element_located((By.CSS_SELECTOR, "[data-testid='training-run-select']"))
+            )
+            WebDriverWait(driver, 10).until(
+                lambda _driver: Select(run_select).first_selected_option.text.startswith("Anima")
+            )
+            canvas = WebDriverWait(driver, 10).until(
+                EC.visibility_of_element_located((By.CSS_SELECTOR, "[data-testid='training-metrics-canvas']"))
+            )
+            self.assertGreater(canvas.size["width"], 300)
+            self.assertGreater(canvas.size["height"], 200)
+
+            image = WebDriverWait(driver, 10).until(
+                EC.presence_of_element_located((By.CSS_SELECTOR, ".training-media-grid > figure img"))
+            )
+            media_response = requests.get(image.get_attribute("src"), timeout=5)
+            self.assertEqual(media_response.status_code, 200, media_response.text)
+            self.assertEqual(media_response.headers["content-type"], "image/png")
+            self.assertEqual(Image.open(BytesIO(media_response.content)).size, (64, 64))
+
+            loss_toggle = driver.find_element(
+                By.XPATH,
+                "//div[contains(@class, 'training-metric-picker')]//label[span[text()='train_loss']]/input",
+            )
+            loss_toggle.click()
+            WebDriverWait(driver, 5).until(lambda _driver: not loss_toggle.is_selected())
+
+            driver.set_window_size(430, 900)
+            workspace = driver.find_element(By.CSS_SELECTOR, ".training-metrics-workspace")
+            WebDriverWait(driver, 5).until(lambda _driver: workspace.size["width"] > 0)
+            overflow = driver.execute_script(
+                "return arguments[0].scrollWidth - arguments[0].clientWidth;",
+                workspace,
+            )
+            self.assertLessEqual(overflow, 1)
+
+        self.for_each_browser("test_training_run_metrics_and_validation_media", scenario)
 
 
 class EventDockUptimeTestCase(_TrainerPageMixin, WebUITestCase):


### PR DESCRIPTION
## Summary
- add a built-in `simpletuner` Accelerate tracker with append-only scalar JSONL, an atomic manifest, validation media indexing, and a self-contained HTML report
- add authenticated training-run metrics APIs and a responsive Training Runs view under Metrics with dynamic scalar charts and validation image, video, and audio comparison
- add optional PNG, WebP, and JPEG validation image storage controls
- document the output contract, WebUI, API, and configuration in all supported documentation translations

## Validation
- `.venv/bin/python -m unittest -v -f` (6,202 passed, 196 skipped)
- `npm test -- --runInBand` (995 passed)
- `SIMPLETUNER_SELENIUM_TESTS=1 .venv/bin/python -m unittest -v tests.test_webui_e2e.TrainingMetricsDashboardTestCase tests.test_webui_e2e.MetricsGpuHealthDashboardTestCase`
- `.venv/bin/mkdocs build --strict`
- pre-commit hooks
- two-step Anima v1.0 LoRA training and validation on one H200; the run completed and produced scalar JSONL, a completed manifest, an indexed WebP validation image, and a self-contained report

Closes #2327
