### PR TITLE
Overlap large prefetched batch transfers with CUDA compute

### DIFF
--- a/documentation/OPTIONS.es.md
+++ b/documentation/OPTIONS.es.md
@@ -786,6 +786,13 @@ Esto es útil para herramientas de monitoreo que reciben webhooks de múltiples 
 - **Qué**: Aumenta o reduce el número de lotes mantenidos en memoria.
 - **Por qué**: Al usar prefetch del dataloader, se mantienen 10 entradas en memoria por GPU/proceso. Esto puede ser demasiado o muy poco. Este valor puede ajustarse para incrementar el número de lotes preparados por adelantado.
 
+### `--dataloader_prefetch_device_threshold_mb`
+
+- **Qué**: Carga mínima única del lote en CPU, en MiB, que el prefetch fija en memoria y transfiere mediante un flujo CUDA dedicado. `0` desactiva la preparación en el dispositivo.
+- **Por qué**: Los embeddings en caché muy grandes pueden serializar la transferencia al dispositivo con el trabajo del modelo. Esta opción solapa la transferencia con el cómputo de la GPU.
+- **Memoria**: Cada entrada preparada de la cola consume memoria fija del host y memoria del acelerador. Empieza con `dataloader_prefetch_qlen: 2` y mide antes de aumentarlo.
+- **Compatibilidad**: Requiere `dataloader_prefetch: true` y CUDA. No es compatible con el paralelismo de contexto.
+
 ### `--compress_disk_cache`
 
 - **Qué**: Comprime los cachés en disco del VAE y de embeddings de texto.
@@ -2228,6 +2235,7 @@ usage: train.py [-h] --model_family
                 [--torch_num_threads TORCH_NUM_THREADS]
                 [--dataloader_prefetch [DATALOADER_PREFETCH]]
                 [--dataloader_prefetch_qlen DATALOADER_PREFETCH_QLEN]
+                [--dataloader_prefetch_device_threshold_mb DATALOADER_PREFETCH_DEVICE_THRESHOLD_MB]
                 [--aspect_bucket_worker_count ASPECT_BUCKET_WORKER_COUNT]
                 [--aspect_bucket_alignment {8,16,24,32,64}]
                 [--minimum_image_size MINIMUM_IMAGE_SIZE]
@@ -2881,6 +2889,10 @@ options:
                         so that it can be immediately available
   --dataloader_prefetch_qlen DATALOADER_PREFETCH_QLEN
                         Set the number of prefetched batches
+  --dataloader_prefetch_device_threshold_mb DATALOADER_PREFETCH_DEVICE_THRESHOLD_MB
+                        Minimum CPU batch payload in MiB to page-lock and
+                        transfer on a dedicated CUDA stream during dataloader
+                        prefetch; 0 disables device staging
   --aspect_bucket_worker_count ASPECT_BUCKET_WORKER_COUNT
                         The number of workers to use for aspect bucketing.
                         This is a CPU-bound task, so the number of workers

--- a/documentation/OPTIONS.hi.md
+++ b/documentation/OPTIONS.hi.md
@@ -785,6 +785,13 @@ Alternative attention mechanisms समर्थित हैं, जिनक�
 - **What**: memory में रखे गए batches की संख्या बढ़ाता या घटाता है।
 - **Why**: dataloader prefetch के साथ, डिफ़ॉल्ट रूप से प्रति GPU/process 10 entries memory में रखी जाती हैं। यह बहुत अधिक या बहुत कम हो सकता है। इस मान को बदलकर batches की संख्या समायोजित की जा सकती है।
 
+### `--dataloader_prefetch_device_threshold_mb`
+
+- **What**: MiB में न्यूनतम unique CPU batch payload जिसे dataloader prefetch page-lock करके dedicated CUDA stream पर transfer करता है। `0` device staging बंद करता है।
+- **Why**: बहुत बड़े cached embeddings host-to-device transfer को model work के साथ serial कर सकते हैं। यह विकल्प transfer और GPU compute को overlap करता है।
+- **Memory**: हर staged queue entry pinned host memory और accelerator memory दोनों उपयोग करती है। `dataloader_prefetch_qlen: 2` से शुरू करें और बढ़ाने से पहले profile करें।
+- **Compatibility**: `dataloader_prefetch: true` और CUDA आवश्यक हैं। Context parallelism के साथ यह समर्थित नहीं है।
+
 ### `--compress_disk_cache`
 
 - **What**: VAE और text embed caches को disk पर compress करता है।
