### PR TITLE
Fix audio RVQ caching for LM training

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -11,6 +11,7 @@ build:
     - printf '%s\n' 'torch==2.11.0+cu128' 'torchvision==0.26.0+cu128' 'torchaudio==2.11.0+cu128' > /tmp/constraints-cuda128.txt
     - pip install --index-url https://download.pytorch.org/whl/cu128 -c /tmp/constraints-cuda128.txt torch torchvision torchaudio
     - pip install --extra-index-url https://download.pytorch.org/whl/cu128 -c /tmp/constraints-cuda128.txt -e "./SimpleTuner[cuda,jxl]"
+    - pip install 'mup>=1.0.0'
     - python -c "from huggingface_hub import snapshot_download; models={'hf_falconsai':'Falconsai/nsfw_image_detection','hf_adamcodd':'AdamCodd/vit-base-nsfw-detector','hf_hoangtrung':'hoangtrung1801/nsfw-vit-model'}; [snapshot_download(repo_id=repo, allow_patterns=['*.json','*.safetensors','*.bin','*.txt'], local_dir=f'/opt/nsfw-classifier-comparison/{key}') for key, repo in models.items()]"
 
 predict: "predict.py:Predictor"

--- a/setup.py
+++ b/setup.py
@@ -334,6 +334,7 @@ base_deps = [
     "hf-xet>=1.1.5",
     "peft-singlora>=0.2.0",
     "vector-quantize-pytorch>=1.27.15",
+    "mup>=1.0.0",
     "cryptography>=41.0.0",
     "torchcodec>=0.10.0",
     "sdnq>=0.2.3",

--- a/simpletuner/helpers/data_backend/builders/huggingface.py
+++ b/simpletuner/helpers/data_backend/builders/huggingface.py
@@ -30,11 +30,14 @@ class HuggingfaceBackendBuilder(BaseBackendBuilder):
         is_mock_backend = hasattr(backend_cls, "_mock_children")
 
         dataset_name = getattr(config, "dataset_name", None)
+        dataset_config = getattr(config, "dataset_config", None)
+        data_files = getattr(config, "data_files", None)
         dataset_type = getattr(config, "dataset_type", "image")
         split = getattr(config, "split", "train")
         revision = getattr(config, "revision", None)
         image_column = getattr(config, "image_column", "image")
         video_column = getattr(config, "video_column", "video")
+        audio_column = getattr(config, "audio_column", "audio")
         cache_dir = getattr(config, "huggingface_cache_dir", None)
         if not cache_dir:
             cache_dir = self._default_cache_dir(config)
@@ -56,11 +59,14 @@ class HuggingfaceBackendBuilder(BaseBackendBuilder):
             "accelerator": self.accelerator,
             "id": config.id,
             "dataset_name": dataset_name,
+            "dataset_config": dataset_config,
+            "data_files": data_files,
             "dataset_type": dataset_type,
             "split": split,
             "revision": revision,
             "image_column": image_column,
             "video_column": video_column,
+            "audio_column": audio_column,
             "cache_dir": cache_dir,
             "compress_cache": compress_cache,
             "streaming": streaming,

--- a/simpletuner/helpers/data_backend/config/base.py
+++ b/simpletuner/helpers/data_backend/config/base.py
@@ -51,6 +51,7 @@ class BaseBackendConfig(ABC):
             DatasetType.CONDITIONING,
             DatasetType.EVAL,
             DatasetType.VIDEO,
+            DatasetType.AUDIO,
             DatasetType.TEXT_EMBEDS,
             DatasetType.IMAGE_EMBEDS,
             DatasetType.CONDITIONING_IMAGE_EMBEDS,

--- a/simpletuner/helpers/data_backend/config/image.py
+++ b/simpletuner/helpers/data_backend/config/image.py
@@ -38,10 +38,13 @@ class ImageBackendConfig(BaseBackendConfig):
     aws_max_pool_connections: Optional[int] = None
 
     dataset_name: Optional[str] = None
+    dataset_config: Optional[str] = None
+    data_files: Optional[Any] = None
     split: Optional[str] = "train"
     revision: Optional[str] = None
     image_column: Optional[str] = "image"
     video_column: Optional[str] = "video"
+    audio_column: Optional[str] = "audio"
     huggingface_cache_dir: Optional[str] = None
     huggingface_streaming: Optional[bool] = None
     huggingface_num_proc: Optional[int] = None
@@ -168,10 +171,13 @@ class ImageBackendConfig(BaseBackendConfig):
             config.has_huggingface_block = "huggingface" in backend_dict
             hf_block = backend_dict.get("huggingface", {})
             config.dataset_name = backend_dict.get("dataset_name", hf_block.get("dataset_name"))
+            config.dataset_config = backend_dict.get("dataset_config", hf_block.get("dataset_config"))
+            config.data_files = backend_dict.get("data_files", hf_block.get("data_files"))
             config.split = backend_dict.get("split", hf_block.get("split", "train"))
             config.revision = backend_dict.get("revision", hf_block.get("revision"))
             config.image_column = backend_dict.get("image_column", hf_block.get("image_column", "image"))
             config.video_column = backend_dict.get("video_column", hf_block.get("video_column", "video"))
+            config.audio_column = backend_dict.get("audio_column", hf_block.get("audio_column", "audio"))
             config.huggingface_cache_dir = hf_block.get("cache_dir", backend_dict.get("cache_dir"))
             config.huggingface_streaming = hf_block.get("streaming", backend_dict.get("streaming"))
             config.huggingface_num_proc = hf_block.get("num_proc", backend_dict.get("num_proc"))
@@ -523,10 +529,13 @@ class ImageBackendConfig(BaseBackendConfig):
 
         if self.backend_type == "huggingface":
             config["dataset_name"] = self.dataset_name
+            config["dataset_config"] = self.dataset_config
+            config["data_files"] = self.data_files
             config["split"] = self.split
             config["revision"] = self.revision
             config["image_column"] = self.image_column
             config["video_column"] = self.video_column
+            config["audio_column"] = self.audio_column
             hf_config = config.setdefault("huggingface", {})
             if self.huggingface_cache_dir is not None:
                 hf_config["cache_dir"] = self.huggingface_cache_dir

--- a/simpletuner/helpers/data_backend/factory.py
+++ b/simpletuner/helpers/data_backend/factory.py
@@ -1420,6 +1420,12 @@ class FactoryRegistry:
         except RuntimeError:
             self.metrics["memory_usage"]["start"] = self._get_memory_usage()
 
+    def _move_text_encoders_for_vae_cache(self, target_device: str):
+        model_hook = getattr(self.model, "move_text_encoders_for_vae_cache", None)
+        if callable(model_hook):
+            return model_hook(target_device=target_device)
+        return move_text_encoders(self.args, self.text_encoders, target_device)
+
     def _get_memory_usage(self) -> float:
         """Get current memory usage in MB."""
         try:
@@ -4149,7 +4155,7 @@ class FactoryRegistry:
                 raise ValueError(
                     f"VAE image embed cache directory {vae_cache_dir} is not set. This is required for the VAE image embed cache."
                 )
-        move_text_encoders(self.args, self.text_encoders, "cpu")
+        self._move_text_encoders_for_vae_cache("cpu")
 
         video_config = init_backend["config"].get("video", {})
         vae = StateTracker.get_vae()
@@ -4661,7 +4667,7 @@ class FactoryRegistry:
             logger.debug(f"Encoding images during training: {init_backend['vaecache'].vae_cache_ondemand}")
             if self._is_multi_process():
                 self.accelerator.wait_for_everyone()
-        move_text_encoders(self.args, self.text_encoders, self.accelerator.device)
+        self._move_text_encoders_for_vae_cache(self.accelerator.device)
         init_backend_debug_info = {
             k: v for k, v in init_backend.items() if isinstance(v, Union[list, int, float, str, dict, tuple])
         }
@@ -4928,6 +4934,8 @@ def get_huggingface_backend(
     identifier: str,
     dataset_name: str,
     dataset_type: str,
+    dataset_config: str = None,
+    data_files=None,
     split: str = "train",
     revision: str = None,
     image_column: str = "image",
@@ -4981,6 +4989,8 @@ def get_huggingface_backend(
         accelerator=accelerator,
         id=identifier,
         dataset_name=dataset_name,
+        dataset_config=dataset_config,
+        data_files=data_files,
         dataset_type=dataset_type,
         split=split,
         revision=revision,

--- a/simpletuner/helpers/data_backend/huggingface.py
+++ b/simpletuner/helpers/data_backend/huggingface.py
@@ -36,6 +36,8 @@ class HuggingfaceDatasetsBackend(BaseDataBackend):
         accelerator,
         id: str,
         dataset_name: str,
+        dataset_config: Optional[str] = None,
+        data_files: Optional[Any] = None,
         split: str = "train",
         revision: str = None,
         image_column: str = "image",
@@ -54,6 +56,8 @@ class HuggingfaceDatasetsBackend(BaseDataBackend):
         self.type = "huggingface"
         self.accelerator = accelerator
         self.dataset_name = dataset_name
+        self.dataset_config = dataset_config
+        self.data_files = data_files
         self.dataset_type = ensure_dataset_type(dataset_type, default=DatasetType.IMAGE)
         if self.dataset_type is DatasetType.VIDEO:
             default_extension = "mp4"
@@ -95,14 +99,26 @@ class HuggingfaceDatasetsBackend(BaseDataBackend):
             return
         self._loading_dataset = True
         try:
-            from datasets import load_dataset, load_dataset_builder
+            from datasets import Features, Value, load_dataset, load_dataset_builder
         except ImportError:
             self._loading_dataset = False
             raise ImportError("Please install datasets: pip install datasets")
 
+        dataset_features = None
+        download_mode = "reuse_dataset_if_exists"
+        if self.dataset_type is DatasetType.AUDIO and self.dataset_name == "audiofolder":
+            dataset_features = Features({self.audio_column: Value("string")})
+            download_mode = "force_redownload"
+
         # First, inspect the dataset structure
         logger.info(f"Inspecting dataset {self.dataset_name}")
-        builder = load_dataset_builder(self.dataset_name, cache_dir=self.cache_dir)
+        builder = load_dataset_builder(
+            self.dataset_name,
+            name=self.dataset_config,
+            data_files=self.data_files,
+            features=dataset_features,
+            cache_dir=self.cache_dir,
+        )
         logger.info(f"Dataset info: {builder.info}")
         try:
             available_splits = list(builder.info.splits.keys()) if builder.info.splits else []
@@ -116,11 +132,14 @@ class HuggingfaceDatasetsBackend(BaseDataBackend):
         try:
             self.dataset = load_dataset(
                 self.dataset_name,
+                name=self.dataset_config,
+                data_files=self.data_files,
                 split=self.split,
                 revision=self.revision,
                 cache_dir=self.cache_dir,
+                features=dataset_features,
                 streaming=self.streaming,
-                download_mode="reuse_dataset_if_exists",  # or "force_redownload" if needed
+                download_mode=download_mode,
             )
 
             # Log the initial size
@@ -419,9 +438,14 @@ class HuggingfaceDatasetsBackend(BaseDataBackend):
             "backend_type": "huggingface",
             "id": self.id,
             "dataset_name": self.dataset_name,
+            "dataset_config": self.dataset_config,
+            "data_files": self.data_files,
+            "dataset_type": self.dataset_type.value,
             "split": self.split,
             "revision": self.revision,
             "image_column": self.image_column,
+            "video_column": self.video_column,
+            "audio_column": self.audio_column,
             "cache_dir": self.cache_dir,
             "compress_cache": self.compress_cache,
             "streaming": self.streaming,
@@ -452,15 +476,20 @@ class HuggingfaceDatasetsBackend(BaseDataBackend):
             accelerator=None,  # Will be set by subprocess if needed
             id=representation["id"],
             dataset_name=representation["dataset_name"],
+            dataset_config=representation.get("dataset_config"),
+            data_files=representation.get("data_files"),
             split=representation.get("split", "train"),
             revision=representation.get("revision"),
             image_column=representation.get("image_column", "image"),
+            video_column=representation.get("video_column", "video"),
+            audio_column=representation.get("audio_column", "audio"),
             cache_dir=representation.get("cache_dir"),
             compress_cache=representation.get("compress_cache", False),
             streaming=representation.get("streaming", False),
             filter_func=filter_func,  # Would need special handling
             num_proc=representation.get("num_proc", 16),
             composite_config=representation.get("composite_config", {}),
+            dataset_type=representation.get("dataset_type", DatasetType.IMAGE),
             auto_load=False,
         )
 
@@ -618,6 +647,22 @@ class HuggingfaceDatasetsBackend(BaseDataBackend):
             elif isinstance(sample, bytes):
                 # Already bytes
                 data = sample
+            elif isinstance(sample, (str, Path)):
+                try:
+                    path = str(sample)
+                    if os.path.isfile(path):
+                        with open(path, "rb") as f:
+                            data = f.read()
+                    else:
+                        from datasets.utils.file_utils import xopen
+
+                        with xopen(path, "rb") as f:
+                            data = f.read()
+                except Exception as exc:
+                    logger.error("Failed to read %s sample from path '%s': %s", self.dataset_type, sample, exc)
+                    data = None
+                if data is None:
+                    return None
             elif VideoReader is not None and isinstance(sample, VideoReader):
                 # VideoReader - encode all frames into a video file in memory
                 import trainingsample as tsr

--- a/simpletuner/helpers/metadata/backends/huggingface.py
+++ b/simpletuner/helpers/metadata/backends/huggingface.py
@@ -6,10 +6,13 @@ import traceback
 from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
+from huggingface_hub import hf_hub_download
+from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError, HFValidationError, LocalEntryNotFoundError
 from PIL import Image
 from tqdm import tqdm
 
 from simpletuner.helpers.data_backend.base import BaseDataBackend
+from simpletuner.helpers.data_backend.dataset_types import ensure_dataset_type
 from simpletuner.helpers.image_manipulation.training_sample import TrainingSample
 from simpletuner.helpers.metadata.backends.base import MetadataBackend
 from simpletuner.helpers.multiaspect.image import MultiaspectImage
@@ -28,6 +31,10 @@ def _coerce_bucket_keys_to_float(indices: dict) -> dict:
             coerced_key = key
         coerced[coerced_key] = list(values) if not isinstance(values, list) else values
     return coerced
+
+
+def _dataset_type_value(dataset_type: Any) -> str:
+    return str(getattr(dataset_type, "value", dataset_type)).lower()
 
 
 logger = logging.getLogger("HuggingfaceMetadataBackend")
@@ -140,6 +147,8 @@ class HuggingfaceMetadataBackend(MetadataBackend):
             repeats=repeats,
             max_num_samples=max_num_samples,
         )
+        if not (StateTracker.get_data_backend_config(id) or {}).get("dataset_type"):
+            self.dataset_type = ensure_dataset_type(dataset_type)
 
         if not hasattr(data_backend, "dataset"):
             raise ValueError("HuggingfaceMetadataBackend requires HuggingfaceDatasetsBackend")
@@ -242,7 +251,7 @@ class HuggingfaceMetadataBackend(MetadataBackend):
                 caption = str(fallback)
 
         # Audio models often store prompts/lyrics in multiple fields; combine them if no caption yet.
-        if not caption and self.dataset_type == "audio":
+        if not caption and _dataset_type_value(self.dataset_type) == "audio":
             parts = []
             for field in self.audio_caption_fields or []:
                 value = self._get_nested_value(item, field)
@@ -250,6 +259,11 @@ class HuggingfaceMetadataBackend(MetadataBackend):
                     parts.append(str(value).strip())
             if parts:
                 caption = " ".join([p for p in parts if p])
+            else:
+                audio_value = item.get("audio")
+                sibling_caption = self._read_audio_text_sibling(self._source_path_from_hf_media(audio_value), ".txt")
+                if sibling_caption:
+                    caption = sibling_caption
 
         # handle description column if specified
         if not caption and self.description_column in item:
@@ -286,6 +300,81 @@ class HuggingfaceMetadataBackend(MetadataBackend):
             return current_value
         else:
             return item.get(key_path)
+
+    @staticmethod
+    def _source_path_from_hf_media(media_value: Any) -> Optional[str]:
+        encoded = getattr(media_value, "_hf_encoded", None)
+        if isinstance(encoded, dict):
+            path = encoded.get("path")
+            if isinstance(path, str) and path:
+                return path
+        if isinstance(media_value, dict):
+            path = media_value.get("path")
+            if isinstance(path, str) and path:
+                return path
+        if isinstance(media_value, str) and media_value:
+            return media_value
+        return None
+
+    @staticmethod
+    def _read_text_sibling(source_path: Optional[str], extension: str) -> Optional[str]:
+        if not source_path:
+            return None
+        sibling_path = os.path.splitext(source_path)[0] + extension
+        if not os.path.isfile(sibling_path):
+            return None
+        try:
+            with open(sibling_path, "r", encoding="utf-8") as sibling_file:
+                value = sibling_file.read().strip()
+        except OSError:
+            return None
+        return value or None
+
+    def _source_dataset_repo_id(self) -> Optional[str]:
+        data_files = getattr(self.data_backend, "data_files", None)
+        stack = [data_files]
+        while stack:
+            value = stack.pop()
+            if isinstance(value, dict):
+                stack.extend(value.values())
+                continue
+            if isinstance(value, (list, tuple, set)):
+                stack.extend(value)
+                continue
+            if not isinstance(value, str):
+                continue
+            marker = "hf://datasets/"
+            if marker not in value:
+                continue
+            path = value.split(marker, 1)[1]
+            parts = [part for part in path.split("/") if part and "*" not in part]
+            if len(parts) >= 2:
+                return "/".join(parts[:2])
+        dataset_name = getattr(self.data_backend, "dataset_name", None)
+        if isinstance(dataset_name, str) and "/" in dataset_name and dataset_name != "audiofolder":
+            return dataset_name
+        return None
+
+    def _read_audio_text_sibling(self, source_path: Optional[str], extension: str) -> Optional[str]:
+        local_value = self._read_text_sibling(source_path, extension)
+        if local_value is not None:
+            return local_value
+        if not source_path:
+            return None
+        repo_id = self._source_dataset_repo_id()
+        if repo_id is None:
+            return None
+        filename = os.path.basename(os.path.splitext(source_path)[0] + extension)
+        try:
+            sibling_path = hf_hub_download(repo_id, filename, repo_type="dataset")
+        except (EntryNotFoundError, HFValidationError, HfHubHTTPError, LocalEntryNotFoundError):
+            return None
+        try:
+            with open(sibling_path, "r", encoding="utf-8") as sibling_file:
+                value = sibling_file.read().strip()
+        except OSError:
+            return None
+        return value or None
 
     def reload_cache(self, set_config: bool = True):
         if self.data_backend.exists(self.cache_file):
@@ -568,14 +657,21 @@ class HuggingfaceMetadataBackend(MetadataBackend):
                     statistics.setdefault("skipped", {}).setdefault("quality", 0)
                     statistics["skipped"]["quality"] += 1
                     return aspect_ratio_bucket_indices
-            if self.dataset_type == "audio":
+            dataset_type_value = _dataset_type_value(self.dataset_type)
+            if dataset_type_value == "audio":
                 sample_metadata = dict(self.image_metadata.get(image_path_str, {}))
+                audio_value = item.get("audio")
+                source_path = self._source_path_from_hf_media(audio_value)
                 # Ensure audio fields are present in metadata
                 if self.audio_caption_fields:
                     for field in self.audio_caption_fields:
                         val = self._get_nested_value(item, field)
                         if val:
                             sample_metadata[field] = str(val)
+                    if not any(sample_metadata.get(field) for field in self.audio_caption_fields):
+                        sibling_caption = self._read_audio_text_sibling(source_path, ".txt")
+                        if sibling_caption:
+                            sample_metadata[self.audio_caption_fields[0]] = sibling_caption
 
                 # Specific handling for lyrics column. Empty strings are preserved: instrumental and
                 # regularisation tracks legitimately carry no lyrics.
@@ -583,6 +679,8 @@ class HuggingfaceMetadataBackend(MetadataBackend):
                     lyrics_val = self._get_nested_value(item, self.lyrics_column)
                     if lyrics_val is not None:
                         sample_metadata["lyrics"] = str(lyrics_val)
+                    elif (sibling_lyrics := self._read_audio_text_sibling(source_path, ".lyrics")) is not None:
+                        sample_metadata["lyrics"] = sibling_lyrics
                     # Fallback for norm_lyrics if not found via lyrics_column
                     elif self.lyrics_column != "norm_lyrics":
                         norm_lyrics = self._get_nested_value(item, "norm_lyrics")
@@ -600,7 +698,6 @@ class HuggingfaceMetadataBackend(MetadataBackend):
                     # Prefer explicit duration columns if provided by the dataset.
                     duration_seconds = item.get("audio_duration") or item.get("duration") or item.get("duration_seconds")
                 if duration_seconds is None:
-                    audio_value = item.get("audio")
                     try:
                         if isinstance(audio_value, dict):
                             array = audio_value.get("array")
@@ -626,7 +723,7 @@ class HuggingfaceMetadataBackend(MetadataBackend):
                     metadata_updates[image_path_str] = sample_metadata
                 statistics["total_processed"] += 1
                 return aspect_ratio_bucket_indices
-            if self.dataset_type == "image":
+            if dataset_type_value == "image":
                 sample_metadata = self._get_image_metadata_from_item(item)
 
                 if "original_size" not in sample_metadata:
@@ -646,7 +743,7 @@ class HuggingfaceMetadataBackend(MetadataBackend):
                     image_metadata=sample_metadata,
                     image_path=image_path_str,
                 )
