### PR TITLE
Share quantized RamTorch storage across local ranks

### DIFF
--- a/simpletuner/helpers/ramtorch/utils.py
+++ b/simpletuner/helpers/ramtorch/utils.py
@@ -291,48 +291,119 @@ def _ramtorch_named_parameters(module: nn.Module) -> List[Tuple[str, nn.Paramete
     ]
 
 
+def _tensor_subclass_leaves(tensor: torch.Tensor, path: Tuple[str, ...] = ()) -> List[Tuple[Tuple[str, ...], torch.Tensor]]:
+    if type(tensor) is torch.Tensor:
+        return [(path, tensor)]
+
+    flatten = getattr(tensor, "__tensor_flatten__", None)
+    if flatten is None:
+        raise TypeError(
+            f"RamTorch buffer type {type(tensor).__module__}.{type(tensor).__name__} does not expose "
+            "__tensor_flatten__; its CPU storage cannot be shared across ranks."
+        )
+
+    names, _metadata = flatten()
+    leaves = []
+    for name in names:
+        child = getattr(tensor, name)
+        if not isinstance(child, torch.Tensor):
+            raise TypeError(f"RamTorch tensor subclass field {'.'.join(path + (name,))} is not a tensor.")
+        leaves.extend(_tensor_subclass_leaves(child, path + (name,)))
+    return leaves
+
+
+def _resolve_buffer_owner(module: nn.Module, full_name: str) -> Tuple[nn.Module, str]:
+    owner = module
+    *parents, attr_name = full_name.split(".")
+    for parent in parents:
+        owner = getattr(owner, parent)
+    return owner, attr_name
+
+
+def _assign_buffer_leaf(owner: nn.Module, attr_name: str, path: Tuple[str, ...], shared_tensor: torch.Tensor) -> None:
+    if not path:
+        shared_tensor.is_ramtorch = True
+        owner._buffers[attr_name] = shared_tensor
+        return
+
+    tensor = owner._buffers[attr_name]
+    for field_name in path[:-1]:
+        tensor = getattr(tensor, field_name)
+    setattr(tensor, path[-1], shared_tensor)
+
+
+def _ramtorch_shared_targets(
+    module: nn.Module,
+) -> List[Tuple[str, torch.Tensor, Callable[[torch.Tensor], None]]]:
+    targets = []
+    for name, param in _ramtorch_named_parameters(module):
+        targets.append((name, param, lambda shared, target=param: setattr(target, "data", shared)))
+
+    for name, buffer in module.named_buffers():
+        if not getattr(buffer, "is_ramtorch", False):
+            continue
+        owner, attr_name = _resolve_buffer_owner(module, name)
+        for path, leaf in _tensor_subclass_leaves(buffer):
+            target_name = ".".join((name, *path))
+            targets.append(
+                (
+                    target_name,
+                    leaf,
+                    lambda shared, target_owner=owner, target_attr=attr_name, target_path=path: _assign_buffer_leaf(
+                        target_owner, target_attr, target_path, shared
+                    ),
+                )
+            )
+    return targets
+
+
 def _ramtorch_shared_metadata(
-    param: nn.Parameter,
-) -> Tuple[Tuple[bytes, bytes, int], Tuple[int, ...], Tuple[int, ...], torch.dtype]:
-    if param.device.type != "cpu":
-        raise ValueError(f"RamTorch parameter must live on CPU for sharing, got {param.device}")
-    storage = param.detach().untyped_storage()
+    tensor: torch.Tensor,
+) -> Tuple[Tuple[bytes, bytes, int], int, Tuple[int, ...], Tuple[int, ...], torch.dtype]:
+    if tensor.device.type != "cpu":
+        raise ValueError(f"RamTorch tensor must live on CPU for sharing, got {tensor.device}")
+    storage = tensor.detach().untyped_storage()
     handle = storage._share_filename_cpu_()
-    return handle, tuple(param.size()), tuple(param.stride()), param.dtype
+    return (
+        handle,
+        tensor.storage_offset(),
+        tuple(tensor.size()),
+        tuple(tensor.stride()),
+        tensor.dtype,
+    )
 
 
 def _attach_shared_tensor(
-    param: nn.Parameter,
     handle: Tuple[bytes, bytes, int],
+    storage_offset: int,
     shape: Tuple[int, ...],
     stride: Tuple[int, ...],
     dtype: torch.dtype,
-) -> None:
+) -> torch.Tensor:
     manager, name, size = handle
     shared_storage = torch.UntypedStorage._new_shared_filename_cpu(manager, name, size)
     shared_tensor = torch.empty(0, dtype=dtype)
