### PR TITLE
Stream checkpointed Musubi blocks through a packed H2D ring

### DIFF
--- a/simpletuner/helpers/models/auraflow/transformer.py
+++ b/simpletuner/helpers/models/auraflow/transformer.py
@@ -806,8 +806,6 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
 
         # MMDiT blocks.
         for index_block, block in enumerate(self.joint_transformer_blocks):
-            if musubi_offload_active and musubi_manager.is_managed_block(global_idx):
-                musubi_manager.stream_in(block, hidden_states.device)
             # TREAD: START a route?
             if use_routing and route_ptr < len(routes) and global_idx == routes[route_ptr]["start_layer_idx"]:
                 mask_ratio = routes[route_ptr]["selection_ratio"]
@@ -827,7 +825,7 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
                     hidden_states = hidden_states + block_controlnet_hidden_states[index_block // interval_control]
                 continue
 
-            if (
+            checkpoint_this_block = (
                 self.training
                 and torch.is_grad_enabled()
                 and should_checkpoint_block(
@@ -836,7 +834,11 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
                     self.gradient_checkpointing_interval,
                     self.gradient_checkpointing_segment_stride,
                 )
-            ):
+            )
+            if musubi_offload_active and musubi_manager.is_managed_block(global_idx):
+                musubi_manager.stream_in(block, hidden_states.device, checkpointed=checkpoint_this_block)
+
+            if checkpoint_this_block:
 
                 if self.gradient_checkpointing_backend.startswith("unsloth"):
                     from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
@@ -916,9 +918,6 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
             for index_block, block in enumerate(self.single_transformer_blocks):
                 actual_index = len(self.joint_transformer_blocks) + index_block
 
-                if musubi_offload_active and musubi_manager.is_managed_block(global_idx):
-                    musubi_manager.stream_in(block, combined_hidden_states.device)
-
                 # TREAD: START a route?
                 if use_routing and route_ptr < len(routes) and global_idx == routes[route_ptr]["start_layer_idx"]:
                     mask_ratio = routes[route_ptr]["selection_ratio"]
@@ -959,7 +958,7 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
                         )
                     continue
 
-                if (
+                checkpoint_this_block = (
                     self.training
                     and torch.is_grad_enabled()
                     and should_checkpoint_block(
@@ -968,7 +967,15 @@ class AuraFlowTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftA
                         self.gradient_checkpointing_interval,
                         self.gradient_checkpointing_segment_stride,
                     )
-                ):
+                )
+                if musubi_offload_active and musubi_manager.is_managed_block(global_idx):
+                    musubi_manager.stream_in(
+                        block,
+                        combined_hidden_states.device,
+                        checkpointed=checkpoint_this_block,
+                    )
+
+                if checkpoint_this_block:
 
                     if self.gradient_checkpointing_backend.startswith("unsloth"):
                         from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint

--- a/simpletuner/helpers/models/chroma/transformer.py
+++ b/simpletuner/helpers/models/chroma/transformer.py
@@ -964,8 +964,6 @@ class ChromaTransformer2DModel(
             grounding_objs = self.position_net(**grounding_kwargs)
 
         for index_block, block in enumerate(self.transformer_blocks):
-            if musubi_offload_active and musubi_manager.is_managed_block(global_idx):
-                musubi_manager.stream_in(block, hidden_states.device)
             actual_index = global_idx
             img_offset = 3 * len(self.single_transformer_blocks)
             txt_offset = img_offset + 6 * len(self.transformer_blocks)
@@ -1034,6 +1032,13 @@ class ChromaTransformer2DModel(
                     self.gradient_checkpointing_segment_stride,
                 )
             )
+
+            if musubi_offload_active and musubi_manager.is_managed_block(global_idx):
+                musubi_manager.stream_in(
+                    block,
+                    hidden_states.device,
+                    checkpointed=use_checkpoint and not self.gradient_checkpointing_backend.endswith("-ffn"),
+                )
 
             if use_checkpoint:
                 if self.gradient_checkpointing_backend.startswith("unsloth"):
@@ -1130,8 +1135,6 @@ class ChromaTransformer2DModel(
         txt_len = encoder_hidden_states.shape[1]
 
         for index_block, block in enumerate(self.single_transformer_blocks):
-            if musubi_offload_active and musubi_manager.is_managed_block(global_idx):
-                musubi_manager.stream_in(block, hidden_states.device)
             actual_index = global_idx
             start_idx = 3 * index_block
             if pooled_temb.ndim == 4:
@@ -1236,6 +1239,13 @@ class ChromaTransformer2DModel(
                     self.gradient_checkpointing_segment_stride,
                 )
             )
+
+            if musubi_offload_active and musubi_manager.is_managed_block(global_idx):
+                musubi_manager.stream_in(
+                    block,
+                    hidden_states.device,
+                    checkpointed=use_checkpoint and not self.gradient_checkpointing_backend.endswith("-ffn"),
+                )
 
             if use_checkpoint:
                 if self.gradient_checkpointing_backend.startswith("unsloth"):

--- a/simpletuner/helpers/models/cosmos/transformer.py
+++ b/simpletuner/helpers/models/cosmos/transformer.py
@@ -895,9 +895,7 @@ class CosmosTransformer3DModel(PatchableModule, ModelMixin, ConfigMixin, FromOri
                         )
                         hidden_states = router.start_route(hidden_states, mask_info)
                         break
