### PR TITLE
Persist and reuse Torch compiler Mega-Caches

### DIFF
--- a/documentation/OPTIONS.es.md
+++ b/documentation/OPTIONS.es.md
@@ -602,6 +602,23 @@ Para persistir los ajustes en `config.json`, añade las claves equivalentes:
 
 Omite cualquier entrada que quieras heredar de los valores predeterminados de Accelerate (por ejemplo, deja fuera `dynamo_mode` para usar la selección automática).
 
+### `--dynamo_wrapper`
+
+Selecciona el wrapper de host de TorchInductor. `cpp` es el valor predeterminado y reduce el overhead de despacho; `python` conserva el comportamiento de versiones anteriores. La selección forma parte del nombre y manifiesto de Mega-Cache.
+
+### `--dynamo_cache_export`
+
+Ruta opcional para un blob acumulativo de PyTorch Mega-Cache. SimpleTuner carga un blob compatible antes de compilar, lo exporta tras el primer paso exitoso del optimizador y comprueba si hay nuevas claves de artefactos tras cada checkpoint y al finalizar. El manifiesto `<ruta>.manifest.json` registra el entorno PyTorch/Triton/GPU y una suma SHA256. Si una forma no está cubierta, PyTorch compila normalmente y el siguiente exportado incorpora esos artefactos. Usa únicamente cachés de confianza que coincidan con el runtime.
+Si el valor es un directorio, termina en un separador o no tiene extensión, SimpleTuner genera allí un nombre estable basado en el modelo, runtime, acelerador y configuración relevante para el grafo, y busca el mismo nombre en Hub.
+
+### `--dynamo_cache_export_after_first_step`
+
+Cuando es `true` (predeterminado), exporta la Mega-Cache tras el primer paso exitoso. Establece `false` para omitir solo esta exportación temprana; las exportaciones de checkpoints y finalización siguen activas.
+
+### `--dynamo_hub_repo_id`
+
+Repositorio opcional de Hugging Face para recuperar y publicar el blob indicado por `--dynamo_cache_export`. El blob y su manifiesto se publican juntos en un solo commit; un repositorio inexistente se crea como privado. Los fallos de Hub no interrumpen el entrenamiento y la copia local se conserva.
+
 ### `--attention_mechanism`
 
 Se soportan mecanismos de atención alternativos, con distintos niveles de compatibilidad u otros compromisos:

--- a/documentation/OPTIONS.hi.md
+++ b/documentation/OPTIONS.hi.md
@@ -601,6 +601,23 @@ Settings को `config.json` में persist करने के लिए �
 
 यदि आप Accelerate defaults inherit करना चाहते हैं तो संबंधित entries छोड़ दें (उदा., `dynamo_mode` न दें ताकि automatic selection उपयोग हो)।
 
+### `--dynamo_wrapper`
+
+TorchInductor का host wrapper चुनता है। `cpp` default है और dispatch overhead घटाता है; `python` पुराने releases का behavior बनाए रखता है। यह चयन Mega-Cache filename और manifest में शामिल होता है।
+
+### `--dynamo_cache_export`
+
+PyTorch Mega-Cache के cumulative blob की optional path। SimpleTuner compilation से पहले compatible blob load करता है, पहले सफल optimizer step के बाद export करता है, और हर checkpoint तथा shutdown पर नई artifact keys की जांच करता है। `<path>.manifest.json` में PyTorch/Triton/GPU runtime और SHA256 दर्ज होते हैं। किसी नई shape के लिए cache entry न मिलने पर PyTorch सामान्य compilation करता है और अगला export नए artifacts जोड़ देता है। केवल trusted cache blobs load करें।
+यदि value directory है, separator पर समाप्त होती है, या उसकी extension नहीं है, तो SimpleTuner model, runtime, accelerator और graph-relevant config से stable filename बनाता है और Hub पर भी वही नाम खोजता है।
+
+### `--dynamo_cache_export_after_first_step`
+
+`true` (default) होने पर पहले सफल optimizer step के बाद Mega-Cache export होती है। केवल इस early export को छोड़ने के लिए `false` करें; checkpoint और final exports सक्रिय रहते हैं।
+
+### `--dynamo_hub_repo_id`
+
+`--dynamo_cache_export` blob को retrieve और publish करने के लिए optional Hugging Face repository। Blob और manifest एक ही commit में upload होते हैं; missing repository private रूप में बनाई जाती है। Hub failure training को abort नहीं करता और local export सुरक्षित रहता है।
+
 ### `--attention_mechanism`
 
 Alternative attention mechanisms समर्थित हैं, जिनके compatibility स्तर या trade‑offs अलग होते हैं:

--- a/documentation/OPTIONS.ja.md
+++ b/documentation/OPTIONS.ja.md
@@ -602,6 +602,23 @@ TRAINING_DYNAMO_BACKEND=inductor
 
 Accelerate の既定値を使いたい項目は省略してください（例: 自動選択の `dynamo_mode` を使うなら省略）。
 
+### `--dynamo_wrapper`
+
+TorchInductor の host wrapper を選択します。`cpp` が既定で dispatch overhead を削減し、`python` は以前の release の動作を維持します。この選択は Mega-Cache の filename と manifest に含まれます。
+
+### `--dynamo_cache_export`
+
+累積 PyTorch Mega-Cache blob の任意パスです。SimpleTuner はコンパイル前に互換 blob を読み込み、最初の成功した optimizer step 後に保存し、各 checkpoint と終了時に新しい artifact key を確認します。`<path>.manifest.json` に PyTorch/Triton/GPU runtime と SHA256 を記録します。未対応の shape は通常どおりコンパイルされ、次の export に追加されます。信頼できる cache blob のみ使用してください。
+値が directory、区切り文字で終わる path、または拡張子のない path の場合、model、runtime、accelerator、graph 関連設定から安定した filename を生成し、Hub でも同じ名前を検索します。
+
+### `--dynamo_cache_export_after_first_step`
+
+`true`（既定）の場合、最初の成功した optimizer step 後に Mega-Cache を export します。`false` はこの初回 export のみを無効にし、checkpoint と終了時の export は継続します。
+
+### `--dynamo_hub_repo_id`
+
+`--dynamo_cache_export` blob の取得と公開に使う任意の Hugging Face repository です。Blob と manifest は 1 commit でアップロードされ、存在しない repository は private で作成されます。Hub 障害で学習は中断されず、local export は保持されます。
+
 ### `--attention_mechanism`
 
 代替アテンション機構が利用可能で、互換性やトレードオフが異なります:

--- a/documentation/OPTIONS.md
+++ b/documentation/OPTIONS.md
@@ -608,6 +608,41 @@ To persist the settings in `config.json`, add the equivalent keys:
 
 Omit any entries you want to inherit from Accelerate’s defaults (for example, leave out `dynamo_mode` to use automatic selection).
 
