### PR TITLE
Fix SDNQ compilation across FakeTensor and checkpoint contexts

### DIFF
--- a/simpletuner/helpers/training/sdnq_workarounds.py
+++ b/simpletuner/helpers/training/sdnq_workarounds.py
@@ -1,8 +1,13 @@
 import logging
 
+import torch
+
 logger = logging.getLogger(__name__)
 
 _PATCHED_FROM_FLOAT_ATTR = "_simpletuner_patched_from_float"
+_PATCHED_GET_HADAMARD_ATTR = "_simpletuner_fake_safe_get_hadamard"
+_PATCHED_SCALED_MM_ATTR = "_simpletuner_allocator_safe_scaled_mm"
+_TRITON_ALLOCATOR_ATTR = "_simpletuner_sdnq_allocator"
 
 
 def _detect_fake_mode(tensor) -> object | None:
@@ -14,22 +19,104 @@ def _detect_fake_mode(tensor) -> object | None:
         return None
 
 
+def _install_triton_allocator() -> bool:
+    try:
+        import triton
+        from triton.runtime import _allocation
+    except ImportError:
+        return False
+
+    allocator_state = getattr(_allocation, "_allocator", None)
+    null_allocator = getattr(_allocation, "NullAllocator", None)
+    set_allocator = getattr(triton, "set_allocator", None)
+    if allocator_state is None or null_allocator is None or not callable(set_allocator):
+        return False
+    try:
+        current_allocator = allocator_state.get()
+    except (AttributeError, LookupError):
+        return False
+    if not isinstance(current_allocator, null_allocator):
+        return False
+
+    def torch_cuda_allocator(size: int, alignment: int, stream: int | None):
+        del alignment, stream
+        return torch.empty(size, dtype=torch.uint8, device=torch.device("cuda", torch.cuda.current_device()))
+
+    setattr(torch_cuda_allocator, _TRITON_ALLOCATOR_ATTR, True)
+    set_allocator(torch_cuda_allocator)
+    logger.debug("Registered the PyTorch CUDA caching allocator for SDNQ Triton scratch buffers.")
+    return True
+
+
+def _patch_sdnq_scaled_mm_allocator_context() -> bool:
+    try:
+        from sdnq.kernels.triton_scaled_mm import sdnq_scaled_mm
+    except ImportError:
+        return False
+
+    backend_fns = getattr(sdnq_scaled_mm, "_backend_fns", None)
+    if not isinstance(backend_fns, dict):
+        return False
+
+    backend = backend_fns.get(None)
+    if backend is None or getattr(backend, _PATCHED_SCALED_MM_ATTR, False):
+        return False
+
+    def allocator_safe_scaled_mm(*args, **kwargs):
+        # Triton's allocator is stored in a ContextVar. Activation checkpoint
+        # recomputation can run in a fresh context, so startup registration is
+        # insufficient for SDNQ's tensor-descriptor scratch allocations.
+        _install_triton_allocator()
+        return backend(*args, **kwargs)
+
+    setattr(allocator_safe_scaled_mm, _PATCHED_SCALED_MM_ATTR, True)
+    backend_fns[None] = allocator_safe_scaled_mm
+    logger.debug("Patched the SDNQ scaled-matmul backend to register its Triton allocator per execution context.")
+    return True
+
+
 def apply_sdnq_workarounds() -> None:
     try:
+        import sdnq.dequantizer as sdnq_dequantizer
+        import sdnq.quant_utils as sdnq_quant_utils
         from sdnq.training.tensor import SDNQTensor
     except ImportError:
         return
 
-    if getattr(SDNQTensor, _PATCHED_FROM_FLOAT_ATTR, False):
-        return
+    _install_triton_allocator()
+    _patch_sdnq_scaled_mm_allocator_context()
 
-    original_from_float = SDNQTensor.from_float
+    if not getattr(SDNQTensor, _PATCHED_FROM_FLOAT_ATTR, False):
+        original_from_float = SDNQTensor.from_float
 
-    def from_float_dequantizing_existing_sdnq(weight, *args, **kwargs):
-        if isinstance(weight, SDNQTensor) and _detect_fake_mode(weight) is None:
-            weight = weight.dequantize()
-        return original_from_float(weight, *args, **kwargs)
+        def from_float_dequantizing_existing_sdnq(weight, *args, **kwargs):
+            if isinstance(weight, SDNQTensor) and _detect_fake_mode(weight) is None:
+                weight = weight.dequantize()
+            return original_from_float(weight, *args, **kwargs)
 