-            elif self.dataset_type == "video":
+            elif dataset_type_value == "video":
                 if self.video_column not in item:
                     logger.warning(f"Video column '{self.video_column}' not found in item {image_path_str}")
                     statistics.setdefault("skipped", {}).setdefault("metadata_missing", 0)

--- a/simpletuner/helpers/models/minimaxh3/model.py
+++ b/simpletuner/helpers/models/minimaxh3/model.py
@@ -1570,8 +1570,7 @@ class MiniMaxH3(VideoModelFoundation):
 
     def _prepare_xm_noise_candidates(self, prepared_batch: dict) -> dict:
         self._validate_xm_support()
-        if prepared_batch.get("audio_target") is not None:
-            raise ValueError(f"{self.NAME} XM noise-candidate training cannot be used with an explicit audio_target.")
+        prepared_batch.pop("audio_target", None)
         if isinstance(prepared_batch.get("conditioning_latents"), list):
             raise ValueError(f"{self.NAME} XM noise-candidate training requires conditioning_latents to be one tensor.")
 

--- a/simpletuner/helpers/models/minimaxmusic/model.py
+++ b/simpletuner/helpers/models/minimaxmusic/model.py
@@ -113,9 +113,142 @@ class MiniMaxMusicRVQCacheEncoder(nn.Module):
         return self
 
     def eval(self):