+### `--dynamo_wrapper`
+
+Select the host-side wrapper used by TorchInductor. `cpp` is the default and reduces Python dispatch overhead for large compiled regions. Set `python` to retain the wrapper behavior used by earlier SimpleTuner releases. SimpleTuner applies the selection before loading or compiling graphs and includes it in generated Mega-Cache names and manifests.
+
+### `--dynamo_cache_export`
+
+Optional path for a cumulative PyTorch `torch.compile` Mega-Cache blob. At startup, SimpleTuner loads a compatible blob from this path before any model compilation. After the first successful optimizer step it exports the compiled AOTAutograd, Inductor, Triton, autotuning, and PGO artifacts so a later training failure does not discard the cold compile. At normal shutdown it re-exports only when PyTorch reports additional artifact keys, such as those generated for a newly encountered latent shape.
+
+When the value ends in a path separator, identifies an existing directory, or has no filename suffix, SimpleTuner generates a stable filename in that directory. The generated name includes the model family and flavour, accelerator, PyTorch runtime digest, and a digest of graph-relevant configuration such as precision, attention, checkpointing, and LoRA layout. Supplying an explicit filename such as `ltx25-h100.ptcache` uses that name unchanged.
+
+SimpleTuner writes a compatibility manifest beside the blob as `<path>.manifest.json`. The manifest records the exact PyTorch, Triton, CUDA/ROCm, Python, platform, and accelerator identity plus advisory model and compilation configuration signatures. An obvious runtime mismatch is rejected before loading; PyTorch's own cache keys and guards remain authoritative for graph, dtype, stride, and shape compatibility. If no entry covers a batch, training continues with normal runtime compilation and the new artifacts are merged into the next export.
+
+Use runtime-specific paths to avoid replacing a useful cache when changing compiler or hardware versions, for example:
+
+```json
+{
+  "dynamo_backend": "inductor",
+  "dynamo_wrapper": "cpp",
+  "dynamo_use_regional_compilation": true,
+  "dynamo_cache_export": "compiler-caches/ltx25-h100-torch2.11-cu128.ptcache"
+}
+```
+
+Compiler cache blobs contain generated executable code. Load them only from paths and repositories you trust.
+
+### `--dynamo_cache_export_after_first_step`
+
+When `true` (the default), export the Dynamo Mega-Cache immediately after the first successful optimizer step. This protects the expensive initial compile if training later fails. SimpleTuner also checks for new compiler artifact keys after every successful scheduled, manual, rolling, or epoch checkpoint and at normal training completion. Set this option to `false` to skip only the first-step export.
+
+### `--dynamo_hub_repo_id`
+
+Optional Hugging Face model repository used with `--dynamo_cache_export`. SimpleTuner checks the configured relative blob path in this repository before falling back to the local path. If compilation adds artifacts, the blob and manifest are written locally and published together in one Hub commit. A missing repository is created as private. Existing repositories retain their current visibility.
+
+Absolute local export paths use only their filename on the Hub. Relative paths are preserved, so `compiler-caches/ltx25.ptcache` is stored under the same repository subdirectory. For a directory value, SimpleTuner looks for the same generated standard filename locally and on the Hub. Authentication uses `HF_TOKEN`, `HUGGING_FACE_HUB_TOKEN`, or the standard Hugging Face token cache. Hub failures never abort training; the local cache remains available for a later upload attempt.
+
 ### `--attention_mechanism`
 
 Alternative attention mechanisms are supported, with varying levels of compatibility or other trade-offs:

--- a/documentation/OPTIONS.pt-BR.md
+++ b/documentation/OPTIONS.pt-BR.md
@@ -600,6 +600,23 @@ Para persistir as configuracoes em `config.json`, adicione as chaves equivalente
 
 Omitir entradas que voce quer herdar dos defaults do Accelerate (por exemplo, deixe `dynamo_mode` ausente para selecao automatica).
 
+### `--dynamo_wrapper`
+
+Seleciona o wrapper host do TorchInductor. `cpp` e o padrao e reduz overhead de dispatch; `python` preserva o comportamento de releases anteriores. A escolha faz parte do filename e manifesto da Mega-Cache.
+
+### `--dynamo_cache_export`
+
+Caminho opcional para um blob cumulativo do PyTorch Mega-Cache. O SimpleTuner carrega um blob compativel antes da compilacao, exporta apos o primeiro passo bem-sucedido do otimizador e verifica novas chaves de artefatos apos cada checkpoint e no encerramento. O manifesto `<caminho>.manifest.json` registra o runtime PyTorch/Triton/GPU e o SHA256. Shapes sem entrada sao compilados normalmente e seus artefatos entram na proxima exportacao. Carregue apenas caches confiaveis.
+Quando o valor e um diretorio, termina em separador ou nao possui extensao, o SimpleTuner gera um filename estavel com base no modelo, runtime, acelerador e configuracao relevante ao grafo, procurando o mesmo nome no Hub.
+
+### `--dynamo_cache_export_after_first_step`
+
+Quando `true` (padrao), exporta a Mega-Cache apos o primeiro passo bem-sucedido. Use `false` para omitir apenas essa exportacao inicial; exportacoes em checkpoints e no final continuam ativas.
+
+### `--dynamo_hub_repo_id`
+
+Repositorio opcional do Hugging Face para recuperar e publicar o blob de `--dynamo_cache_export`. Blob e manifesto sao enviados juntos em um unico commit; um repositorio ausente e criado como privado. Falhas do Hub nao interrompem o treino e a exportacao local e preservada.
+
 ### `--attention_mechanism`
 
 Mecanismos de atencao alternativos sao suportados, com diferentes niveis de compatibilidade e trade-offs:

--- a/documentation/OPTIONS.zh.md
+++ b/documentation/OPTIONS.zh.md
@@ -604,6 +604,23 @@ TRAINING_DYNAMO_BACKEND=inductor
 
 省略你希望继承 Accelerate 默认值的项（例如省略 `dynamo_mode` 以使用自动选择）。
 
+### `--dynamo_wrapper`
+
+选择 TorchInductor 的 host wrapper。`cpp` 为默认值并减少调度开销；`python` 保留旧版本行为。该选择会写入 Mega-Cache 文件名和 manifest。
+
+### `--dynamo_cache_export`
+
+累积 PyTorch Mega-Cache blob 的可选路径。SimpleTuner 会在编译前加载兼容 blob，在第一个成功的优化器步骤后导出，并在每次 checkpoint 和关闭时检查新的 artifact key。`<路径>.manifest.json` 会记录 PyTorch/Triton/GPU 运行时和 SHA256。未覆盖的 shape 会正常编译，其产物会加入下一次导出。只应加载可信的缓存 blob。
+当该值是目录、以路径分隔符结尾或没有扩展名时，SimpleTuner 会根据模型、运行时、加速器和影响计算图的配置生成稳定文件名，并在 Hub 上查找同名文件。
+
+### `--dynamo_cache_export_after_first_step`
+
+为 `true`（默认）时，在第一个成功的优化器步骤后导出 Mega-Cache。设为 `false` 只会跳过这次早期导出；checkpoint 和训练结束导出仍会执行。
+
+### `--dynamo_hub_repo_id`
+
+用于获取和发布 `--dynamo_cache_export` blob 的可选 Hugging Face 仓库。Blob 与 manifest 会在一次 commit 中上传；不存在的仓库会创建为 private。Hub 故障不会中止训练，本地导出仍会保留。
+
 ### `--attention_mechanism`
 
 支持多种注意力机制，兼容性与权衡不同：

--- a/simpletuner/helpers/training/dynamo.py
+++ b/simpletuner/helpers/training/dynamo.py
@@ -1,5 +1,6 @@
 import contextlib
 import contextvars
+import importlib
 import logging
 import os
 from collections.abc import Callable, Iterator
@@ -59,6 +60,17 @@ def _normalise_text(value: Any) -> str:
     return str(value).strip().lower().replace("_", "-")
 
 
+def _effective_dynamo_backend(config: Any) -> str:
+    config_backend = _normalise_text(getattr(config, "dynamo_backend", None))
+    training_backend = _normalise_text(os.environ.get("TRAINING_DYNAMO_BACKEND"))
+    accelerate_backend = _normalise_text(os.environ.get("ACCELERATE_DYNAMO_BACKEND"))
+    inactive = {"", "no", "none", "disabled"}
+    for backend in (config_backend, training_backend, accelerate_backend):
+        if backend not in inactive:
+            return backend
+    return "no"
+
+
 def apply_checkpointing_cudagraph_compatibility(config: Any) -> bool:
     backend = _normalise_text(getattr(config, "dynamo_backend", None))
     mode = _normalise_text(getattr(config, "dynamo_mode", None))
@@ -78,12 +90,35 @@ def apply_checkpointing_cudagraph_compatibility(config: Any) -> bool:
     return True
 
 