-    SDNQTensor.from_float = staticmethod(from_float_dequantizing_existing_sdnq)
-    setattr(SDNQTensor, _PATCHED_FROM_FLOAT_ATTR, True)
-    logger.debug("Patched SDNQTensor.from_float to dequantize existing SDNQTensor inputs before requantizing.")
+        SDNQTensor.from_float = staticmethod(from_float_dequantizing_existing_sdnq)
+        setattr(SDNQTensor, _PATCHED_FROM_FLOAT_ATTR, True)
+        logger.debug("Patched SDNQTensor.from_float to dequantize existing SDNQTensor inputs before requantizing.")
+
+    get_hadamard = sdnq_quant_utils.get_hadamard
+    if not getattr(get_hadamard, _PATCHED_GET_HADAMARD_ATTR, False):
+
+        def fake_safe_get_hadamard(n, dtype=None, device=None):
+            if torch.compiler.is_compiling():
+                # SDNQ compiles weight quantization separately. Dynamo already
+                # executes tensor construction under FakeTensorMode there, and
+                # returning the mode object through the FX graph is unsupported.
+                return sdnq_quant_utils.build_hadamard(n, dtype=dtype, device=device)
+            fake_mode = _detect_fake_mode(None)
+            if fake_mode is None:
+                return get_hadamard(n, dtype=dtype, device=device)
+            # SDNQ's global cache may contain a real CUDA tensor from eager
+            # quantization. Reusing it while Dynamo traces FakeTensors makes
+            # the Hadamard matmul mix real and fake inputs.
+            with fake_mode:
+                return sdnq_quant_utils.build_hadamard(n, dtype=dtype, device=device)
+
+        setattr(fake_safe_get_hadamard, _PATCHED_GET_HADAMARD_ATTR, True)
+        sdnq_quant_utils.get_hadamard = fake_safe_get_hadamard
+        sdnq_dequantizer.get_hadamard = fake_safe_get_hadamard
+        logger.debug("Patched SDNQ Hadamard lookup to avoid real tensors during FakeTensor tracing.")

--- a/tests/test_quantization_config_parsing.py
+++ b/tests/test_quantization_config_parsing.py
@@ -105,6 +105,104 @@ class TestQuantizationConfigParsing(unittest.TestCase):
         with patch.dict(sys.modules, {"torch._guards": guards}):
             self.assertIsNone(_detect_fake_mode(object()))
 