-    shared_tensor.set_(shared_storage, 0, shape, stride)
-    param.data = shared_tensor
-    param.is_ramtorch = True
+    shared_tensor.set_(shared_storage, storage_offset, shape, stride)
+    return shared_tensor
 
 
 def attach_shared_ramtorch_parameters(module: nn.Module, process_group: Optional[dist.ProcessGroup] = None) -> int:
     """
-    Rebind RamTorch parameters to shared CPU storage across independently launched processes.
+    Rebind RamTorch parameters and tensor-subclass buffer payloads to shared CPU storage across ranks.
 
     Call this after torch.distributed has been initialized (e.g., in torchrun/Accelerate
     entrypoints) so ramtorch parameters no longer rely on fork-based sharing.
 
     Returns:
-        Number of RamTorch parameters that were attached to shared storage.
+        Number of RamTorch tensor storages that were attached to shared storage.
     """
     if not dist.is_available() or not dist.is_initialized():
         return 0
 
     group = process_group if process_group is not None else dist.group.WORLD
     rank = dist.get_rank(group)
-    ramtorch_params = _ramtorch_named_parameters(module)
-    if not ramtorch_params:
+    ramtorch_targets = _ramtorch_shared_targets(module)
+    if not ramtorch_targets:
         return 0
 
     metadata: List[
@@ -340,34 +411,38 @@ def attach_shared_ramtorch_parameters(module: nn.Module, process_group: Optional
             Tuple[
                 str,
                 Tuple[bytes, bytes, int],
+                int,
                 Tuple[int, ...],
                 Tuple[int, ...],
                 torch.dtype,
             ]
         ]
-    ] = [None for _ in ramtorch_params]
+    ] = [None for _ in ramtorch_targets]
 
     if rank == 0:
-        for idx, (name, param) in enumerate(ramtorch_params):
-            handle, shape, stride, dtype = _ramtorch_shared_metadata(param)
-            metadata[idx] = (name, handle, shape, stride, dtype)
+        for idx, (name, tensor, _assign) in enumerate(ramtorch_targets):
+            handle, storage_offset, shape, stride, dtype = _ramtorch_shared_metadata(tensor)
+            metadata[idx] = (name, handle, storage_offset, shape, stride, dtype)
 
     dist.broadcast_object_list(metadata, src=0, group=group)
 
     attached = 0
-    for (name, param), entry in zip(ramtorch_params, metadata):
+    for (target_name, tensor, assign), entry in zip(ramtorch_targets, metadata):
         if entry is None:
             continue
-        _, handle, shape, stride, dtype = entry
+        source_name, handle, storage_offset, shape, stride, dtype = entry
+        if source_name != target_name:
+            raise RuntimeError(f"RamTorch shared tensor topology differs across ranks: {source_name} != {target_name}")
 
         if rank != 0:
-            _attach_shared_tensor(param, handle, shape, stride, dtype)
+            shared_tensor = _attach_shared_tensor(handle, storage_offset, shape, stride, dtype)
+            assign(shared_tensor)
         else:
-            storage = param.detach().untyped_storage()
+            storage = tensor.detach().untyped_storage()
             if not storage.is_shared():
-                param.data.share_memory_()
+                tensor.share_memory_()
 
-        param.is_ramtorch = True
+        tensor.is_ramtorch = True
         attached += 1
 
     dist.barrier(group)

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -4467,7 +4467,7 @@ class Trainer:
             if attach_shared_ramtorch_parameters is not None:
                 attached = attach_shared_ramtorch_parameters(primary_model)
                 if attached:
