### PR TITLE
minimax music3: cache rvq codes as if its a VAE

### DIFF
--- a/documentation/OPTIONS.es.md
+++ b/documentation/OPTIONS.es.md
@@ -73,7 +73,7 @@ Donde `foo` es tu entorno de configuración; o simplemente usa `config/config.js
 - **Opciones**: `transformer` (predeterminado), `language_model`
 - **Notas**:
   - `transformer` entrena el DiT musical de flow matching sobre latentes Flow-VAE en caché (la ruta estándar).
-  - `language_model` entrena la etapa autorregresiva Qwen3 con entropía cruzada de siguiente token sobre códigos semánticos RVQ. Los datasets deben proporcionar tokens de audio crudos por codebook precomputados (metadato `audio_tokens_path`, con forma `[frames, codebooks]`) junto con `prompt` (o `tags`) y `lyrics`. Solo se admite LoRA PEFT estándar, `--lora_format comfyui` se rechaza y el audio de validación dentro del entrenador está deshabilitado: renderiza desde los checkpoints guardados.
+  - `language_model` entrena la etapa autorregresiva Qwen3 con entropía cruzada de siguiente token sobre códigos semánticos RVQ. Para `dataset_type=audio`, SimpleTuner codifica las ondas crudas mediante el DAV de MiniMax Music y el codificador RVQ v4 predeterminado durante la caché VAE. Los datasets aún pueden proporcionar tokens de audio crudos por codebook precomputados (`audio_tokens` o `audio_tokens_path`, con forma `[frames, codebooks]`) junto con `prompt` (o `tags`) y `lyrics`. Solo se admite LoRA PEFT estándar, `--lora_format comfyui` se rechaza y el audio de validación dentro del entrenador está deshabilitado: renderiza desde los checkpoints guardados.
 
 ### `--minimax_music_lm_max_frames`
 
@@ -82,6 +82,31 @@ Donde `foo` es tu entorno de configuración; o simplemente usa `config/config.js
 - **Notas**:
   - Un frame son 40ms; 7500 frames son cinco minutos. Reduce este valor si las pistas largas agotan la VRAM.
   - Las muestras truncadas no reciben objetivo de fin de audio, por lo que el modelo no aprende a detenerse antes de tiempo.
+
+### `--minimax_music_rvq_encoder_model_name_or_path`
+
+- **Qué**: Solo para entrenamiento `language_model` de MiniMax Music: repositorio Hub o directorio local con el codificador RVQ que convierte latentes DAV cacheados en códigos de audio por codebook.
+- **Predeterminado**: `SimpleTuner/open-rvq-encoder-minimax-music3-169m-v4`
+- **Relacionado**: `--minimax_music_rvq_encoder_subfolder` usa `final` por defecto; `--minimax_music_rvq_encoder_revision` puede fijar una revisión de Hub.
+- **Notas**: El paquete predeterminado incluye `rvq_encoder_config.json`, `rvq_encoder.safetensors` y metadatos muP de formas base. Cámbialo solo si usas un codificador RVQ compatible entrenado para los codebooks de MiniMax Music 3.
+
+### `--minimax_music_rvq_encoder_subfolder`
+
+- **Qué**: Subcarpeta dentro del repositorio o directorio local del codificador RVQ.
+- **Predeterminado**: `final`
+- **Notas**: La carpeta seleccionada debe contener `rvq_encoder_config.json`, `rvq_encoder.safetensors` y cualquier metadato muP de formas base requerido.
+
+### `--minimax_music_rvq_encoder_revision`
+
+- **Qué**: Revisión Hub opcional para `--minimax_music_rvq_encoder_model_name_or_path`.
+- **Predeterminado**: sin definir; se usa el valor principal de `--revision` cuando existe.
+- **Notas**: Úsalo cuando el codificador RVQ deba fijarse por separado del checkpoint base de MiniMax Music 3.
+
+### `--minimax_music_rvq_vae_model_name_or_path`
+
+- **Qué**: Solo para entrenamiento `language_model` de MiniMax Music: repositorio, directorio local o archivo `dav.pth` del DAV/audio VAE usado antes del codificador RVQ durante la caché VAE.
+- **Predeterminado**: sin definir; se usa primero `--pretrained_vae_model_name_or_path` y luego `SimpleTuner/MiniMax-Music-3-Encoder`.
+- **Notas**: Esta es la etapa que convierte la onda en latentes DAV. Después, el codificador RVQ convierte esos latentes DAV en el tensor de códigos que aprende a predecir el LM global.
 
 ### `--minimax_music_lm_adapter`
 

--- a/documentation/OPTIONS.hi.md
+++ b/documentation/OPTIONS.hi.md
@@ -73,7 +73,7 @@ simpletuner configure config/foo/config.json
 - **विकल्प**: `transformer` (डिफ़ॉल्ट), `language_model`
 - **नोट्स**:
   - `transformer` कैश किए गए Flow-VAE latents पर फ्लो-मैचिंग संगीत DiT को प्रशिक्षित करता है (मानक पथ)।
-  - `language_model` RVQ सिमेंटिक कोड पर नेक्स्ट-टोकन क्रॉस-एंट्रॉपी के साथ Qwen3 ऑटोरिग्रेसिव चरण को प्रशिक्षित करता है। डेटासेट को `prompt` (या `tags`) और `lyrics` के साथ पूर्व-गणित कच्चे प्रति-कोडबुक ऑडियो टोकन (`audio_tokens_path` मेटाडेटा, आकार `[frames, codebooks]`) प्रदान करने होंगे। केवल मानक PEFT LoRA समर्थित है, `--lora_format comfyui` अस्वीकार किया जाता है, और ट्रेनर के भीतर सत्यापन ऑडियो अक्षम है — सहेजे गए चेकपॉइंट से रेंडर करें।
+  - `language_model` RVQ सिमेंटिक कोड पर नेक्स्ट-टोकन क्रॉस-एंट्रॉपी के साथ Qwen3 ऑटोरिग्रेसिव चरण को प्रशिक्षित करता है। `dataset_type=audio` के लिए, SimpleTuner VAE cache समय raw waveform को MiniMax Music DAV और default v4 RVQ encoder से कोड में बदलता है। डेटासेट फिर भी `prompt` (या `tags`) और `lyrics` के साथ पूर्व-गणित कच्चे प्रति-कोडबुक ऑडियो टोकन (`audio_tokens` या `audio_tokens_path`, आकार `[frames, codebooks]`) दे सकते हैं। केवल मानक PEFT LoRA समर्थित है, `--lora_format comfyui` अस्वीकार किया जाता है, और ट्रेनर के भीतर सत्यापन ऑडियो अक्षम है — सहेजे गए चेकपॉइंट से रेंडर करें।
 
 ### `--minimax_music_lm_max_frames`
 