+    def test_sdnq_hadamard_cache_does_not_leak_real_tensor_into_fake_mode(self):
+        import sdnq.dequantizer as sdnq_dequantizer
+        import sdnq.quant_utils as sdnq_quant_utils
+        import torch
+        from sdnq.training.tensor import SDNQTensor
+        from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+
+        from simpletuner.helpers.training.sdnq_workarounds import _PATCHED_FROM_FLOAT_ATTR, apply_sdnq_workarounds
+
+        original_get_hadamard = sdnq_quant_utils.get_hadamard
+        original_dequantizer_get_hadamard = sdnq_dequantizer.get_hadamard
+        original_from_float = SDNQTensor.from_float
+        original_from_float_patched = getattr(SDNQTensor, _PATCHED_FROM_FLOAT_ATTR, False)
+        cache_key = (4, torch.device("cpu"), torch.float32)
+        original_cached = sdnq_quant_utils.HADAMARD_MATRIX_CACHE.get(cache_key)
+        try:
+            sdnq_quant_utils.HADAMARD_MATRIX_CACHE[cache_key] = torch.eye(4)
+            apply_sdnq_workarounds()
+            with FakeTensorMode():
+                result = sdnq_quant_utils.get_hadamard(4, dtype=torch.float32, device=torch.device("cpu"))
+            self.assertIsInstance(result, FakeTensor)
+
+            sentinel = object()
+            with (
+                patch.object(torch.compiler, "is_compiling", return_value=True),
+                patch.object(sdnq_quant_utils, "build_hadamard", return_value=sentinel) as build,
+            ):
+                self.assertIs(sdnq_quant_utils.get_hadamard(4, dtype=torch.float32, device=torch.device("cpu")), sentinel)
+            build.assert_called_once_with(4, dtype=torch.float32, device=torch.device("cpu"))
+        finally:
+            sdnq_quant_utils.get_hadamard = original_get_hadamard
+            sdnq_dequantizer.get_hadamard = original_dequantizer_get_hadamard
+            SDNQTensor.from_float = staticmethod(original_from_float)
+            setattr(SDNQTensor, _PATCHED_FROM_FLOAT_ATTR, original_from_float_patched)
+            if original_cached is None:
+                sdnq_quant_utils.HADAMARD_MATRIX_CACHE.pop(cache_key, None)
+            else:
+                sdnq_quant_utils.HADAMARD_MATRIX_CACHE[cache_key] = original_cached
+
+    def test_sdnq_installs_triton_allocator_only_for_null_default(self):
+        from simpletuner.helpers.training.sdnq_workarounds import _TRITON_ALLOCATOR_ATTR, _install_triton_allocator
+
+        class NullAllocator:
+            pass
+
+        state = SimpleNamespace(current=NullAllocator(), installed=None)
+        allocation_module = ModuleType("triton.runtime._allocation")
+        allocation_module.NullAllocator = NullAllocator
+        allocation_module._allocator = SimpleNamespace(get=lambda: state.current)
+        runtime_module = ModuleType("triton.runtime")
+        runtime_module._allocation = allocation_module
+        triton_module = ModuleType("triton")
+        triton_module.runtime = runtime_module
+        triton_module.set_allocator = lambda allocator: setattr(state, "installed", allocator)
+
+        with patch.dict(
+            sys.modules,
+            {
+                "triton": triton_module,
+                "triton.runtime": runtime_module,
+                "triton.runtime._allocation": allocation_module,
+            },
+        ):
+            self.assertTrue(_install_triton_allocator())
+            self.assertTrue(getattr(state.installed, _TRITON_ALLOCATOR_ATTR))
+            state.current = object()
+            self.assertFalse(_install_triton_allocator())
+
+    def test_sdnq_scaled_mm_installs_allocator_in_execution_context(self):
+        from simpletuner.helpers.training.sdnq_workarounds import (
+            _PATCHED_SCALED_MM_ATTR,
+            _patch_sdnq_scaled_mm_allocator_context,
+        )
+
+        calls = []
+        custom_op = SimpleNamespace(_backend_fns={None: lambda value: calls.append(("backend", value)) or value})
+        kernels_module = ModuleType("sdnq.kernels")
+        scaled_mm_module = ModuleType("sdnq.kernels.triton_scaled_mm")
+        scaled_mm_module.sdnq_scaled_mm = custom_op
+
+        with (
+            patch.dict(
+                sys.modules,
+                {
+                    "sdnq.kernels": kernels_module,
+                    "sdnq.kernels.triton_scaled_mm": scaled_mm_module,
+                },
+            ),
+            patch("simpletuner.helpers.training.sdnq_workarounds._install_triton_allocator") as install,
+        ):
+            self.assertTrue(_patch_sdnq_scaled_mm_allocator_context())
+            self.assertFalse(_patch_sdnq_scaled_mm_allocator_context())
+            self.assertEqual(custom_op._backend_fns[None](17), 17)
+
+        install.assert_called_once_with()
+        self.assertEqual(calls, [("backend", 17)])
+        self.assertTrue(getattr(custom_op._backend_fns[None], _PATCHED_SCALED_MM_ATTR))
+
     def test_sdnq_compile_mode_sets_env_before_import(self):
         from simpletuner.helpers.training.sdnq_compile import configure_sdnq_compile_mode
 


### PR DESCRIPTION
## Summary

- make SDNQ Hadamard construction safe during Dynamo FakeTensor tracing
- prevent SDNQ's global Hadamard cache from mixing cached real tensors into fake-mode graphs
- register a PyTorch-backed Triton scratch allocator when the current Triton execution context has no allocator
- restore that allocator inside SDNQ scaled-matmul calls used by activation-checkpoint recomputation
- keep all workarounds guarded and idempotent

## Motivation

The compiled int8-SDNQ training path failed for two independent reasons. Eager quantization could populate SDNQ's global Hadamard cache with real CUDA tensors that were later returned while Dynamo was tracing FakeTensors. Separately, Triton's allocator is held in context-local state, and activation-checkpoint recomputation can execute SDNQ scaled matmul in a fresh context with a null allocator.

The patch bypasses the Hadamard cache only while compiling or tracing in fake mode, preserving the normal eager cache. It installs the scratch allocator only when Triton reports its null allocator, preserving any allocator already configured by the runtime.

In an end-to-end H100 Krea2 run, the corrected default-mode regional compile path reached a 0.8023 s post-warmup median with int8-SDNQ. A compiled BF16 control reached 0.7870 s, indicating no material steady-state SDNQ penalty. This PR deliberately does not change the separate `reduce-overhead` CUDA Graph path, which still exposes a PyTorch replay failure.

## Tests

```text
.venv/bin/python -m unittest -v tests.test_quantization_config_parsing
```

15 tests passed.