-                    logger.info("Attached %s shared RamTorch parameters across ranks.", attached)
+                    logger.info("Attached %s shared RamTorch tensor storages across ranks.", attached)
             else:
                 logger.warning(
                     "RamTorch shared parameters are disabled; each rank will retain its own CPU copy of streamed weights."
@@ -4610,7 +4610,9 @@ class Trainer:
                         logger.info("Marking %s RamTorch parameters to ignore for DDP on text_encoder_%s.", ignored, idx)
                     attached = attach_shared_ramtorch_parameters(encoder)
                     if attached:
-                        logger.info("Attached %s shared RamTorch parameters across ranks on text_encoder_%s.", attached, idx)
+                        logger.info(
+                            "Attached %s shared RamTorch tensor storages across ranks on text_encoder_%s.", attached, idx
+                        )
             self.text_encoder_1, self.text_encoder_2 = self.accelerator.prepare(self.text_encoder_1, self.text_encoder_2)
         self._recalculate_training_steps()
         self.accelerator.wait_for_everyone()

--- a/tests/test_ramtorch_shared_storage.py
+++ b/tests/test_ramtorch_shared_storage.py
@@ -1,0 +1,105 @@
+import os
+import tempfile
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch import nn
+
+from simpletuner.helpers.ramtorch.utils import attach_shared_ramtorch_parameters
+
+
+class _QuantizedBuffer(torch.Tensor):
+    @staticmethod
+    def __new__(cls, weight: torch.Tensor, scale: torch.Tensor):
+        return torch.Tensor._make_wrapper_subclass(
+            cls,
+            weight.shape,
+            strides=weight.stride(),
+            storage_offset=weight.storage_offset(),
+            dtype=torch.float32,
+            device=weight.device,
+        )
+
+    def __init__(self, weight: torch.Tensor, scale: torch.Tensor):
+        self.weight = weight
+        self.scale = scale
+
+    def __tensor_flatten__(self):
+        return ["weight", "scale"], None
+
+    @classmethod
+    def __tensor_unflatten__(cls, inner_tensors, _metadata, outer_size=None, outer_stride=None):
+        del outer_size, outer_stride
+        return cls(inner_tensors["weight"], inner_tensors["scale"])
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+        raise NotImplementedError(f"{cls.__name__} does not implement {func}")
+
+
+class _QuantizedBufferModel(nn.Module):
+    def __init__(self, rank: int):
+        super().__init__()
+        payload = _QuantizedBuffer(
+            torch.full((4, 4), float(rank), dtype=torch.float32),
+            torch.full((4, 1), float(rank), dtype=torch.float32),
+        )
+        payload.is_ramtorch = True
+        self.register_buffer("quantized_weight", payload)
+
+
+def _distributed_shared_buffer_worker(rank: int, world_size: int, rendezvous_path: str, use_cuda: bool) -> None:
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"file://{rendezvous_path}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        model = _QuantizedBufferModel(rank)
+        attached = attach_shared_ramtorch_parameters(model)
+        if attached != 2:
+            raise AssertionError(f"expected two shared payload storages, got {attached}")
+
+        if rank == 0:
+            model.quantized_weight.weight.fill_(7)
+            model.quantized_weight.scale.fill_(3)
+        dist.barrier()
+
+        torch.testing.assert_close(model.quantized_weight.weight, torch.full((4, 4), 7.0))
+        torch.testing.assert_close(model.quantized_weight.scale, torch.full((4, 1), 3.0))
+        if not model.quantized_weight.weight.untyped_storage().is_shared():
+            raise AssertionError("quantized weight storage is not shared")
+        if not model.quantized_weight.scale.untyped_storage().is_shared():
+            raise AssertionError("quantized scale storage is not shared")
+
+        if use_cuda:
+            device = torch.device("cuda", 0)
+            torch.testing.assert_close(
+                model.quantized_weight.weight.to(device, non_blocking=True).cpu(),
+                torch.full((4, 4), 7.0),
+            )
+            torch.testing.assert_close(
+                model.quantized_weight.scale.to(device, non_blocking=True).cpu(),
+                torch.full((4, 1), 3.0),
+            )
+    finally:
+        dist.destroy_process_group()
+
+
+class RamTorchSharedStorageTests(unittest.TestCase):
+    def test_tensor_subclass_payloads_share_storage_across_independent_ranks(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            rendezvous_path = os.path.join(temp_dir, "gloo-store")
+            mp.spawn(
+                _distributed_shared_buffer_worker,
+                args=(2, rendezvous_path, torch.cuda.is_available()),
+                nprocs=2,
+                join=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- share RamTorch tensor-subclass buffer payloads in addition to dense parameters
- recursively enumerate quantized tensor leaves through `__tensor_flatten__` and preserve storage offsets, shapes, strides, and dtypes
- reject rank topology mismatches before attaching shared storage
- add a two-process regression test covering independent wrapper construction and shared payload visibility

## Root cause

RamTorch converts supported quantized tensor-subclass weights into module buffers. The distributed sharing helper only enumerated named parameters, so independently launched DDP ranks retained duplicate CPU copies of the frozen quantized payload even when shared RamTorch storage was enabled.

## Validation

- `.venv/bin/python -m unittest -v tests.test_ramtorch_shared_storage tests.test_ramtorch_distributed_config tests.test_ramtorch`
- two-rank H100 probe verified shared packed weight and scale storage followed by CUDA transfer