+        super().eval()
         self.audio_vae.eval()
         self.rvq_encoder.eval()
         return self
+
+    @staticmethod
+    def _legacy_frame_latent_starts(n_frames: int) -> list[int]:
+        latent_rate_num = 441
+        latent_rate_den = 128
+        chunk_frames = 200
+        chunk_hop_frames = 100
+        stitched_hop_latents = 345
+        non_first_chunk_owned_from = 25
+        num_windows = max(1, (n_frames - 1) // chunk_hop_frames)
+        starts = []
+        for frame_index in range(n_frames + 1):
+            chunk_index = min(
+                max((frame_index - non_first_chunk_owned_from) // chunk_hop_frames, 0),
+                num_windows - 1,
+            )
+            local_frame = frame_index - chunk_index * chunk_hop_frames
+            current_chunk_frames = min(chunk_frames, n_frames - chunk_index * chunk_hop_frames)
+            chunk_latents = current_chunk_frames * latent_rate_num // latent_rate_den
+            local_latent = (local_frame * chunk_latents + current_chunk_frames - 1) // current_chunk_frames
+            starts.append(chunk_index * stitched_hop_latents + local_latent)
+        return starts
+
+    @staticmethod
+    def _build_window_pool(bounds: list[int], device: torch.device) -> tuple[torch.Tensor, int, int]:
+        if len(bounds) < 2:
+            raise ValueError("At least two frame/latent boundaries are required.")
+        origin = int(bounds[0])
+        local_bounds = [int(value) - origin for value in bounds]
+        latent_count = local_bounds[-1]
+        if latent_count <= 0:
+            raise ValueError(f"Invalid MiniMax Music RVQ latent bounds: {bounds[:4]}...{bounds[-4:]}.")
+        pool = torch.zeros((len(local_bounds) - 1, latent_count), dtype=torch.float32, device=device)
+        for frame_index, (start, end) in enumerate(zip(local_bounds[:-1], local_bounds[1:])):
+            if end <= start:
+                raise ValueError(f"MiniMax Music RVQ frame {frame_index} has invalid latent span [{start}, {end}).")
+            pool[frame_index, start:end] = 1.0 / float(end - start)
+        return pool, origin, int(bounds[-1])
+
+    def _max_position_embeddings(self) -> int:
+        configured = getattr(getattr(self.rvq_encoder, "config", None), "max_position_embeddings", None)
+        if configured is not None:
+            return int(configured)
+        position = getattr(self.rvq_encoder, "position", None)
+        if torch.is_tensor(position) and position.ndim >= 2:
+            return int(position.shape[1])
+        raise ValueError("MiniMax Music RVQ encoder does not expose max_position_embeddings.")
+
+    @classmethod
+    def _frame_count_for_cache(
+        cls,
+        *,
+        latent_frames: int,
+        sample_frames: int,
+        sample_rate: int,
+        frame_rate: float,
+    ) -> int:
+        duration_frames = max(1, int(round(float(sample_frames) / float(sample_rate) * float(frame_rate))))
+        frame_count = min(duration_frames, _MAX_AUDIO_FRAMES)
+        while frame_count > 1 and cls._legacy_frame_latent_starts(frame_count)[-1] > latent_frames:
+            frame_count -= 1
+        return frame_count
+
+    @staticmethod
+    def _resample_audio_if_needed(
+        waveform: torch.Tensor,
+        *,
+        source_rate: Optional[int],
+        target_rate: int,
+    ) -> torch.Tensor:
+        if source_rate is None or int(source_rate) == int(target_rate):
+            return waveform
+        import torchaudio
+
+        return torchaudio.functional.resample(waveform, int(source_rate), int(target_rate))
+
+    @torch.no_grad()
+    def encode_audio_codes(
+        self,
+        samples: torch.Tensor,
+        *,
+        sample_rates: Optional[list[Optional[int]]] = None,
+        device: Optional[torch.device] = None,
+        frame_rate: float = 25.0,
+    ) -> torch.Tensor:
+        if samples.ndim != 3:
+            raise ValueError(
+                f"MiniMax Music LM RVQ cache expects audio [batch, channels, samples], got {tuple(samples.shape)}."
+            )
+
+        device = device or self.device
+        target_rate = int(getattr(self.audio_vae.config, "sampling_rate", 44100) or 44100)
+        sample_rates = sample_rates or [None for _ in range(samples.shape[0])]
+        code_rows = []
+        for index in range(samples.shape[0]):
+            source_rate = sample_rates[index] if index < len(sample_rates) else None
+            waveform = samples[index : index + 1].to(device=device, dtype=self.dtype)
+            waveform = self._resample_audio_if_needed(
+                waveform.squeeze(0),
+                source_rate=int(source_rate) if source_rate else None,
+                target_rate=target_rate,
+            ).unsqueeze(0)
+            latents = self.audio_vae.encode(waveform)
+            if not isinstance(latents, torch.Tensor):
+                raise TypeError("MiniMax Music LM RVQ cache DAV encode() must return a tensor.")
+            latent_rows = latents[0].transpose(0, 1).contiguous()
+            latent_frames = int(latent_rows.shape[0])
+            frame_count = self._frame_count_for_cache(
+                latent_frames=latent_frames,
+                sample_frames=int(waveform.shape[-1]),
+                sample_rate=target_rate,
+                frame_rate=frame_rate,
+            )
+            bounds = self._legacy_frame_latent_starts(frame_count)
+            max_window = self._max_position_embeddings()
+            code_windows = []
+            for frame_start in range(0, frame_count, max_window):
+                frame_end = min(frame_start + max_window, frame_count)
+                pool, latent_start, latent_end = self._build_window_pool(
+                    bounds[frame_start : frame_end + 1],
+                    device=latent_rows.device,
+                )
+                window_latents = latent_rows[latent_start:latent_end].unsqueeze(0).to(dtype=torch.float32)
+                logits = self.rvq_encoder(window_latents, pool.unsqueeze(0))
+                if not isinstance(logits, (list, tuple)) or len(logits) == 0:
+                    raise TypeError("MiniMax Music RVQ encoder must return one logits tensor per codebook.")
+                code_windows.append(torch.stack([book_logits.argmax(dim=-1).squeeze(0) for book_logits in logits], dim=-1))
+            codes = torch.cat(code_windows, dim=0)
+            code_rows.append(codes.to(device="cpu", dtype=torch.long))
+        if len(code_rows) == 1:
+            return code_rows[0].unsqueeze(0)
+        return pad_sequence(code_rows, batch_first=True, padding_value=0)
 
 
 class MiniMaxMusic(AudioModelFoundation):
@@ -762,7 +895,8 @@ class MiniMaxMusic(AudioModelFoundation):
 
     def load_vae(self, move_to_device: bool = True):
         if self._train_language_model:
-            return None
+            self.vae = self.load_lm_rvq_cache_encoder(move_to_device=move_to_device)
+            return self.vae
         if self.vae is None:
             checkpoint_path = self._vae_checkpoint_path()
             if self._has_diffusers_audio_vae(checkpoint_path):
@@ -896,67 +1030,6 @@ class MiniMaxMusic(AudioModelFoundation):
             raise TypeError("MiniMax Music 3 DAV encode() must return a tensor.")
         return latents.to(dtype=self.config.weight_dtype)
 
-    @staticmethod
-    def _lm_legacy_frame_latent_starts(n_frames: int) -> list[int]:
-        latent_rate_num = 441
-        latent_rate_den = 128
-        chunk_frames = 200
-        chunk_hop_frames = 100
-        stitched_hop_latents = 345
-        non_first_chunk_owned_from = 25
-        num_windows = max(1, (n_frames - 1) // chunk_hop_frames)
-        starts = []
-        for frame_index in range(n_frames + 1):
-            chunk_index = min(
-                max((frame_index - non_first_chunk_owned_from) // chunk_hop_frames, 0),
-                num_windows - 1,
-            )
-            local_frame = frame_index - chunk_index * chunk_hop_frames
-            current_chunk_frames = min(chunk_frames, n_frames - chunk_index * chunk_hop_frames)
-            chunk_latents = current_chunk_frames * latent_rate_num // latent_rate_den
-            local_latent = (local_frame * chunk_latents + current_chunk_frames - 1) // current_chunk_frames
-            starts.append(chunk_index * stitched_hop_latents + local_latent)
-        return starts
-
-    @staticmethod
-    def _lm_build_pool_matrix(bounds: list[int], latent_frames: int, device: torch.device) -> torch.Tensor:
-        if len(bounds) < 2:
-            raise ValueError("At least two frame/latent boundaries are required.")
-        local_bounds = [max(0, min(int(value), latent_frames)) for value in bounds]
-        pool = torch.zeros((len(local_bounds) - 1, latent_frames), dtype=torch.float32, device=device)
-        for frame_index, (start, end) in enumerate(zip(local_bounds[:-1], local_bounds[1:])):
-            if end <= start:
-                end = min(start + 1, latent_frames)
-                start = max(0, end - 1)
-            pool[frame_index, start:end] = 1.0 / float(end - start)
-        return pool
-
-    def _lm_frame_count_for_rvq_cache(
-        self,
-        *,
-        latent_frames: int,
-        sample_frames: int,
-        sample_rate: int,
-    ) -> int:
-        duration_frames = max(1, int(round(float(sample_frames) / float(sample_rate) * self._frame_rate())))
-        frame_count = min(duration_frames, _MAX_AUDIO_FRAMES)
-        while frame_count > 1 and self._lm_legacy_frame_latent_starts(frame_count)[-1] > latent_frames:
-            frame_count -= 1
-        return frame_count
-
-    def _resample_lm_audio_if_needed(
-        self,
-        waveform: torch.Tensor,
-        *,
-        source_rate: Optional[int],
-        target_rate: int,
-    ) -> torch.Tensor:
-        if source_rate is None or int(source_rate) == int(target_rate):
-            return waveform
-        import torchaudio
-
-        return torchaudio.functional.resample(waveform, int(source_rate), int(target_rate))
-
     def _encode_lm_rvq_cache_batch(
         self,
         cache_encoder,
@@ -967,56 +1040,28 @@ class MiniMaxMusic(AudioModelFoundation):
             raise TypeError(
                 "MiniMax Music LM VAE cache expects MiniMaxMusicRVQCacheEncoder; " f"received {type(cache_encoder)}."
             )
-        if samples.ndim != 3:
-            raise ValueError(
-                f"MiniMax Music LM RVQ cache expects audio [batch, channels, samples], got {tuple(samples.shape)}."
-            )
 
-        target_rate = int(getattr(cache_encoder.audio_vae.config, "sampling_rate", 44100) or 44100)
         entries = metadata_entries or [{} for _ in range(samples.shape[0])]
-        code_rows = []
-        with torch.no_grad():
-            for index in range(samples.shape[0]):
-                entry = entries[index] if index < len(entries) else {}
-                metadata = entry.get("metadata", {}) if isinstance(entry, dict) else {}
-                backend_id = entry.get("data_backend_id") if isinstance(entry, dict) else None
-                backend_audio_config = {}
-                if backend_id:
-                    from simpletuner.helpers.training.state_tracker import StateTracker
+        sample_rates = []
+        for index in range(samples.shape[0]):
+            entry = entries[index] if index < len(entries) else {}
+            metadata = entry.get("metadata", {}) if isinstance(entry, dict) else {}
+            backend_id = entry.get("data_backend_id") if isinstance(entry, dict) else None
+            backend_audio_config = {}
+            if backend_id:
+                from simpletuner.helpers.training.state_tracker import StateTracker
 
-                    backend_audio_config = (StateTracker.get_data_backend_config(backend_id) or {}).get("audio", {})
-                source_rate = (
-                    metadata.get("sample_rate") or metadata.get("sampling_rate") or backend_audio_config.get("sample_rate")
-                )
-                waveform = samples[index : index + 1].to(device=self.accelerator.device, dtype=torch.float32)
-                waveform = self._resample_lm_audio_if_needed(
-                    waveform.squeeze(0),
-                    source_rate=int(source_rate) if source_rate else None,
-                    target_rate=target_rate,
-                ).unsqueeze(0)
-                latents = cache_encoder.audio_vae.encode(waveform)
-                if not isinstance(latents, torch.Tensor):
-                    raise TypeError("MiniMax Music LM RVQ cache DAV encode() must return a tensor.")
-                latent_rows = latents[0].transpose(0, 1).contiguous()
-                latent_frames = int(latent_rows.shape[0])
-                frame_count = self._lm_frame_count_for_rvq_cache(
-                    latent_frames=latent_frames,
-                    sample_frames=int(waveform.shape[-1]),
-                    sample_rate=target_rate,
-                )
-                bounds = self._lm_legacy_frame_latent_starts(frame_count)
-                pool = self._lm_build_pool_matrix(bounds, latent_frames, device=latent_rows.device).unsqueeze(0)
-                logits = cache_encoder.rvq_encoder(
-                    latent_rows.unsqueeze(0).to(dtype=torch.float32),
-                    pool,
-                )
-                if not isinstance(logits, (list, tuple)) or len(logits) == 0:
-                    raise TypeError("MiniMax Music RVQ encoder must return one logits tensor per codebook.")
-                codes = torch.stack([book_logits.argmax(dim=-1).squeeze(0) for book_logits in logits], dim=-1)
-                code_rows.append(codes.to(device="cpu", dtype=torch.long))
-        if len(code_rows) == 1:
-            return code_rows[0].unsqueeze(0)
-        return pad_sequence(code_rows, batch_first=True, padding_value=0)
+                backend_audio_config = (StateTracker.get_data_backend_config(backend_id) or {}).get("audio", {})
+            source_rate = (
+                metadata.get("sample_rate") or metadata.get("sampling_rate") or backend_audio_config.get("sample_rate")
+            )
+            sample_rates.append(int(source_rate) if source_rate else None)
+        return cache_encoder.encode_audio_codes(
+            samples,
+            sample_rates=sample_rates,
+            device=self.accelerator.device,
+            frame_rate=self._frame_rate(),
+        )
 
     def _lm_prompt_text(self, caption: str, lyrics: str) -> str:
         return (
@@ -1459,6 +1504,27 @@ class MiniMaxMusic(AudioModelFoundation):
         self.condition_encoder = condition_encoder
         self.text_encoders = [language_model]
         self.text_encoder_1 = language_model
+
+    def move_text_encoders_for_vae_cache(self, target_device):
+        components = (
+            ("language_model", self.language_model),
+            ("rvq_depth_decoder", self.rvq_depth_decoder),
+            ("condition_encoder", self.condition_encoder),
+        )
+        target = torch.device(target_device)
+        for component_name, component in components:
+            if component is None:
+                continue
+            if component_name == "language_model" and self._ramtorch_text_encoders_requested():
+                logger.debug("Skipping %s VAE-cache move because ramtorch_text_encoder is enabled.", component_name)
+                continue
+            if target.type == "cpu":
+                component.to(target)
+            else:
+                component.to(target, dtype=self.config.weight_dtype)
+        if self.language_model is not None:
+            self.text_encoders = [self.language_model]
+            self.text_encoder_1 = self.language_model
 
     def load_condition_encoder(self, move_to_device: bool = True):
         if self.condition_encoder is None:

--- a/simpletuner/helpers/training/nextlat.py
+++ b/simpletuner/helpers/training/nextlat.py
@@ -52,6 +52,7 @@ def infer_nextlat_hidden_size(model: nn.Module) -> int:
 
 def infer_nextlat_block_count(model: nn.Module) -> int:
     candidates = (
+        ("transformer_blocks",),
         ("transformer_blocks", "single_transformer_blocks"),
         ("joint_transformer_blocks", "single_transformer_blocks"),
         ("double_stream_layers", "single_stream_layers"),
@@ -86,6 +87,9 @@ class NextLatPredictor(nn.Module):
         if hidden_states.ndim < 3:
             raise ValueError("NextLat expects hidden states with batch, token, and feature dimensions.")
         tokens = hidden_states.reshape(hidden_states.shape[0], -1, hidden_states.shape[-1])
+        parameter_dtype = self.norm.weight.dtype
+        if tokens.dtype != parameter_dtype:
+            tokens = tokens.to(dtype=parameter_dtype)
         return self.down(F.gelu(self.up(self.norm(tokens))))
 
 

--- a/tests/test_backend_builders.py
+++ b/tests/test_backend_builders.py
@@ -4,8 +4,10 @@ Component tests for data backend builder classes.
 Validates builder classes for creating backend instances and handling configurations.
 """
 
+import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict
 from unittest.mock import MagicMock, Mock, patch
 
@@ -21,6 +23,8 @@ from simpletuner.helpers.data_backend.builders import (
     create_backend_builder,
 )
 from simpletuner.helpers.data_backend.config import ImageBackendConfig, ImageEmbedBackendConfig, TextEmbedBackendConfig
+from simpletuner.helpers.data_backend.dataset_types import DatasetType
+from simpletuner.helpers.data_backend.huggingface import HuggingfaceDatasetsBackend
 
 
 class TestBaseBackendBuilder(unittest.TestCase):
@@ -588,10 +592,13 @@ class TestHuggingfaceBackendBuilder(unittest.TestCase):
                 "metadata_backend": "huggingface",
                 "huggingface": {
                     "cache_dir": "/tmp/hf_cache",
+                    "dataset_config": "default",
+                    "data_files": {"train": "hf://datasets/test/dataset/**/*.flac"},
                     "split": "validation",
                     "revision": "v1.1",
                     "image_column": "image",
                     "video_column": "video",
+                    "audio_column": "audio",
                     "streaming": False,
                     "num_proc": 4,
                     "auto_load": True,
@@ -603,13 +610,54 @@ class TestHuggingfaceBackendBuilder(unittest.TestCase):
         result = self.builder.build(config)
 
         call_kwargs = mock_hf_backend_class.call_args[1]
+        self.assertEqual(call_kwargs["dataset_config"], "default")
+        self.assertEqual(call_kwargs["data_files"], {"train": "hf://datasets/test/dataset/**/*.flac"})
         self.assertEqual(call_kwargs["split"], "validation")
         self.assertEqual(call_kwargs["revision"], "v1.1")
         self.assertEqual(call_kwargs["image_column"], "image")
         self.assertEqual(call_kwargs["video_column"], "video")
+        self.assertEqual(call_kwargs["audio_column"], "audio")
         self.assertFalse(call_kwargs["streaming"])
         self.assertEqual(call_kwargs["num_proc"], 4)
         self.assertTrue(call_kwargs["auto_load"])
+
+    @patch("datasets.load_dataset")
+    @patch("datasets.load_dataset_builder")
+    def test_audiofolder_loads_audio_without_decode(self, mock_load_dataset_builder, mock_load_dataset):
+        mock_load_dataset_builder.return_value = SimpleNamespace(info=SimpleNamespace(splits={"train": None}))
+        mock_load_dataset.return_value = []
+
+        HuggingfaceDatasetsBackend(
+            accelerator=self.accelerator,
+            id="test_audiofolder",
+            dataset_name="audiofolder",
+            data_files={"train": "hf://datasets/example/audio/**/*.flac"},
+            dataset_type=DatasetType.AUDIO,
+            auto_load=True,
+        )
+
+        features = mock_load_dataset.call_args.kwargs["features"]
+        self.assertIn("audio", features)
+        self.assertEqual(features["audio"].dtype, "string")
+        self.assertEqual(mock_load_dataset.call_args.kwargs["download_mode"], "force_redownload")
+        self.assertIs(mock_load_dataset_builder.call_args.kwargs["features"], features)
+
+    def test_audiofolder_read_accepts_path_string_sample(self):
+        backend = HuggingfaceDatasetsBackend(
+            accelerator=self.accelerator,
+            id="test_audiofolder",
+            dataset_name="audiofolder",
+            dataset_type=DatasetType.AUDIO,
+            auto_load=False,
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            audio_path = Path(temp_dir) / "sample.flac"
+            audio_path.write_bytes(b"audio bytes")
+            backend.dataset = [{"audio": str(audio_path)}]
+            backend._build_path_mapping()
+
+            self.assertEqual(backend.read("0.wav"), b"audio bytes")
 
     @patch("simpletuner.helpers.data_backend.builders.huggingface.HuggingfaceDatasetsBackend")
     def test_build_assigns_default_cache_dir_when_missing(self, mock_hf_backend_class):

--- a/tests/test_huggingface_metadata_backend.py
+++ b/tests/test_huggingface_metadata_backend.py
@@ -1,4 +1,6 @@
+import tempfile
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -39,6 +41,22 @@ class _MinimalHuggingfaceMetadataBackend(HuggingfaceMetadataBackend):
 
 
 class HuggingfaceMetadataBackendTests(unittest.TestCase):
+    def test_audio_caption_falls_back_to_text_sibling(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audio_path = Path(tmpdir) / "song.flac"
+            audio_path.touch()
+            audio_path.with_suffix(".txt").write_text("riff-heavy caption", encoding="utf-8")
+            media = SimpleNamespace(_hf_encoded={"path": str(audio_path)})
+
+            backend = HuggingfaceMetadataBackend.__new__(HuggingfaceMetadataBackend)
+            backend.dataset_type = "audio"
+            backend.caption_column = "caption"
+            backend.fallback_caption_column = None
+            backend.audio_caption_fields = ["prompt", "tags"]
+            backend.description_column = "description"
+
+            self.assertEqual(backend._extract_caption_from_item({"audio": media}), "riff-heavy caption")
+
     @patch("simpletuner.helpers.metadata.backends.huggingface.TrainingSample")
     def test_video_without_maximum_num_frames_is_not_flagged_as_too_many(self, mock_training_sample):
         prepared = SimpleNamespace(

--- a/tests/test_minimaxh3_xm.py
+++ b/tests/test_minimaxh3_xm.py
@@ -96,6 +96,31 @@ class MiniMaxH3XMTests(unittest.TestCase):
         self.assertTrue(torch.allclose(batch["audio_target"], batch["audio_latents"] - audio_noise))
         self.assertEqual(batch["xm_candidate_count"], 3)
 
+    def test_prepare_xm_noise_candidates_replaces_existing_audio_target(self):
+        model = self._model(candidate_count=2)
+        latents = torch.zeros(1, 2, 1, 2, 2)
+        audio_latents = torch.zeros(1, 2, 3, 2)
+        video_noise = torch.ones(2, 2, 1, 2, 2)
+        audio_noise = torch.ones(2, 2, 3, 2) * 2.0
+        batch = {
+            "latents": latents,
+            "noisy_latents": torch.zeros_like(latents),
+            "sigmas": torch.tensor([0.25], dtype=torch.float32),
+            "timesteps": torch.tensor([250.0], dtype=torch.float32),
+            "encoder_hidden_states": torch.zeros(1, 2, 3),
+            "conditioning_latents": torch.ones(1, 2, 1, 2, 2),
+            "audio_latents": audio_latents,
+            "audio_noisy_latents": torch.zeros_like(audio_latents),
+            "audio_sigmas": torch.tensor([0.1], dtype=torch.float32),
+            "audio_timesteps": torch.tensor([0.9], dtype=torch.float32),
+            "audio_target": torch.full_like(audio_latents, 99.0),
+        }
+
+        with patch("torch.randn_like", side_effect=[video_noise, audio_noise]):
+            model._prepare_xm_noise_candidates(batch)
+
+        self.assertTrue(torch.equal(batch["audio_target"], batch["audio_latents"] - audio_noise))
+
     def test_model_predict_tags_xm_output(self):
         model = self._model(candidate_count=2)
         model._prepare_xm_noise_candidates = MagicMock()

--- a/tests/test_minimaxmusic_model.py
+++ b/tests/test_minimaxmusic_model.py
@@ -1033,6 +1033,7 @@ class MiniMaxMusicLanguageModelTrainingTests(unittest.TestCase):
             vae_path=None,
             minimax_music_train_component="language_model",
             minimax_music_lm_max_frames=0,
+            weight_dtype=torch.float32,
         )
         for key, value in overrides.items():
             setattr(config, key, value)
@@ -1087,16 +1088,18 @@ class MiniMaxMusicLanguageModelTrainingTests(unittest.TestCase):
             return torch.ones(waveform.shape[0], 128, latent_frames, device=waveform.device, dtype=torch.float32)
 
     class _FakeRVQEncoder(torch.nn.Module):
-        def __init__(self, codebooks=4, vocab=8):
+        def __init__(self, codebooks=4, vocab=8, max_position_embeddings=128):
             super().__init__()
             self.weight = torch.nn.Parameter(torch.zeros(1))
             self.codebooks = codebooks
             self.vocab = vocab
-            self.config = SimpleNamespace(max_position_embeddings=128)
+            self.config = SimpleNamespace(max_position_embeddings=max_position_embeddings)
+            self.pool_shapes = []
 
         def forward(self, latents, pool, teacher_forcing_targets=None):
             del latents, teacher_forcing_targets
             batch, frames, _ = pool.shape
+            self.pool_shapes.append(tuple(pool.shape))
             logits = []
             for book in range(self.codebooks):
                 values = torch.zeros(batch, frames, self.vocab, device=pool.device)
@@ -1106,6 +1109,12 @@ class MiniMaxMusicLanguageModelTrainingTests(unittest.TestCase):
 
     def test_lm_mode_switches_component_contracts(self):
         model = self._lm_model()
+        cache_encoder = MiniMaxMusicRVQCacheEncoder(
+            audio_vae=self._FakeAudioVAE(),
+            rvq_encoder=self._FakeRVQEncoder(codebooks=4, vocab=8),
+        )
+        model.load_lm_rvq_cache_encoder = MagicMock(return_value=cache_encoder)
+
         self.assertTrue(model._train_language_model)
         self.assertTrue(model.uses_audio_tokens())
         self.assertFalse(model.uses_audio_latents())
@@ -1114,7 +1123,36 @@ class MiniMaxMusicLanguageModelTrainingTests(unittest.TestCase):
         self.assertEqual(model.MODEL_SUBFOLDER, "language_model")
         self.assertEqual(model._music_lora_component_name(), "language_model")
         self.assertIn("q_proj", model.DEFAULT_LORA_TARGET)
-        self.assertIsNone(model.load_vae())
+        self.assertIs(model.load_vae(), cache_encoder)
+        self.assertIs(model.vae, cache_encoder)
+        self.assertEqual(model.vae.dtype, torch.float32)
+        model.load_lm_rvq_cache_encoder.assert_called_once_with(move_to_device=True)
+
+    def test_lm_vae_cache_text_offload_moves_all_lm_components(self):
+        model = self._lm_model(weight_dtype=torch.bfloat16)
+        language_model = MagicMock()
+        depth_decoder = MagicMock()
+        condition_encoder = MagicMock()
+        model.language_model = language_model
+        model.rvq_depth_decoder = depth_decoder
+        model.condition_encoder = condition_encoder
+
+        model.move_text_encoders_for_vae_cache("cpu")
+
+        language_model.to.assert_called_once_with(torch.device("cpu"))
+        depth_decoder.to.assert_called_once_with(torch.device("cpu"))
+        condition_encoder.to.assert_called_once_with(torch.device("cpu"))
+        self.assertEqual(model.text_encoders, [language_model])
+        self.assertIs(model.text_encoder_1, language_model)
+
+        for component in (language_model, depth_decoder, condition_encoder):
+            component.to.reset_mock()
+
+        model.move_text_encoders_for_vae_cache(torch.device("cuda"))
+
+        language_model.to.assert_called_once_with(torch.device("cuda"), dtype=torch.bfloat16)
+        depth_decoder.to.assert_called_once_with(torch.device("cuda"), dtype=torch.bfloat16)
+        condition_encoder.to.assert_called_once_with(torch.device("cuda"), dtype=torch.bfloat16)
 
     def test_lm_rvq_audio_vae_path_prefers_explicit_override_then_shared_vae(self):
         model = self._lm_model()
@@ -1226,6 +1264,24 @@ class MiniMaxMusicLanguageModelTrainingTests(unittest.TestCase):
         self.assertEqual(codes.shape[0], 1)
         self.assertEqual(codes.shape[2], 4)
         self.assertTrue(torch.equal(codes[0, 0], torch.tensor([0, 1, 2, 3])))
+
+    def test_lm_encode_cache_batch_chunks_to_rvq_position_limit(self):
+        model = self._lm_model()
+        rvq_encoder = self._FakeRVQEncoder(codebooks=4, vocab=8, max_position_embeddings=3)
+        cache_encoder = MiniMaxMusicRVQCacheEncoder(
+            audio_vae=self._FakeAudioVAE(),
+            rvq_encoder=rvq_encoder,
+        )
+        samples = torch.zeros(1, 2, 44100)
+        codes = model.encode_cache_batch(
+            cache_encoder,
+            samples,
+            metadata_entries=[{"metadata": {"sample_rate": 44100}, "data_backend_id": "songs"}],
+        )
+
+        self.assertGreater(codes.shape[1], 3)
+        self.assertGreater(len(rvq_encoder.pool_shapes), 1)
+        self.assertTrue(all(shape[1] <= 3 for shape in rvq_encoder.pool_shapes))
 
     def test_lm_loss_targets_audio_positions_only(self):
         from simpletuner.helpers.models.minimaxmusic.encoders import _AUDIO_CODE_OFFSET, _AUDIO_END_TOKEN_ID

--- a/tests/test_nextlat_xm.py
+++ b/tests/test_nextlat_xm.py
@@ -33,6 +33,13 @@ class DummyTransformer(nn.Module):
         self.model = SimpleNamespace(layers=nn.ModuleList([nn.Linear(4, 4) for _ in range(3)]))
 
 
+class TransformerBlocksOnly(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(hidden_size=4)
+        self.transformer_blocks = nn.ModuleList([nn.Linear(4, 4) for _ in range(2)])
+
+
 class NextLatXmTests(unittest.TestCase):
     def test_field_registry_exposes_nextlat_and_xm_options(self):
         registry = FieldRegistry()
@@ -113,6 +120,25 @@ class NextLatXmTests(unittest.TestCase):
         self.assertGreater(loss.item(), 0.0)
         self.assertIn("nextlat_loss", logs)
         self.assertIn("nextlat_state_loss", logs)
+
+    def test_nextlat_block_count_accepts_transformer_blocks_without_single_blocks(self):
+        self.assertEqual(infer_nextlat_block_count(TransformerBlocksOnly()), 2)
+
+    def test_nextlat_predictor_accepts_bfloat16_hidden_states_with_float_parameters(self):
+        config = SimpleNamespace(
+            nextlat_enabled=True,
+            nextlat_weight=0.5,
+            nextlat_block_index=-1,
+            nextlat_state_loss="smooth_l1",
+            nextlat_kl_weight=0.0,
+        )
+        regularizer = NextLatRegularizer(config, DummyAccelerator(), hidden_size=4, block_count=1)
+        regularizer.attach_to_model(nn.Module(), dtype=torch.float32)
+        hidden = torch.randn(2, 5, 4, dtype=torch.bfloat16)
+
+        loss, _ = regularizer.compute_loss({"layer_0": hidden}, {})
+
+        self.assertGreaterEqual(loss.item(), 0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add HF audiofolder support for string audio paths and sibling caption/lyrics discovery
- use the MiniMax Music RVQ encoder as the LM VAE-cache encoder with proper offload behavior
- fix NextLat/XM runtime edge cases found during audio tournament runs

## Tests
- .venv/bin/python -m unittest -v -f tests.test_nextlat_xm tests.test_minimaxh3_xm tests.test_minimaxmusic_model.MiniMaxMusicLanguageModelTrainingTests tests.test_backend_builders.TestHuggingfaceBackendBuilder tests.test_huggingface_metadata_backend