### PR TITLE
Document LTX regional compilation performance caveat

### DIFF
--- a/documentation/quickstart/LTXVIDEO2.es.md
+++ b/documentation/quickstart/LTXVIDEO2.es.md
@@ -29,6 +29,8 @@ Esta configuración es intensiva en VRAM, y el pre-caché del VAE puede disparar
   - ~16 s/step en 7900XTX (ejecución local).
   - ~30 min por 200 steps en A100-80G SXM4.
 
+> ⚠️ **Prueba la compilación regional antes de mantenerla activada.** `dynamo_use_regional_compilation` no acelera universalmente LTX Video 2 y puede reducir el rendimiento estable incluso después del calentamiento de la compilación. Compara ejecuciones eager y compiladas con el mismo lote, número de frames y resolución fijos, y evalúa varios steps de entrenamiento posteriores al calentamiento en vez de los steps iniciales de compilación.
+
 ## Requisitos previos
 
 Asegúrate de que Python 3.12 esté instalado.

--- a/documentation/quickstart/LTXVIDEO2.hi.md
+++ b/documentation/quickstart/LTXVIDEO2.hi.md
@@ -29,6 +29,8 @@ LTX Video 2 एक भारी **19B** मॉडल है। यह निम�
   - 7900XTX पर ~16 sec/step (लोकल रन)।
   - A100-80G SXM4 पर 200 steps ~30 मिनट।
 
+> ⚠️ **Regional compilation को enabled रखने से पहले test करें।** `dynamo_use_regional_compilation` LTX Video 2 के लिए हमेशा speedup नहीं देता और compilation warm up होने के बाद भी steady-state throughput घटा सकता है। समान fixed batch, frame count और resolution पर eager तथा compiled runs की तुलना करें, और शुरुआती compilation steps के बजाय warmup के बाद के कई training steps से निर्णय लें।
+
 ## पूर्वापेक्षाएँ
 
 Python 3.12 इंस्टॉल होना सुनिश्चित करें।

--- a/documentation/quickstart/LTXVIDEO2.ja.md
+++ b/documentation/quickstart/LTXVIDEO2.ja.md
@@ -29,6 +29,8 @@ LTX Video 2 は重量級の **19B** モデルです。以下を組み合わせ�
   - 7900XTX で ~16 秒/step（ローカル実行）。
   - A100-80G SXM4 で 200 steps あたり ~30 分。
 
+> ⚠️ **Regional compilation は有効のままにする前にテストしてください。** `dynamo_use_regional_compilation` は LTX Video 2 で常に高速化するとは限らず、コンパイルのウォームアップ後でも定常スループットを低下させる場合があります。同じ固定バッチ、フレーム数、解像度で eager 実行と compiled 実行を比較し、最初のコンパイル step ではなくウォームアップ後の複数の training step で判断してください。
+
 ## 前提条件
 
 Python 3.12 がインストールされていることを確認してください。

--- a/documentation/quickstart/LTXVIDEO2.md
+++ b/documentation/quickstart/LTXVIDEO2.md
@@ -29,6 +29,8 @@ This setup is VRAM-intensive, and the VAE pre-caching step can spike memory usag
   - ~16 sec/step on 7900XTX (local run).
   - ~30 min for 200 steps on A100-80G SXM4.
 
+> ⚠️ **Test regional compilation before keeping it enabled.** `dynamo_use_regional_compilation` is not a universal speedup for LTX Video 2 and can reduce steady-state throughput even after compilation has warmed up. Compare eager and compiled runs with the same fixed batch, frame count, and resolution, and judge them by several post-warmup training steps rather than the initial compilation steps.
+
 ## Prerequisites
 
 Ensure Python 3.12 is installed.

--- a/documentation/quickstart/LTXVIDEO2.pt-BR.md
+++ b/documentation/quickstart/LTXVIDEO2.pt-BR.md
@@ -29,6 +29,8 @@ Este setup é intensivo em VRAM, e o pré-cache do VAE pode aumentar o uso de me
   - ~16 s/step em 7900XTX (execução local).
   - ~30 min para 200 steps em A100-80G SXM4.
 
+> ⚠️ **Teste a compilação regional antes de mantê-la ativada.** `dynamo_use_regional_compilation` não acelera universalmente o LTX Video 2 e pode reduzir o throughput estável mesmo após o aquecimento da compilação. Compare execuções eager e compiladas com o mesmo batch, número de frames e resolução fixos, e avalie vários steps de treinamento após o warmup em vez dos steps iniciais de compilação.
+
 ## Pré-requisitos
 
 Garanta que o Python 3.12 esteja instalado.

--- a/documentation/quickstart/LTXVIDEO2.zh.md
+++ b/documentation/quickstart/LTXVIDEO2.zh.md
@@ -29,6 +29,8 @@ LTX Video 2 是重量级 **19B** 模型，由以下组件组成：
   - 7900XTX 约 16 秒/step（本地运行）。
   - A100-80G SXM4 跑 200 steps 约 30 分钟。
 
+> ⚠️ **请先测试 regional compilation，再决定是否保留。** `dynamo_use_regional_compilation` 并不一定能加速 LTX Video 2，即使编译预热完成后也可能降低稳定吞吐。请在相同的固定 batch、帧数和分辨率下比较 eager 与 compiled 运行，并根据预热后的多个训练 step 判断，而不是依据最初的编译 step。
+
 ## 前提条件
 
 确保已安装 Python 3.12。


### PR DESCRIPTION
## Summary

- warn that `dynamo_use_regional_compilation` is not a universal LTX Video 2 speedup
- tell users to compare eager and compiled runs at identical fixed shapes
- clarify that several post-warmup steps, rather than cold compilation steps, should determine the configuration
- add the guidance to the English, Spanish, Hindi, Japanese, Portuguese, and Chinese quickstarts

## Motivation

In an end-to-end H100 LTX 2.5 training comparison, regional compilation increased the post-warmup median from 3.9581 s/step to 4.8095 s/step, a 21.5% regression. Dedicated transfer overlap remained effective in both modes, but its eager path was still faster than its compiled path. The compile setting therefore needs to be treated as a model- and workload-specific benchmark choice rather than an assumed optimization.

## Tests

Documentation-only change; `git diff --check` passes.