@@ -82,6 +82,31 @@ simpletuner configure config/foo/config.json
 - **नोट्स**:
   - एक फ्रेम 40ms का है; 7500 फ्रेम पाँच मिनट हैं। यदि लंबे ट्रैक VRAM समाप्त कर दें तो इसे कम करें।
   - काटे गए नमूनों को ऑडियो-समाप्ति लक्ष्य नहीं मिलता, इसलिए मॉडल जल्दी रुकना नहीं सीखता।
+
+### `--minimax_music_rvq_encoder_model_name_or_path`
+
+- **क्या**: केवल MiniMax Music `language_model` training के लिए: Hub repository या local directory जिसमें RVQ encoder हो, जो cached DAV audio latents को प्रति-codebook audio codes में बदलता है।
+- **डिफ़ॉल्ट**: `SimpleTuner/open-rvq-encoder-minimax-music3-169m-v4`
+- **संबंधित**: `--minimax_music_rvq_encoder_subfolder` का default `final` है; `--minimax_music_rvq_encoder_revision` Hub revision pin कर सकता है।
+- **नोट्स**: Default package में `rvq_encoder_config.json`, `rvq_encoder.safetensors`, और muP base-shape metadata शामिल हैं। इसे केवल तब बदलें जब आप MiniMax Music 3 codebooks के लिए trained compatible RVQ encoder इस्तेमाल कर रहे हों।
+
+### `--minimax_music_rvq_encoder_subfolder`
+
+- **क्या**: RVQ encoder repository या local directory के अंदर subfolder।
+- **डिफ़ॉल्ट**: `final`
+- **नोट्स**: चुने गए folder में `rvq_encoder_config.json`, `rvq_encoder.safetensors`, और जरूरी muP base-shape metadata होना चाहिए।
+
+### `--minimax_music_rvq_encoder_revision`
+
+- **क्या**: `--minimax_music_rvq_encoder_model_name_or_path` के लिए optional Hub revision।
+- **डिफ़ॉल्ट**: unset; जब main `--revision` दिया जाता है तो वही इस्तेमाल होता है।
+- **नोट्स**: इसे तब इस्तेमाल करें जब RVQ encoder को MiniMax Music 3 base checkpoint से अलग pin करना हो।
+
+### `--minimax_music_rvq_vae_model_name_or_path`
+
+- **क्या**: केवल MiniMax Music `language_model` training के लिए: VAE caching के दौरान RVQ encoder से पहले इस्तेमाल होने वाला DAV/audio VAE repository, local directory, या `dav.pth` file।
+- **डिफ़ॉल्ट**: unset; पहले `--pretrained_vae_model_name_or_path` इस्तेमाल होता है, फिर `SimpleTuner/MiniMax-Music-3-Encoder`।
+- **नोट्स**: यह waveform से DAV latent बनाने वाला encoder stage है। फिर RVQ encoder उन DAV latents को उस code tensor में बदलता है जिसे global LM predict करना सीखता है।
 
 ### `--minimax_music_lm_adapter`
 

--- a/documentation/OPTIONS.ja.md
+++ b/documentation/OPTIONS.ja.md
@@ -73,7 +73,7 @@ simpletuner configure config/foo/config.json
 - **選択肢**: `transformer`（デフォルト）、`language_model`
 - **メモ**:
   - `transformer` はキャッシュされた Flow-VAE latent 上でフローマッチング音楽 DiT をトレーニングします（標準パス）。
-  - `language_model` は RVQ セマンティックコードの次トークン交差エントロピーで Qwen3 自己回帰ステージをトレーニングします。データセットは、`prompt`（または `tags`）と `lyrics` に加えて、事前計算された生のコードブック別オーディオトークン（`audio_tokens_path` メタデータ、形状 `[frames, codebooks]`）を提供する必要があります。標準 PEFT LoRA のみ対応、`--lora_format comfyui` は拒否され、トレーナー内の検証オーディオは無効になります——保存されたチェックポイントからレンダリングしてください。
+  - `language_model` は RVQ セマンティックコードの次トークン交差エントロピーで Qwen3 自己回帰ステージをトレーニングします。`dataset_type=audio` では、SimpleTuner が VAE キャッシュ時に MiniMax Music DAV とデフォルトの v4 RVQ エンコーダーで raw waveform をコード化します。データセットは引き続き、`prompt`（または `tags`）と `lyrics` に加えて、事前計算された生のコードブック別オーディオトークン（`audio_tokens` または `audio_tokens_path`、形状 `[frames, codebooks]`）を提供できます。標準 PEFT LoRA のみ対応、`--lora_format comfyui` は拒否され、トレーナー内の検証オーディオは無効になります——保存されたチェックポイントからレンダリングしてください。
 
 ### `--minimax_music_lm_max_frames`
 
@@ -82,6 +82,31 @@ simpletuner configure config/foo/config.json
 - **メモ**:
   - 1 フレームは 40ms、7500 フレームは 5 分です。長いトラックで VRAM が不足する場合は下げてください。
   - 切り詰められたサンプルにはオーディオ終端ターゲットが与えられないため、モデルが早期停止を学習することはありません。
+
+### `--minimax_music_rvq_encoder_model_name_or_path`
+
+- **内容**: MiniMax Music の `language_model` トレーニング専用です。キャッシュ済み DAV オーディオ latent をコードブック別オーディオコードへ変換する RVQ エンコーダーを含む Hub リポジトリまたはローカルディレクトリです。
+- **デフォルト**: `SimpleTuner/open-rvq-encoder-minimax-music3-169m-v4`
+- **関連**: `--minimax_music_rvq_encoder_subfolder` はデフォルトで `final`、`--minimax_music_rvq_encoder_revision` は Hub revision の固定に使えます。
+- **メモ**: デフォルトパッケージには `rvq_encoder_config.json`、`rvq_encoder.safetensors`、muP base-shape メタデータが含まれます。MiniMax Music 3 の codebook 用にトレーニングされた互換 RVQ エンコーダーを使う場合だけ変更してください。
+
+### `--minimax_music_rvq_encoder_subfolder`
+
+- **内容**: RVQ エンコーダーのリポジトリまたはローカルディレクトリ内のサブフォルダです。
+- **デフォルト**: `final`
+- **メモ**: 選択したフォルダには `rvq_encoder_config.json`、`rvq_encoder.safetensors`、必要な muP base-shape メタデータが含まれている必要があります。
+
+### `--minimax_music_rvq_encoder_revision`
+
+- **内容**: `--minimax_music_rvq_encoder_model_name_or_path` 用の任意の Hub revision です。
+- **デフォルト**: 未設定。主な `--revision` が指定されている場合はそれを使用します。
+- **メモ**: RVQ エンコーダーを MiniMax Music 3 ベースチェックポイントとは別に固定したい場合に使用します。
+
+### `--minimax_music_rvq_vae_model_name_or_path`
+
+- **内容**: MiniMax Music の `language_model` トレーニング専用です。VAE キャッシュ中、RVQ エンコーダーの前に使う DAV/audio VAE のリポジトリ、ローカルディレクトリ、または `dav.pth` ファイルです。
+- **デフォルト**: 未設定。まず `--pretrained_vae_model_name_or_path` を使用し、その後 `SimpleTuner/MiniMax-Music-3-Encoder` を使用します。
+- **メモ**: これは waveform を DAV latent にするエンコード段階です。その後、RVQ エンコーダーが DAV latent をグローバル LM の予測対象コードテンソルへ変換します。
 
 ### `--minimax_music_lm_adapter`
 