+def configure_inductor_wrapper(config: Any) -> str:
+    """Apply the selected Inductor runtime wrapper before any graphs compile."""
+    configured_wrapper = getattr(config, "dynamo_wrapper", None)
+    if not isinstance(configured_wrapper, str):
+        configured_wrapper = None
+    wrapper = _normalise_text(configured_wrapper) or "cpp"
+    if wrapper in {"cpp", "c++"}:
+        wrapper = "cpp"
+        enabled = True
+    elif wrapper == "python":
+        enabled = False
+    else:
+        raise ValueError("--dynamo_wrapper must be either 'cpp' or 'python'.")
+
+    if _effective_dynamo_backend(config) != "inductor":
+        return wrapper
+
+    os.environ["TORCHINDUCTOR_CPP_WRAPPER"] = "1" if enabled else "0"
+    try:
+        inductor_config = importlib.import_module("torch._inductor.config")
+        inductor_config.cpp_wrapper = enabled
+    except Exception as exc:
+        logger.warning("Unable to configure the TorchInductor %s wrapper: %s", wrapper, exc)
+    logger.info("TorchInductor wrapper: %s", wrapper)
+    return wrapper
+
+
 def _inductor_cudagraphs_enabled(config: Any = None) -> bool:
-    config_backend = _normalise_text(getattr(config, "dynamo_backend", None))
-    training_backend = _normalise_text(os.environ.get("TRAINING_DYNAMO_BACKEND"))
-    accelerate_backend = _normalise_text(os.environ.get("ACCELERATE_DYNAMO_BACKEND"))
-    backend = config_backend or training_backend or accelerate_backend
-    if backend != "inductor":
+    if _effective_dynamo_backend(config) != "inductor":
         return False
 
     config_mode = _normalise_text(getattr(config, "dynamo_mode", None))