-            if musubi_offload_active and musubi_manager.is_managed_block(bid):
-                musubi_manager.stream_in(block, hidden_states.device)
-            if (
+            checkpoint_this_block = (
                 grad_enabled
                 and self.gradient_checkpointing
                 and should_checkpoint_block(
@@ -906,7 +904,10 @@ class CosmosTransformer3DModel(PatchableModule, ModelMixin, ConfigMixin, FromOri
                     self.gradient_checkpointing_interval,
                     self.gradient_checkpointing_segment_stride,
                 )
-            ):
+            )
+            if musubi_offload_active and musubi_manager.is_managed_block(bid):
+                musubi_manager.stream_in(block, hidden_states.device, checkpointed=checkpoint_this_block)
+            if checkpoint_this_block:
                 hidden_states = self._gradient_checkpointing_func(
                     block,
                     hidden_states,

--- a/simpletuner/helpers/models/cosmos3/transformer.py
+++ b/simpletuner/helpers/models/cosmos3/transformer.py
@@ -707,7 +707,7 @@ class Cosmos3OmniTransformer(ModelMixin, ConfigMixin, PeftAdapterMixin, Attentio
     @staticmethod
     def _stream_in_for_checkpoint_recompute(musubi_manager, layer_idx: int, layer: nn.Module, device: torch.device) -> None:
         if musubi_manager is not None and musubi_manager.is_managed_block(layer_idx):
-            musubi_manager.stream_in(layer, device)
+            musubi_manager.stream_in(layer, device, checkpointed=True)
 
     # -------------------------------------------------------------------------
     # Pure-tensor packing/unpacking helpers (no layer state).
@@ -1057,9 +1057,14 @@ class Cosmos3OmniTransformer(ModelMixin, ConfigMixin, PeftAdapterMixin, Attentio
             gen_seq = hidden_states
             rotary_gen = (cos[und_len:], sin[und_len:])
             for layer_idx, decoder_layer in enumerate(self.layers):
+                checkpoint_this_block = self._should_gradient_checkpoint_layer(layer_idx)
                 if musubi_offload_active and musubi_manager.is_managed_block(layer_idx):
-                    musubi_manager.stream_in(decoder_layer, gen_seq.device)
-                if self._should_gradient_checkpoint_layer(layer_idx):
+                    musubi_manager.stream_in(
+                        decoder_layer,
+                        gen_seq.device,
+                        checkpointed=checkpoint_this_block,
+                    )
+                if checkpoint_this_block:
 
                     def checkpointed_gen_only(
                         x,
@@ -1088,9 +1093,14 @@ class Cosmos3OmniTransformer(ModelMixin, ConfigMixin, PeftAdapterMixin, Attentio
             rotary_emb = (cos[:und_len], sin[:und_len], cos[und_len:], sin[und_len:])
             vision_gen_indexes = vision_mse_loss_indexes - und_len
             for layer_idx, decoder_layer in enumerate(self.layers):
+                checkpoint_this_block = self._should_gradient_checkpoint_layer(layer_idx)
                 if musubi_offload_active and musubi_manager.is_managed_block(layer_idx):
-                    musubi_manager.stream_in(decoder_layer, gen_seq.device)
-                if self._should_gradient_checkpoint_layer(layer_idx):
+                    musubi_manager.stream_in(
+                        decoder_layer,
+                        gen_seq.device,
+                        checkpointed=checkpoint_this_block,
+                    )
+                if checkpoint_this_block:
 
                     def checkpointed_layer(
                         und,

--- a/simpletuner/helpers/models/ernie/transformer.py
+++ b/simpletuner/helpers/models/ernie/transformer.py
@@ -260,8 +260,19 @@ class ErnieImageTransformer2DModel(
             musubi_offload_active = musubi_manager.activate(combined_blocks, hidden_states.device, grad_enabled)
 
         for layer_idx, layer in enumerate(self.layers):
+            checkpoint_this_block = (
+                layer_idx not in skip_set
+                and grad_enabled
+                and self.gradient_checkpointing
+                and should_checkpoint_block(
+                    layer_idx,
+                    True,
+                    self.gradient_checkpointing_interval,
+                    getattr(self, "gradient_checkpointing_segment_stride", None),
+                )
+            )
             if musubi_offload_active and musubi_manager.is_managed_block(layer_idx):
-                musubi_manager.stream_in(layer, hidden_states.device)
+                musubi_manager.stream_in(layer, hidden_states.device, checkpointed=checkpoint_this_block)
             if use_routing and route_ptr < len(routes) and layer_idx == routes[route_ptr]["start_layer_idx"]:
                 keep_mask = torch.zeros(
                     (batch_size, hidden_states.shape[1]),

--- a/simpletuner/helpers/models/flux/transformer.py
+++ b/simpletuner/helpers/models/flux/transformer.py
@@ -1208,8 +1208,18 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
                     capture_idx += len(segment_blocks)
                     continue
 
+            checkpoint_this_block = (
+                self.training
+                and self.gradient_checkpointing
+                and not run_gap_eagerly
+                and (self.gradient_checkpointing_interval is None or index_block % self.gradient_checkpointing_interval == 0)
+            )
             if musubi_offload_active and musubi_manager.is_managed_block(global_idx):
-                musubi_manager.stream_in(block, hidden_states.device)
+                musubi_manager.stream_in(
+                    block,
+                    hidden_states.device,
+                    checkpointed=checkpoint_this_block and not self.gradient_checkpointing_backend.endswith("-ffn"),
+                )
             # TREAD: START a route?
             if use_routing and route_ptr < len(routes) and global_idx == routes[route_ptr]["start_layer_idx"]:
                 mask_ratio = routes[route_ptr]["selection_ratio"]
@@ -1237,12 +1247,7 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
 
                 # concatenate text + image rope
                 current_rope = tuple(torch.cat([tr, ir], dim=1) for tr, ir in zip(text_rope_b, img_rope_r))
-            if (
-                self.training
-                and self.gradient_checkpointing
-                and not run_gap_eagerly
-                and (self.gradient_checkpointing_interval is None or index_block % self.gradient_checkpointing_interval == 0)
-            ):
+            if checkpoint_this_block:
                 checkpoint_ffn = self.gradient_checkpointing_backend.endswith("-ffn")
 
                 def create_custom_forward(module):
@@ -1365,8 +1370,18 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
                     capture_idx += len(segment_blocks)
                     continue
 
+            checkpoint_this_block = (
+                self.training
+                and self.gradient_checkpointing
+                and not run_gap_eagerly
+                and (self.gradient_checkpointing_interval is None or index_block % self.gradient_checkpointing_interval == 0)
+            )
             if musubi_offload_active and musubi_manager.is_managed_block(global_idx):
-                musubi_manager.stream_in(block, hidden_states.device)
+                musubi_manager.stream_in(
+                    block,
+                    hidden_states.device,
+                    checkpointed=checkpoint_this_block and not self.gradient_checkpointing_backend.endswith("-ffn"),
+                )
             # TREAD: START? (operate on *image* tokens only)
             if use_routing and route_ptr < len(routes) and global_idx == routes[route_ptr]["start_layer_idx"]:
                 mask_ratio = routes[route_ptr]["selection_ratio"]
@@ -1402,12 +1417,7 @@ class FluxTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
                 )
                 current_rope = tuple(torch.cat([tr, ir], dim=1) for tr, ir in zip(text_rope_b, img_rope_r))
 
-            if (
-                self.training
-                and self.gradient_checkpointing
-                and not run_gap_eagerly
-                and (self.gradient_checkpointing_interval is None or index_block % self.gradient_checkpointing_interval == 0)
-            ):
+            if checkpoint_this_block:
                 checkpoint_ffn = self.gradient_checkpointing_backend.endswith("-ffn")
 
                 def create_custom_forward(module):

--- a/simpletuner/helpers/models/flux2/transformer.py
+++ b/simpletuner/helpers/models/flux2/transformer.py
@@ -1315,9 +1315,14 @@ class Flux2Transformer2DModel(
                 break
 
             global_layer_idx = index_block
+            checkpoint_this_block = grad_enabled and self.gradient_checkpointing
 
             if musubi_offload_active and musubi_manager.is_managed_block(global_layer_idx):
-                musubi_manager.stream_in(block, hidden_states.device)
+                musubi_manager.stream_in(
+                    block,
+                    hidden_states.device,
+                    checkpointed=checkpoint_this_block,
+                )
 
             # Check for TREAD routing
             if self._tread_router is not None and self.training:
@@ -1356,7 +1361,7 @@ class Flux2Transformer2DModel(
                 torch.cat([current_pe_txt[1], current_pe_img[1]], dim=0),
             )
 
-            if torch.is_grad_enabled() and self.gradient_checkpointing:
+            if checkpoint_this_block:
 
                 def create_custom_forward(module):
                     def custom_forward(*inputs):
@@ -1442,9 +1447,14 @@ class Flux2Transformer2DModel(
                 break
 
             global_layer_idx = num_double + index_block
+            checkpoint_this_block = grad_enabled and self.gradient_checkpointing
 
             if musubi_offload_active and musubi_manager.is_managed_block(global_layer_idx):
-                musubi_manager.stream_in(block, hidden_states.device)
+                musubi_manager.stream_in(
+                    block,
+                    hidden_states.device,
+                    checkpointed=checkpoint_this_block,
+                )
 
             # Check for TREAD routing
             if self._tread_router is not None and self.training:
@@ -1490,7 +1500,7 @@ class Flux2Transformer2DModel(
                     tread_routing_info = None
                     current_concat_pe = concat_rotary_emb
 
-            if torch.is_grad_enabled() and self.gradient_checkpointing:
+            if checkpoint_this_block:
 
                 def create_custom_forward(module):
                     def custom_forward(*inputs):

--- a/simpletuner/helpers/models/hidream/transformer.py
+++ b/simpletuner/helpers/models/hidream/transformer.py
@@ -1666,8 +1666,18 @@ class HiDreamImageTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, P
         # Process through double stream blocks
         capture_idx = 0
         for bid, block in enumerate(self.double_stream_blocks):
+            checkpoint_this_block = self.training and should_checkpoint_block(
+                bid,
+                self.gradient_checkpointing,
+                self.gradient_checkpointing_interval,
+                self.gradient_checkpointing_segment_stride,
+            )
             if musubi_offload_active and musubi_manager.is_managed_block(block_id):
-                musubi_manager.stream_in(block, hidden_states.device)
+                musubi_manager.stream_in(
+                    block,
+                    hidden_states.device,
+                    checkpointed=checkpoint_this_block,
+                )
             # TREAD routing for this layer
             if use_routing:
                 # Check if this layer should use routing
@@ -1698,12 +1708,7 @@ class HiDreamImageTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, P
             )
 
             # Process through the block with optional gradient checkpointing
-            if self.training and should_checkpoint_block(
-                bid,
-                self.gradient_checkpointing,
-                self.gradient_checkpointing_interval,
-                self.gradient_checkpointing_segment_stride,
-            ):
+            if checkpoint_this_block:
 
                 def create_custom_forward(module, return_dict=None):
                     def custom_forward(*inputs):
@@ -1797,8 +1802,18 @@ class HiDreamImageTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, P
 
         # 7. Process through single stream blocks
         for bid, block in enumerate(self.single_stream_blocks):
+            checkpoint_this_block = self.training and should_checkpoint_block(
+                len(self.double_stream_blocks) + bid,
+                self.gradient_checkpointing,
+                self.gradient_checkpointing_interval,
+                self.gradient_checkpointing_segment_stride,
+            )
             if musubi_offload_active and musubi_manager.is_managed_block(block_id):
-                musubi_manager.stream_in(block, hidden_states.device)
+                musubi_manager.stream_in(
+                    block,
+                    hidden_states.device,
+                    checkpointed=checkpoint_this_block,
+                )
             # TREAD routing for single stream layers
             if use_routing:
                 # Check if this layer should use routing
@@ -1835,12 +1850,7 @@ class HiDreamImageTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, P
             hidden_states = torch.cat([hidden_states, cur_llama_embedding], dim=1)
 
             # Process through the block with optional gradient checkpointing
-            if self.training and should_checkpoint_block(
-                len(self.double_stream_blocks) + bid,
-                self.gradient_checkpointing,
-                self.gradient_checkpointing_interval,
-                self.gradient_checkpointing_segment_stride,
-            ):
+            if checkpoint_this_block:
 
                 def create_custom_forward(module, return_dict=None):
                     def custom_forward(*inputs):

--- a/simpletuner/helpers/models/hunyuanvideo/transformer.py
+++ b/simpletuner/helpers/models/hunyuanvideo/transformer.py
@@ -1056,13 +1056,14 @@ class HunyuanVideo15Transformer3DModel(
                 and self.gradient_checkpointing_interval > 1
                 and hidden_states_buffer is None
                 and not self.gradient_checkpointing_backend.endswith("-ffn")
+                and not musubi_offload_active
             )
 
             if use_sequential_segments:
 
                 def run_segment_block(idx, block, segment_hidden_states, segment_encoder_hidden_states):
                     if musubi_offload_active and musubi_manager.is_managed_block(idx):
-                        musubi_manager.stream_in(block, segment_hidden_states.device)
+                        musubi_manager.stream_in(block, segment_hidden_states.device, checkpointed=True)
                     result = block(
                         segment_hidden_states,
                         segment_encoder_hidden_states,
@@ -1087,15 +1088,22 @@ class HunyuanVideo15Transformer3DModel(
                 )
             else:
                 for idx, block in enumerate(self.transformer_blocks):
-                    if musubi_offload_active and musubi_manager.is_managed_block(idx):
-                        musubi_manager.stream_in(block, hidden_states.device)
                     checkpoint_this_block = should_checkpoint_block(
                         idx,
                         True,
                         self.gradient_checkpointing_interval,
                         self.gradient_checkpointing_segment_stride,
                     )
-                    if checkpoint_this_block and not self.gradient_checkpointing_backend.endswith("-ffn"):
+                    checkpoint_entire_block = checkpoint_this_block and not self.gradient_checkpointing_backend.endswith(
+                        "-ffn"
+                    )
+                    if musubi_offload_active and musubi_manager.is_managed_block(idx):
+                        musubi_manager.stream_in(
+                            block,
+                            hidden_states.device,
+                            checkpointed=checkpoint_entire_block,
+                        )
+                    if checkpoint_entire_block:
                         hidden_states, encoder_hidden_states = checkpoint_fn(
                             block,
                             hidden_states,
@@ -1134,7 +1142,7 @@ class HunyuanVideo15Transformer3DModel(
         else:
             for idx, block in enumerate(self.transformer_blocks):
                 if musubi_offload_active and musubi_manager.is_managed_block(idx):
-                    musubi_manager.stream_in(block, hidden_states.device)
+                    musubi_manager.stream_in(block, hidden_states.device, checkpointed=False)
                 hidden_states, encoder_hidden_states = block(
                     hidden_states,
                     encoder_hidden_states,

--- a/simpletuner/helpers/models/krea2/transformer.py
+++ b/simpletuner/helpers/models/krea2/transformer.py
@@ -821,8 +821,14 @@ class Krea2Transformer2DModel(ModelMixin, ConfigMixin, AttentionMixin, PeftAdapt
             return Transformer2DModelOutput(sample=output)
 
         for idx, block in enumerate(self.transformer_blocks):
+            checkpoint_this_block = (
+                idx not in skip_set
+                and torch.is_grad_enabled()
+                and self.gradient_checkpointing
+                and not self.gradient_checkpointing_backend.endswith("-ffn")
+            )
             if musubi_offload_active and musubi_manager.is_managed_block(idx):
-                musubi_manager.stream_in(block, hidden_states.device)
+                musubi_manager.stream_in(block, hidden_states.device, checkpointed=checkpoint_this_block)
 
             if use_routing and route_ptr < len(routes) and idx == routes[route_ptr]["start_layer_idx"]:
                 mask_ratio = routes[route_ptr]["selection_ratio"]

--- a/simpletuner/helpers/models/longcat_image/transformer.py
+++ b/simpletuner/helpers/models/longcat_image/transformer.py
@@ -473,10 +473,8 @@ class LongCatImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
 
         capture_idx = 0
         for index_block, block in enumerate(self.transformer_blocks):
-            if musubi_offload_active and musubi_manager.is_managed_block(capture_idx):
-                musubi_manager.stream_in(block, hidden_states.device)
-            if (
-                torch.is_grad_enabled()
+            checkpoint_this_block = (
+                grad_enabled
                 and self.use_checkpoint[index_block]
                 and should_checkpoint_block(
                     capture_idx,
@@ -484,7 +482,10 @@ class LongCatImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
                     self.gradient_checkpointing_interval,
                     self.gradient_checkpointing_segment_stride,
                 )
-            ):
+            )
+            if musubi_offload_active and musubi_manager.is_managed_block(capture_idx):
+                musubi_manager.stream_in(block, hidden_states.device, checkpointed=checkpoint_this_block)
+            if checkpoint_this_block:
                 encoder_hidden_states, hidden_states = self._gradient_checkpointing_func(
                     _run_longcat_transformer_block,
                     block,
@@ -511,10 +512,8 @@ class LongCatImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
             capture_idx += 1
 
         for index_block, block in enumerate(self.single_transformer_blocks):
-            if musubi_offload_active and musubi_manager.is_managed_block(capture_idx):
-                musubi_manager.stream_in(block, hidden_states.device)
-            if (
-                torch.is_grad_enabled()
+            checkpoint_this_block = (
+                grad_enabled
                 and self.use_single_checkpoint[index_block]
                 and should_checkpoint_block(
                     capture_idx,
@@ -522,7 +521,10 @@ class LongCatImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
                     self.gradient_checkpointing_interval,
                     self.gradient_checkpointing_segment_stride,
                 )
-            ):
+            )
+            if musubi_offload_active and musubi_manager.is_managed_block(capture_idx):
+                musubi_manager.stream_in(block, hidden_states.device, checkpointed=checkpoint_this_block)
+            if checkpoint_this_block:
                 encoder_hidden_states, hidden_states = self._gradient_checkpointing_func(
                     _run_longcat_single_transformer_block,
                     block,

--- a/simpletuner/helpers/models/longcat_video/transformer.py
+++ b/simpletuner/helpers/models/longcat_video/transformer.py
@@ -1297,15 +1297,16 @@ class LongCatVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         kv_cache_dict_ret = {}
         capture_idx = 0
         for i, block in enumerate(self.blocks):
-            if musubi_offload_active and musubi_manager.is_managed_block(i):
-                musubi_manager.stream_in(block, hidden_states.device)
-
-            if grad_enabled and should_checkpoint_block(
+            checkpoint_this_block = grad_enabled and should_checkpoint_block(
                 capture_idx,
                 self.gradient_checkpointing,
                 self.gradient_checkpointing_interval,
                 self.gradient_checkpointing_segment_stride,
-            ):
+            )
+            if musubi_offload_active and musubi_manager.is_managed_block(i):
+                musubi_manager.stream_in(block, hidden_states.device, checkpointed=checkpoint_this_block)
+
+            if checkpoint_this_block:
                 if self.gradient_checkpointing_backend.startswith("unsloth"):
                     from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 

--- a/simpletuner/helpers/models/ltxvideo/transformer.py
+++ b/simpletuner/helpers/models/ltxvideo/transformer.py
@@ -768,14 +768,18 @@ class LTXVideoTransformer3DModel(
                         )
                         hidden_states = router.start_route(hidden_states, mask_info)
                         break
-            if musubi_offload_active and musubi_manager.is_managed_block(bid):
-                musubi_manager.stream_in(block, hidden_states.device)
             checkpoint_this_block = should_checkpoint_block(
                 bid,
                 grad_enabled and self.gradient_checkpointing,
                 self.gradient_checkpointing_interval,
                 self.gradient_checkpointing_segment_stride,
             )
+            if musubi_offload_active and musubi_manager.is_managed_block(bid):
+                musubi_manager.stream_in(
+                    block,
+                    hidden_states.device,
+                    checkpointed=checkpoint_this_block and not self.gradient_checkpointing_backend.endswith("-ffn"),
+                )
             if checkpoint_this_block:
                 if self.gradient_checkpointing_backend.startswith("unsloth"):
                     from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint

--- a/simpletuner/helpers/models/ltxvideo2/transformer.py
+++ b/simpletuner/helpers/models/ltxvideo2/transformer.py
@@ -2117,10 +2117,11 @@ class LTX2VideoTransformer3DModel(
                 musubi_offload_active = musubi_manager.activate(self.transformer_blocks, hidden_states.device, grad_enabled)
 
             for block_idx, block in enumerate(self.transformer_blocks):
+                checkpoint_this_block = torch.is_grad_enabled() and self.gradient_checkpointing
                 if musubi_offload_active and musubi_manager.is_managed_block(block_idx):
-                    musubi_manager.stream_in(block, hidden_states.device)
+                    musubi_manager.stream_in(block, hidden_states.device, checkpointed=checkpoint_this_block)
 
-                if torch.is_grad_enabled() and self.gradient_checkpointing:
+                if checkpoint_this_block:
                     checkpoint_kwargs = {"use_reentrant": False, **_transformerengine_checkpoint_kwargs(block)}
                     hidden_states, audio_hidden_states = simpletuner_checkpoint(
                         block,
@@ -2555,10 +2556,15 @@ class LTX2VideoTransformer3DModel(
                 )
                 routing_now = True
 
+            checkpoint_this_block = torch.is_grad_enabled() and self.gradient_checkpointing
             if musubi_offload_active and musubi_manager.is_managed_block(block_idx):
-                musubi_manager.stream_in(block, hidden_states.device)
+                musubi_manager.stream_in(
+                    block,
+                    hidden_states.device,
+                    checkpointed=checkpoint_this_block and not self.gradient_checkpointing_backend.endswith("-ffn"),
+                )
 
-            if torch.is_grad_enabled() and self.gradient_checkpointing:
+            if checkpoint_this_block:
                 if self.gradient_checkpointing_backend.startswith("unsloth"):
                     from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 

--- a/simpletuner/helpers/models/lumina2/transformer.py
+++ b/simpletuner/helpers/models/lumina2/transformer.py
@@ -769,15 +769,20 @@ class Lumina2Transformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromO
                 )
                 continue
 
-            if musubi_offload_active and musubi_manager.is_managed_block(idx):
-                musubi_manager.stream_in(layer, hidden_states.device)
-
-            if torch.is_grad_enabled() and should_checkpoint_block(
+            checkpoint_this_block = torch.is_grad_enabled() and should_checkpoint_block(
                 idx,
                 self.gradient_checkpointing,
                 self.gradient_checkpointing_interval,
                 self.gradient_checkpointing_segment_stride,
-            ):
+            )
+            if musubi_offload_active and musubi_manager.is_managed_block(idx):
+                musubi_manager.stream_in(
+                    layer,
+                    hidden_states.device,
+                    checkpointed=checkpoint_this_block and not self.gradient_checkpointing_backend.endswith("-ffn"),
+                )
+
+            if checkpoint_this_block:
                 if self.gradient_checkpointing_backend.startswith("unsloth"):
                     from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 

--- a/simpletuner/helpers/models/mageflow/transformer.py
+++ b/simpletuner/helpers/models/mageflow/transformer.py
@@ -311,8 +311,14 @@ class MageFlowTransformer2DModel(MageFlow, ModelMixin, ConfigMixin, PeftAdapterM
 
             _ensure_module_device(getattr(block, "img_mod", None), img.device)
             _ensure_module_device(getattr(block, "txt_mod", None), img.device)
+            checkpoint_this_block = (
+                index_block not in skip_layers_set
+                and self.training
+                and self.checkpoint
+                and self.gradient_checkpointing_scope == "layer"
+            )
             if musubi_offload_active and musubi_manager.is_managed_block(index_block):
-                musubi_manager.stream_in(block, img.device)
+                musubi_manager.stream_in(block, img.device, checkpointed=checkpoint_this_block)
             if index_block in skip_layers_set:
                 pass
             elif self.training and self.checkpoint and self.gradient_checkpointing_scope == "ffn":

--- a/simpletuner/helpers/models/minimaxh3/transformer.py
+++ b/simpletuner/helpers/models/minimaxh3/transformer.py
@@ -2290,15 +2290,20 @@ class MiniMaxH3Transformer3DModel(ModelMixin, ConfigMixin, AttentionMixin, PeftA
                 if block_idx in skip_set:
                     continue
 
-                if musubi_offload_active and musubi_manager.is_managed_block(block_idx):
-                    musubi_manager.stream_in(block, hidden_states.device)
-
-                if grad_enabled and should_checkpoint_block(
+                checkpoint_this_block = grad_enabled and should_checkpoint_block(
                     block_idx,
                     self.gradient_checkpointing,
                     self.gradient_checkpointing_interval,
                     self.gradient_checkpointing_segment_stride,
-                ):
+                )
+                if musubi_offload_active and musubi_manager.is_managed_block(block_idx):
+                    musubi_manager.stream_in(
+                        block,
+                        hidden_states.device,
+                        checkpointed=checkpoint_this_block and not self.gradient_checkpointing_backend.endswith("-ffn"),
+                    )
+
+                if checkpoint_this_block:
                     if self.gradient_checkpointing_backend.startswith("unsloth"):
                         from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 

--- a/simpletuner/helpers/models/minimaxmusic/transformer.py
+++ b/simpletuner/helpers/models/minimaxmusic/transformer.py
@@ -420,18 +420,21 @@ class MiniMaxMusic3Transformer1DModel(ModelMixin, ConfigMixin, PeftAdapterMixin)
             )
         for block_idx, block in enumerate(self.transformer_blocks):
             managed_block = musubi_offload_active and musubi_manager.is_managed_block(block_idx)
-            if managed_block:
-                musubi_manager.stream_in(block, hidden_states.device)
             if block_idx in skip_set:
-                if managed_block:
-                    musubi_manager.stream_out(block)
                 continue
-            if torch.is_grad_enabled() and should_checkpoint_block(
+            checkpoint_this_block = torch.is_grad_enabled() and should_checkpoint_block(
                 block_idx,
                 self.gradient_checkpointing,
                 self.gradient_checkpointing_interval,
                 self.gradient_checkpointing_segment_stride,
-            ):
+            )
+            if managed_block:
+                musubi_manager.stream_in(
+                    block,
+                    hidden_states.device,
+                    checkpointed=checkpoint_this_block and not self.gradient_checkpointing_backend.endswith("-ffn"),
+                )
+            if checkpoint_this_block:
                 if self.gradient_checkpointing_backend.startswith("unsloth"):
                     from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 

--- a/simpletuner/helpers/models/omnigen/transformer.py
+++ b/simpletuner/helpers/models/omnigen/transformer.py
@@ -591,10 +591,11 @@ class OmniGenTransformer2DModel(ModelMixin, ConfigMixin):
 
         capture_idx = 0
         for idx, block in enumerate(self.layers):
+            checkpoint_this_block = torch.is_grad_enabled() and self.gradient_checkpointing
             if musubi_offload_active and musubi_manager.is_managed_block(idx):
-                musubi_manager.stream_in(block, hidden_states.device)
+                musubi_manager.stream_in(block, hidden_states.device, checkpointed=checkpoint_this_block)
 
-            if torch.is_grad_enabled() and self.gradient_checkpointing:
+            if checkpoint_this_block:
                 hidden_states = self._gradient_checkpointing_func(block, hidden_states, attention_mask, image_rotary_emb)
             else:
                 hidden_states = block(hidden_states, attention_mask=attention_mask, image_rotary_emb=image_rotary_emb)

--- a/simpletuner/helpers/models/pixart/transformer.py
+++ b/simpletuner/helpers/models/pixart/transformer.py
@@ -672,8 +672,6 @@ class PixArtTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAda
                 )
                 continue
 
-            if musubi_offload_active and musubi_manager.is_managed_block(index_block):
-                musubi_manager.stream_in(block, hidden_states.device)
             # TREAD: START a route?
             if use_routing and route_ptr < len(routes) and global_idx == routes[route_ptr]["start_layer_idx"]:
                 mask_ratio = routes[route_ptr]["selection_ratio"]
@@ -686,12 +684,16 @@ class PixArtTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAda
                 hidden_states = router.start_route(hidden_states, tread_mask_info)
                 routing_now = True
 
-            if torch.is_grad_enabled() and should_checkpoint_block(
+            checkpoint_this_block = torch.is_grad_enabled() and should_checkpoint_block(
                 index_block,
                 self.gradient_checkpointing,
                 self.gradient_checkpointing_interval,
                 self.gradient_checkpointing_segment_stride,
-            ):
+            )
+            if musubi_offload_active and musubi_manager.is_managed_block(index_block):
+                musubi_manager.stream_in(block, hidden_states.device, checkpointed=checkpoint_this_block)
+
+            if checkpoint_this_block:
                 if self.gradient_checkpointing_backend.startswith("unsloth"):
                     from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 

--- a/simpletuner/helpers/models/qwen_image/transformer.py
+++ b/simpletuner/helpers/models/qwen_image/transformer.py
@@ -1367,8 +1367,18 @@ class QwenImageTransformer2DModel(
 
         capture_idx = 0
         for index_block, block in enumerate(self.transformer_blocks):
+            checkpoint_this_block = torch.is_grad_enabled() and should_checkpoint_block(
+                index_block,
+                self.gradient_checkpointing,
+                self.gradient_checkpointing_interval,
+                self.gradient_checkpointing_segment_stride,
+            )
             if musubi_offload_active and musubi_manager.is_managed_block(index_block):
-                musubi_manager.stream_in(block, hidden_states.device)
+                musubi_manager.stream_in(
+                    block,
+                    hidden_states.device,
+                    checkpointed=checkpoint_this_block and not self.gradient_checkpointing_backend.endswith("-ffn"),
+                )
 
             # TREAD: START a route?
             if use_routing and route_ptr < len(routes) and index_block == routes[route_ptr]["start_layer_idx"]:
@@ -1382,12 +1392,7 @@ class QwenImageTransformer2DModel(
                 hidden_states = router.start_route(hidden_states, tread_mask_info)
                 routing_now = True
 
-            if torch.is_grad_enabled() and should_checkpoint_block(
-                index_block,
-                self.gradient_checkpointing,
-                self.gradient_checkpointing_interval,
-                self.gradient_checkpointing_segment_stride,
-            ):
+            if checkpoint_this_block:
 
                 def create_custom_forward(module, mod_idx):
                     def custom_forward(

--- a/simpletuner/helpers/models/sana/transformer.py
+++ b/simpletuner/helpers/models/sana/transformer.py
@@ -721,8 +721,18 @@ class SanaTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
 
         capture_idx = 0
         for i, block in enumerate(self.transformer_blocks):
+            checkpoint_this_block = (
+                self.training
+                and self.gradient_checkpointing
+                and should_checkpoint_block(
+                    i,
+                    True,
+                    self.gradient_checkpointing_interval,
+                    self.gradient_checkpointing_segment_stride,
+                )
+            )
             if musubi_offload_active and musubi_manager.is_managed_block(i):
-                musubi_manager.stream_in(block, hidden_states.device)
+                musubi_manager.stream_in(block, hidden_states.device, checkpointed=checkpoint_this_block)
             mask_info = None
             original_hidden_states = None
 
@@ -744,16 +754,7 @@ class SanaTransformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapt
                         original_hidden_states = hidden_states
                         hidden_states = router.start_route(hidden_states, mask_info)
                         break
-            if (
-                self.training
-                and self.gradient_checkpointing
-                and should_checkpoint_block(
-                    i,
-                    True,
-                    self.gradient_checkpointing_interval,
-                    self.gradient_checkpointing_segment_stride,
-                )
-            ):
+            if checkpoint_this_block:
 
                 def create_custom_forward(module):
                     def custom_forward(*inputs):

--- a/simpletuner/helpers/models/sanavideo/transformer.py
+++ b/simpletuner/helpers/models/sanavideo/transformer.py
@@ -1046,14 +1046,19 @@ class SanaVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fro
             )
         elif torch.is_grad_enabled() and self.gradient_checkpointing:
             for index_block, block in enumerate(self.transformer_blocks):
-                if musubi_offload_active and musubi_manager.is_managed_block(index_block):
-                    musubi_manager.stream_in(block, hidden_states.device)
-                if should_checkpoint_block(
+                checkpoint_this_block = should_checkpoint_block(
                     index_block,
                     self.gradient_checkpointing,
                     self.gradient_checkpointing_interval,
                     self.gradient_checkpointing_segment_stride,
-                ):
+                )
+                if musubi_offload_active and musubi_manager.is_managed_block(index_block):
+                    musubi_manager.stream_in(
+                        block,
+                        hidden_states.device,
+                        checkpointed=checkpoint_this_block and not self.gradient_checkpointing_backend.endswith("-ffn"),
+                    )
+                if checkpoint_this_block:
                     if self.gradient_checkpointing_backend.startswith("unsloth"):
                         from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 
@@ -1121,7 +1126,7 @@ class SanaVideoTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fro
         else:
             for index_block, block in enumerate(self.transformer_blocks):
                 if musubi_offload_active and musubi_manager.is_managed_block(index_block):
-                    musubi_manager.stream_in(block, hidden_states.device)
+                    musubi_manager.stream_in(block, hidden_states.device, checkpointed=False)
                 hidden_states = block(
                     hidden_states,
                     attention_mask,

--- a/simpletuner/helpers/models/sd3/transformer.py
+++ b/simpletuner/helpers/models/sd3/transformer.py
@@ -779,8 +779,6 @@ class SD3Transformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapte
         else:
             capture_idx = 0
             for index_block, block in enumerate(self.transformer_blocks):
-                if musubi_offload_active and musubi_manager.is_managed_block(index_block):
-                    musubi_manager.stream_in(block, hidden_states.device)
                 # TREAD: START a route?
                 if use_routing and route_ptr < len(routes) and global_idx == routes[route_ptr]["start_layer_idx"]:
                     mask_ratio = routes[route_ptr]["selection_ratio"]
@@ -800,7 +798,7 @@ class SD3Transformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapte
                         hidden_states = hidden_states + block_controlnet_hidden_states[index_block // interval_control]
                     continue
 
-                if (
+                checkpoint_this_block = (
                     self.training
                     and self.gradient_checkpointing
                     and should_checkpoint_block(
@@ -809,7 +807,11 @@ class SD3Transformer2DModel(PatchableModule, ModelMixin, ConfigMixin, PeftAdapte
                         self.gradient_checkpointing_interval,
                         self.gradient_checkpointing_segment_stride,
                     )
-                ):
+                )
+                if musubi_offload_active and musubi_manager.is_managed_block(index_block):
+                    musubi_manager.stream_in(block, hidden_states.device, checkpointed=checkpoint_this_block)
+
+                if checkpoint_this_block:
 
                     def custom_forward(*inputs, checkpoint_block=block, attention_kwargs=joint_attention_kwargs):
                         return _sd3_apply_joint_transformer_block(

--- a/simpletuner/helpers/models/wan/transformer.py
+++ b/simpletuner/helpers/models/wan/transformer.py
@@ -1106,8 +1106,13 @@ class WanTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrigi
                 if skip_layers is not None and i in skip_layers:
                     continue
 
+                checkpoint_this_block = torch.is_grad_enabled() and self.gradient_checkpointing
                 if musubi_offload_active and musubi_manager.is_managed_block(i):
-                    musubi_manager.stream_in(block, hidden_states.device)
+                    musubi_manager.stream_in(
+                        block,
+                        hidden_states.device,
+                        checkpointed=checkpoint_this_block and not self.gradient_checkpointing_backend.endswith("-ffn"),
+                    )
 
                 # Apply transformer block
                 # Each block does:
@@ -1115,7 +1120,7 @@ class WanTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrigi
                 # 2. Cross-attention from video to text tokens
                 # 3. Feed-forward on video tokens
                 # Only video tokens are routed; text tokens always remain full sequence
-                if torch.is_grad_enabled() and self.gradient_checkpointing:
+                if checkpoint_this_block:
                     if self.gradient_checkpointing_backend.startswith("unsloth"):
                         from simpletuner.helpers.training.offloaded_gradient_checkpointer import offloaded_checkpoint
 

--- a/simpletuner/helpers/models/wan_s2v/transformer.py
+++ b/simpletuner/helpers/models/wan_s2v/transformer.py
@@ -1329,16 +1329,17 @@ class WanS2VTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
                 current_rope = router.route_rope(rotary_emb, tread_mask_info)
                 routing_now = True
 
-            # Musubi: stream in block if managed
-            if musubi_offload_active and musubi_manager.is_managed_block(block_idx):
-                musubi_manager.stream_in(block, hidden_states.device)
-
-            if self.training and should_checkpoint_block(
+            checkpoint_this_block = self.training and should_checkpoint_block(
                 block_idx,
                 self.gradient_checkpointing,
                 self.gradient_checkpointing_interval,
                 self.gradient_checkpointing_segment_stride,
-            ):
+            )
+            # Musubi: stream in block if managed
+            if musubi_offload_active and musubi_manager.is_managed_block(block_idx):
+                musubi_manager.stream_in(block, hidden_states.device, checkpointed=checkpoint_this_block)
+
+            if checkpoint_this_block:
                 hidden_states = self._gradient_checkpointing_func(
                     block, hidden_states, encoder_hidden_states, timestep_proj, current_rope
                 )

--- a/simpletuner/helpers/models/z_image/transformer.py
+++ b/simpletuner/helpers/models/z_image/transformer.py
@@ -1142,8 +1142,14 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
         for idx, layer in enumerate(self.layers):
             if use_segmented_checkpointing:
                 break
+            checkpoint_this_block = (
+                idx not in skip_set
+                and grad_enabled
+                and self.gradient_checkpointing
+                and not self.gradient_checkpointing_backend.endswith("-ffn")
+            )
             if musubi_offload_active and musubi_manager.is_managed_block(idx):
-                musubi_manager.stream_in(layer, unified.device)
+                musubi_manager.stream_in(layer, unified.device, checkpointed=checkpoint_this_block)
             if use_routing and route_ptr < len(routes) and idx == routes[route_ptr]["start_layer_idx"]:
                 mask_ratio = routes[route_ptr]["selection_ratio"]
                 force_keep = torch.zeros_like(unified_attn_mask)

--- a/simpletuner/helpers/models/z_image_omni/transformer.py
+++ b/simpletuner/helpers/models/z_image_omni/transformer.py
@@ -1348,8 +1348,9 @@ class ZImageOmniTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fr
             musubi_offload_active = musubi_manager.activate(combined_blocks, unified.device, grad_enabled)
 
         for idx, layer in enumerate(self.layers):
+            checkpoint_this_block = idx not in skip_set and grad_enabled and self.gradient_checkpointing
             if musubi_offload_active and musubi_manager.is_managed_block(idx):
-                musubi_manager.stream_in(layer, unified.device)
+                musubi_manager.stream_in(layer, unified.device, checkpointed=checkpoint_this_block)
             if use_routing and route_ptr < len(routes) and idx == routes[route_ptr]["start_layer_idx"]:
                 mask_ratio = routes[route_ptr]["selection_ratio"]
                 force_keep = torch.zeros_like(unified_attn_mask)

--- a/simpletuner/helpers/models/zlab_i1/transformer.py
+++ b/simpletuner/helpers/models/zlab_i1/transformer.py
@@ -880,8 +880,18 @@ class ZlabI1Transformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
             image_tokens, text_tokens = segmented_state[:2]
         else:
             for block in self.in_blocks:
+                checkpoint_this_block = (
+                    global_idx not in skip_set
+                    and torch.is_grad_enabled()
+                    and should_checkpoint_block(
+                        global_idx,
+                        self.gradient_checkpointing,
+                        self.gradient_checkpointing_interval,
+                        self.gradient_checkpointing_segment_stride,
+                    )
+                )
                 if musubi_offload_active and musubi_manager.is_managed_block(global_idx):
-                    musubi_manager.stream_in(block, x.device)
+                    musubi_manager.stream_in(block, x.device, checkpointed=checkpoint_this_block)
                 maybe_start_route()
                 if global_idx not in skip_set:
                     image_tokens, text_tokens = run_block(block)
@@ -893,8 +903,18 @@ class ZlabI1Transformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
                     musubi_manager.stream_out(block)
                 global_idx += 1
 
+            checkpoint_this_block = (
+                global_idx not in skip_set
+                and torch.is_grad_enabled()
+                and should_checkpoint_block(
+                    global_idx,
+                    self.gradient_checkpointing,
+                    self.gradient_checkpointing_interval,
+                    self.gradient_checkpointing_segment_stride,
+                )
+            )
             if musubi_offload_active and musubi_manager.is_managed_block(global_idx):
-                musubi_manager.stream_in(self.mid_block, x.device)
+                musubi_manager.stream_in(self.mid_block, x.device, checkpointed=checkpoint_this_block)
             maybe_start_route()
             if global_idx not in skip_set:
                 image_tokens, text_tokens = run_block(self.mid_block)
@@ -906,8 +926,18 @@ class ZlabI1Transformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
             global_idx += 1
 
             for block in self.out_blocks:
+                checkpoint_this_block = (
+                    global_idx not in skip_set
+                    and torch.is_grad_enabled()
+                    and should_checkpoint_block(
+                        global_idx,
+                        self.gradient_checkpointing,
+                        self.gradient_checkpointing_interval,
+                        self.gradient_checkpointing_segment_stride,
+                    )
+                )
                 if musubi_offload_active and musubi_manager.is_managed_block(global_idx):
-                    musubi_manager.stream_in(block, x.device)
+                    musubi_manager.stream_in(block, x.device, checkpointed=checkpoint_this_block)
                 maybe_start_route()
                 skip = skips.pop()
                 if global_idx not in skip_set:

--- a/simpletuner/helpers/musubi_block_swap.py
+++ b/simpletuner/helpers/musubi_block_swap.py
@@ -1,5 +1,7 @@
 import logging
-from typing import Iterable, List, Optional
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Any, Iterable, List, Optional
 
 import torch
 import torch.nn as nn
@@ -103,6 +105,18 @@ def _module_has_local_quantized_payload(module: nn.Module) -> bool:
     )
 
 
+def _module_has_cpu_h2d_payload(module: nn.Module) -> bool:
+    has_frozen_parameter = any(
+        parameter.device.type == "cpu"
+        and (not parameter.requires_grad or _is_quanto_tensor(parameter) or _is_sdnq_tensor(parameter))
+        for parameter in module.parameters()
+    )
+    has_quantized_buffer = any(
+        buffer.device.type == "cpu" and (_is_quanto_tensor(buffer) or _is_sdnq_tensor(buffer)) for buffer in module.buffers()
+    )
+    return has_frozen_parameter or has_quantized_buffer
+
+
 def _move_quanto_tensor_to_device(tensor, device: torch.device):
     if not _same_device(tensor.device, device):
         tensor.data = tensor.data.to(device, non_blocking=True)
@@ -173,19 +187,224 @@ def prepare_musubi_model_for_ddp(module: nn.Module, device: torch.device) -> tup
     target_device = torch.device(device)
     moved_trainable = 0
     for param in module.parameters():
-        if not param.requires_grad or _same_device(param.device, target_device):
+        is_quantized_payload = _is_quanto_tensor(param) or _is_sdnq_tensor(param)
+        if not param.requires_grad or is_quantized_payload or _same_device(param.device, target_device):
             continue
         param.data = param.data.to(target_device, non_blocking=True)
         if param.grad is not None:
             param.grad = param.grad.to(target_device, non_blocking=True)
         moved_trainable += 1
 
-    ignored_names = {name for name, param in module.named_parameters() if not param.requires_grad}
+    ignored_names = {
+        name
+        for name, param in module.named_parameters()
+        if not param.requires_grad or _is_quanto_tensor(param) or _is_sdnq_tensor(param)
+    }
     ignored_names.update(name for name, _buffer in module.named_buffers())
     existing = set(getattr(module, "_ddp_params_and_buffers_to_ignore", set()))
     newly_ignored = ignored_names - existing
     module._ddp_params_and_buffers_to_ignore = existing | ignored_names
     return moved_trainable, len(newly_ignored)
+
+
+@dataclass
+class _TensorTree:
+    tensor_type: type
+    metadata: Any
+    outer_size: tuple[int, ...]
+    outer_stride: tuple[int, ...]
+    children: tuple[tuple[str, "_TensorTree"], ...]
+    leaf_index: Optional[int] = None
+
+    def rebuild(self, leaves: List[torch.Tensor]) -> torch.Tensor:
+        if self.leaf_index is not None:
+            return leaves[self.leaf_index]
+        inner_tensors = {name: child.rebuild(leaves) for name, child in self.children}
+        return self.tensor_type.__tensor_unflatten__(
+            inner_tensors,
+            self.metadata,
+            self.outer_size,
+            self.outer_stride,
+        )
+
+
+def _flatten_tensor_tree(tensor: torch.Tensor, leaves: List[torch.Tensor]) -> _TensorTree:
+    if type(tensor) is torch.Tensor:
+        leaf_index = len(leaves)
+        leaves.append(tensor)
+        return _TensorTree(
+            tensor_type=torch.Tensor,
+            metadata=None,
+            outer_size=tuple(tensor.size()),
+            outer_stride=tuple(tensor.stride()),
+            children=(),
+            leaf_index=leaf_index,
+        )
+
+    flatten = getattr(tensor, "__tensor_flatten__", None)
+    if flatten is None:
+        raise TypeError(
+            f"Musubi H2D block swap cannot stream tensor type "
+            f"{type(tensor).__module__}.{type(tensor).__name__}: __tensor_flatten__ is unavailable."
+        )
+    child_names, metadata = flatten()
+    children = []
+    for child_name in child_names:
+        child = getattr(tensor, child_name)
+        if not isinstance(child, torch.Tensor):
+            raise TypeError(
+                f"Musubi H2D block swap expected tensor field {child_name!r} on "
+                f"{type(tensor).__module__}.{type(tensor).__name__}."
+            )
+        children.append((child_name, _flatten_tensor_tree(child, leaves)))
+    return _TensorTree(
+        tensor_type=type(tensor),
+        metadata=metadata,
+        outer_size=tuple(tensor.size()),
+        outer_stride=tuple(tensor.stride()),
+        children=tuple(children),
+    )
+
+
+@dataclass
+class _FrozenTensorBinding:
+    owner: nn.Module
+    name: str
+    parameter: Optional[nn.Parameter]
+    tree: _TensorTree
+    replace_parameter: bool = False
+
+    def bind(self, leaves: List[torch.Tensor]) -> None:
+        tensor = self.tree.rebuild(leaves)
+        if self.parameter is not None:
+            if self.replace_parameter:
+                self.owner._parameters[self.name] = tensor
+            else:
+                self.parameter.data = tensor
+        else:
+            self.owner._buffers[self.name] = tensor
+
+
+@dataclass
+class _H2DRingSlot:
+    flat: torch.Tensor
+    leaves: List[torch.Tensor]
+    owner_block_id: Optional[int] = None
+    reusable_event: Optional[torch.cuda.Event] = None
+    load_event: Optional[torch.cuda.Event] = None
+
+
+@dataclass
+class _H2DBlockState:
+    block: nn.Module
+    cpu_flat: torch.Tensor
+    cpu_leaves: List[torch.Tensor]
+    bindings: List[_FrozenTensorBinding]
+    signature: tuple
+    slot: Optional[_H2DRingSlot] = None
+
+    def bind(self, leaves: List[torch.Tensor]) -> None:
+        for binding in self.bindings:
+            binding.bind(leaves)
+
+
+def _required_storage_elements(shape: tuple[int, ...], stride: tuple[int, ...]) -> int:
+    if not shape or any(size == 0 for size in shape):
+        return 0 if shape else 1
+    if any(value < 0 for value in stride):
+        raise ValueError("Musubi H2D block swap does not support negative-stride frozen tensors.")
+    return 1 + sum((size - 1) * step for size, step in zip(shape, stride))
+
+
+def _flat_tensor_layout(leaves: List[torch.Tensor]) -> tuple[tuple, int]:
+    alignment = 256
+    offset = 0
+    layout = []
+    for leaf in leaves:
+        offset = (offset + alignment - 1) // alignment * alignment
+        shape = tuple(leaf.size())
+        stride = tuple(leaf.stride())
+        storage_elements = _required_storage_elements(shape, stride)
+        storage_bytes = storage_elements * leaf.element_size()
+        layout.append((offset, shape, stride, leaf.dtype, storage_bytes))
+        offset += storage_bytes
+    return tuple(layout), offset
+
+
+def _flat_tensor_views(flat: torch.Tensor, layout: tuple) -> List[torch.Tensor]:
+    views = []
+    for offset, shape, stride, dtype, storage_bytes in layout:
+        storage = flat[offset : offset + storage_bytes].view(dtype)
+        views.append(storage.as_strided(shape, stride))
+    return views
+
+
+class _StagedH2DCopier:
+    """Copies pageable block masters through a small pinned pool on a worker thread."""
+
+    def __init__(self, device: torch.device, staging_count: int):
+        self.device = device
+        self.device_index = device.index if device.index is not None else torch.cuda.current_device()
+        self.staging_count = max(1, staging_count)
+        self.copy_stream = torch.cuda.Stream(device=device)
+        self._worker = ThreadPoolExecutor(max_workers=1, thread_name_prefix="musubi-h2d")
+        self._futures: dict[int, Future] = {}
+        self._staging: dict[int, List[torch.Tensor]] = {}
+        self._staging_free: dict[int, List[Optional[torch.cuda.Event]]] = {}
+        self._next_staging: dict[int, int] = {}
+
+    def _ensure_staging(self, nbytes: int) -> None:
+        if nbytes in self._staging:
+            return
+        self._staging[nbytes] = [
+            torch.empty(nbytes, dtype=torch.uint8, device="cpu", pin_memory=True) for _ in range(self.staging_count)
+        ]
+        self._staging_free[nbytes] = [None] * self.staging_count
+        self._next_staging[nbytes] = 0
+
+    def _copy(
+        self,
+        destination: torch.Tensor,
+        source: torch.Tensor,
+        reusable_event: Optional[torch.cuda.Event],
+    ) -> torch.cuda.Event:
+        torch.cuda.set_device(self.device_index)
+        nbytes = source.numel()
+        index = self._next_staging[nbytes]
+        self._next_staging[nbytes] = (index + 1) % self.staging_count
+        staging = self._staging[nbytes][index]
+        staging_free = self._staging_free[nbytes][index]
+        if staging_free is not None:
+            staging_free.synchronize()
+
+        staging.copy_(source)
+        with torch.cuda.stream(self.copy_stream):
+            if reusable_event is not None:
+                self.copy_stream.wait_event(reusable_event)
+            destination.copy_(staging, non_blocking=True)
+            complete = self.copy_stream.record_event()
+        self._staging_free[nbytes][index] = complete
+        return complete
+
+    def submit(
+        self,
+        key: int,
+        destination: torch.Tensor,
+        source: torch.Tensor,
+        reusable_event: Optional[torch.cuda.Event],
+    ) -> None:
+        self._ensure_staging(source.numel())
+        self._futures[key] = self._worker.submit(self._copy, destination, source, reusable_event)
+
+    def wait(self, key: int) -> torch.cuda.Event:
+        return self._futures.pop(key).result()
+
+    def close(self) -> None:
+        for future in list(self._futures.values()):
+            future.result()
+        self._futures.clear()
+        self.copy_stream.synchronize()
+        self._worker.shutdown(wait=True)
 
 
 class MusubiBlockSwapManager:
@@ -203,6 +422,18 @@ class MusubiBlockSwapManager:
         self._backward_hooks: List[torch.utils.hooks.RemovableHandle] = []
         self._hooked_block_ids: tuple[int, ...] = ()
         self._backward_hook_device: Optional[torch.device] = None
+        self._h2d_block_modes: dict[int, bool] = {}
+        self._h2d_block_states: dict[int, _H2DBlockState] = {}
+        self._h2d_ring_pools: dict[tuple, List[_H2DRingSlot]] = {}
+        self._h2d_copiers: dict[torch.device, _StagedH2DCopier] = {}
+        self._h2d_ring_size = 2
+
+    def __del__(self):
+        for copier in getattr(self, "_h2d_copiers", {}).values():
+            try:
+                copier.close()
+            except Exception:
+                continue
 
     @classmethod
     def build(
@@ -252,7 +483,20 @@ class MusubiBlockSwapManager:
     def is_managed_block(self, index: int) -> bool:
         return index in self.block_indices
 
-    def stream_in(self, block: nn.Module, device: torch.device):
+    def stream_in(self, block: nn.Module, device: torch.device, checkpointed: Optional[bool] = None):
+        block_id = id(block)
+        if checkpointed is not None:
+            self._h2d_block_modes[block_id] = bool(
+                checkpointed
+                and device.type == "cuda"
+                and self.offload_device.type == "cpu"
+                and _module_has_cpu_h2d_payload(block)
+            )
+        if self._h2d_block_modes.get(block_id, False):
+            state = self._h2d_state(block, device)
+            self._load_h2d_state(state, device)
+            return
+
         self.move_module(block, device)
         # Verify the move succeeded
         if not _module_on_device(block, device):
@@ -262,6 +506,10 @@ class MusubiBlockSwapManager:
             )
 
     def stream_out(self, block: nn.Module):
+        state = self._h2d_block_states.get(id(block))
+        if self._h2d_block_modes.get(id(block), False) and state is not None:
+            self._release_h2d_state(state)
+            return
         self.move_module(block, self.offload_device)
 
     def move_module(self, module: nn.Module, device: torch.device):
@@ -272,6 +520,113 @@ class MusubiBlockSwapManager:
             if idx < 0 or idx >= len(blocks):
                 continue
             self._move_module(blocks[idx], self.offload_device)
+
+    def _h2d_state(self, block: nn.Module, device: torch.device) -> _H2DBlockState:
+        block_id = id(block)
+        existing = self._h2d_block_states.get(block_id)
+        if existing is not None:
+            return existing
+
+        cpu_leaves: List[torch.Tensor] = []
+        bindings: List[_FrozenTensorBinding] = []
+        for owner in block.modules():
+            for name, parameter in owner._parameters.items():
+                is_quantized_payload = parameter is not None and (_is_quanto_tensor(parameter) or _is_sdnq_tensor(parameter))
+                if parameter is None or (parameter.requires_grad and not is_quantized_payload):
+                    continue
+                tree = _flatten_tensor_tree(parameter.detach(), cpu_leaves)
+                bindings.append(
+                    _FrozenTensorBinding(
+                        owner=owner,
+                        name=name,
+                        parameter=parameter,
+                        tree=tree,
+                        replace_parameter=is_quantized_payload,
+                    )
+                )
+            for name, buffer in owner._buffers.items():
+                if buffer is None or buffer.device.type != "cpu":
+                    continue
+                tree = _flatten_tensor_tree(buffer, cpu_leaves)
+                bindings.append(
+                    _FrozenTensorBinding(
+                        owner=owner,
+                        name=name,
+                        parameter=None,
+                        tree=tree,
+                    )
+                )
+
+        if not cpu_leaves:
+            raise ValueError("Musubi H2D block swap found no frozen tensor payloads in a checkpointed block.")
+        for leaf in cpu_leaves:
+            if leaf.device.type != "cpu":
+                raise ValueError(f"Musubi H2D CPU master must be on CPU before ring initialization, got {leaf.device}.")
+
+        layout, total_bytes = _flat_tensor_layout(cpu_leaves)
+        cpu_flat = torch.empty(total_bytes, dtype=torch.uint8, device="cpu")
+        packed_cpu_leaves = _flat_tensor_views(cpu_flat, layout)
+        for destination, source in zip(packed_cpu_leaves, cpu_leaves):
+            destination.copy_(source)
+
+        signature = (layout, total_bytes)
+        state = _H2DBlockState(
+            block=block,
+            cpu_flat=cpu_flat,
+            cpu_leaves=packed_cpu_leaves,
+            bindings=bindings,
+            signature=signature,
+        )
+        state.bind(state.cpu_leaves)
+        self._h2d_block_states[block_id] = state
+        pool_key = (device, signature)
+        if pool_key not in self._h2d_ring_pools:
+            slots = []
+            for _ in range(self._h2d_ring_size):
+                flat = torch.empty(total_bytes, dtype=torch.uint8, device=device)
+                slots.append(_H2DRingSlot(flat=flat, leaves=_flat_tensor_views(flat, layout)))
+            self._h2d_ring_pools[pool_key] = slots
+        return state
+
+    def _h2d_copier(self, device: torch.device) -> _StagedH2DCopier:
+        copier = self._h2d_copiers.get(device)
+        if copier is None:
+            copier = _StagedH2DCopier(device, staging_count=self._h2d_ring_size)
+            self._h2d_copiers[device] = copier
+        return copier
+
+    def _load_h2d_state(self, state: _H2DBlockState, device: torch.device) -> None:
+        if state.slot is not None:
+            if state.slot.load_event is not None:
+                torch.cuda.current_stream(device).wait_event(state.slot.load_event)
+            state.bind(state.slot.leaves)
+            return
+
+        slots = self._h2d_ring_pools[(device, state.signature)]
+        slot = next((candidate for candidate in slots if candidate.owner_block_id is None), None)
+        if slot is None:
+            raise RuntimeError(
+                "Musubi H2D ring has no reusable slot. A checkpointed block retained a slot past its execution."
+            )
+
+        copier = self._h2d_copier(device)
+        copier.submit(id(state.block), slot.flat, state.cpu_flat, slot.reusable_event)
+        slot.load_event = copier.wait(id(state.block))
+
+        slot.owner_block_id = id(state.block)
+        state.slot = slot
+        state.bind(slot.leaves)
+        torch.cuda.current_stream(device).wait_event(slot.load_event)
+
+    def _release_h2d_state(self, state: _H2DBlockState) -> None:
+        slot = state.slot
+        if slot is None:
+            return
+        device = slot.leaves[0].device
+        slot.reusable_event = torch.cuda.current_stream(device).record_event()
+        state.bind(state.cpu_leaves)
+        state.slot = None
+        slot.owner_block_id = None
 
     def _clear_lifecycle_hooks(self):
         for handle in self._forward_hooks + self._backward_hooks:
@@ -305,7 +660,8 @@ class MusubiBlockSwapManager:
 
             def _make_forward_hook(owner_block):
                 def _forward_hook(_module, _args, output):
-                    self.stream_out(owner_block)
+                    if not self._h2d_block_modes.get(id(owner_block), False):
+                        self.stream_out(owner_block)
                     return output
 
                 return _forward_hook

--- a/tests/test_minimaxh3.py
+++ b/tests/test_minimaxh3.py
@@ -744,8 +744,8 @@ class FakeMusubiManager:
     def is_managed_block(self, block_idx):
         return block_idx == self.managed_block_idx
 
-    def stream_in(self, block, compute_device):
-        self.calls.append(("stream_in", id(block), str(compute_device)))
+    def stream_in(self, block, compute_device, checkpointed=None):
+        self.calls.append(("stream_in", id(block), str(compute_device), checkpointed))
 
     def stream_out(self, block):
         self.calls.append(("stream_out", id(block)))
@@ -1327,7 +1327,7 @@ class MiniMaxH3Tests(unittest.TestCase):
             fake_manager.calls,
             [
                 ("activate", 3, "cpu", True),
-                ("stream_in", id(model.transformer_blocks[1]), "cpu"),
+                ("stream_in", id(model.transformer_blocks[1]), "cpu", False),
                 ("stream_out", id(model.transformer_blocks[1])),
             ],
         )

--- a/tests/test_minimaxmusic_model.py
+++ b/tests/test_minimaxmusic_model.py
@@ -584,7 +584,11 @@ class MiniMaxMusicModelTests(unittest.TestCase):
         )
 
         manager.activate.assert_called_once()
-        manager.stream_in.assert_called_once_with(transformer.transformer_blocks[1], torch.device("cpu"))
+        manager.stream_in.assert_called_once_with(
+            transformer.transformer_blocks[1],
+            torch.device("cpu"),
+            checkpointed=False,
+        )
         manager.stream_out.assert_called_once_with(transformer.transformer_blocks[1])
 
     def test_transformer_accepts_tokenwise_timesteps_for_self_flow(self):

--- a/tests/test_musubi_block_swap.py
+++ b/tests/test_musubi_block_swap.py
@@ -9,6 +9,38 @@ from torch.utils.checkpoint import checkpoint
 from simpletuner.helpers.musubi_block_swap import MusubiBlockSwapManager, _module_on_device, prepare_musubi_model_for_ddp
 
 
+class _QuantizedBuffer(torch.Tensor):
+    @staticmethod
+    def __new__(cls, weight: torch.Tensor, scale: torch.Tensor):
+        return torch.Tensor._make_wrapper_subclass(
+            cls,
+            weight.shape,
+            strides=weight.stride(),
+            storage_offset=weight.storage_offset(),
+            dtype=weight.dtype,
+            device=weight.device,
+        )
+
+    def __init__(self, weight: torch.Tensor, scale: torch.Tensor):
+        self.weight = weight
+        self.scale = scale
+
+    def __tensor_flatten__(self):
+        return ["weight", "scale"], None
+
+    @classmethod
+    def __tensor_unflatten__(cls, inner_tensors, _metadata, outer_size=None, outer_stride=None):
+        del outer_size, outer_stride
+        return cls(inner_tensors["weight"], inner_tensors["scale"])
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+        raise NotImplementedError(f"{cls.__name__} does not implement {func}")
+
+
+_QuantizedBuffer.__module__ = "sdnq.testing"
+
+
 class MusubiBlockSwapTests(unittest.TestCase):
     def test_prepare_for_ddp_ignores_only_frozen_state(self):
         module = nn.Sequential(nn.Linear(4, 4), nn.Linear(4, 4))
@@ -178,6 +210,131 @@ class MusubiBlockSwapTests(unittest.TestCase):
         self.assertTrue(all(block.adapter_down.weight.grad is not None for block in blocks))
         self.assertTrue(all(block.adapter_up.weight.grad is not None for block in blocks))
         optimizer.step()
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for the H2D ring test")
+    def test_checkpointed_blocks_reuse_h2d_ring_storage(self):
+        device = torch.device("cuda")
+
+        class AdapterBlock(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.base = nn.Linear(64, 64, bias=False)
+                self.adapter = nn.Linear(64, 64, bias=False)
+                self.base.weight.requires_grad_(False)
+
+            def forward(self, hidden_states):
+                return torch.nn.functional.silu(self.base(hidden_states) + self.adapter(hidden_states))
+
+        blocks = nn.ModuleList([AdapterBlock().to(device) for _ in range(2)])
+        manager = MusubiBlockSwapManager(
+            block_indices=[0, 1],
+            offload_device=torch.device("cpu"),
+            logger=logging.getLogger(__name__),
+        )
+        manager.activate(blocks, device, grad_enabled=True)
+
+        hidden_states = torch.randn(2, 8, 64, device=device, requires_grad=True)
+        ring_pointers = []
+        for block in blocks:
+            manager.stream_in(block, device, checkpointed=True)
+            state = manager._h2d_block_states[id(block)]
+            ring_pointers.append(state.slot.leaves[0].data_ptr())
+            self.assertEqual(state.slot.flat.untyped_storage().data_ptr(), state.slot.leaves[0].untyped_storage().data_ptr())
+            self.assertFalse(state.cpu_flat.is_pinned())
+            hidden_states = checkpoint(block, hidden_states, use_reentrant=False)
+            manager.stream_out(block)
+
+        self.assertEqual(ring_pointers[0], ring_pointers[1])
+        copier = manager._h2d_copiers[device]
+        self.assertTrue(all(staging.is_pinned() for pool in copier._staging.values() for staging in pool))
+        self.assertTrue(all(block.base.weight.device.type == "cpu" for block in blocks))
+        hidden_states.square().mean().backward()
+        self.assertTrue(all(block.base.weight.device.type == "cpu" for block in blocks))
+        self.assertTrue(all(block.adapter.weight.grad is not None for block in blocks))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for the quantized H2D ring test")
+    def test_checkpointed_quanto_payload_uses_h2d_ring(self):
+        try:
+            from optimum.quanto import freeze, qint8, quantize
+        except ImportError as exc:
+            self.skipTest(f"Quanto int8 quantization is unavailable: {exc}")
+
+        device = torch.device("cuda")
+
+        class QuantizedAdapterBlock(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.base = nn.Sequential(nn.Linear(32, 32, bias=False))
+                self.adapter = nn.Linear(32, 32, bias=False)
+
+            def forward(self, hidden_states):
+                return self.base(hidden_states) + self.adapter(hidden_states)
+
+        block = QuantizedAdapterBlock()
+        quantize(block.base, weights=qint8)
+        freeze(block.base)
+        block.adapter.to(device)
+        _moved, ignored = prepare_musubi_model_for_ddp(block, device)
+        self.assertIn("base.0.weight", block._ddp_params_and_buffers_to_ignore)
+        self.assertGreaterEqual(ignored, 1)
+        manager = MusubiBlockSwapManager(
+            block_indices=[0],
+            offload_device=torch.device("cpu"),
+            logger=logging.getLogger(__name__),
+        )
+        manager.activate([block], device, grad_enabled=True)
+
+        hidden_states = torch.randn(2, 8, 32, device=device, requires_grad=True)
+        manager.stream_in(block, device, checkpointed=True)
+        self.assertEqual(block.base[0].weight.device.type, "cuda")
+        self.assertEqual(block.base[0].weight._data.device.type, "cuda")
+        hidden_states = checkpoint(block, hidden_states, use_reentrant=False)
+        manager.stream_out(block)
+        self.assertEqual(block.base[0].weight.device.type, "cpu")
+        self.assertEqual(block.base[0].weight._data.device.type, "cpu")
+
+        hidden_states.square().mean().backward()
+        self.assertEqual(block.base[0].weight.device.type, "cpu")
+        self.assertIsNotNone(block.adapter.weight.grad)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for the quantized H2D ring test")
+    def test_checkpointed_quantized_buffer_payload_uses_h2d_ring(self):
+        device = torch.device("cuda")
+
+        class QuantizedAdapterBlock(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer(
+                    "quantized_weight",
+                    _QuantizedBuffer(torch.randn(32, 32), torch.ones(32, 1)),
+                )
+                self.adapter = nn.Linear(32, 32, bias=False)
+
+            def forward(self, hidden_states):
+                base = hidden_states @ self.quantized_weight.weight.t()
+                return base * self.quantized_weight.scale.mean() + self.adapter(hidden_states)
+
+        block = QuantizedAdapterBlock()
+        block.adapter.to(device)
+        manager = MusubiBlockSwapManager(
+            block_indices=[0],
+            offload_device=torch.device("cpu"),
+            logger=logging.getLogger(__name__),
+        )
+        manager.activate([block], device, grad_enabled=True)
+
+        hidden_states = torch.randn(2, 8, 32, device=device, requires_grad=True)
+        manager.stream_in(block, device, checkpointed=True)
+        self.assertEqual(block.quantized_weight.weight.device.type, "cuda")
+        self.assertEqual(block.quantized_weight.scale.device.type, "cuda")
+        hidden_states = checkpoint(block, hidden_states, use_reentrant=False)
+        manager.stream_out(block)
+        self.assertEqual(block.quantized_weight.weight.device.type, "cpu")
+        self.assertEqual(block.quantized_weight.scale.device.type, "cpu")
+
+        hidden_states.square().mean().backward()
+        self.assertEqual(block.quantized_weight.weight.device.type, "cpu")
+        self.assertIsNotNone(block.adapter.weight.grad)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- pack each checkpointed block's immutable frozen parameters and quantized buffers into one pageable CPU master
- stage each block through a small pinned-memory pool and issue one H2D copy into a reusable two-slot GPU ring
- leave trainable LoRA, LoHa, and LoKr parameters resident on the accelerator and eliminate the redundant D2H transfer for frozen base weights
- activate ring reuse only for blocks that are actually checkpointed as a whole; non-checkpointed and FFN-only-checkpointed blocks retain the stable residency path
- preserve Quanto and SDNQ tensor-subclass structure through `__tensor_flatten__` / `__tensor_unflatten__` and exclude their frozen payloads from DDP synchronization

## Why the checkpoint plan matters

A reusable GPU slot is overwritten by later blocks. Ordinary autograd may retain a view of a frozen weight until backward, so reusing that storage for a non-checkpointed block can trigger a version mismatch or consume the wrong value. Whole-block activation checkpointing reconstructs the block during backward and gives the ring a bounded lifetime: load before the block, retain it through recomputation and backward, then release the slot.

Every supported transformer now passes its actual per-block decision to the Musubi manager. Interval and segment-stride schedules are respected, while `*-ffn` backends are deliberately treated as non-checkpointed because the enclosing block is still saved by autograd.

## Transfer path

Frozen tensor leaves are aligned and viewed through one flat byte allocation. CPU masters remain pageable, avoiding permanently pinning the full offloaded model. A worker copies into a two-entry pinned staging pool while prior GPU work is still running, then a private CUDA stream performs one asynchronous H2D copy. Eviction only rebinds the block to its immutable CPU master; no D2H copy or device allocation is required.

Blocks without a frozen CPU payload fall back automatically, so full-finetune configurations do not enter this path.

## Validation

- 627 targeted model and checkpointing tests passed locally
- 9 CUDA block-swap tests passed on H100, including real `optimum-quanto` weights and an SDNQ-style tensor-subclass buffer
- an 8-block BF16 transformer workload with attention, SwiGLU, rank-64 adapters, and complete checkpointed forward/backward measured 0.0831 s/iteration versus 0.1171 s for corrected bidirectional swapping: 1.41x throughput with about 64 MiB additional ring residency

## Dependency

Built on the backward-residency lifecycle merged in #3148.