### PR TITLE
torchcodec + H3 single file fixes

### DIFF
--- a/simpletuner/helpers/audio/load.py
+++ b/simpletuner/helpers/audio/load.py
@@ -126,18 +126,16 @@ def load_audio(source: AudioSource) -> Tuple[torch.Tensor, int]:
         _, ext = os.path.splitext(stream)
         if ext:
             format_hint = ext.lstrip(".")
-    # Container formats that may need ffmpeg fallback
-    container_formats = {"mp4", "mpeg", "mpg", "mkv", "webm", "avi", "mov", "m4a", "m4v"}
-
     try:
         waveform, sample_rate = torchaudio.load(stream, format=format_hint)
     except (RuntimeError, ImportError, OSError) as torchaudio_error:
-        # For file paths, try ffmpeg for container formats
-        if isinstance(stream, str) and format_hint and format_hint.lower() in container_formats:
+        # TorchCodec can fail to initialize independently of the input format, so
+        # let ffmpeg handle every filesystem path before using format-specific fallbacks.
+        if isinstance(stream, str):
             try:
                 waveform, sample_rate = _load_with_ffmpeg(stream)
             except Exception as ffmpeg_error:
-                logger.warning(f"ffmpeg fallback failed for {stream}: {ffmpeg_error}")
+                logger.warning("ffmpeg fallback failed for %s: %s", stream, ffmpeg_error)
                 raise torchaudio_error from ffmpeg_error
         elif hasattr(stream, "read"):
             try:

--- a/simpletuner/helpers/models/minimaxh3/model.py
+++ b/simpletuner/helpers/models/minimaxh3/model.py
@@ -479,7 +479,7 @@ class MiniMaxH3(VideoModelFoundation):
     def _model_config_path(self):
         model_path = getattr(self.config, "pretrained_model_name_or_path", None)
         transformer_path = getattr(self.config, "pretrained_transformer_model_name_or_path", None)
-        if _is_single_file_path(model_path) or _is_single_file_path(transformer_path):
+        if _is_single_file_path(model_path) or (not model_path and _is_single_file_path(transformer_path)):
             return MINIMAX_H3_BASE_REPO
         return super()._model_config_path()
 

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -763,9 +763,13 @@ class Trainer:
             os.environ["TORCHINDUCTOR_DISABLED_PASSES"] = ",".join(disabled_passes)
 
         try:
-            import torch._inductor.config as inductor_config
+            inductor_config = importlib.import_module("torch._inductor.config")
         except Exception as exc:
             logger.warning("Unable to configure TorchInductor pass disables: %s", exc)
+            return
+
+        if not hasattr(inductor_config, "disabled_passes"):
+            logger.info("TorchInductor config.disabled_passes is unavailable; retaining the environment-only pass disable.")
             return
 
         if getattr(inductor_config, "disabled_passes", "") != os.environ["TORCHINDUCTOR_DISABLED_PASSES"]:

--- a/tests/test_audio_load.py
+++ b/tests/test_audio_load.py
@@ -1,0 +1,27 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from simpletuner.helpers.audio.load import load_audio
+
+
+class AudioLoadTests(unittest.TestCase):
+    def test_filesystem_path_uses_ffmpeg_when_torchaudio_fails(self):
+        expected = torch.ones(2, 32)
+        with (
+            patch("simpletuner.helpers.audio.load.torchaudio.load", side_effect=OSError("torchcodec unavailable")),
+            patch(
+                "simpletuner.helpers.audio.load._load_with_ffmpeg",
+                return_value=(expected, 16_000),
+            ) as ffmpeg_load,
+        ):
+            waveform, sample_rate = load_audio("/tmp/example.flac")
+
+        ffmpeg_load.assert_called_once_with("/tmp/example.flac")
+        self.assertIs(waveform, expected)
+        self.assertEqual(sample_rate, 16_000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_minimaxh3.py
+++ b/tests/test_minimaxh3.py
@@ -711,6 +711,16 @@ class MiniMaxH3Tests(unittest.TestCase):
         resolved = model_cls.get_real_class() if hasattr(model_cls, "get_real_class") else model_cls
         self.assertIs(resolved, MiniMaxH3)
 
+    def test_model_config_path_keeps_local_components_with_single_file_transformer(self):
+        model = MiniMaxH3.__new__(MiniMaxH3)
+        model.config = SimpleNamespace(
+            model_family="minimaxh3",
+            pretrained_model_name_or_path="/src/model",
+            pretrained_transformer_model_name_or_path="/src/weights/transformer.safetensors",
+        )
+
+        self.assertEqual(model._model_config_path(), "/src/model")
+
     def test_image_mode_keeps_single_frame_geometry(self):
         self.assertEqual(MiniMaxH3.adjust_video_frames(1), 1)
         self.assertEqual(align_num_frames(1), 1)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -3605,6 +3605,22 @@ class TestTrainer(unittest.TestCase):
                 os.environ["TORCHINDUCTOR_DISABLED_PASSES"] = original_env
             inductor_config.disabled_passes = original_config
 
+    @patch("simpletuner.helpers.training.trainer.importlib.import_module")
+    def test_configure_inductor_dynamic_training_passes_allows_missing_config_option(self, import_module):
+        trainer = object.__new__(Trainer)
+        original_env = os.environ.get("TORCHINDUCTOR_DISABLED_PASSES")
+        import_module.return_value = object()
+
+        try:
+            os.environ.pop("TORCHINDUCTOR_DISABLED_PASSES", None)
+            trainer._configure_inductor_dynamic_training_passes("inductor")
+            self.assertEqual(os.environ["TORCHINDUCTOR_DISABLED_PASSES"], "PASS_PATTERN_1")
+        finally:
+            if original_env is None:
+                os.environ.pop("TORCHINDUCTOR_DISABLED_PASSES", None)
+            else:
+                os.environ["TORCHINDUCTOR_DISABLED_PASSES"] = original_env
+
     @patch("simpletuner.helpers.training.trainer.TorchDynamoPlugin")
     @patch("simpletuner.helpers.training.trainer.Accelerator")
     def test_dynamo_plugin_created_when_advanced_options_enabled(self, mock_accelerator, mock_dynamo_plugin):


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes across audio loading, model configuration, and TorchInductor training pass handling, along with new and enhanced tests to ensure the reliability of these changes.

**Audio Loading Improvements:**
- The `load_audio` function now attempts to use ffmpeg for all filesystem paths if `torchaudio` fails, regardless of file extension, improving robustness when TorchCodec is unavailable. Logging for ffmpeg fallback failures is also improved.
- Added a new test `AudioLoadTests.test_filesystem_path_uses_ffmpeg_when_torchaudio_fails` to verify that ffmpeg is used as a fallback when `torchaudio.load` fails.

**TorchInductor Training Pass Handling:**
- Updated the dynamic training pass configuration to import the TorchInductor config module more robustly and handle cases where the `disabled_passes` attribute is missing, with appropriate logging.
- Added a test to ensure that missing `disabled_passes` in TorchInductor config is handled gracefully and the environment variable is still set.

**Model Configuration Logic:**
- Improved `_model_config_path` in the MiniMaxH3 model to correctly handle cases where only the transformer path is a single file, ensuring local components are preserved.
- Added a test to verify that `_model_config_path` returns the correct path when the transformer is a single file.