--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -73,7 +73,7 @@ Where `foo` is your config environment - or just use `config/config.json` if you
 - **Choices**: `transformer` (default), `language_model`
 - **Notes**:
   - `transformer` trains the flow-matching music DiT on cached Flow-VAE latents (the standard path).
-  - `language_model` trains the Qwen3 autoregressive stage with next-token cross-entropy on RVQ semantic codes. Datasets must provide precomputed raw per-codebook audio tokens (`audio_tokens_path` metadata, shaped `[frames, codebooks]`) alongside `prompt` (or `tags`) and `lyrics`. Only standard PEFT LoRA is supported, `--lora_format comfyui` is rejected, and in-trainer validation audio is disabled — render from saved checkpoints instead.
+  - `language_model` trains the Qwen3 autoregressive stage with next-token cross-entropy on RVQ semantic codes. For `dataset_type=audio`, SimpleTuner encodes raw waveforms through the MiniMax Music DAV and the default v4 RVQ encoder at VAE-cache time. Datasets may still provide precomputed raw per-codebook audio tokens (`audio_tokens` or `audio_tokens_path`, shaped `[frames, codebooks]`) alongside `prompt` (or `tags`) and `lyrics`. Only standard PEFT LoRA is supported, `--lora_format comfyui` is rejected, and in-trainer validation audio is disabled — render from saved checkpoints instead.
 
 ### `--minimax_music_lm_max_frames`
 
@@ -82,6 +82,31 @@ Where `foo` is your config environment - or just use `config/config.json` if you
 - **Notes**:
   - One frame is 40ms; 7500 frames is five minutes. Lower this if long tracks exhaust VRAM.
   - Truncated samples do not receive an end-of-audio target, so the model is not taught to stop early.
+
+### `--minimax_music_rvq_encoder_model_name_or_path`
+
+- **What**: MiniMax Music `language_model` training only: Hub repository or local directory containing the RVQ encoder used to turn cached DAV audio latents into per-codebook audio codes.
+- **Default**: `SimpleTuner/open-rvq-encoder-minimax-music3-169m-v4`
+- **Related**: `--minimax_music_rvq_encoder_subfolder` defaults to `final`; `--minimax_music_rvq_encoder_revision` optionally pins a Hub revision.
+- **Notes**: The default package includes `rvq_encoder_config.json`, `rvq_encoder.safetensors`, and muP base-shape metadata. Change this only when using a compatible RVQ encoder trained for MiniMax Music 3 codebooks.
+
+### `--minimax_music_rvq_encoder_subfolder`
+
+- **What**: Subfolder inside the RVQ encoder repository or local directory.
+- **Default**: `final`
+- **Notes**: The selected folder must contain `rvq_encoder_config.json`, `rvq_encoder.safetensors`, and any required muP base-shape metadata.
+
+### `--minimax_music_rvq_encoder_revision`
+
+- **What**: Optional Hub revision for `--minimax_music_rvq_encoder_model_name_or_path`.
+- **Default**: unset; the main `--revision` value is used when provided.
+- **Notes**: Use this when the RVQ encoder should be pinned separately from the MiniMax Music 3 base checkpoint.
+
+### `--minimax_music_rvq_vae_model_name_or_path`
+
+- **What**: MiniMax Music `language_model` training only: DAV/audio VAE repository, local directory, or `dav.pth` file used before the RVQ encoder during VAE caching.
+- **Default**: unset; `--pretrained_vae_model_name_or_path` is used first, then `SimpleTuner/MiniMax-Music-3-Encoder`.
+- **Notes**: This is the waveform-to-DAV-latent encoder stage. The RVQ encoder then converts those DAV latents into the code tensor the global LM learns to predict.
 
 ### `--minimax_music_lm_adapter`
 

--- a/documentation/OPTIONS.pt-BR.md
+++ b/documentation/OPTIONS.pt-BR.md
@@ -73,7 +73,7 @@ Onde `foo` e seu ambiente de config — ou use `config/config.json` se nao estiv
 - **Opções**: `transformer` (padrão), `language_model`
 - **Notas**:
   - `transformer` treina o DiT musical de flow matching sobre latentes Flow-VAE em cache (o caminho padrão).
-  - `language_model` treina o estágio autorregressivo Qwen3 com entropia cruzada de próximo token sobre códigos semânticos RVQ. Os datasets devem fornecer tokens de áudio brutos por codebook pré-computados (metadado `audio_tokens_path`, com formato `[frames, codebooks]`) junto com `prompt` (ou `tags`) e `lyrics`. Apenas LoRA PEFT padrão é suportado, `--lora_format comfyui` é rejeitado e o áudio de validação no treinador fica desabilitado — renderize a partir dos checkpoints salvos.
+  - `language_model` treina o estágio autorregressivo Qwen3 com entropia cruzada de próximo token sobre códigos semânticos RVQ. Para `dataset_type=audio`, o SimpleTuner codifica as ondas brutas pelo DAV do MiniMax Music e pelo codificador RVQ v4 padrão durante o cache VAE. Os datasets ainda podem fornecer tokens de áudio brutos por codebook pré-computados (`audio_tokens` ou `audio_tokens_path`, com formato `[frames, codebooks]`) junto com `prompt` (ou `tags`) e `lyrics`. Apenas LoRA PEFT padrão é suportado, `--lora_format comfyui` é rejeitado e o áudio de validação no treinador fica desabilitado — renderize a partir dos checkpoints salvos.
 
 ### `--minimax_music_lm_max_frames`
 
@@ -82,6 +82,31 @@ Onde `foo` e seu ambiente de config — ou use `config/config.json` se nao estiv
 - **Notas**:
   - Um frame são 40ms; 7500 frames são cinco minutos. Reduza se faixas longas esgotarem a VRAM.
   - Amostras truncadas não recebem alvo de fim de áudio, então o modelo não aprende a parar cedo demais.