@@ -2225,6 +2232,7 @@ usage: train.py [-h] --model_family
                 [--torch_num_threads TORCH_NUM_THREADS]
                 [--dataloader_prefetch [DATALOADER_PREFETCH]]
                 [--dataloader_prefetch_qlen DATALOADER_PREFETCH_QLEN]
+                [--dataloader_prefetch_device_threshold_mb DATALOADER_PREFETCH_DEVICE_THRESHOLD_MB]
                 [--aspect_bucket_worker_count ASPECT_BUCKET_WORKER_COUNT]
                 [--aspect_bucket_alignment {8,16,24,32,64}]
                 [--minimum_image_size MINIMUM_IMAGE_SIZE]
@@ -2878,6 +2886,10 @@ options:
                         so that it can be immediately available
   --dataloader_prefetch_qlen DATALOADER_PREFETCH_QLEN
                         Set the number of prefetched batches
+  --dataloader_prefetch_device_threshold_mb DATALOADER_PREFETCH_DEVICE_THRESHOLD_MB
+                        Minimum CPU batch payload in MiB to page-lock and
+                        transfer on a dedicated CUDA stream during dataloader
+                        prefetch; 0 disables device staging
   --aspect_bucket_worker_count ASPECT_BUCKET_WORKER_COUNT
                         The number of workers to use for aspect bucketing.
                         This is a CPU-bound task, so the number of workers

--- a/documentation/OPTIONS.ja.md
+++ b/documentation/OPTIONS.ja.md
@@ -786,6 +786,13 @@ Accelerate の既定値を使いたい項目は省略してください（例: �
 - **内容**: メモリに保持するバッチ数を増減します。
 - **理由**: dataloader prefetch の既定では GPU/プロセスあたり 10 エントリを保持します。多すぎる/少なすぎる場合に調整できます。
 
+### `--dataloader_prefetch_device_threshold_mb`
+
+- **内容**: dataloader prefetch がページロックし、専用 CUDA ストリームで転送する CPU バッチの最小ユニークペイロードを MiB 単位で指定します。`0` でデバイスへのステージングを無効にします。
+- **理由**: 非常に大きなキャッシュ済み埋め込みでは、ホストからデバイスへの転送とモデル処理が直列化される場合があります。この設定により転送と GPU 計算を重ねます。
+- **メモリ**: ステージングされた各キューエントリは、固定ホストメモリとアクセラレータメモリの両方を消費します。`dataloader_prefetch_qlen: 2` から始め、増やす前にプロファイルしてください。
+- **互換性**: `dataloader_prefetch: true` と CUDA が必要です。context parallelism とは併用できません。
+
 ### `--compress_disk_cache`
 
 - **内容**: VAE とテキスト埋め込みキャッシュをディスク上で圧縮します。
@@ -2228,6 +2235,7 @@ usage: train.py [-h] --model_family
                 [--torch_num_threads TORCH_NUM_THREADS]
                 [--dataloader_prefetch [DATALOADER_PREFETCH]]
                 [--dataloader_prefetch_qlen DATALOADER_PREFETCH_QLEN]
+                [--dataloader_prefetch_device_threshold_mb DATALOADER_PREFETCH_DEVICE_THRESHOLD_MB]
                 [--aspect_bucket_worker_count ASPECT_BUCKET_WORKER_COUNT]
                 [--aspect_bucket_alignment {8,16,24,32,64}]
                 [--minimum_image_size MINIMUM_IMAGE_SIZE]
@@ -2880,6 +2888,10 @@ options:
                         so that it can be immediately available
   --dataloader_prefetch_qlen DATALOADER_PREFETCH_QLEN
                         Set the number of prefetched batches
