### PR TITLE
Make LTX regional compilation fully capturable

### DIFF
--- a/simpletuner/helpers/models/ltxvideo2/transformer.py
+++ b/simpletuner/helpers/models/ltxvideo2/transformer.py
@@ -251,10 +251,17 @@ def _ltx2_prepare_flash_attention_metadata(
         max_seqlen_k = seq_len_kv
     else:
         seqlens_k = keep_mask.sum(dim=1, dtype=torch.int32)
-        if torch.any(seqlens_k == 0):
+        if not torch.compiler.is_compiling() and torch.any(seqlens_k == 0):
             raise ValueError("LTX-2 varlen attention received a mask with no valid key/value tokens.")
-        indices_k = keep_mask.flatten().nonzero(as_tuple=False).flatten()
-        max_seqlen_k = int(seqlens_k.max().item())
+        flat_keep_mask = keep_mask.flatten()
+        valid_destinations = torch.cumsum(flat_keep_mask, dim=0, dtype=torch.int64) - 1
+        invalid_destinations = (
+            flat_keep_mask.sum(dtype=torch.int64) + torch.cumsum(~flat_keep_mask, dim=0, dtype=torch.int64) - 1
+        )
+        destinations = torch.where(flat_keep_mask, valid_destinations, invalid_destinations)
+        source_indices = torch.arange(flat_keep_mask.numel(), device=device)
+        indices_k = torch.empty_like(source_indices).scatter(0, destinations, source_indices)
+        max_seqlen_k = seq_len_kv
 
     cu_seqlens_q = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
     cu_seqlens_k = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
@@ -282,6 +289,10 @@ def _ltx2_flash_varlen_hub_attention_prepared(
     else:
         key_packed = key.flatten(0, 1)[metadata.indices_k]
         value_packed = value.flatten(0, 1)[metadata.indices_k]
+        valid_rows = torch.arange(key_packed.shape[0], device=key.device) < metadata.cu_seqlens_k[-1]
+        valid_rows = valid_rows[:, None, None]
+        key_packed = torch.where(valid_rows, key_packed, torch.zeros_like(key_packed))
+        value_packed = torch.where(valid_rows, value_packed, torch.zeros_like(value_packed))
 
     func = _HUB_KERNELS_REGISTRY[AttentionBackendName.FLASH_VARLEN_HUB].kernel_fn
     if func is None:
@@ -303,6 +314,38 @@ def _ltx2_flash_varlen_hub_attention_prepared(
     if isinstance(output, tuple):
         output = output[0]
     return output.unflatten(0, (batch_size, seq_len_q))
+
+
+def _ltx2_native_efficient_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: Optional[torch.Tensor],
+) -> torch.Tensor:
+    query, key, value = (tensor.permute(0, 2, 1, 3) for tensor in (query, key, value))
+    if attention_mask is not None and attention_mask.dtype == torch.bool:
+        zero = torch.zeros((), dtype=query.dtype, device=query.device)
+        masked = torch.full((), torch.finfo(query.dtype).min, dtype=query.dtype, device=query.device)
+        attention_mask = torch.where(attention_mask, zero, masked)
+    elif attention_mask is not None and attention_mask.dtype != query.dtype:
+        attention_mask = attention_mask.to(query.dtype)
+    if attention_mask is not None and attention_mask.shape[-2] != query.shape[-2]:
+        attention_mask = attention_mask.expand(*attention_mask.shape[:-2], query.shape[-2], attention_mask.shape[-1])
+    if attention_mask is not None and attention_mask.shape[-1] % 8:
+        key_length = attention_mask.shape[-1]
+        padding = 8 - key_length % 8
+        attention_mask = torch.nn.functional.pad(attention_mask, (0, padding))[..., :key_length]
+    output, _, _, _ = torch.ops.aten._scaled_dot_product_efficient_attention(
+        query,
+        key,
+        value,
+        attention_mask,
+        True,
+        dropout_p=0.0,
+        is_causal=False,
+        scale=None,
+    )
+    return output.permute(0, 2, 1, 3)
 
 
 def _ltx2_dispatch_attention(
@@ -333,6 +376,8 @@ def _ltx2_dispatch_attention(
                 raise ValueError("Precomputed LTX-2 Flash Attention metadata does not support context parallelism.")
             return _ltx2_flash_varlen_hub_attention_prepared(query, key, value, flash_attention_metadata)
         attention_mask = _ltx2_normalize_varlen_mask(attention_mask, key.shape[0], key.shape[1])
+    if backend_name == AttentionBackendName._NATIVE_EFFICIENT and parallel_config is None:
+        return _ltx2_native_efficient_attention(query, key, value, attention_mask)
     return dispatch_attention_fn(
         query,
         key,
@@ -2637,7 +2682,8 @@ class LTX2VideoTransformer3DModel(
                 for processor in attention_processors
             ) and all(getattr(processor, "_parallel_config", None) is None for processor in attention_processors)
             if use_prepared_flash_attention:
-                _maybe_download_kernel_for_backend(AttentionBackendName.FLASH_VARLEN_HUB)
+                if not torch.compiler.is_compiling():
+                    _maybe_download_kernel_for_backend(AttentionBackendName.FLASH_VARLEN_HUB)
 
                 def prepare_flash_metadata(mask, seq_len_q, seq_len_kv):
                     return _ltx2_prepare_flash_attention_metadata(

--- a/simpletuner/helpers/training/checkpointing.py
+++ b/simpletuner/helpers/training/checkpointing.py
@@ -13,7 +13,4 @@ def checkpoint(function: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
     use_reentrant = kwargs.get("use_reentrant")
     if use_reentrant is False and _dynamo_backend_enabled():
         kwargs.setdefault("determinism_check", "none")
-        if torch.compiler.is_compiling():
-            checkpoint_eager = torch.compiler.disable(torch.utils.checkpoint.checkpoint)
-            return checkpoint_eager(function, *args, **kwargs)
     return torch.utils.checkpoint.checkpoint(function, *args, **kwargs)

--- a/tests/test_ltxvideo2_attention.py
+++ b/tests/test_ltxvideo2_attention.py
@@ -116,6 +116,41 @@ class TestLTX2AttentionDispatch(unittest.TestCase):
         prepared_attention.assert_called_once_with(query, key, value, metadata)
         dispatch_attention.assert_not_called()
 
+    def test_native_efficient_uses_compile_safe_direct_operator_without_context_parallelism(self):
+        query = torch.randn(1, 2, 1, 4)
+        key = torch.randn(1, 3, 1, 4)
+        value = torch.randn(1, 3, 1, 4)
+        expected = torch.randn(1, 2, 1, 4)
+
+        with (
+            patch.object(ltx2_transformer, "_ltx2_native_efficient_attention", return_value=expected) as native_attention,
+            patch.object(ltx2_transformer, "dispatch_attention_fn") as dispatch_attention,
+        ):
+            result = ltx2_transformer._ltx2_dispatch_attention(
+                query=query,
+                key=key,
+                value=value,
+                attention_mask=None,
+                backend=AttentionBackendName._NATIVE_EFFICIENT,
+                parallel_config=None,
+            )
+
+        self.assertIs(result, expected)
+        native_attention.assert_called_once_with(query, key, value, None)
+        dispatch_attention.assert_not_called()
+
+    def test_native_efficient_expands_broadcast_query_mask(self):
+        query = torch.randn(1, 5, 2, 8)
+        key = torch.randn(1, 7, 2, 8)
+        value = torch.randn(1, 7, 2, 8)
+        attention_mask = torch.ones(1, 1, 1, 7, dtype=torch.bool)
+
+        with patch.object(torch.ops.aten, "_scaled_dot_product_efficient_attention") as efficient_attention:
+            efficient_attention.return_value = (torch.randn(1, 2, 5, 8), None, None, None)
+            ltx2_transformer._ltx2_native_efficient_attention(query, key, value, attention_mask)
+
+        self.assertEqual(efficient_attention.call_args.args[3].shape, (1, 1, 5, 7))
+
     def test_prepares_flash_metadata_once_for_masked_keys(self):
         metadata = ltx2_transformer._ltx2_prepare_flash_attention_metadata(
             torch.tensor([[True, False, True], [True, True, False]]),
@@ -125,11 +160,11 @@ class TestLTX2AttentionDispatch(unittest.TestCase):
             device=torch.device("cpu"),
         )
 
-        self.assertTrue(torch.equal(metadata.indices_k, torch.tensor([0, 2, 3, 4])))
+        self.assertTrue(torch.equal(metadata.indices_k, torch.tensor([0, 2, 3, 4, 1, 5])))
         self.assertTrue(torch.equal(metadata.cu_seqlens_q, torch.tensor([0, 4, 8], dtype=torch.int32)))
         self.assertTrue(torch.equal(metadata.cu_seqlens_k, torch.tensor([0, 2, 4], dtype=torch.int32)))
         self.assertEqual(metadata.max_seqlen_q, 4)
-        self.assertEqual(metadata.max_seqlen_k, 2)
+        self.assertEqual(metadata.max_seqlen_k, 3)
 
     def test_prompt_timesteps_use_batch_axis_from_tokenwise_timesteps(self):
         timesteps = torch.tensor([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])

--- a/tests/test_training_checkpointing.py
+++ b/tests/test_training_checkpointing.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import Mock, patch
 
+import torch
+
 from simpletuner.helpers.training import checkpointing
 
 
@@ -37,6 +39,21 @@ class TrainingCheckpointingTests(unittest.TestCase):
             checkpointing.checkpoint(function, "input", use_reentrant=False, determinism_check="default")
 
         mock_checkpoint.assert_called_once_with(function, "input", use_reentrant=False, determinism_check="default")
+
+    def test_non_reentrant_checkpoint_captures_in_fullgraph(self):
+        def forward(value):
+            return checkpointing.checkpoint(torch.sin, value, use_reentrant=False)
+
+        eager_input = torch.randn(8, requires_grad=True)
+        compiled_input = eager_input.detach().clone().requires_grad_(True)
+        with patch.dict("os.environ", {"TRAINING_DYNAMO_BACKEND": "inductor"}, clear=False):
+            eager_output = forward(eager_input)
+            compiled_output = torch.compile(forward, backend="eager", fullgraph=True)(compiled_input)
+
+        eager_output.sum().backward()
+        compiled_output.sum().backward()
+        self.assertTrue(torch.equal(eager_output, compiled_output))
+        self.assertTrue(torch.equal(eager_input.grad, compiled_input.grad))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Stack

Follows the mask and Flash Attention metadata hoisting merged in #3156. This PR contains the compile-safe follow-up commit.

## Summary

Remove the remaining graph breaks from LTX-2 regional compilation: replace data-dependent Flash Attention packing operations with a static-shape tensor formulation, invoke native efficient SDPA directly, and keep non-reentrant gradient checkpointing inside the compiled graph.

## Why

After #3156, repeated blocks no longer rebuilt invariant masks, but three capture problems remained:

1. FA2 metadata still used `nonzero()` and `.item()`, creating data-dependent graph boundaries.
2. Diffusers native-efficient backend selection entered a dynamic dispatch context for every region and changed compiler identities across runs.
3. SimpleTuner dynamically wrapped non-reentrant checkpointing with `torch.compiler.disable()`, preventing fullgraph capture.

## Changes

- Build packed FA2 indices with cumulative sums and scatter into a static-length tensor.
- Zero padded key/value rows while cumulative sequence lengths retain the real packed lengths.
- Use a conservative static maximum sequence length accepted by the varlen kernel.
- Call `aten._scaled_dot_product_efficient_attention` directly when context parallelism is inactive.
- Normalize boolean masks, expand the query axis, and preserve key-stride alignment in that direct path.
- Retain the existing dispatcher when context parallelism is active.
- Skip lazy Flash kernel download while Dynamo is compiling.
- Let PyTorch capture non-reentrant checkpointing natively with `fullgraph=True`.

## Performance

On one H100 with the LTX-2.5 22B 768x512/49-frame LoRA example, including the prerequisite from #3156:

| path | warm step p50 |
| --- | ---: |
| eager native-efficient SDPA | 3.687 s |
| regional compile, Python wrapper | 4.502 s |
| regional compile, C++ wrapper | 2.622 s |

The compiled C++ path is about 29% faster than eager. Profiling showed regional compilation removed 35,772 CUDA launches and about 383 ms of GPU kernel work per step; the C++ wrapper avoids the host launch-pacing penalty that obscured those savings in the Python-wrapper path.

## Validation

- `python -m unittest tests.test_ltxvideo2_attention tests.test_training_checkpointing`
- 12 focused tests pass.
- Native-efficient and prepared FA2 paths cover dispatch, mask broadcasting, static metadata, and fullgraph checkpoint capture.
- H100 regional training smoke completed with expected losses and approximately 49 GiB peak VRAM.