+
+### `--minimax_music_rvq_encoder_model_name_or_path`
+
+- **O quê**: Apenas para treinamento `language_model` do MiniMax Music: repositório Hub ou diretório local com o codificador RVQ que converte latentes DAV em cache em códigos de áudio por codebook.
+- **Padrão**: `SimpleTuner/open-rvq-encoder-minimax-music3-169m-v4`
+- **Relacionado**: `--minimax_music_rvq_encoder_subfolder` usa `final` por padrão; `--minimax_music_rvq_encoder_revision` pode fixar uma revisão do Hub.
+- **Notas**: O pacote padrão inclui `rvq_encoder_config.json`, `rvq_encoder.safetensors` e metadados muP de formas base. Altere apenas ao usar um codificador RVQ compatível treinado para os codebooks do MiniMax Music 3.
+
+### `--minimax_music_rvq_encoder_subfolder`
+
+- **O quê**: Subpasta dentro do repositório ou diretório local do codificador RVQ.
+- **Padrão**: `final`
+- **Notas**: A pasta selecionada deve conter `rvq_encoder_config.json`, `rvq_encoder.safetensors` e qualquer metadado muP de formas base necessário.
+
+### `--minimax_music_rvq_encoder_revision`
+
+- **O quê**: Revisão Hub opcional para `--minimax_music_rvq_encoder_model_name_or_path`.
+- **Padrão**: não definido; o valor principal de `--revision` é usado quando fornecido.
+- **Notas**: Use quando o codificador RVQ precisar ser fixado separadamente do checkpoint base do MiniMax Music 3.
+
+### `--minimax_music_rvq_vae_model_name_or_path`
+
+- **O quê**: Apenas para treinamento `language_model` do MiniMax Music: repositório, diretório local ou arquivo `dav.pth` do DAV/audio VAE usado antes do codificador RVQ durante o cache VAE.
+- **Padrão**: não definido; `--pretrained_vae_model_name_or_path` é usado primeiro, depois `SimpleTuner/MiniMax-Music-3-Encoder`.
+- **Notas**: Esta é a etapa que converte waveform em latentes DAV. Depois, o codificador RVQ converte esses latentes DAV no tensor de códigos que o LM global aprende a prever.
 
 ### `--minimax_music_lm_adapter`
 

--- a/documentation/OPTIONS.zh.md
+++ b/documentation/OPTIONS.zh.md
@@ -73,7 +73,7 @@ simpletuner configure config/foo/config.json
 - **选项**：`transformer`（默认）、`language_model`
 - **说明**：
   - `transformer` 在缓存的 Flow-VAE latent 上训练流匹配音乐 DiT（标准路径）。
-  - `language_model` 使用 RVQ 语义码的下一 token 交叉熵训练 Qwen3 自回归阶段。数据集必须提供预计算的原始逐码本音频 token（`audio_tokens_path` 元数据，形状为 `[frames, codebooks]`），以及 `prompt`（或 `tags`）和 `lyrics`。仅支持标准 PEFT LoRA，`--lora_format comfyui` 会被拒绝，且训练器内验证音频被禁用——请从保存的检查点渲染。
+  - `language_model` 使用 RVQ 语义码的下一 token 交叉熵训练 Qwen3 自回归阶段。对于 `dataset_type=audio`，SimpleTuner 会在 VAE 缓存阶段用 MiniMax Music DAV 和默认 v4 RVQ 编码器把原始 waveform 编成代码。数据集仍可提供预计算的原始逐码本音频 token（`audio_tokens` 或 `audio_tokens_path`，形状为 `[frames, codebooks]`），以及 `prompt`（或 `tags`）和 `lyrics`。仅支持标准 PEFT LoRA，`--lora_format comfyui` 会被拒绝，且训练器内验证音频被禁用——请从保存的检查点渲染。
 
 ### `--minimax_music_lm_max_frames`
 
@@ -82,6 +82,31 @@ simpletuner configure config/foo/config.json
 - **说明**：
   - 一帧为 40 毫秒；7500 帧即五分钟。如果长曲目耗尽显存，请降低该值。
   - 被截断的样本不会获得音频结束目标，因此模型不会被教导提前停止。
+
+### `--minimax_music_rvq_encoder_model_name_or_path`
+
+- **内容**：仅用于 MiniMax Music `language_model` 训练：包含 RVQ 编码器的 Hub 仓库或本地目录，用于将缓存的 DAV 音频 latent 转成逐码本音频代码。
+- **默认**：`SimpleTuner/open-rvq-encoder-minimax-music3-169m-v4`
+- **相关**：`--minimax_music_rvq_encoder_subfolder` 默认是 `final`；`--minimax_music_rvq_encoder_revision` 可固定 Hub revision。
+- **说明**：默认包包含 `rvq_encoder_config.json`、`rvq_encoder.safetensors` 和 muP base-shape 元数据。只有在使用为 MiniMax Music 3 codebook 训练的兼容 RVQ 编码器时才更改。
+
+### `--minimax_music_rvq_encoder_subfolder`
+
+- **内容**：RVQ 编码器仓库或本地目录中的子文件夹。
+- **默认**：`final`
+- **说明**：所选文件夹必须包含 `rvq_encoder_config.json`、`rvq_encoder.safetensors` 以及所需的 muP base-shape 元数据。
+
+### `--minimax_music_rvq_encoder_revision`
+
+- **内容**：`--minimax_music_rvq_encoder_model_name_or_path` 的可选 Hub revision。
+- **默认**：未设置；如果提供了主 `--revision`，则使用它。
+- **说明**：当 RVQ 编码器需要与 MiniMax Music 3 基础 checkpoint 分开固定版本时使用。
+
+### `--minimax_music_rvq_vae_model_name_or_path`
+
+- **内容**：仅用于 MiniMax Music `language_model` 训练：VAE 缓存时在 RVQ 编码器之前使用的 DAV/audio VAE 仓库、本地目录或 `dav.pth` 文件。
+- **默认**：未设置；先使用 `--pretrained_vae_model_name_or_path`，然后使用 `SimpleTuner/MiniMax-Music-3-Encoder`。
+- **说明**：这是 waveform 到 DAV latent 的编码阶段。随后 RVQ 编码器会把这些 DAV latent 转成全局 LM 学习预测的代码张量。
 
 ### `--minimax_music_lm_adapter`
 

--- a/simpletuner/helpers/data_backend/factory.py
+++ b/simpletuner/helpers/data_backend/factory.py
@@ -4109,13 +4109,18 @@ class FactoryRegistry:
             return
         if dataset_type_enum is DatasetType.AUDIO:
             uses_audio_latents = False
+            uses_audio_tokens = False
             try:
                 uses_audio_latents = bool(self.model.uses_audio_latents_for_data_backend(init_backend.get("id")))
             except AttributeError:
                 uses_audio_latents = False
-            if not uses_audio_latents:
+            try:
+                uses_audio_tokens = bool(self.model.uses_audio_tokens())
+            except AttributeError:
+                uses_audio_tokens = False
+            if not uses_audio_latents and not uses_audio_tokens:
                 info_log(
-                    f"(id={init_backend['id']}) Skipping VAE cache for audio dataset; model does not use audio latents."
+                    f"(id={init_backend['id']}) Skipping VAE cache for audio dataset; model does not use audio latents or tokens."
                 )
                 return
         vae_cache_dir = backend.get("cache_dir_vae", None)