+  --dataloader_prefetch_device_threshold_mb DATALOADER_PREFETCH_DEVICE_THRESHOLD_MB
+                        Minimum CPU batch payload in MiB to page-lock and
+                        transfer on a dedicated CUDA stream during dataloader
+                        prefetch; 0 disables device staging
   --aspect_bucket_worker_count ASPECT_BUCKET_WORKER_COUNT
                         The number of workers to use for aspect bucketing.
                         This is a CPU-bound task, so the number of workers

--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -792,6 +792,13 @@ This is useful for monitoring tools receiving webhooks from multiple training ru
 - **What**: Increase or reduce the number of batches held in memory.
 - **Why**: When using dataloader prefetch, a default of 10 entries are kept in memory per GPU/process. This may be too much or too little. This value can be adjusted to increase the number of batches prepared in advance.
 
+### `--dataloader_prefetch_device_threshold_mb`
+
+- **What**: Minimum unique CPU batch payload, in MiB, that is page-locked and transferred on a dedicated CUDA stream by dataloader prefetch. `0` disables device staging.
+- **Why**: Very large cached embeddings can otherwise serialize host-to-device transfer with model work. This option overlaps the transfer with GPU compute.
+- **Memory**: Every staged queue entry consumes both pinned host memory and accelerator memory. Start with `dataloader_prefetch_qlen: 2` and profile before increasing it.
+- **Compatibility**: Requires `dataloader_prefetch: true` and CUDA. It is not supported with context parallelism.
+
 ### `--compress_disk_cache`
 
 - **What**: Compress the VAE and text embed caches on-disk.
@@ -2233,6 +2240,7 @@ usage: train.py [-h] --model_family
                 [--torch_num_threads TORCH_NUM_THREADS]
                 [--dataloader_prefetch [DATALOADER_PREFETCH]]
                 [--dataloader_prefetch_qlen DATALOADER_PREFETCH_QLEN]
+                [--dataloader_prefetch_device_threshold_mb DATALOADER_PREFETCH_DEVICE_THRESHOLD_MB]
                 [--aspect_bucket_worker_count ASPECT_BUCKET_WORKER_COUNT]
                 [--aspect_bucket_alignment {8,16,24,32,64}]
                 [--minimum_image_size MINIMUM_IMAGE_SIZE]
@@ -2887,6 +2895,10 @@ options:
                         so that it can be immediately available
   --dataloader_prefetch_qlen DATALOADER_PREFETCH_QLEN
                         Set the number of prefetched batches
+  --dataloader_prefetch_device_threshold_mb DATALOADER_PREFETCH_DEVICE_THRESHOLD_MB
+                        Minimum CPU batch payload in MiB to page-lock and
+                        transfer on a dedicated CUDA stream during dataloader
+                        prefetch; 0 disables device staging
   --aspect_bucket_worker_count ASPECT_BUCKET_WORKER_COUNT
                         The number of workers to use for aspect bucketing.
                         This is a CPU-bound task, so the number of workers

--- a/documentation/OPTIONS.pt-BR.md
+++ b/documentation/OPTIONS.pt-BR.md
@@ -784,6 +784,13 @@ Isso e util para ferramentas de monitoramento que recebem webhooks de varios tre
 - **O que**: Aumenta ou reduz o numero de lotes mantidos em memoria.
 - **Por que**: Quando prefetch esta habilitado, o padrao e manter 10 entradas por GPU/processo em memoria. Esse valor pode ser ajustado para preparar mais ou menos lotes.
 
+### `--dataloader_prefetch_device_threshold_mb`
+
+- **O que**: Carga minima unica do lote na CPU, em MiB, que o prefetch fixa na memoria e transfere em um stream CUDA dedicado. `0` desativa o staging no dispositivo.
+- **Por que**: Embeddings em cache muito grandes podem serializar a transferencia para o dispositivo com o trabalho do modelo. Esta opcao sobrepoe a transferencia ao calculo da GPU.
+- **Memoria**: Cada entrada preparada na fila consome memoria fixa do host e memoria do acelerador. Comece com `dataloader_prefetch_qlen: 2` e meça antes de aumentar.
+- **Compatibilidade**: Requer `dataloader_prefetch: true` e CUDA. Nao e compativel com paralelismo de contexto.
+
 ### `--compress_disk_cache`
 
 - **O que**: Compacta em disco os caches de VAE e embeddings de texto.
