### PR TITLE
Fix Musubi block residency across checkpointed backward

### DIFF
--- a/simpletuner/helpers/musubi_block_swap.py
+++ b/simpletuner/helpers/musubi_block_swap.py
@@ -199,7 +199,9 @@ class MusubiBlockSwapManager:
         self._warned_grad = False
         self._warned_device = False
         self._logger = logger
+        self._forward_hooks: List[torch.utils.hooks.RemovableHandle] = []
         self._backward_hooks: List[torch.utils.hooks.RemovableHandle] = []
+        self._hooked_block_ids: tuple[int, ...] = ()
         self._backward_hook_device: Optional[torch.device] = None
 
     @classmethod
@@ -242,7 +244,7 @@ class MusubiBlockSwapManager:
             return False
 
         blocks_list = list(blocks)
-        self._ensure_backward_hooks(blocks_list, compute_device, grad_enabled)
+        self._ensure_lifecycle_hooks(blocks_list, compute_device, grad_enabled)
 
         self.mark_blocks_for_offload(blocks_list)
         return True
@@ -271,26 +273,47 @@ class MusubiBlockSwapManager:
                 continue
             self._move_module(blocks[idx], self.offload_device)
 
-    def _clear_backward_hooks(self):
-        for handle in self._backward_hooks:
+    def _clear_lifecycle_hooks(self):
+        for handle in self._forward_hooks + self._backward_hooks:
             try:
                 handle.remove()
             except Exception:
                 continue
+        self._forward_hooks.clear()
         self._backward_hooks.clear()
+        self._hooked_block_ids = ()
         self._backward_hook_device = None
 
-    def _ensure_backward_hooks(self, blocks: List[nn.Module], compute_device: torch.device, grad_enabled: bool) -> None:
-        if not grad_enabled:
+    def _ensure_lifecycle_hooks(self, blocks: List[nn.Module], compute_device: torch.device, grad_enabled: bool) -> None:
+        managed_blocks = [block for idx, block in enumerate(blocks) if self.is_managed_block(idx)]
+        managed_block_ids = tuple(id(block) for block in managed_blocks)
+        hooks_ready = self._forward_hooks and (not grad_enabled or self._backward_hooks)
+        if self._backward_hook_device == compute_device and self._hooked_block_ids == managed_block_ids and hooks_ready:
             return
 
-        if self._backward_hook_device == compute_device and self._backward_hooks:
-            return
+        self._clear_lifecycle_hooks()
+        self._hooked_block_ids = managed_block_ids
+        self._backward_hook_device = compute_device
 
-        self._clear_backward_hooks()
+        for block in managed_blocks:
 
-        for idx, block in enumerate(blocks):
-            if not self.is_managed_block(idx):
+            def _make_forward_pre_hook(owner_block):
+                def _pre_hook(_module, _args):
+                    self.stream_in(owner_block, compute_device)
+
+                return _pre_hook
+
+            def _make_forward_hook(owner_block):
+                def _forward_hook(_module, _args, output):
+                    self.stream_out(owner_block)
+                    return output
+
+                return _forward_hook
+
+            self._forward_hooks.append(block.register_forward_pre_hook(_make_forward_pre_hook(block)))
+            self._forward_hooks.append(block.register_forward_hook(_make_forward_hook(block), always_call=True))
+
+            if not grad_enabled:
                 continue
 
             def _make_pre_hook(owner_block):
@@ -300,13 +323,18 @@ class MusubiBlockSwapManager:
 
                 return _pre_hook
 
+            def _make_post_hook(owner_block):
+                def _post_hook(_module, _grad_input, _grad_output):
+                    self.stream_out(owner_block)
+
+                return _post_hook
+
             # Module-level hooks on the block itself can fire too late for saved
             # tensors inside child ops, so every descendant streams the owning
             # block back in before its own backward work begins.
             for hook_module in block.modules():
                 self._backward_hooks.append(hook_module.register_full_backward_pre_hook(_make_pre_hook(block)))