--- a/simpletuner/helpers/models/field_registry/minimaxmusic.py
+++ b/simpletuner/helpers/models/field_registry/minimaxmusic.py
@@ -19,8 +19,9 @@ def register_fields(registry) -> None:
             help_text=(
                 "Which MiniMax Music 3 component receives training. transformer trains the flow-matching music "
                 "DiT on cached Flow-VAE latents. language_model trains the Qwen3 autoregressive stage with "
-                "next-token cross-entropy on RVQ semantic codes; datasets must provide precomputed audio tokens "
-                "(audio_tokens_path metadata) alongside caption and lyrics."
+                "next-token cross-entropy on RVQ semantic codes; raw audio datasets are encoded through the "
+                "MiniMax Music RVQ cache encoder unless the dataset provides audio_tokens or audio_tokens_path "
+                "metadata alongside caption and lyrics."
             ),
             tooltip=(
                 "language_model mode is for style/keyword adaptation of the AR planner (dreambooth-style trigger "
@@ -29,6 +30,87 @@ def register_fields(registry) -> None:
             importance=ImportanceLevel.ADVANCED,
             order=39,
             documentation="OPTIONS.md#--minimax_music_train_component",
+        )
+    )
+    registry._add_field(
+        ConfigField(
+            name="minimax_music_rvq_encoder_model_name_or_path",
+            arg_name="--minimax_music_rvq_encoder_model_name_or_path",
+            ui_label="MiniMax Music RVQ Encoder",
+            field_type=FieldType.TEXT,
+            tab="model",
+            section="model_specific",
+            model_specific=["minimaxmusic"],
+            default_value="SimpleTuner/open-rvq-encoder-minimax-music3-169m-v4",
+            help_text=(
+                "MiniMax Music language_model training only: model repository or local directory containing the "
+                "RVQ encoder config and weights used to convert cached DAV audio latents into per-codebook codes."
+            ),
+            tooltip="The default is SimpleTuner's v4 open RVQ encoder for MiniMax Music 3.",
+            importance=ImportanceLevel.ADVANCED,
+            order=44,
+            documentation="OPTIONS.md#--minimax_music_rvq_encoder_model_name_or_path",
+        )
+    )
+    registry._add_field(
+        ConfigField(
+            name="minimax_music_rvq_encoder_subfolder",
+            arg_name="--minimax_music_rvq_encoder_subfolder",
+            ui_label="MiniMax Music RVQ Encoder Subfolder",
+            field_type=FieldType.TEXT,
+            tab="model",
+            section="model_specific",
+            model_specific=["minimaxmusic"],
+            default_value="final",
+            help_text=(
+                "Subfolder within the RVQ encoder repository or local directory that contains "
+                "rvq_encoder_config.json, rvq_encoder.safetensors, and any muP base-shape metadata."
+            ),
+            tooltip="Leave at final for the default SimpleTuner v4 RVQ encoder package.",
+            importance=ImportanceLevel.ADVANCED,
+            order=45,
+            documentation="OPTIONS.md#--minimax_music_rvq_encoder_subfolder",
+        )
+    )
+    registry._add_field(
+        ConfigField(
+            name="minimax_music_rvq_encoder_revision",
+            arg_name="--minimax_music_rvq_encoder_revision",
+            ui_label="MiniMax Music RVQ Encoder Revision",
+            field_type=FieldType.TEXT,
+            tab="model",
+            section="model_specific",
+            model_specific=["minimaxmusic"],
+            default_value="",
+            help_text=(
+                "Optional Hub revision for the RVQ encoder. If unset, SimpleTuner uses the main training revision "
+                "setting when one is provided."
+            ),
+            tooltip="Use this only when pinning a specific RVQ encoder checkpoint revision.",
+            importance=ImportanceLevel.ADVANCED,
+            order=46,
+            documentation="OPTIONS.md#--minimax_music_rvq_encoder_revision",
+        )
+    )
+    registry._add_field(
+        ConfigField(
+            name="minimax_music_rvq_vae_model_name_or_path",
+            arg_name="--minimax_music_rvq_vae_model_name_or_path",
+            ui_label="MiniMax Music RVQ Audio VAE",
+            field_type=FieldType.TEXT,
+            tab="model",
+            section="model_specific",
+            model_specific=["minimaxmusic"],
+            default_value="",
+            help_text=(
+                "MiniMax Music language_model training only: DAV/audio VAE repository, local directory, or dav.pth "
+                "file used before the RVQ encoder. If unset in config, the standard pretrained VAE path is used "
+                "before this default."
+            ),
+            tooltip="This is the audio encoder stage, not the RVQ code predictor.",
+            importance=ImportanceLevel.ADVANCED,
+            order=47,
+            documentation="OPTIONS.md#--minimax_music_rvq_vae_model_name_or_path",
         )
     )
     registry._add_field(

--- a/simpletuner/helpers/models/minimaxmusic/model.py
+++ b/simpletuner/helpers/models/minimaxmusic/model.py
@@ -3,10 +3,12 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
 import torch
@@ -74,6 +76,47 @@ from simpletuner.helpers.training.lora_format import (
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_RVQ_ENCODER_MODEL = "SimpleTuner/open-rvq-encoder-minimax-music3-169m-v4"
+DEFAULT_RVQ_ENCODER_SUBFOLDER = "final"
+DEFAULT_LM_AUDIO_VAE_MODEL = "SimpleTuner/MiniMax-Music-3-Encoder"
+
+
+class MiniMaxMusicRVQCacheEncoder(nn.Module):
+    """Cache-time encoder that turns waveforms into MiniMax Music RVQ code tensors."""
+
+    def __init__(self, *, audio_vae: MiniMaxMusic3DAV, rvq_encoder: nn.Module):
+        super().__init__()
+        self.audio_vae = audio_vae
+        self.rvq_encoder = rvq_encoder
+        self.config = getattr(rvq_encoder, "config", SimpleNamespace())
+
+    @property
+    def device(self) -> torch.device:
+        try:
+            return next(self.rvq_encoder.parameters()).device
+        except StopIteration:
+            return torch.device("cpu")
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return torch.float32
+
+    def to(self, device=None, dtype=None, **kwargs):
+        del dtype
+        self.audio_vae.to(device=device, dtype=torch.float32, **kwargs)
+        self.rvq_encoder.to(device=device, dtype=torch.float32, **kwargs)
+        return self
+
+    def requires_grad_(self, requires_grad: bool = False):
+        self.audio_vae.requires_grad_(requires_grad)
+        self.rvq_encoder.requires_grad_(requires_grad)
+        return self
+
+    def eval(self):
+        self.audio_vae.eval()
+        self.rvq_encoder.eval()
+        return self
+
 
 class MiniMaxMusic(AudioModelFoundation):
     NAME = "MiniMax Music 3"
@@ -123,10 +166,13 @@ class MiniMaxMusic(AudioModelFoundation):
     XM_ROUTE_EMBEDDING_MODULE_NAME = "xm_route_embeddings"
 
     def __init__(self, config, accelerator):
+        user_pretrained_vae_model_name_or_path = getattr(config, "pretrained_vae_model_name_or_path", None)
         super().__init__(config, accelerator)
+        self._user_pretrained_vae_model_name_or_path = user_pretrained_vae_model_name_or_path
         self.condition_encoder: Optional[MiniMaxMusic3ConditionEncoder] = None
         self.rvq_depth_decoder: Optional[MiniMaxMusic3RVQDepthDecoder] = None
         self.language_model: Optional[Qwen3ForCausalLM] = None
+        self.lm_rvq_cache_encoder: Optional[MiniMaxMusicRVQCacheEncoder] = None
         self.guider: Optional[ClassifierFreeGuidance] = None
         self.vae = None
         train_component = str(getattr(config, "minimax_music_train_component", "transformer") or "transformer")
@@ -135,7 +181,7 @@ class MiniMaxMusic(AudioModelFoundation):
             self.PREDICTION_TYPE = PredictionTypes.AUTOREGRESSIVE_NEXT_TOKEN
             self.MODEL_CLASS = Qwen3ForCausalLM
             self.MODEL_SUBFOLDER = "language_model"
-            self.AUTOENCODER_CLASS = None
+            self.AUTOENCODER_CLASS = MiniMaxMusicRVQCacheEncoder
             self.TEXT_ENCODER_CONFIGURATION = {}
             self.DEFAULT_LORA_TARGET = ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
 
@@ -683,6 +729,11 @@ class MiniMaxMusic(AudioModelFoundation):
     def uses_text_embeddings_cache(self) -> bool:
         return not self._train_language_model
 
+    def get_vae_for_dataset_type(self, dataset_type: str):
+        if self._train_language_model and str(dataset_type).lower() == "audio":
+            return self.load_lm_rvq_cache_encoder(move_to_device=True)
+        return super().get_vae_for_dataset_type(dataset_type)
+
     def load_model(self, move_to_device: bool = True):
         if not self._train_language_model:
             return super().load_model(move_to_device=move_to_device)
@@ -730,7 +781,108 @@ class MiniMaxMusic(AudioModelFoundation):
             self.vae.to(self.accelerator.device, dtype=vae_dtype)
         return self.vae
 
+    def _lm_rvq_encoder_path(self) -> str:
+        return getattr(self.config, "minimax_music_rvq_encoder_model_name_or_path", None) or DEFAULT_RVQ_ENCODER_MODEL
+
+    def _lm_rvq_encoder_subfolder(self) -> str:
+        return (getattr(self.config, "minimax_music_rvq_encoder_subfolder", None) or DEFAULT_RVQ_ENCODER_SUBFOLDER).strip(
+            "/"
+        )
+
+    def _lm_rvq_encoder_revision(self) -> Optional[str]:
+        return getattr(self.config, "minimax_music_rvq_encoder_revision", None) or getattr(self.config, "revision", None)
+
+    def _resolve_lm_rvq_file(self, filename: str) -> str:
+        root = self._lm_rvq_encoder_path()
+        subfolder = self._lm_rvq_encoder_subfolder()
+        if os.path.isdir(root):
+            candidates = []
+            if subfolder:
+                candidates.append(os.path.join(root, subfolder, filename))
+            candidates.append(os.path.join(root, filename))
+            for candidate in candidates:
+                if os.path.isfile(candidate):
+                    return candidate
+            raise FileNotFoundError(f"MiniMax Music RVQ encoder file not found under {root}: {filename}")
+        repo_filename = f"{subfolder}/{filename}" if subfolder else filename
+        return hf_hub_download(
+            root,
+            repo_filename,
+            revision=self._lm_rvq_encoder_revision(),
+            repo_type="model",
+        )
+
+    def _lm_audio_vae_path(self) -> str:
+        return (
+            getattr(self.config, "minimax_music_rvq_vae_model_name_or_path", None)
+            or self._user_pretrained_vae_model_name_or_path
+            or DEFAULT_LM_AUDIO_VAE_MODEL
+        )
+
+    def _load_lm_audio_vae(self) -> MiniMaxMusic3DAV:
+        checkpoint_path = self._lm_audio_vae_path()
+        if self._has_diffusers_audio_vae(checkpoint_path):
+            return self._load_diffusers_audio_vae(checkpoint_path)
+        if os.path.isfile(checkpoint_path):
+            return MiniMaxMusic3DAV.from_original_dav(checkpoint_path)
+        if os.path.isdir(checkpoint_path):
+            dav_path = os.path.join(checkpoint_path, "dav.pth")
+            if os.path.isfile(dav_path):
+                return MiniMaxMusic3DAV.from_original_dav(dav_path)
+        dav_checkpoint = None
+        try:
+            dav_checkpoint = hf_hub_download(
+                checkpoint_path,
+                "dav.pth",
+                revision=getattr(self.config, "revision", None),
+                repo_type="model",
+            )
+        except (EntryNotFoundError, LocalEntryNotFoundError, RepositoryNotFoundError, HFValidationError):
+            dav_checkpoint = None
+        if dav_checkpoint is not None:
+            return MiniMaxMusic3DAV.from_original_dav(dav_checkpoint)
+        return self._load_diffusers_audio_vae(checkpoint_path)
+
+    def load_lm_rvq_cache_encoder(self, move_to_device: bool = True) -> MiniMaxMusicRVQCacheEncoder:
+        if not self._train_language_model:
+            raise ValueError("MiniMax Music RVQ cache encoder is only used for language_model training.")
+        if self.lm_rvq_cache_encoder is None:
+            from safetensors.torch import load_file as load_safetensors_file
+
+            from scripts.train_minimax_music_rvq_encoder import (
+                MiniMaxMusicRVQEncoder,
+                RVQEncoderConfig,
+                _load_mup_package,
+                _validate_mup_shape_metadata,
+            )
+
+            config_path = self._resolve_lm_rvq_file("rvq_encoder_config.json")
+            config_values = json.loads(Path(config_path).read_text(encoding="utf-8"))
+            config_values["codebook_vocab_sizes"] = tuple(int(value) for value in config_values["codebook_vocab_sizes"])
+            config_values["conv_dilations"] = tuple(int(value) for value in config_values["conv_dilations"])
+            rvq_config = RVQEncoderConfig(**config_values)
+            rvq_encoder = MiniMaxMusicRVQEncoder(rvq_config)
+            if rvq_config.mup:
+                base_shapes_path = self._resolve_lm_rvq_file("mup_base_shapes.bsh")
+                self._resolve_lm_rvq_file("mup_base_shapes.bsh.meta.json")
+                _validate_mup_shape_metadata(base_shapes_path, rvq_encoder)
+                _load_mup_package().set_base_shapes(rvq_encoder, base_shapes_path, rescale_params=False)
+            state_path = self._resolve_lm_rvq_file("rvq_encoder.safetensors")
+            rvq_encoder.load_state_dict(load_safetensors_file(state_path, device="cpu"), strict=True)
+            rvq_encoder.eval()
+            rvq_encoder.requires_grad_(False)
+
+            audio_vae = self._load_lm_audio_vae()
+            audio_vae.eval()
+            audio_vae.requires_grad_(False)
+            self.lm_rvq_cache_encoder = MiniMaxMusicRVQCacheEncoder(audio_vae=audio_vae, rvq_encoder=rvq_encoder)
+        if move_to_device:
+            self.lm_rvq_cache_encoder.to(self.accelerator.device)
+        return self.lm_rvq_cache_encoder
+
     def encode_cache_batch(self, vae, samples, metadata_entries: Optional[list] = None):
+        if self._train_language_model:
+            return self._encode_lm_rvq_cache_batch(vae, samples, metadata_entries=metadata_entries)
         del metadata_entries
         if not hasattr(vae, "encode"):
             raise RuntimeError(
@@ -744,6 +896,128 @@ class MiniMaxMusic(AudioModelFoundation):
             raise TypeError("MiniMax Music 3 DAV encode() must return a tensor.")
         return latents.to(dtype=self.config.weight_dtype)
 
+    @staticmethod
+    def _lm_legacy_frame_latent_starts(n_frames: int) -> list[int]:
+        latent_rate_num = 441
+        latent_rate_den = 128
+        chunk_frames = 200
+        chunk_hop_frames = 100
+        stitched_hop_latents = 345
+        non_first_chunk_owned_from = 25
+        num_windows = max(1, (n_frames - 1) // chunk_hop_frames)
+        starts = []
+        for frame_index in range(n_frames + 1):
+            chunk_index = min(
+                max((frame_index - non_first_chunk_owned_from) // chunk_hop_frames, 0),
+                num_windows - 1,
+            )
+            local_frame = frame_index - chunk_index * chunk_hop_frames
+            current_chunk_frames = min(chunk_frames, n_frames - chunk_index * chunk_hop_frames)
+            chunk_latents = current_chunk_frames * latent_rate_num // latent_rate_den
+            local_latent = (local_frame * chunk_latents + current_chunk_frames - 1) // current_chunk_frames
+            starts.append(chunk_index * stitched_hop_latents + local_latent)
+        return starts
+
+    @staticmethod
+    def _lm_build_pool_matrix(bounds: list[int], latent_frames: int, device: torch.device) -> torch.Tensor:
+        if len(bounds) < 2:
+            raise ValueError("At least two frame/latent boundaries are required.")
+        local_bounds = [max(0, min(int(value), latent_frames)) for value in bounds]
+        pool = torch.zeros((len(local_bounds) - 1, latent_frames), dtype=torch.float32, device=device)
+        for frame_index, (start, end) in enumerate(zip(local_bounds[:-1], local_bounds[1:])):
+            if end <= start:
+                end = min(start + 1, latent_frames)
+                start = max(0, end - 1)
+            pool[frame_index, start:end] = 1.0 / float(end - start)
+        return pool
+
+    def _lm_frame_count_for_rvq_cache(
+        self,
+        *,
+        latent_frames: int,
+        sample_frames: int,
+        sample_rate: int,
+    ) -> int:
+        duration_frames = max(1, int(round(float(sample_frames) / float(sample_rate) * self._frame_rate())))
+        frame_count = min(duration_frames, _MAX_AUDIO_FRAMES)
+        while frame_count > 1 and self._lm_legacy_frame_latent_starts(frame_count)[-1] > latent_frames:
+            frame_count -= 1
+        return frame_count
+
+    def _resample_lm_audio_if_needed(
+        self,
+        waveform: torch.Tensor,
+        *,
+        source_rate: Optional[int],
+        target_rate: int,
+    ) -> torch.Tensor:
+        if source_rate is None or int(source_rate) == int(target_rate):
+            return waveform
+        import torchaudio
+
+        return torchaudio.functional.resample(waveform, int(source_rate), int(target_rate))
+
+    def _encode_lm_rvq_cache_batch(
+        self,
+        cache_encoder,
+        samples: torch.Tensor,
+        metadata_entries: Optional[list] = None,
+    ) -> torch.Tensor:
+        if not isinstance(cache_encoder, MiniMaxMusicRVQCacheEncoder):
+            raise TypeError(
+                "MiniMax Music LM VAE cache expects MiniMaxMusicRVQCacheEncoder; " f"received {type(cache_encoder)}."
+            )
+        if samples.ndim != 3:
+            raise ValueError(
+                f"MiniMax Music LM RVQ cache expects audio [batch, channels, samples], got {tuple(samples.shape)}."
+            )
+
+        target_rate = int(getattr(cache_encoder.audio_vae.config, "sampling_rate", 44100) or 44100)
+        entries = metadata_entries or [{} for _ in range(samples.shape[0])]
+        code_rows = []
+        with torch.no_grad():
+            for index in range(samples.shape[0]):
+                entry = entries[index] if index < len(entries) else {}
+                metadata = entry.get("metadata", {}) if isinstance(entry, dict) else {}
+                backend_id = entry.get("data_backend_id") if isinstance(entry, dict) else None
+                backend_audio_config = {}
+                if backend_id:
+                    from simpletuner.helpers.training.state_tracker import StateTracker
+
+                    backend_audio_config = (StateTracker.get_data_backend_config(backend_id) or {}).get("audio", {})
+                source_rate = (
+                    metadata.get("sample_rate") or metadata.get("sampling_rate") or backend_audio_config.get("sample_rate")
+                )
+                waveform = samples[index : index + 1].to(device=self.accelerator.device, dtype=torch.float32)
+                waveform = self._resample_lm_audio_if_needed(
+                    waveform.squeeze(0),
+                    source_rate=int(source_rate) if source_rate else None,
+                    target_rate=target_rate,
+                ).unsqueeze(0)
+                latents = cache_encoder.audio_vae.encode(waveform)
+                if not isinstance(latents, torch.Tensor):
+                    raise TypeError("MiniMax Music LM RVQ cache DAV encode() must return a tensor.")
+                latent_rows = latents[0].transpose(0, 1).contiguous()
+                latent_frames = int(latent_rows.shape[0])
+                frame_count = self._lm_frame_count_for_rvq_cache(
+                    latent_frames=latent_frames,
+                    sample_frames=int(waveform.shape[-1]),
+                    sample_rate=target_rate,
+                )
+                bounds = self._lm_legacy_frame_latent_starts(frame_count)
+                pool = self._lm_build_pool_matrix(bounds, latent_frames, device=latent_rows.device).unsqueeze(0)
+                logits = cache_encoder.rvq_encoder(
+                    latent_rows.unsqueeze(0).to(dtype=torch.float32),
+                    pool,
+                )
+                if not isinstance(logits, (list, tuple)) or len(logits) == 0:
+                    raise TypeError("MiniMax Music RVQ encoder must return one logits tensor per codebook.")
+                codes = torch.stack([book_logits.argmax(dim=-1).squeeze(0) for book_logits in logits], dim=-1)
+                code_rows.append(codes.to(device="cpu", dtype=torch.long))
+        if len(code_rows) == 1:
+            return code_rows[0].unsqueeze(0)
+        return pad_sequence(code_rows, batch_first=True, padding_value=0)
+
     def _lm_prompt_text(self, caption: str, lyrics: str) -> str:
         return (
             f"<|im_start|><|caption_start|>{_clean_caption(str(caption))}<|caption_end|>"
@@ -755,25 +1029,36 @@ class MiniMaxMusic(AudioModelFoundation):
         codes = example.get("audio_tokens")
         if codes is None:
             token_path = example.get("audio_tokens_path")
-            if not token_path:
-                raise ValueError(
-                    "MiniMax Music 3 language model training requires audio_tokens or audio_tokens_path metadata "
-                    "with raw per-codebook RVQ codes shaped [frames, codebooks]."
-                )
-            resolved = str(token_path)
-            if not os.path.isabs(resolved):
+            if token_path:
+                resolved = str(token_path)
+                if not os.path.isabs(resolved):
+                    backend_id = example.get("data_backend_id")
+                    from simpletuner.helpers.training.state_tracker import StateTracker
+
+                    backend_cfg = StateTracker.get_data_backend_config(backend_id) if backend_id else {}
+                    dataset_root = backend_cfg.get("instance_data_dir") if backend_cfg else None
+                    if dataset_root:
+                        resolved = os.path.join(dataset_root, resolved)
+                if not os.path.exists(resolved):
+                    raise FileNotFoundError(f"MiniMax Music 3 audio token file not found: {resolved}")
+                codes = torch.load(resolved, map_location="cpu", weights_only=True)
+            else:
                 backend_id = example.get("data_backend_id")
+                filepath = example.get("image_path") or example.get("filepath")
+                if not backend_id or not filepath:
+                    raise ValueError(
+                        "MiniMax Music 3 language model training requires audio_tokens, audio_tokens_path, "
+                        "or an audio dataset sample with data_backend_id and image_path so the RVQ VAE cache can "
+                        "provide raw per-codebook codes."
+                    )
                 from simpletuner.helpers.training.state_tracker import StateTracker
 
-                backend_cfg = StateTracker.get_data_backend_config(backend_id) if backend_id else {}
-                dataset_root = backend_cfg.get("instance_data_dir") if backend_cfg else None
-                if dataset_root:
-                    resolved = os.path.join(dataset_root, resolved)
-            if not os.path.exists(resolved):
-                raise FileNotFoundError(f"MiniMax Music 3 audio token file not found: {resolved}")
-            codes = torch.load(resolved, map_location="cpu", weights_only=True)
+                codes = StateTracker.get_vaecache(id=backend_id).retrieve_from_cache(filepath)
         if isinstance(codes, dict):
-            codes = codes.get("codes")
+            for key in ("codes", "audio_tokens", "latents"):
+                if codes.get(key) is not None:
+                    codes = codes[key]
+                    break
         if not isinstance(codes, torch.Tensor):
             codes = torch.as_tensor(codes)
         codes = codes.to(dtype=torch.long)


### PR DESCRIPTION
This pull request updates documentation and code to clarify and expand support for MiniMax Music's RVQ encoder and VAE configuration, especially for `language_model` training. The main improvements include adding detailed documentation for new RVQ encoder/decoder options in all supported languages and updating the VAE cache logic to consider both audio latents and audio tokens.

**Documentation updates for MiniMax Music RVQ encoder and VAE:**

- Added detailed explanations and options for `--minimax_music_rvq_encoder_model_name_or_path`, `--minimax_music_rvq_encoder_subfolder`, `--minimax_music_rvq_encoder_revision`, and `--minimax_music_rvq_vae_model_name_or_path` to all OPTIONS docs (`OPTIONS.md`, `OPTIONS.pt-BR.md`, `OPTIONS.es.md`, `OPTIONS.ja.md`, `OPTIONS.zh.md`, `OPTIONS.hi.md`). These clarify how to specify and override the RVQ encoder and VAE used during training. [[1]](diffhunk://#diff-45e063db3ebcffb55dde68f083e92399a74f4cefbb464e8cd36911971c50933fR86-R110) [[2]](diffhunk://#diff-2c007ae9176f9f69b3ae16558be55b46d524f460a626f4e5c31e1e9a1d1b14b8R86-R110) [[3]](diffhunk://#diff-3f0cd39e3a7f176d81408ae40dc4f8c6271347f75b1cee5cf71c4e701d7db561R86-R110) [[4]](diffhunk://#diff-fd629904ab3e1ecdd5b568c3ef6ac61e71e3d7741700e360820849938158a1d9R86-R110) [[5]](diffhunk://#diff-cddcc50c252e719be92644d65ea8542cc51d08f15e67d918bfae737904142b1fR86-R110) [[6]](diffhunk://#diff-39b5789a705b2e70400106934436b619d10413ca5e37bd7a2b5fa7aa0c0fb8cfR86-R110)

- Updated the description of `language_model` training in all docs to explain that SimpleTuner will encode raw waveforms using the MiniMax Music DAV and default v4 RVQ encoder at VAE-cache time, and that datasets may still provide precomputed audio tokens. [[1]](diffhunk://#diff-45e063db3ebcffb55dde68f083e92399a74f4cefbb464e8cd36911971c50933fL76-R76) [[2]](diffhunk://#diff-2c007ae9176f9f69b3ae16558be55b46d524f460a626f4e5c31e1e9a1d1b14b8L76-R76) [[3]](diffhunk://#diff-3f0cd39e3a7f176d81408ae40dc4f8c6271347f75b1cee5cf71c4e701d7db561L76-R76) [[4]](diffhunk://#diff-fd629904ab3e1ecdd5b568c3ef6ac61e71e3d7741700e360820849938158a1d9L76-R76) [[5]](diffhunk://#diff-cddcc50c252e719be92644d65ea8542cc51d08f15e67d918bfae737904142b1fL76-R76) [[6]](diffhunk://#diff-39b5789a705b2e70400106934436b619d10413ca5e37bd7a2b5fa7aa0c0fb8cfL76-R76)

**Backend logic improvement:**

- In `_configure_vae_cache` (`factory.py`), updated the logic to skip VAE caching only if neither audio latents nor audio tokens are used by the model, improving compatibility with models that use either.

These changes ensure that users have clear, localized documentation for configuring MiniMax Music training, and the backend more robustly detects when VAE caching is required.