@@ -2223,6 +2230,7 @@ usage: train.py [-h] --model_family
                 [--torch_num_threads TORCH_NUM_THREADS]
                 [--dataloader_prefetch [DATALOADER_PREFETCH]]
                 [--dataloader_prefetch_qlen DATALOADER_PREFETCH_QLEN]
+                [--dataloader_prefetch_device_threshold_mb DATALOADER_PREFETCH_DEVICE_THRESHOLD_MB]
                 [--aspect_bucket_worker_count ASPECT_BUCKET_WORKER_COUNT]
                 [--aspect_bucket_alignment {8,16,24,32,64}]
                 [--minimum_image_size MINIMUM_IMAGE_SIZE]
@@ -2875,6 +2883,10 @@ options:
                         so that it can be immediately available
   --dataloader_prefetch_qlen DATALOADER_PREFETCH_QLEN
                         Set the number of prefetched batches
+  --dataloader_prefetch_device_threshold_mb DATALOADER_PREFETCH_DEVICE_THRESHOLD_MB
+                        Minimum CPU batch payload in MiB to page-lock and
+                        transfer on a dedicated CUDA stream during dataloader
+                        prefetch; 0 disables device staging
   --aspect_bucket_worker_count ASPECT_BUCKET_WORKER_COUNT
                         The number of workers to use for aspect bucketing.
                         This is a CPU-bound task, so the number of workers

--- a/documentation/OPTIONS.zh.md
+++ b/documentation/OPTIONS.zh.md
@@ -788,6 +788,13 @@ TRAINING_DYNAMO_BACKEND=inductor
 - **内容**：增减内存中缓存的批次数。
 - **原因**：启用预取后，默认每个 GPU/进程保留 10 个条目。该值可调以增加或减少预取批次数。
 
+### `--dataloader_prefetch_device_threshold_mb`
+
+- **内容**：指定 dataloader 预取进行页锁定并通过专用 CUDA 流传输的最小 CPU 唯一批次载荷（MiB）。`0` 表示禁用设备暂存。
+- **原因**：非常大的缓存嵌入可能会使主机到设备的传输与模型计算串行执行。此选项让传输与 GPU 计算重叠。
+- **内存**：每个暂存的队列条目都会同时消耗固定主机内存和加速器内存。请从 `dataloader_prefetch_qlen: 2` 开始，并在增大前进行性能分析。
+- **兼容性**：需要 `dataloader_prefetch: true` 和 CUDA。不支持与上下文并行同时使用。
+
 ### `--compress_disk_cache`
 
 - **内容**：压缩磁盘上的 VAE 与文本嵌入缓存。
@@ -2230,6 +2237,7 @@ usage: train.py [-h] --model_family
                 [--torch_num_threads TORCH_NUM_THREADS]
                 [--dataloader_prefetch [DATALOADER_PREFETCH]]
                 [--dataloader_prefetch_qlen DATALOADER_PREFETCH_QLEN]
+                [--dataloader_prefetch_device_threshold_mb DATALOADER_PREFETCH_DEVICE_THRESHOLD_MB]
                 [--aspect_bucket_worker_count ASPECT_BUCKET_WORKER_COUNT]
                 [--aspect_bucket_alignment {8,16,24,32,64}]
                 [--minimum_image_size MINIMUM_IMAGE_SIZE]
@@ -2881,6 +2889,10 @@ options:
                         so that it can be immediately available
   --dataloader_prefetch_qlen DATALOADER_PREFETCH_QLEN
                         Set the number of prefetched batches