--- a/simpletuner/helpers/training/dynamo_cache.py
+++ b/simpletuner/helpers/training/dynamo_cache.py
@@ -1,0 +1,482 @@
+import hashlib
+import importlib.metadata
+import json
+import logging
+import os
+import platform
+import struct
+import sys
+import tempfile
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import torch
+from huggingface_hub import CommitOperationAdd, HfApi, hf_hub_download
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA_VERSION = 2
+_BUNDLE_MAGIC = b"SIMPLETUNER_DYNAMO_MEGACACHE\x00\x02"
+_CONFIG_SIGNATURE_FIELDS = (
+    "model_family",
+    "model_flavour",
+    "model_type",
+    "revision",
+    "variant",
+    "resolution",
+    "resolution_type",
+    "base_model_precision",
+    "model_precision",
+    "mixed_precision",
+    "quantize_via",
+    "quantization_config",
+    "attention_mechanism",
+    "dynamo_backend",
+    "dynamo_mode",
+    "dynamo_fullgraph",
+    "dynamo_dynamic",
+    "dynamo_use_regional_compilation",
+    "dynamo_wrapper",
+    "gradient_checkpointing",
+    "gradient_checkpointing_backend",
+    "gradient_checkpointing_interval",
+    "gradient_checkpointing_segment_stride",
+    "gradient_checkpointing_offload_attention",
+    "gradient_checkpointing_offload_prefetch",
+    "train_batch_size",
+    "lora_type",
+    "lora_rank",
+    "lora_alpha",
+    "lora_dropout",
+    "lora_target",
+    "lora_format",
+    "fsdp_enable",
+    "fsdp_sharding_strategy",
+    "musubi_blocks_to_swap",
+    "ramtorch",
+    "ramtorch_target_modules",
+    "ramtorch_transformer_percent",
+    "context_parallel_size",
+    "tensor_parallel_size",
+    "xm_training_target",
+    "distillation_method",
+)
+
+
+def _json_value(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, dict):
+        return {str(key): _json_value(item) for key, item in sorted(value.items(), key=lambda item: str(item[0]))}
+    if isinstance(value, set):
+        normalized_items = [_json_value(item) for item in value]
+        return sorted(normalized_items, key=lambda item: json.dumps(item, sort_keys=True))
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, Enum):
+        return _json_value(value.value)
+    return str(value)
+
+
+def _package_version(package_name: str) -> str | None:
+    try:
+        return importlib.metadata.version(package_name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _runtime_signature() -> dict[str, Any]:
+    accelerator: dict[str, Any]
+    if torch.cuda.is_available():
+        device_index = torch.cuda.current_device()
+        accelerator = {
+            "type": "cuda",
+            "name": torch.cuda.get_device_name(device_index),
+            "capability": list(torch.cuda.get_device_capability(device_index)),
+        }
+    else:
+        accelerator = {"type": "cpu"}
+
+    return {
+        "torch": torch.__version__,
+        "triton": _package_version("triton"),
+        "cuda": getattr(torch.version, "cuda", None),
+        "hip": getattr(torch.version, "hip", None),
+        "python": f"{sys.version_info.major}.{sys.version_info.minor}",
+        "platform_system": platform.system(),
+        "platform_machine": platform.machine(),
+        "accelerator": accelerator,
+    }
+
+
+def _software_signature() -> dict[str, str | None]:
+    return {package: _package_version(package) for package in ("simpletuner", "diffusers", "accelerate", "peft")}
+
+
+def _config_signature(config: Any) -> tuple[str, dict[str, Any]]:
+    values = {field: _json_value(getattr(config, field, None)) for field in _CONFIG_SIGNATURE_FIELDS}
+    values["torchinductor_cpp_wrapper"] = os.environ.get("TORCHINDUCTOR_CPP_WRAPPER")
+    serialized = json.dumps(values, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(serialized).hexdigest(), values
+
+
+def _cache_keys(cache_info: Any) -> dict[str, set[str]]:
+    artifacts = getattr(cache_info, "artifacts", None) or {}
+    return {str(kind): {str(key) for key in keys} for kind, keys in artifacts.items()}
+
+
+def _cache_counts(cache_keys: dict[str, set[str]]) -> dict[str, int]:
+    return {kind: len(keys) for kind, keys in sorted(cache_keys.items())}
+
+
+def _merge_cache_keys(*inventories: dict[str, set[str]]) -> dict[str, set[str]]:
+    merged: dict[str, set[str]] = {}
+    for inventory in inventories:
+        for kind, keys in inventory.items():
+            merged.setdefault(kind, set()).update(keys)
+    return merged
+
+
+def _sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _slug(value: Any, fallback: str) -> str:
+    normalized = "".join(character.lower() if character.isalnum() else "-" for character in str(value or ""))
+    normalized = "-".join(part for part in normalized.split("-") if part)
+    return normalized or fallback
+
+
+def _pack_segments(segments: list[bytes]) -> bytes:
+    payload = bytearray(_BUNDLE_MAGIC)
+    payload.extend(struct.pack(">I", len(segments)))
+    for segment in segments:
+        payload.extend(struct.pack(">Q", len(segment)))
+        payload.extend(segment)
+    return bytes(payload)
+
+
+def _unpack_segments(payload: bytes) -> list[bytes]:
+    if not payload.startswith(_BUNDLE_MAGIC):
+        return [payload]
+    offset = len(_BUNDLE_MAGIC)
+    if len(payload) < offset + 4:
+        raise ValueError("Dynamo cache bundle is truncated before its segment count.")
+    segment_count = struct.unpack_from(">I", payload, offset)[0]
+    offset += 4
+    segments: list[bytes] = []
+    for _ in range(segment_count):
+        if len(payload) < offset + 8:
+            raise ValueError("Dynamo cache bundle is truncated before a segment length.")
+        segment_length = struct.unpack_from(">Q", payload, offset)[0]
+        offset += 8
+        segment_end = offset + segment_length
+        if segment_end > len(payload):
+            raise ValueError("Dynamo cache bundle contains a truncated segment.")
+        segments.append(payload[offset:segment_end])
+        offset = segment_end
+    if offset != len(payload):
+        raise ValueError("Dynamo cache bundle contains trailing data.")
+    if not segments:
+        raise ValueError("Dynamo cache bundle contains no segments.")
+    return segments
+
+
+def _atomic_write(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    file_descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(file_descriptor, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, path)
+    except Exception:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+class DynamoCacheManager:
+    """Load, grow, and optionally publish PyTorch Mega-Cache artifacts."""
+
+    def __init__(self, config: Any):
+        configured_path = getattr(config, "dynamo_cache_export", None)
+        self.enabled = isinstance(configured_path, (str, os.PathLike)) and str(configured_path) not in (
+            "",
+            "None",
+        )
+        self.config = config
+        configured_hub_repo = getattr(config, "dynamo_hub_repo_id", None)
+        if isinstance(configured_hub_repo, str):
+            self.hub_repo_id = configured_hub_repo.strip() or None
+        else:
+            self.hub_repo_id = None
+        self.runtime_signature = _runtime_signature()
+        self.config_signature, self.config_values = _config_signature(config)
+        self.generated_filename = self._standard_filename()
+        self.local_path, directory_mode = self._resolve_local_path(configured_path)
+        self.manifest_path = Path(f"{self.local_path}.manifest.json") if self.local_path is not None else None
+        self.hub_path = self._hub_path(str(configured_path), directory_mode) if self.enabled else None
+        self.hub_manifest_path = f"{self.hub_path}.manifest.json" if self.hub_path else None
+        self.known_keys: dict[str, set[str]] = {}
+        self.base_segments: list[bytes] = []
+        self.base_keys: dict[str, set[str]] = {}
+        self.process_keys: dict[str, set[str]] = {}
+        self.manifest: dict[str, Any] = {}
+        self.loaded = False
+        self.first_step_export_attempted = False
+
+        if self.hub_repo_id and not self.enabled:
+            raise ValueError("--dynamo_hub_repo_id requires --dynamo_cache_export to name the cache blob.")
+
+    def _standard_filename(self) -> str:
+        model = _slug(getattr(self.config, "model_family", None), "model")
+        flavour = _slug(getattr(self.config, "model_flavour", None), "default")
+        accelerator = _slug(self.runtime_signature.get("accelerator", {}).get("name"), "cpu")
+        torch_version = _slug(self.runtime_signature.get("torch"), "torch")
+        runtime_payload = json.dumps(self.runtime_signature, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        runtime_digest = hashlib.sha256(runtime_payload).hexdigest()[:10]
+        return (
+            f"simpletuner-dynamo-{model}-{flavour}-{accelerator}-{torch_version}-"
+            f"{runtime_digest}-{self.config_signature[:12]}.ptcache"
+        )
+
+    def _resolve_local_path(self, configured_path: Any) -> tuple[Path | None, bool]:
+        if not self.enabled:
+            return None, False
+        raw_path = str(configured_path)
+        expanded = Path(os.path.expanduser(raw_path))
+        directory_mode = raw_path.endswith(("/", "\\")) or expanded.is_dir() or not expanded.suffix
+        if directory_mode:
+            expanded = expanded / self.generated_filename
+        return expanded, directory_mode
+
+    def _hub_path(self, configured_path: str, directory_mode: bool) -> str:
+        expanded = Path(os.path.expanduser(configured_path))
+        if expanded.is_absolute():
+            return self.generated_filename if directory_mode else expanded.name
+        candidate = PurePosixPath(configured_path.replace("\\", "/"))
+        if ".." in candidate.parts:
+            raise ValueError("--dynamo_cache_export cannot contain '..' when used as a Hub artifact path.")
+        normalized = str(candidate).lstrip("./")
+        if not normalized:
+            raise ValueError("--dynamo_cache_export must name a file.")
+        if directory_mode:
+            normalized = str(PurePosixPath(normalized) / self.generated_filename)
+        return normalized
+
+    @staticmethod
+    def _hub_token() -> str | None:
+        return os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+
+    def _runtime_compatible(self, manifest: dict[str, Any]) -> bool:
+        expected = manifest.get("runtime")
+        return not expected or expected == self.runtime_signature
+
+    def _read_local_source(self) -> tuple[bytes, dict[str, Any]] | None:
+        if self.local_path is None or not self.local_path.is_file():
+            return None
+        manifest: dict[str, Any] = {}
+        if self.manifest_path is not None and self.manifest_path.is_file():
+            manifest = json.loads(self.manifest_path.read_text(encoding="utf-8"))
+        return self.local_path.read_bytes(), manifest
+
+    def _read_hub_source(self) -> tuple[bytes, dict[str, Any]] | None:
+        if self.hub_repo_id is None or self.hub_path is None:
+            return None
+        api = HfApi(token=self._hub_token())
+        if not api.file_exists(self.hub_repo_id, self.hub_path, token=self._hub_token()):
+            return None
+        blob_path = hf_hub_download(
+            repo_id=self.hub_repo_id,
+            filename=self.hub_path,
+            token=self._hub_token(),
+        )
+        manifest: dict[str, Any] = {}
+        if self.hub_manifest_path and api.file_exists(
+            self.hub_repo_id,
+            self.hub_manifest_path,
+            token=self._hub_token(),
+        ):
+            downloaded_manifest = hf_hub_download(
+                repo_id=self.hub_repo_id,
+                filename=self.hub_manifest_path,
+                token=self._hub_token(),
+            )
+            manifest = json.loads(Path(downloaded_manifest).read_text(encoding="utf-8"))
+        return Path(blob_path).read_bytes(), manifest
+
+    def load(self) -> bool:
+        if not self.enabled:
+            return False
+        load_cache_artifacts = getattr(torch.compiler, "load_cache_artifacts", None)
+        if load_cache_artifacts is None:
+            logger.warning("This PyTorch build does not support Mega-Cache loading; continuing without a Dynamo cache.")
+            return False
+
+        sources: list[tuple[str, tuple[bytes, dict[str, Any]]]] = []
+        if self.hub_repo_id is not None:
+            try:
+                hub_source = self._read_hub_source()
+                if hub_source is not None:
+                    sources.append((f"{self.hub_repo_id}/{self.hub_path}", hub_source))
+            except Exception as exc:
+                logger.warning("Unable to retrieve Dynamo cache from %s: %s", self.hub_repo_id, exc)
+        try:
+            local_source = self._read_local_source()
+            if local_source is not None:
+                sources.append((str(self.local_path), local_source))
+        except Exception as exc:
+            logger.warning("Unable to read local Dynamo cache %s: %s", self.local_path, exc)
+        if not sources:
+            logger.info(
+                "No existing Dynamo Mega-Cache found at %s; it will be exported after compilation.",
+                self.local_path,
+            )
+            return False
+
+        for source_name, (payload, manifest) in sources:
+            schema_version = manifest.get("schema_version") if manifest else None
+            if schema_version is not None and schema_version > _SCHEMA_VERSION:
+                logger.warning(
+                    "Dynamo cache %s uses unsupported manifest schema %s; ignoring it.",
+                    source_name,
+                    schema_version,
+                )
+                continue
+            if manifest and not self._runtime_compatible(manifest):
+                logger.warning(
+                    "Dynamo cache %s was created for a different PyTorch/Triton/device runtime; ignoring it. "
+                    "Use a runtime-specific cache path to preserve both variants.",
+                    source_name,
+                )
+                continue
+            expected_hash = manifest.get("sha256") if manifest else None
+            if expected_hash and expected_hash != _sha256(payload):
+                logger.warning("Dynamo cache %s failed its SHA256 check; ignoring it.", source_name)
+                continue
+            if not manifest:
+                logger.warning(
+                    "Loading explicitly configured Dynamo cache %s without a compatibility manifest.",
+                    source_name,
+                )
+
+            try:
+                segments = _unpack_segments(payload)
+                loaded_inventories = []
+                for segment in segments:
+                    cache_info = load_cache_artifacts(segment)
+                    if cache_info is None:
+                        raise ValueError("PyTorch returned no cache inventory for a bundle segment.")
+                    loaded_inventories.append(_cache_keys(cache_info))
+            except Exception as exc:
+                logger.warning("PyTorch rejected Dynamo cache %s: %s", source_name, exc)
+                continue
+            self.base_segments = segments
+            self.base_keys = _merge_cache_keys(*loaded_inventories)
+            self.known_keys = _merge_cache_keys(self.base_keys)
+            self.process_keys = {}
+            self.manifest = manifest
+            self.loaded = True
+            logger.info("Loaded Dynamo Mega-Cache %s with artifacts: %s", source_name, _cache_counts(self.known_keys))
+            return True
+        return False
+
+    def _build_manifest(
+        self,
+        payload: bytes,
+        cache_keys: dict[str, set[str]],
+        segment_count: int,
+    ) -> dict[str, Any]:
+        config_signatures = dict(self.manifest.get("config_signatures") or {})
+        config_signatures[self.config_signature] = self.config_values
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "sha256": _sha256(payload),
+            "size_bytes": len(payload),
+            "segment_count": segment_count,
+            "runtime": self.runtime_signature,
+            "software": _software_signature(),
+            "artifact_counts": _cache_counts(cache_keys),
+            "config_signatures": config_signatures,
+        }
+
+    def _upload(self, payload: bytes, manifest_payload: bytes, reason: str) -> None:
+        if self.hub_repo_id is None or self.hub_path is None or self.hub_manifest_path is None:
+            return
+        token = self._hub_token()
+        api = HfApi(token=token)
+        api.create_repo(repo_id=self.hub_repo_id, token=token, exist_ok=True, private=True)
+        api.create_commit(
+            repo_id=self.hub_repo_id,
+            token=token,
+            commit_message=f"Update SimpleTuner Dynamo cache ({reason})",
+            operations=[
+                CommitOperationAdd(path_in_repo=self.hub_path, path_or_fileobj=payload),
+                CommitOperationAdd(path_in_repo=self.hub_manifest_path, path_or_fileobj=manifest_payload),
+            ],
+        )
+
+    def export(self, reason: str) -> bool:
+        if not self.enabled or self.local_path is None or self.manifest_path is None:
+            return False
+        save_cache_artifacts = getattr(torch.compiler, "save_cache_artifacts", None)
+        if save_cache_artifacts is None:
+            logger.warning("This PyTorch build does not support Mega-Cache export.")
+            return False
+        try:
+            result = save_cache_artifacts()
+        except Exception as exc:
+            logger.warning("Unable to serialize the Dynamo Mega-Cache: %s", exc)
+            return False
+        if result is None:
+            logger.info("PyTorch produced no Dynamo cache artifacts to export during %s.", reason)
+            return False
+
+        process_payload, cache_info = result
+        process_keys = _cache_keys(cache_info)
+        new_keys = {
+            kind: keys - self.known_keys.get(kind, set())
+            for kind, keys in process_keys.items()
+            if keys - self.known_keys.get(kind, set())
+        }
+        if not new_keys:
+            logger.info("Dynamo Mega-Cache has no new artifacts during %s; skipping re-export.", reason)
+            return False
+        cache_keys = _merge_cache_keys(self.base_keys, process_keys)
+        segments = [*self.base_segments, process_payload]
+        payload = _pack_segments(segments)
+        manifest = self._build_manifest(payload, cache_keys, len(segments))
+        manifest_payload = json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8") + b"\n"
+        try:
+            _atomic_write(self.local_path, payload)
+            _atomic_write(self.manifest_path, manifest_payload)
+        except Exception as exc:
+            logger.warning("Unable to write Dynamo Mega-Cache to %s: %s", self.local_path, exc)
+            return False
+
+        self.known_keys = cache_keys
+        self.process_keys = process_keys
+        self.manifest = manifest
+        logger.info(
+            "Exported Dynamo Mega-Cache to %s with new artifacts %s.",
+            self.local_path,
+            _cache_counts(new_keys),
+        )
+        if self.hub_repo_id is not None:
+            try:
+                self._upload(payload, manifest_payload, reason)
+                logger.info("Published Dynamo Mega-Cache to %s/%s.", self.hub_repo_id, self.hub_path)
+            except Exception as exc:
+                logger.warning(
+                    "Unable to publish Dynamo Mega-Cache to %s: %s. The local export remains available.",
+                    self.hub_repo_id,
+                    exc,
+                )
+        return True

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -71,9 +71,11 @@ from simpletuner.helpers.training.deepspeed_optimizers import sanitize_optimizer
 from simpletuner.helpers.training.default_settings.safety_check import safety_check
 from simpletuner.helpers.training.dynamo import (
     apply_checkpointing_cudagraph_compatibility,
+    configure_inductor_wrapper,
     install_cudagraph_workarounds,
     mark_cudagraph_step_begin,
 )
+from simpletuner.helpers.training.dynamo_cache import DynamoCacheManager
 from simpletuner.helpers.training.evaluation import ModelEvaluator
 from simpletuner.helpers.training.exceptions import GPUHealthError
 from simpletuner.helpers.training.gpu_circuit_breaker import get_current_gpu_index, get_gpu_circuit_breaker, is_cuda_error
@@ -270,6 +272,7 @@ class Trainer:
     sidecar_is_schedulefree = False
     sidecar_scheduler_disabled = False
     publishing_manager = None
+    dynamo_cache_manager = None
     _cleanup_invoked = False
 
     def __init__(
@@ -293,6 +296,7 @@ class Trainer:
         self.webhook_handler = None
         self.custom_tracker = None
         self.publishing_manager = None
+        self.dynamo_cache_manager = None
         self.should_abort = False
         self._external_abort_checker = None
         self._manual_validation_consumer: Optional[Callable[[], bool]] = None
@@ -322,6 +326,11 @@ class Trainer:
         except Exception as e:
             self._send_webhook_msg(f"Error: {e}", message_level="critical")
             raise e
+
+        if getattr(self, "config", None) is not None:
+            configure_inductor_wrapper(self.config)
+            self.dynamo_cache_manager = DynamoCacheManager(self.config)
+            self.dynamo_cache_manager.load()
 
         if getattr(self, "config", None) is not None:
             logger.info(
@@ -354,6 +363,33 @@ class Trainer:
         if not config:
             return None
         return type("Config", (object,), config)
+
+    def _export_dynamo_cache(self, reason: str) -> None:
+        manager = self.dynamo_cache_manager
+        if manager is None or not manager.enabled:
+            return
+        if self.accelerator is not None:
+            self.accelerator.wait_for_everyone()
+        try:
+            if self.accelerator is None or self.accelerator.is_main_process:
+                manager.export(reason=reason)
+        except Exception as exc:
+            logger.warning("Unexpected failure while exporting the Dynamo Mega-Cache: %s", exc)
+        finally:
+            if self.accelerator is not None:
+                self.accelerator.wait_for_everyone()
+
+    def _export_dynamo_cache_after_first_step(self) -> None:
+        manager = self.dynamo_cache_manager
+        if (
+            manager is None
+            or not manager.enabled
+            or manager.first_step_export_attempted
+            or not getattr(self.config, "dynamo_cache_export_after_first_step", True)
+        ):
+            return
+        manager.first_step_export_attempted = True
+        self._export_dynamo_cache(reason="first successful optimizer step")
 
     def register_manual_validation_trigger(self, consumer: Callable[[], bool]) -> None:
         """Register a callable that returns True once per manual validation request."""
@@ -5705,6 +5741,8 @@ class Trainer:
                 checkpoint_limit,
                 protected_checkpoint=save_path,
             )
+        checkpoint_step = getattr(self, "state", {}).get("global_step", "unknown")
+        self._export_dynamo_cache(reason=f"checkpoint {checkpoint_step}")
 
         hub_upload_planned = upload_to_hub and self.hub_manager is not None
         if hub_upload_planned and not defer_hub_upload:
@@ -5729,6 +5767,8 @@ class Trainer:
                 "rolling",
                 protected_checkpoint=save_path,
             )
+        checkpoint_step = getattr(self, "state", {}).get("global_step", "unknown")
+        self._export_dynamo_cache(reason=f"rolling checkpoint {checkpoint_step}")
         return save_path
 
     def _send_webhook_msg(
@@ -7353,6 +7393,7 @@ class Trainer:
                     current_epoch_step += 1
                     StateTracker.set_global_step(self.state["global_step"])
                     self.iteration_tracker.record_step(self.state["global_step"])
+                    self._export_dynamo_cache_after_first_step()
                     if ramtorch_profile.profile_enabled():
                         ramtorch_profile.record_train_step(
                             self.state["global_step"],
@@ -7814,6 +7855,7 @@ class Trainer:
                     job_id=self.job_id,
                 )
                 self._emit_event(event)
+        self._export_dynamo_cache(reason="training completion")
         self.accelerator.end_training()
         # Emit training_complete event after all model saving and validation is complete
         event = lifecycle_stage_event(

--- a/simpletuner/simpletuner_sdk/server/services/field_registry/sections/advanced.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_registry/sections/advanced.py
@@ -2154,6 +2154,100 @@ def register_advanced_fields(registry: "FieldRegistry") -> None:
         )
     )
 
+    registry._add_field(
+        ConfigField(
+            name="dynamo_wrapper",
+            arg_name="--dynamo_wrapper",
+            ui_label="TorchInductor Wrapper",
+            field_type=FieldType.SELECT,
+            tab="hardware",
+            section="accelerate",
+            subsection="advanced",
+            default_value="cpp",
+            choices=[
+                {"value": "cpp", "label": "C++ (recommended)"},
+                {"value": "python", "label": "Python (legacy)"},
+            ],
+            help_text="Selects the host-side wrapper used to dispatch TorchInductor kernels.",
+            tooltip="The C++ wrapper is the default because it substantially reduces launch pacing overhead for large compiled regions. Python preserves earlier SimpleTuner behavior.",
+            dependencies=[
+                FieldDependency(field="i_know_what_i_am_doing", operator="equals", value=True, action="show"),
+                FieldDependency(field="dynamo_backend", operator="equals", value="inductor", action="show"),
+            ],
+            importance=ImportanceLevel.EXPERIMENTAL,
+            order=55,
+            documentation="OPTIONS.md#--dynamo_wrapper",
+        )
+    )
+
+    registry._add_field(
+        ConfigField(
+            name="dynamo_cache_export",
+            arg_name="--dynamo_cache_export",
+            ui_label="Dynamo Mega-Cache Path",
+            field_type=FieldType.TEXT,
+            tab="hardware",
+            section="accelerate",
+            subsection="advanced",
+            default_value=None,
+            allow_empty=True,
+            help_text="Load and cumulatively export PyTorch compiler cache artifacts at this path.",
+            tooltip="The cache is loaded before compilation, exported after the first optimizer step, and checked for new artifacts at checkpoints and shutdown.",
+            dependencies=[
+                FieldDependency(field="i_know_what_i_am_doing", operator="equals", value=True, action="show"),
+                FieldDependency(field="dynamo_backend", operator="not_equals", value="no", action="show"),
+            ],
+            importance=ImportanceLevel.EXPERIMENTAL,
+            order=56,
+            documentation="OPTIONS.md#--dynamo_cache_export",
+        )
+    )
+
+    registry._add_field(
+        ConfigField(
+            name="dynamo_cache_export_after_first_step",
+            arg_name="--dynamo_cache_export_after_first_step",
+            ui_label="Export Dynamo Cache After First Step",
+            field_type=FieldType.CHECKBOX,
+            tab="hardware",
+            section="accelerate",
+            subsection="advanced",
+            default_value=True,
+            help_text="Persist compiler artifacts immediately after the first successful optimizer step.",
+            tooltip="Enabled by default so a later crash does not discard the initial cold compile. Checkpoint and final exports still occur when disabled.",
+            dependencies=[
+                FieldDependency(field="i_know_what_i_am_doing", operator="equals", value=True, action="show"),
+                FieldDependency(field="dynamo_backend", operator="not_equals", value="no", action="show"),
+            ],
+            importance=ImportanceLevel.EXPERIMENTAL,
+            order=57,
+            documentation="OPTIONS.md#--dynamo_cache_export_after_first_step",
+        )
+    )
+
+    registry._add_field(
+        ConfigField(
+            name="dynamo_hub_repo_id",
+            arg_name="--dynamo_hub_repo_id",
+            ui_label="Dynamo Cache Hub Repository",
+            field_type=FieldType.TEXT,
+            tab="hardware",
+            section="accelerate",
+            subsection="advanced",
+            default_value=None,
+            allow_empty=True,
+            help_text="Optional Hugging Face model repository used to retrieve and publish the Dynamo Mega-Cache.",
+            tooltip="SimpleTuner checks the configured cache path in this repository, loads it when compatible, and publishes cumulative updates in one commit.",
+            dependencies=[
+                FieldDependency(field="i_know_what_i_am_doing", operator="equals", value=True, action="show"),
+                FieldDependency(field="dynamo_backend", operator="not_equals", value="no", action="show"),
+            ],
+            importance=ImportanceLevel.EXPERIMENTAL,
+            order=58,
+            documentation="OPTIONS.md#--dynamo_hub_repo_id",
+        )
+    )
+
     # Max Workers
     registry._add_field(
         ConfigField(

--- a/simpletuner/simpletuner_sdk/server/services/field_service.py
+++ b/simpletuner/simpletuner_sdk/server/services/field_service.py
@@ -1704,6 +1704,10 @@ class FieldService:
             "dynamo_fullgraph",
             "dynamo_dynamic",
             "dynamo_use_regional_compilation",
+            "dynamo_wrapper",
+            "dynamo_cache_export",
+            "dynamo_cache_export_after_first_step",
+            "dynamo_hub_repo_id",
         }:
             backend_value = self._get_config_value(config_values, "dynamo_backend")
             if backend_value is None and isinstance(raw_config, dict):

--- a/tests/test_dynamo.py
+++ b/tests/test_dynamo.py
@@ -56,6 +56,54 @@ class DynamoCudagraphWorkaroundTests(unittest.TestCase):
 
         self.assertEqual(config.dynamo_mode, "reduce-overhead")
 
+    def test_inductor_wrapper_defaults_to_cpp(self):
+        from simpletuner.helpers.training import dynamo
+
+        inductor_config = SimpleNamespace(cpp_wrapper=False)
+        with (
+            unittest.mock.patch.dict(os.environ, {}, clear=True),
+            unittest.mock.patch.object(dynamo.importlib, "import_module", return_value=inductor_config),
+        ):
+            wrapper = dynamo.configure_inductor_wrapper(SimpleNamespace(dynamo_backend="inductor"))
+
+            self.assertEqual(wrapper, "cpp")
+            self.assertEqual(os.environ["TORCHINDUCTOR_CPP_WRAPPER"], "1")
+            self.assertTrue(inductor_config.cpp_wrapper)
+
+    def test_inductor_wrapper_ignores_inactive_accelerate_backend(self):
+        from simpletuner.helpers.training import dynamo
+
+        inductor_config = SimpleNamespace(cpp_wrapper=False)
+        with (
+            unittest.mock.patch.dict(os.environ, {"ACCELERATE_DYNAMO_BACKEND": "NO"}, clear=True),
+            unittest.mock.patch.object(dynamo.importlib, "import_module", return_value=inductor_config),
+        ):
+            wrapper = dynamo.configure_inductor_wrapper(SimpleNamespace(dynamo_backend="inductor"))
+
+            self.assertEqual(wrapper, "cpp")
+            self.assertEqual(os.environ["TORCHINDUCTOR_CPP_WRAPPER"], "1")
+            self.assertTrue(inductor_config.cpp_wrapper)
+
+    def test_inductor_wrapper_supports_legacy_python_mode(self):
+        from simpletuner.helpers.training import dynamo
+
+        inductor_config = SimpleNamespace(cpp_wrapper=True)
+        with (
+            unittest.mock.patch.dict(os.environ, {}, clear=True),
+            unittest.mock.patch.object(dynamo.importlib, "import_module", return_value=inductor_config),
+        ):
+            wrapper = dynamo.configure_inductor_wrapper(SimpleNamespace(dynamo_backend="inductor", dynamo_wrapper="python"))
+
+            self.assertEqual(wrapper, "python")
+            self.assertEqual(os.environ["TORCHINDUCTOR_CPP_WRAPPER"], "0")
+            self.assertFalse(inductor_config.cpp_wrapper)
+
+    def test_inductor_wrapper_rejects_unknown_value(self):
+        from simpletuner.helpers.training import dynamo
+
+        with self.assertRaisesRegex(ValueError, "--dynamo_wrapper"):
+            dynamo.configure_inductor_wrapper(SimpleNamespace(dynamo_wrapper="unknown"))
+
     def test_peft_lora_cudagraph_patch_clones_base_result(self):
         from peft import LoraConfig
         from peft.tuners.lora.layer import Linear

--- a/tests/test_dynamo_cache.py
+++ b/tests/test_dynamo_cache.py
@@ -1,0 +1,264 @@
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from simpletuner.helpers.training import dynamo_cache
+
+
+def _config(path, hub_repo_id=None, **overrides):
+    values = dict(
+        dynamo_cache_export=str(path) if path is not None else None,
+        dynamo_hub_repo_id=hub_repo_id,
+        dynamo_backend="inductor",
+        model_family="test",
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _cache_info(**artifacts):
+    return SimpleNamespace(artifacts=artifacts)
+
+
+class DynamoCacheManagerTests(unittest.TestCase):
+    def test_hub_repo_requires_cache_path(self):
+        with self.assertRaisesRegex(ValueError, "requires --dynamo_cache_export"):
+            dynamo_cache.DynamoCacheManager(_config(None, "owner/cache"))
+
+    def test_directory_path_uses_stable_generated_filename_locally_and_on_hub(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cache_directory = Path(directory) / "compiler-caches"
+            manager = dynamo_cache.DynamoCacheManager(_config(f"{cache_directory}/", "owner/cache"))
+
+            self.assertEqual(manager.local_path.parent, cache_directory)
+            self.assertEqual(manager.local_path.name, manager.generated_filename)
+            self.assertTrue(manager.generated_filename.startswith("simpletuner-dynamo-test-default-"))
+            self.assertTrue(manager.generated_filename.endswith(".ptcache"))
+            self.assertEqual(manager.hub_path, manager.generated_filename)
+
+        relative_manager = dynamo_cache.DynamoCacheManager(_config("compiler-caches", "owner/cache"))
+        self.assertEqual(
+            relative_manager.hub_path,
+            f"compiler-caches/{relative_manager.generated_filename}",
+        )
+
+    def test_generated_filename_changes_with_graph_relevant_config(self):
+        first = dynamo_cache.DynamoCacheManager(
+            _config("compiler-caches", resolution=512, gradient_checkpointing_segment_stride=4)
+        )
+        second = dynamo_cache.DynamoCacheManager(
+            _config("compiler-caches", resolution=768, gradient_checkpointing_segment_stride=4)
+        )
+        third = dynamo_cache.DynamoCacheManager(
+            _config("compiler-caches", resolution=512, gradient_checkpointing_segment_stride=8)
+        )
+        fourth = dynamo_cache.DynamoCacheManager(
+            _config(
+                "compiler-caches",
+                resolution=512,
+                gradient_checkpointing_segment_stride=4,
+                dynamo_wrapper="python",
+            )
+        )
+
+        self.assertNotEqual(first.generated_filename, second.generated_filename)
+        self.assertNotEqual(first.generated_filename, third.generated_filename)
+        self.assertNotEqual(first.generated_filename, fourth.generated_filename)
+
+    def test_loads_compatible_local_cache(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cache_path = Path(directory) / "cache.ptcache"
+            payload = b"compiled-cache"
+            cache_path.write_bytes(payload)
+            manager = dynamo_cache.DynamoCacheManager(_config(cache_path))
+            Path(f"{cache_path}.manifest.json").write_text(
+                json.dumps(
+                    {
+                        "runtime": manager.runtime_signature,
+                        "sha256": hashlib.sha256(payload).hexdigest(),
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch.object(
+                dynamo_cache.torch.compiler,
+                "load_cache_artifacts",
+                return_value=_cache_info(aot_autograd=["aot-1"], inductor=["inductor-1"]),
+            ) as load_cache:
+                loaded = manager.load()
+
+            self.assertTrue(loaded)
+            load_cache.assert_called_once_with(payload)
+            self.assertEqual(manager.known_keys["aot_autograd"], {"aot-1"})
+
+    def test_rejects_incompatible_runtime_before_loading(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cache_path = Path(directory) / "cache.ptcache"
+            cache_path.write_bytes(b"compiled-cache")
+            Path(f"{cache_path}.manifest.json").write_text(
+                json.dumps({"runtime": {"torch": "different"}}),
+                encoding="utf-8",
+            )
+            manager = dynamo_cache.DynamoCacheManager(_config(cache_path))
+
+            with patch.object(dynamo_cache.torch.compiler, "load_cache_artifacts") as load_cache:
+                loaded = manager.load()
+
+            self.assertFalse(loaded)
+            load_cache.assert_not_called()
+
+    def test_exports_only_when_artifact_keys_grow(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cache_path = Path(directory) / "cache.ptcache"
+            manager = dynamo_cache.DynamoCacheManager(_config(cache_path))
+            cache_info = _cache_info(aot_autograd=["aot-1"], inductor=["inductor-1"])
+
+            with patch.object(
+                dynamo_cache.torch.compiler,
+                "save_cache_artifacts",
+                return_value=(b"first-cache", cache_info),
+            ):
+                self.assertTrue(manager.export("first step"))
+
+            self.assertEqual(dynamo_cache._unpack_segments(cache_path.read_bytes()), [b"first-cache"])
+            manifest = json.loads(Path(f"{cache_path}.manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["artifact_counts"], {"aot_autograd": 1, "inductor": 1})
+            self.assertEqual(manifest["segment_count"], 1)
+
+            with (
+                patch.object(
+                    dynamo_cache.torch.compiler,
+                    "save_cache_artifacts",
+                    return_value=(b"different-serialization", cache_info),
+                ),
+                patch.object(dynamo_cache, "_atomic_write") as atomic_write,
+            ):
+                self.assertFalse(manager.export("training completion"))
+            atomic_write.assert_not_called()
+
+    def test_new_process_segment_preserves_loaded_segments(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cache_path = Path(directory) / "cache.ptcache"
+            cache_path.write_bytes(dynamo_cache._pack_segments([b"loaded-segment"]))
+            manager = dynamo_cache.DynamoCacheManager(_config(cache_path))
+
+            with patch.object(
+                dynamo_cache.torch.compiler,
+                "load_cache_artifacts",
+                return_value=_cache_info(inductor=["loaded-key"]),
+            ):
+                self.assertTrue(manager.load())
+
+            with patch.object(
+                dynamo_cache.torch.compiler,
+                "save_cache_artifacts",
+                return_value=(b"current-process-v1", _cache_info(inductor=["new-key-1"])),
+            ):
+                self.assertTrue(manager.export("first step"))
+            self.assertEqual(
+                dynamo_cache._unpack_segments(cache_path.read_bytes()),
+                [b"loaded-segment", b"current-process-v1"],
+            )
+
+            with patch.object(
+                dynamo_cache.torch.compiler,
+                "save_cache_artifacts",
+                return_value=(
+                    b"current-process-v2",
+                    _cache_info(inductor=["new-key-1", "new-key-2"]),
+                ),
+            ):
+                self.assertTrue(manager.export("training completion"))
+            self.assertEqual(
+                dynamo_cache._unpack_segments(cache_path.read_bytes()),
+                [b"loaded-segment", b"current-process-v2"],
+            )
+            manifest = json.loads(Path(f"{cache_path}.manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["segment_count"], 2)
+
+    def test_rejects_future_manifest_schema_before_loading(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cache_path = Path(directory) / "cache.ptcache"
+            cache_path.write_bytes(b"compiled-cache")
+            Path(f"{cache_path}.manifest.json").write_text(
+                json.dumps({"schema_version": dynamo_cache._SCHEMA_VERSION + 1}),
+                encoding="utf-8",
+            )
+            manager = dynamo_cache.DynamoCacheManager(_config(cache_path))
+
+            with patch.object(dynamo_cache.torch.compiler, "load_cache_artifacts") as load_cache:
+                loaded = manager.load()
+
+            self.assertFalse(loaded)
+            load_cache.assert_not_called()
+
+    def test_loads_hub_cache_before_local_fallback(self):
+        with tempfile.TemporaryDirectory() as directory:
+            local_path = Path(directory) / "compiler" / "cache.ptcache"
+            remote_blob = Path(directory) / "remote-cache.ptcache"
+            remote_manifest = Path(directory) / "remote-cache.manifest.json"
+            payload = b"hub-cache"
+            remote_blob.write_bytes(payload)
+            manager = dynamo_cache.DynamoCacheManager(_config(local_path, "owner/cache"))
+            remote_manifest.write_text(
+                json.dumps(
+                    {
+                        "runtime": manager.runtime_signature,
+                        "sha256": hashlib.sha256(payload).hexdigest(),
+                    }
+                ),
+                encoding="utf-8",
+            )
+            api = MagicMock()
+            api.file_exists.return_value = True
+
+            def _download(*, filename, **kwargs):
+                if filename.endswith(".manifest.json"):
+                    return str(remote_manifest)
+                return str(remote_blob)
+
+            with (
+                patch.object(dynamo_cache, "HfApi", return_value=api),
+                patch.object(dynamo_cache, "hf_hub_download", side_effect=_download),
+                patch.object(
+                    dynamo_cache.torch.compiler,
+                    "load_cache_artifacts",
+                    return_value=_cache_info(inductor=["hub-key"]),
+                ),
+            ):
+                self.assertTrue(manager.load())
+
+            self.assertEqual(manager.known_keys["inductor"], {"hub-key"})
+
+    def test_uploads_blob_and_manifest_in_one_commit(self):
+        manager = dynamo_cache.DynamoCacheManager(_config("cache/ltx.ptcache", "owner/cache"))
+        api = MagicMock()
+        with (
+            patch.object(dynamo_cache, "HfApi", return_value=api),
+            patch.object(manager, "_hub_token", return_value=None),
+        ):
+            manager._upload(b"blob", b"manifest", "first step")
+
+        api.create_repo.assert_called_once_with(
+            repo_id="owner/cache",
+            token=None,
+            exist_ok=True,
+            private=True,
+        )
+        operations = api.create_commit.call_args.kwargs["operations"]
+        self.assertEqual(
+            [operation.path_in_repo for operation in operations],
+            [
+                "cache/ltx.ptcache",
+                "cache/ltx.ptcache.manifest.json",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Stack

Depends on #3157. This PR intentionally targets `perf/ltx-hierarchical-compile`; only commit `b9aba1328` is new in this layer.

## Summary

Add a reusable, cumulative transport for PyTorch compiler artifacts so expensive `torch.compile` work can survive process restarts, checkpoints, and preemptions. The same cache blob can optionally be retrieved from and published to the Hugging Face Hub.

This also exposes the TorchInductor host wrapper as `dynamo_wrapper`, defaulting to the C++ wrapper while retaining `python` as the previous-release behavior.

## User-facing configuration

- `dynamo_cache_export`: local cache blob path or directory.
- `dynamo_hub_repo_id`: optional Hub model repository containing the same blob and manifest.
- `dynamo_cache_export_after_first_step`: enabled by default so the initial cold compile is persisted immediately.
- `dynamo_wrapper`: `cpp` by default; `python` selects the legacy wrapper.

When `dynamo_cache_export` names a directory or omits a suffix, SimpleTuner derives a stable filename from the model family/flavour, accelerator, exact Torch runtime, and graph-relevant training configuration. Explicit filenames remain unchanged.

## Cache lifecycle

1. Configure the selected Inductor wrapper before model construction.
2. Prefer a compatible Hub artifact, then fall back to the local blob.
3. Load all cache segments through `torch.compiler.load_cache_artifacts()`.
4. Export after the first successful optimizer step.
5. Check for newly generated artifact keys after each checkpoint and at normal completion.
6. Rewrite and upload only when the artifact inventory grows.

The export synchronization runs on all ranks while serialization and file/Hub writes remain main-process-only, avoiding distributed checkpoint deadlocks. Local writes use an atomic replacement. Hub blob and manifest updates are sent in one commit, and Hub failures never abort training.

## Why the blob is segmented

PyTorch does not include artifacts loaded earlier in a process when `save_cache_artifacts()` later serializes newly compiled entries. A plain overwrite would therefore discard imported shapes.

SimpleTuner stores an append-only bundle of raw public-API PyTorch cache payloads. Imported segments are preserved, while the current process segment is replaced as its artifact inventory grows. Every segment is loaded through PyTorch’s public API on the next run.

## Compatibility and trust

A sidecar manifest records exact Torch, Triton, CUDA/ROCm, Python, platform, accelerator identity, software versions, artifact counts, checksums, and advisory model/config signatures. Obvious runtime mismatches are rejected before loading; PyTorch cache keys and guards remain authoritative for graph and shape compatibility.

Compiler cache blobs contain generated executable code. Documentation explicitly limits loading to trusted local paths and Hub repositories. Missing Hub repositories are created private; existing visibility is never changed.

## Inductor wrapper

`dynamo_wrapper=cpp` sets both the process environment and live Inductor configuration before cache loading or compilation. An inactive Accelerate `ACCELERATE_DYNAMO_BACKEND=NO` no longer overrides an explicit SimpleTuner `dynamo_backend=inductor`. `dynamo_wrapper=python` restores the earlier behavior. The wrapper selection participates in generated cache identities.

## H100 validation

Using the LTX-2.5 22B regional-compile workload from #3156 with independent empty `TORCHINDUCTOR_CACHE_DIR` directories:

| measurement | cold | imported Mega-Cache |
| --- | ---: | ---: |
| first step | 210.7 s | 79.2 s |
| three-step training loop | 219.5 s | 86.7 s |
| warm steps | approximately 2-3 s | approximately 2-3 s |

The exported bundle was 61.6 MB and contained 17 AOTAutograd entries, 23 Inductor entries, and 95 autotune entries. The import run recorded 17 AOTAutograd hits. A checkpoint-at-step-2 smoke confirmed first-step, checkpoint, and completion growth checks skipped unchanged rewrites while saving the checkpoint normally.

A separate run with no wrapper environment override logged `TorchInductor wrapper: cpp`, emitted `"cpp_wrapper": true` in the effective Inductor configuration, and completed successfully.

## Tests

`python -m unittest tests.test_dynamo_cache tests.test_dynamo tests.test_parser_type_override tests.test_model_field_registry tests.test_trainer tests.test_ltxvideo2_attention tests.test_training_checkpointing`

149 tests pass in the populated H100 environment. Formatting, syntax, and diff checks pass.