### PR TITLE
Fix H3 audio-only XM and NextLat runtime paths

### DIFF
--- a/simpletuner/helpers/models/minimaxh3/model.py
+++ b/simpletuner/helpers/models/minimaxh3/model.py
@@ -36,6 +36,7 @@ from simpletuner.helpers.models.minimaxh3.packing import (
     MINIMAX_H3_AUDIO_LATENTS_PER_SECOND,
     MINIMAX_H3_FPS,
     MINIMAX_H3_KEYFRAME_NOISE_AUG,
+    MINIMAX_H3_MAX_DURATION,
     MINIMAX_H3_PIXEL_MEAN,
     MINIMAX_H3_PIXEL_STD,
     MINIMAX_H3_TEXT_TAG,
@@ -1279,6 +1280,29 @@ class MiniMaxH3(VideoModelFoundation):
             dtype=dtype,
         )
 
+    @staticmethod
+    def _max_audio_only_audio_latents() -> int:
+        max_frames = int(MINIMAX_H3_MAX_DURATION * MINIMAX_H3_FPS)
+        while max_frames > 1 and align_num_frames(max_frames) > int(MINIMAX_H3_MAX_DURATION * MINIMAX_H3_FPS):
+            max_frames -= 1
+        return audio_latent_num_frames(align_num_frames(max_frames))
+
+    def _trim_audio_only_latents_for_supported_duration(self, batch: dict) -> None:
+        audio_latents = batch.get("audio_latent_batch")
+        audio_latents_dict = audio_latents if isinstance(audio_latents, dict) else None
+        if audio_latents_dict is not None:
+            audio_latents = audio_latents_dict.get("latents")
+        if not torch.is_tensor(audio_latents) or audio_latents.ndim != 4:
+            return
+        max_audio_latents = self._max_audio_only_audio_latents()
+        if int(audio_latents.shape[-1]) <= max_audio_latents:
+            return
+        audio_latents = audio_latents[..., :max_audio_latents].contiguous()
+        if audio_latents_dict is not None:
+            audio_latents_dict["latents"] = audio_latents
+        else:
+            batch["audio_latent_batch"] = audio_latents
+
     def _build_fake_video_latents(self, batch: dict, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
         audio_latents = batch.get("audio_latent_batch")
         if isinstance(audio_latents, dict):
@@ -1310,6 +1334,7 @@ class MiniMaxH3(VideoModelFoundation):
 
     def prepare_batch(self, batch: dict, state: dict) -> dict:
         if batch.get("is_audio_only", False) and batch.get("latent_batch") is None:
+            self._trim_audio_only_latents_for_supported_duration(batch)
             batch["latent_batch"] = self._build_fake_video_latents(
                 batch,
                 self.accelerator.device,
@@ -1629,7 +1654,7 @@ class MiniMaxH3(VideoModelFoundation):
         return float(flat[0].item())
 
     def model_predict(self, prepared_batch):
-        if self._xm_noise_candidates_enabled():
+        if self._xm_noise_candidates_enabled() and prepared_batch.get("xm_winner_indices") is None:
             self._prepare_xm_noise_candidates(prepared_batch)
             model_output = self._model_predict_for_prepared_batch(prepared_batch)
             model_output["xm_candidate_count"] = self.xm_config.candidate_count

--- a/simpletuner/helpers/training/nextlat.py
+++ b/simpletuner/helpers/training/nextlat.py
@@ -35,14 +35,14 @@ def _resolve_module_path(model: nn.Module, path: str):
 def infer_nextlat_hidden_size(model: nn.Module) -> int:
     config = getattr(model, "config", None)
     if config is not None:
-        heads = _config_value(config, "num_attention_heads")
-        head_dim = _config_value(config, "attention_head_dim")
-        if heads is not None and head_dim is not None:
-            return int(heads * head_dim)
         for attribute in ("hidden_size", "d_model", "model_dim", "dim", "inner_dim", "embed_dim", "emb_dim", "n_embd"):
             value = _config_value(config, attribute)
             if value is not None:
                 return int(value)
+        heads = _config_value(config, "num_attention_heads")
+        head_dim = _config_value(config, "attention_head_dim")
+        if heads is not None and head_dim is not None:
+            return int(heads * head_dim)
 
     for module in model.modules():
         if isinstance(module, nn.LayerNorm) and module.normalized_shape:

--- a/tests/test_minimaxh3.py
+++ b/tests/test_minimaxh3.py
@@ -142,6 +142,32 @@ class H3ContextParallelOutputGatherTests(unittest.TestCase):
         self.assertTrue(torch.equal(tensor.grad, torch.ones_like(tensor)))
 
 
+class H3AudioOnlyLatentLimitTests(unittest.TestCase):
+    def _model(self):
+        model = MiniMaxH3.__new__(MiniMaxH3)
+        model.model = SimpleNamespace(config=SimpleNamespace(patch_size=(1, 2, 2)))
+        model.unwrap_model = lambda transformer: transformer
+        return model
+
+    def test_audio_only_latents_are_trimmed_to_h3_duration_limit(self):
+        model = self._model()
+        batch = {"audio_latent_batch": torch.zeros(1, 2, 3, 1602)}
+
+        model._trim_audio_only_latents_for_supported_duration(batch)
+
+        self.assertEqual(batch["audio_latent_batch"].shape[-1], 575)
+
+    def test_audio_only_dict_latents_are_trimmed_before_fake_video_build(self):
+        model = self._model()
+        batch = {"audio_latent_batch": {"latents": torch.zeros(1, 2, 3, 1602)}}
+
+        model._trim_audio_only_latents_for_supported_duration(batch)
+        fake_video = model._build_fake_video_latents(batch, torch.device("cpu"), torch.float32)
+
+        self.assertEqual(batch["audio_latent_batch"]["latents"].shape[-1], 575)
+        self.assertEqual(tuple(fake_video.shape), (1, 24, 102, 2, 2))
+
+
 def tiny_inputs(batch_size: int = 1):
     text_tags = torch.full((5,), MINIMAX_H3_TEXT_TAG, dtype=torch.long)
     layout = build_packed_sequence(

--- a/tests/test_minimaxh3_xm.py
+++ b/tests/test_minimaxh3_xm.py
@@ -132,6 +132,22 @@ class MiniMaxH3XMTests(unittest.TestCase):
         model._model_predict_for_prepared_batch.assert_called_once()
         self.assertEqual(output["xm_candidate_count"], 2)
 
+    def test_model_predict_skips_xm_expansion_after_winner_selection(self):
+        model = self._model(candidate_count=2)
+        model._prepare_xm_noise_candidates = MagicMock()
+        model._model_predict_for_prepared_batch = MagicMock(return_value={"model_prediction": torch.zeros(1, 1)})
+
+        output = model.model_predict(
+            {
+                "latents": torch.zeros(1, 1),
+                "xm_winner_indices": torch.tensor([0]),
+            }
+        )
+
+        model._prepare_xm_noise_candidates.assert_not_called()
+        model._model_predict_for_prepared_batch.assert_called_once()
+        self.assertNotIn("xm_candidate_count", output)
+
     def test_xm_loss_selects_winners_and_trims_before_auxiliary_loss(self):
         model = self._model(candidate_count=2)
         latents = torch.zeros(4, 1, 1, 1, 1)

--- a/tests/test_nextlat_xm.py
+++ b/tests/test_nextlat_xm.py
@@ -40,6 +40,13 @@ class TransformerBlocksOnly(nn.Module):
         self.transformer_blocks = nn.ModuleList([nn.Linear(4, 4) for _ in range(2)])
 
 
+class AttentionInnerDimDiffers(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(hidden_size=4, num_attention_heads=3, attention_head_dim=2)
+        self.transformer_blocks = nn.ModuleList([nn.Linear(4, 4)])
+
+
 class NextLatXmTests(unittest.TestCase):
     def test_field_registry_exposes_nextlat_and_xm_options(self):
         registry = FieldRegistry()
@@ -123,6 +130,9 @@ class NextLatXmTests(unittest.TestCase):
 
     def test_nextlat_block_count_accepts_transformer_blocks_without_single_blocks(self):
         self.assertEqual(infer_nextlat_block_count(TransformerBlocksOnly()), 2)
+
+    def test_nextlat_hidden_size_prefers_token_width_over_attention_inner_dim(self):
+        self.assertEqual(infer_nextlat_hidden_size(AttentionInnerDimDiffers()), 4)
 
     def test_nextlat_predictor_accepts_bfloat16_hidden_states_with_float_parameters(self):
         config = SimpleNamespace(


### PR DESCRIPTION
## Summary
- cap MiniMax-H3 audio-only cached latents to the model-supported duration before building fake video latents
- avoid re-expanding XM candidates during the H3 drift reference pass after winner selection

## Tests
- .venv/bin/python -m unittest -v -f tests.test_minimaxh3.H3AudioOnlyLatentLimitTests tests.test_minimaxh3_xm tests.test_nextlat_xm