+  --dataloader_prefetch_device_threshold_mb DATALOADER_PREFETCH_DEVICE_THRESHOLD_MB
+                        Minimum CPU batch payload in MiB to page-lock and
+                        transfer on a dedicated CUDA stream during dataloader
+                        prefetch; 0 disables device staging
   --aspect_bucket_worker_count ASPECT_BUCKET_WORKER_COUNT
                         The number of workers to use for aspect bucketing.
                         This is a CPU-bound task, so the number of workers

--- a/simpletuner/helpers/data_backend/runtime/batch_fetcher.py
+++ b/simpletuner/helpers/data_backend/runtime/batch_fetcher.py
@@ -52,7 +52,14 @@ def _resolve_random_iterator():
 class BatchFetcher:
     """Prefetch batches using the last consumed training step as the first schedule hint."""
 
-    def __init__(self, step: int, max_size: int = 10, datasets: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(
+        self,
+        step: int,
+        max_size: int = 10,
+        datasets: Optional[Dict[str, Any]] = None,
+        device=None,
+        device_prefetch_threshold_bytes: int = 0,
+    ) -> None:
         if DEFAULT_KEEP_RUNNING_PROPERTY is not None:
             type(self).keep_running = DEFAULT_KEEP_RUNNING_PROPERTY
         self.queue = queue.Queue(max_size)
@@ -60,6 +67,14 @@ class BatchFetcher:
         self._keep_running = True
         self.step = step
         self._next_fetch_step = step
+        self.device_prefetcher = None
+        if device_prefetch_threshold_bytes > 0:
+            from .device_prefetch import CudaBatchPrefetcher
+
+            self.device_prefetcher = CudaBatchPrefetcher(
+                device=device,
+                minimum_bytes=device_prefetch_threshold_bytes,
+            )
 
     def start_fetching(self) -> threading.Thread:
         thread = threading.Thread(target=self.fetch_responses)
@@ -93,6 +108,8 @@ class BatchFetcher:
                     except Exception as exc:
                         logger.debug(f"BatchFetcher encountered exception: {exc}")
                         break
+                    if self.device_prefetcher is not None:
+                        item = self.device_prefetcher.prefetch(item)
                     self.queue.put(item)
                     self._next_fetch_step += 1
                     if self.queue.qsize() >= self.queue.maxsize:
@@ -119,6 +136,8 @@ class BatchFetcher:
             continue
         prefetch_log_debug("Queue has data. Yielding next item.")
         item = self.queue.get()
+        if self.device_prefetcher is not None:
+            item = self.device_prefetcher.consume(item)
         _set_epoch_step_for_training_step(step)
         return item
 

--- a/simpletuner/helpers/data_backend/runtime/device_prefetch.py
+++ b/simpletuner/helpers/data_backend/runtime/device_prefetch.py
@@ -1,0 +1,127 @@
+"""CUDA staging for batches produced by the background dataloader fetcher."""
+
+import threading
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import torch
+
+
+def _map_tensors(value: Any, transform: Callable[[torch.Tensor], torch.Tensor], memo=None) -> Any:
+    if memo is None:
+        memo = {}
+    if torch.is_tensor(value):
+        identity = id(value)
+        if identity not in memo:
+            memo[identity] = transform(value)
+        return memo[identity]
+    if isinstance(value, dict):
+        return {key: _map_tensors(child, transform, memo) for key, child in value.items()}
+    if isinstance(value, list):
+        return [_map_tensors(child, transform, memo) for child in value]
+    if isinstance(value, tuple):
+        children = [_map_tensors(child, transform, memo) for child in value]
+        if hasattr(value, "_fields"):
+            return type(value)(*children)
+        return tuple(children)
+    return value
+
+
+def cpu_tensor_bytes(value: Any) -> int:
+    seen = set()
+
+    def count(item: Any) -> int:
+        if torch.is_tensor(item):
+            identity = id(item)
+            if identity in seen or item.device.type != "cpu":
+                return 0
+            seen.add(identity)
+            return item.numel() * item.element_size()
+        if isinstance(item, dict):
+            return sum(count(child) for child in item.values())
+        if isinstance(item, (list, tuple)):
+            return sum(count(child) for child in item)
+        return 0
+
+    return count(value)
+
+
+def _pin_cpu_tensors(value: Any) -> Any:
+    return _map_tensors(
+        value,
+        lambda tensor: tensor.pin_memory() if tensor.device.type == "cpu" and not tensor.is_pinned() else tensor,
+    )
+
+
+def _move_cpu_tensors(value: Any, device: torch.device) -> Any:
+    return _map_tensors(
+        value,
+        lambda tensor: tensor.to(device=device, non_blocking=True) if tensor.device.type == "cpu" else tensor,
+    )
+
+
+def _record_device_stream(value: Any, stream: torch.cuda.Stream) -> Any:
+    def record(tensor: torch.Tensor) -> torch.Tensor:
+        if tensor.device.type == "cuda":
+            tensor.record_stream(stream)
+        return tensor
+
+    return _map_tensors(value, record)
+
+
+@dataclass
+class DevicePrefetchedBatch:
+    batch: Any
+    ready_event: torch.cuda.Event
+    source_batch: Any
+
+
+class CudaBatchPrefetcher:
+    """Page-lock and transfer sufficiently large batches on a dedicated CUDA stream."""
+
+    def __init__(self, device: torch.device, minimum_bytes: int) -> None:
+        if device is None:
+            raise ValueError("CUDA batch prefetch requires an accelerator device")
+        self.device = torch.device(device)
+        if self.device.type != "cuda":
+            raise ValueError("CUDA batch prefetch requires a CUDA device")
+        if minimum_bytes <= 0:
+            raise ValueError("CUDA batch prefetch requires a positive payload threshold")
+        self.minimum_bytes = minimum_bytes
+        self._pending_sources = []
+        self._pending_sources_lock = threading.Lock()
+        with torch.cuda.device(self.device):
+            self.stream = torch.cuda.Stream(device=self.device)
+
+    def _retire_completed_sources(self) -> None:
+        with self._pending_sources_lock:
+            self._pending_sources = [(event, source) for event, source in self._pending_sources if not event.query()]
+
+    def prefetch(self, batch: Any) -> Any:
+        self._retire_completed_sources()
+        if cpu_tensor_bytes(batch) < self.minimum_bytes:
+            return batch
+
+        source_batch = _pin_cpu_tensors(batch)
+        with torch.cuda.device(self.device), torch.cuda.stream(self.stream):
+            device_batch = _move_cpu_tensors(source_batch, self.device)
+            ready_event = torch.cuda.Event(enable_timing=False)
+            ready_event.record(self.stream)
+        return DevicePrefetchedBatch(
+            batch=device_batch,
+            ready_event=ready_event,
+            source_batch=source_batch,
+        )
+
+    def consume(self, value: Any) -> Any:
+        if not isinstance(value, DevicePrefetchedBatch):
+            return value
+
+        with torch.cuda.device(self.device):
+            current_stream = torch.cuda.current_stream(self.device)
+            current_stream.wait_event(value.ready_event)
+            batch = _record_device_stream(value.batch, current_stream)
+            if not value.ready_event.query():
+                with self._pending_sources_lock:
+                    self._pending_sources.append((value.ready_event, value.source_batch))
+        return batch

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -6930,6 +6930,12 @@ class Trainer:
             prefetch_on_rank = not cp_batch_synchronizer.is_cp_enabled or cp_batch_synchronizer.is_cp_leader
             should_prefetch = self.config.dataloader_prefetch and prefetch_on_rank
             if should_prefetch:
+                device_prefetch_threshold_mb = self.config.dataloader_prefetch_device_threshold_mb
+                if device_prefetch_threshold_mb > 0 and cp_batch_synchronizer.is_cp_enabled:
+                    raise ValueError(
+                        "Dataloader device prefetch is not compatible with context-parallel batch broadcasting. "
+                        "Set --dataloader_prefetch_device_threshold_mb=0 when context parallelism is enabled."
+                    )
                 iterator_args = []
                 if self.bf is not None:
                     self.bf.stop_fetching()
@@ -6937,6 +6943,8 @@ class Trainer:
                     datasets=train_backends,
                     max_size=self.config.dataloader_prefetch_qlen,
                     step=step,
+                    device=self.accelerator.device,
+                    device_prefetch_threshold_bytes=int(device_prefetch_threshold_mb * 1024 * 1024),
                 )
                 if fetch_thread is not None:
                     fetch_thread.join()

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/advanced.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/advanced.py
@@ -2246,6 +2246,26 @@ def register_advanced_fields(registry: "FieldRegistry") -> None:
         )
     )
 