-
-        self._backward_hook_device = compute_device
+            self._backward_hooks.append(block.register_full_backward_hook(_make_post_hook(block)))
 
     def _move_module(self, module: nn.Module, device: torch.device):
         if _module_on_device(module, device):

--- a/tests/test_musubi_block_swap.py
+++ b/tests/test_musubi_block_swap.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import torch
 from torch import nn
+from torch.utils.checkpoint import checkpoint
 
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager, _module_on_device, prepare_musubi_model_for_ddp
 
@@ -130,6 +131,53 @@ class MusubiBlockSwapTests(unittest.TestCase):
         self.assertEqual(block.adapter_weight.device.type, device.type)
         self.assertEqual(block.adapter_scalar.device.type, device.type)
         self.assertEqual(block[0].weight.device.type, "cpu")
+
+    @unittest.skipUnless(
+        torch.cuda.is_available(),
+        "CUDA is required for the block-swap training lifecycle test",
+    )
+    def test_checkpointed_training_reoffloads_frozen_blocks_after_backward(self):
+        device = torch.device("cuda")
+
+        class AdapterBlock(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.base = nn.Linear(64, 64, bias=False)
+                self.adapter_down = nn.Linear(64, 8, bias=False)
+                self.adapter_up = nn.Linear(8, 64, bias=False)
+                self.base.weight.requires_grad_(False)
+
+            def forward(self, hidden_states):
+                return torch.nn.functional.silu(self.base(hidden_states) + self.adapter_up(self.adapter_down(hidden_states)))
+
+        blocks = nn.ModuleList([AdapterBlock().to(device) for _ in range(3)])
+        manager = MusubiBlockSwapManager(
+            block_indices=list(range(len(blocks))),
+            offload_device=torch.device("cpu"),
+            logger=logging.getLogger(__name__),
+        )
+        manager.activate(blocks, device, grad_enabled=True)
+        optimizer = torch.optim.SGD(
+            [parameter for block in blocks for parameter in block.parameters() if parameter.requires_grad],
+            lr=0.01,
+        )
+
+        hidden_states = torch.randn(2, 16, 64, device=device, requires_grad=True)
+        for block in blocks:
+            manager.stream_in(block, device)
+            hidden_states = checkpoint(block, hidden_states, use_reentrant=False)
+            manager.stream_out(block)
+
+        self.assertTrue(all(block.base.weight.device.type == "cpu" for block in blocks))
+        loss = hidden_states.square().mean()
+        loss.backward()
+
+        self.assertTrue(all(block.base.weight.device.type == "cpu" for block in blocks))
+        self.assertTrue(all(block.adapter_down.weight.device.type == "cuda" for block in blocks))
+        self.assertTrue(all(block.adapter_up.weight.device.type == "cuda" for block in blocks))
+        self.assertTrue(all(block.adapter_down.weight.grad is not None for block in blocks))
+        self.assertTrue(all(block.adapter_up.weight.grad is not None for block in blocks))
+        optimizer.step()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- restore managed frozen blocks around forward execution, checkpoint replay, and backward
- return frozen block state to the offload device after backward while keeping trainable adapters resident
- add a CUDA regression test covering checkpointed forward, backward, and an optimizer step

## Root cause

The block-swap manager reloaded managed blocks before backward work, but it did not own the complete forward lifecycle and did not evict blocks after backward. Checkpoint replay could therefore leave frozen blocks resident and allow residency to accumulate across training steps.

## Validation

- `.venv/bin/python -m unittest -v tests.test_musubi_block_swap`
- `ruff check --select E999,F821 simpletuner/helpers/musubi_block_swap.py tests/test_musubi_block_swap.py`
- H100 checkpointed and non-checkpointed training probes completed backward with frozen base weights on CPU and trainable adapters on CUDA