+    # Dataloader Device Prefetch Threshold
+    registry._add_field(
+        ConfigField(
+            name="dataloader_prefetch_device_threshold_mb",
+            arg_name="--dataloader_prefetch_device_threshold_mb",
+            ui_label="Dataloader Device Prefetch Threshold",
+            field_type=FieldType.NUMBER,
+            tab="basic",
+            section="data_config",
+            subsection="advanced",
+            default_value=0,
+            validation_rules=[ValidationRule(ValidationRuleType.MIN, value=0, message="Must be at least 0")],
+            help_text="Minimum CPU batch payload in MiB to page-lock and transfer on a dedicated CUDA stream during dataloader prefetch; 0 disables device staging",
+            tooltip="When dataloader prefetch is enabled, batches at or above this CPU payload are page-locked and transferred on a dedicated CUDA stream. Each queued batch consumes additional pinned host memory and accelerator memory. Set to 0 to disable device staging.",
+            importance=ImportanceLevel.ADVANCED,
+            order=66,
+            documentation="OPTIONS.md#--dataloader_prefetch_device_threshold_mb",
+        )
+    )
+
     # Aspect Bucket Worker Count
     registry._add_field(
         ConfigField(

--- a/tests/test_batch_device_prefetch.py
+++ b/tests/test_batch_device_prefetch.py
@@ -1,0 +1,98 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from simpletuner.helpers.data_backend.runtime.device_prefetch import (
+    CudaBatchPrefetcher,
+    DevicePrefetchedBatch,
+    _map_tensors,
+    cpu_tensor_bytes,
+)
+
+
+class BatchDevicePrefetchTests(unittest.TestCase):
+    def test_device_prefetch_requires_an_accelerator_device(self):
+        with self.assertRaisesRegex(ValueError, "accelerator device"):
+            CudaBatchPrefetcher(None, minimum_bytes=1)
+
+    def test_cpu_tensor_bytes_counts_unique_nested_tensors(self):
+        tensor = torch.zeros(4, dtype=torch.float32)
+        batch = {"first": tensor, "nested": [tensor, torch.zeros(2, dtype=torch.int16)]}
+
+        self.assertEqual(cpu_tensor_bytes(batch), 20)
+
+    def test_map_tensors_preserves_aliases(self):
+        tensor = torch.ones(2)
+        mapped = _map_tensors({"first": tensor, "second": [tensor]}, lambda value: value + 1)
+
+        self.assertIs(mapped["first"], mapped["second"][0])
+        torch.testing.assert_close(mapped["first"], torch.full((2,), 2.0))
+
+    @patch("simpletuner.helpers.data_backend.runtime.device_prefetch.torch.cuda.Stream")
+    @patch("simpletuner.helpers.data_backend.runtime.device_prefetch.torch.cuda.device")
+    def test_payload_below_threshold_stays_on_cpu(self, cuda_device, stream_factory):
+        cuda_device.return_value = MagicMock()
+        prefetcher = CudaBatchPrefetcher(torch.device("cuda:0"), minimum_bytes=1024)
+        batch = {"tensor": torch.zeros(4)}
+
+        self.assertIs(prefetcher.prefetch(batch), batch)
+        stream_factory.assert_called_once_with(device=torch.device("cuda:0"))
+
+    @patch("simpletuner.helpers.data_backend.runtime.device_prefetch._record_device_stream")
+    @patch("simpletuner.helpers.data_backend.runtime.device_prefetch._move_cpu_tensors")
+    @patch("simpletuner.helpers.data_backend.runtime.device_prefetch._pin_cpu_tensors")
+    @patch("simpletuner.helpers.data_backend.runtime.device_prefetch.torch.cuda.Event")
+    @patch("simpletuner.helpers.data_backend.runtime.device_prefetch.torch.cuda.Stream")
+    @patch("simpletuner.helpers.data_backend.runtime.device_prefetch.torch.cuda.stream")
+    @patch("simpletuner.helpers.data_backend.runtime.device_prefetch.torch.cuda.device")
+    @patch("simpletuner.helpers.data_backend.runtime.device_prefetch.torch.cuda.current_stream")
+    def test_large_batch_transfers_and_waits_on_consumer_stream(
+        self,
+        current_stream,
+        cuda_device,
+        cuda_stream,
+        stream_factory,
+        event_factory,
+        pin_batch,
+        move_batch,
+        record_stream,
+    ):
+        cuda_device.return_value = MagicMock()
+        cuda_stream.return_value = MagicMock()
+        transfer_stream = stream_factory.return_value
+        ready_event = event_factory.return_value
+        ready_event.query.return_value = False
+        source_batch = {"tensor": "pinned"}
+        device_batch = {"tensor": "cuda"}
+        consumed_batch = {"tensor": "recorded"}
+        pin_batch.return_value = source_batch
+        move_batch.return_value = device_batch
+        record_stream.return_value = consumed_batch
+
+        prefetcher = CudaBatchPrefetcher(torch.device("cuda:0"), minimum_bytes=1)
+        queued = prefetcher.prefetch({"tensor": torch.zeros(2)})
+
+        self.assertIsInstance(queued, DevicePrefetchedBatch)
+        self.assertIs(queued.source_batch, source_batch)
+        move_batch.assert_called_once_with(source_batch, torch.device("cuda:0"))
+        ready_event.record.assert_called_once_with(transfer_stream)
+
+        result = prefetcher.consume(queued)
+
+        self.assertIs(result, consumed_batch)
+        current_stream.return_value.wait_event.assert_called_once_with(ready_event)
+        record_stream.assert_called_once_with(device_batch, current_stream.return_value)
+        self.assertEqual(prefetcher._pending_sources, [(ready_event, source_batch)])
+
+    def test_prefetch_threshold_field_is_registered(self):
+        from simpletuner.simpletuner_sdk.server.services.field_registry.registry import FieldRegistry
+
+        field = FieldRegistry().get_field("dataloader_prefetch_device_threshold_mb")
+
+        self.assertEqual(field.arg_name, "--dataloader_prefetch_device_threshold_mb")
+        self.assertEqual(field.default_value, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add opt-in CUDA staging to the existing background `BatchFetcher`
- page-lock sufficiently large CPU batches and transfer them on a dedicated CUDA stream
- synchronize consumption with CUDA events and retain source storage until the transfer completes
- expose `dataloader_prefetch_device_threshold_mb`, defaulting to `0` so existing behavior is unchanged
- reject device staging with context-parallel object broadcasting and document the queue memory cost in every option translation

## Motivation

End-to-end H100 profiling showed that a startup pool of exact-shape pinned buffers does not improve steady-state throughput. PyTorch's caching host allocator already stabilizes after queue fill, while a pool adds a recurring CPU copy.

The useful optimization was producer-side overlap for very large cached batches. For an LTX 2.5 workload with a 367.51 MiB CPU payload, the measured post-warmup median changed from 3.9581 s/step without prefetch to 3.2833 s/step with producer prefetch and 3.1917 s/step with dedicated pinned transfer. Anima and Krea2 did not show a stable dedicated-transfer benefit, so this is payload-thresholded rather than enabled globally or keyed to a model family.

Each staged queue entry consumes pinned host memory and accelerator memory. The documentation recommends starting with `dataloader_prefetch_qlen: 2` and profiling before increasing it.

## Tests

```text
.venv/bin/python -m unittest -v tests.test_batch_device_prefetch tests.test_runtime_components
```

63 tests passed.
