### PR TITLE
support Krea2 turbo LoRA from TheDivergentAI

### DIFF
--- a/simpletuner/helpers/models/krea2/lora_pipeline.py
+++ b/simpletuner/helpers/models/krea2/lora_pipeline.py
@@ -34,6 +34,15 @@ if is_torch_version(">=", "1.9.0"):
 TRANSFORMER_NAME = "transformer"
 KREA2_LORA_TRANSFORMER_PREFIXES = ("transformer", "diffusion_model")
 KREA2_EXTERNAL_LORA_MODULE_MAP = (
+    ("first.", "img_in."),
+    ("tmlp.0.", "time_embed.linear_1."),
+    ("tmlp.2.", "time_embed.linear_2."),
+    ("tproj.1.", "time_mod_proj."),
+    ("txtmlp.1.", "txt_in.linear_1."),
+    ("txtmlp.3.", "txt_in.linear_2."),
+    ("last.linear.", "final_layer.linear."),
+    ("last.modulation.lin.", "final_layer.scale_shift_table."),
+    ("txtfusion.", "text_fusion."),
     ("blocks.", "transformer_blocks."),
     (".attn.wq.", ".attn.to_q."),
     (".attn.wk.", ".attn.to_k."),
@@ -88,6 +97,98 @@ def _infer_krea2_lora_target_modules(state_dict: dict[str, torch.Tensor]) -> lis
     return list(target_modules)
 
 
+def _krea2_lora_alpha_for_target(
+    target: str,
+    rank: int,
+    state_dict: dict[str, torch.Tensor],
+    metadata: dict | None,
+) -> float:
+    alpha = state_dict.get(f"{target}.alpha")
+    if alpha is not None:
+        return float(alpha.detach().float().cpu().item() if torch.is_tensor(alpha) else alpha)
+    if metadata and metadata.get("ss_network_alpha") is not None:
+        return float(metadata["ss_network_alpha"])
+    return float(rank)
+
+
+def _resolve_krea2_lora_live_names(targets: list[str], live_names: list[str]) -> tuple[dict[str, str], dict[str, list[str]]]:
+    live_name_set = set(live_names)
+    remap: dict[str, str] = {}
+    ambiguous: dict[str, list[str]] = {}
+    for target in targets:
+        if target in live_name_set:
+            remap[target] = target
+            continue
+        suffix = f".{target}"
+        matches = [name for name in live_names if name.endswith(suffix)]
+        if len(matches) == 1:
+            remap[target] = matches[0]
+        elif len(matches) > 1:
+            ambiguous[target] = matches[:5]
+    return remap, ambiguous
+
+
+def _split_krea2_parameter_lora_state_dict(
+    state_dict: dict[str, torch.Tensor],
+    target_modules: list[str],
+    transformer,
+    metadata: dict | None,
+) -> tuple[dict[str, torch.Tensor], list[str], dict[str, torch.Tensor]]:
+    """Extract LoRA deltas for KREA tensors represented as parameters rather than modules."""
+    try:
+        named_parameters = [(name, parameter) for name, parameter in transformer.named_parameters() if name]
+    except Exception:
+        return state_dict, target_modules, {}
+
+    parameter_names = [name for name, _ in named_parameters]
+    parameter_map = dict(named_parameters)
+    parameter_remap, ambiguous = _resolve_krea2_lora_live_names(target_modules, parameter_names)
+    if ambiguous:
+        preview = ", ".join(f"{target}: {matches}" for target, matches in list(ambiguous.items())[:3])
+        raise ValueError(f"Ambiguous KREA2 LoRA parameter targets in wrapped transformer: {preview}")
+
+    parameter_targets = [target for target in target_modules if target in parameter_remap]
+    if not parameter_targets:
+        return state_dict, target_modules, {}
+
+    parameter_lora_deltas: dict[str, torch.Tensor] = {}
+    module_state_dict = dict(state_dict)
+    module_targets = [target for target in target_modules if target not in parameter_remap]
+    for target in parameter_targets:
+        lora_a_key = f"{target}.lora_A.weight"
+        lora_b_key = f"{target}.lora_B.weight"
+        if lora_a_key not in state_dict or lora_b_key not in state_dict:
+            raise ValueError(f"KREA2 parameter LoRA target `{target}` is missing lora_A or lora_B weights.")
+        lora_a = state_dict[lora_a_key]
+        lora_b = state_dict[lora_b_key]
+        if getattr(lora_a, "ndim", 0) != 2 or getattr(lora_b, "ndim", 0) != 2:
+            raise ValueError(f"KREA2 parameter LoRA target `{target}` must contain rank-2 lora_A and lora_B tensors.")
+        rank = int(lora_a.shape[0])
+        if rank <= 0 or int(lora_b.shape[1]) != rank:
+            raise ValueError(f"KREA2 parameter LoRA target `{target}` has incompatible LoRA rank shapes.")
+        alpha = _krea2_lora_alpha_for_target(target, rank, state_dict, metadata)
+        delta = torch.matmul(lora_b.detach().float(), lora_a.detach().float()) * (alpha / rank)
+        live_parameter_name = parameter_remap[target]
+        live_parameter = parameter_map[live_parameter_name]
+        if tuple(delta.shape) != tuple(live_parameter.shape):
+            raise ValueError(
+                f"KREA2 parameter LoRA target `{target}` produces delta shape {tuple(delta.shape)}, "
+                f"expected {tuple(live_parameter.shape)}."
+            )
+        parent_name, _ = live_parameter_name.rsplit(".", 1)
+        parent_module = transformer.get_submodule(parent_name)
+        if not hasattr(parent_module, "register_parameter_lora_delta"):
+            raise ValueError(
+                f"KREA2 parameter LoRA target `{live_parameter_name}` cannot be applied to "
+                f"{parent_module.__class__.__name__}."
+            )
+        parameter_lora_deltas[live_parameter_name] = delta
+        for key in (lora_a_key, lora_b_key, f"{target}.alpha", f"{target}.lora_alpha"):
+            module_state_dict.pop(key, None)
+
+    return module_state_dict, module_targets, parameter_lora_deltas
+
+
 def _unwrap_krea2_lora_transformer(transformer):
     """Return the real KREA2 module when validation hands us a compiled wrapper."""
     return getattr(transformer, "_orig_mod", transformer)
@@ -115,18 +216,7 @@ def _align_krea2_lora_state_dict_to_transformer(
     if target_modules and all(target in live_module_set for target in target_modules):
         return state_dict, target_modules
 
-    remap: dict[str, str] = {}
-    ambiguous: dict[str, list[str]] = {}
-    for target in target_modules:
-        if target in live_module_set:
-            remap[target] = target
-            continue
-        suffix = f".{target}"
-        matches = [name for name in live_module_names if name.endswith(suffix)]
-        if len(matches) == 1:
-            remap[target] = matches[0]
-        elif len(matches) > 1:
-            ambiguous[target] = matches[:5]
+    remap, ambiguous = _resolve_krea2_lora_live_names(target_modules, live_module_names)
 
     if ambiguous:
         preview = ", ".join(f"{target}: {matches}" for target, matches in list(ambiguous.items())[:3])
@@ -155,6 +245,23 @@ def _align_krea2_lora_state_dict_to_transformer(
         aligned_state_dict[rewritten] = value
 
     return aligned_state_dict, list(dict.fromkeys(remap[target] for target in target_modules))
+
+
+def _register_krea2_parameter_lora_deltas(
+    transformer,
+    adapter_name: str,
+    parameter_lora_deltas: dict[str, torch.Tensor],
+) -> None:
+    for parameter_name, delta in parameter_lora_deltas.items():
+        parent_name, child_name = parameter_name.rsplit(".", 1)
+        parent_module = transformer.get_submodule(parent_name)
+        register_lora_delta = getattr(parent_module, "register_parameter_lora_delta", None)
+        if register_lora_delta is None:
+            raise ValueError(
+                f"KREA2 parameter LoRA target `{parameter_name}` cannot be applied to "
+                f"{parent_module.__class__.__name__}."
+            )
+        register_lora_delta(child_name, adapter_name, delta)
 
 
 class Krea2LoraLoaderMixin(LoraBaseMixin):
@@ -314,6 +421,8 @@ class Krea2LoraLoaderMixin(LoraBaseMixin):
             raise ValueError(
                 f"Adapter name {adapter_name} already in use in the transformer - please select a new adapter name."
             )
+        if adapter_name is None:
+            adapter_name = get_adapter_name(transformer)
 
         target_modules = _infer_krea2_lora_target_modules(state_dict)
         if not target_modules:
@@ -321,6 +430,12 @@ class Krea2LoraLoaderMixin(LoraBaseMixin):
                 "Could not infer KREA2 LoRA target modules from the adapter state dict. "
                 "Expected keys ending in .lora_A.weight and .lora_B.weight."
             )
+        state_dict, target_modules, parameter_lora_deltas = _split_krea2_parameter_lora_state_dict(
+            state_dict,
+            target_modules,
+            transformer,
+            metadata,
+        )
         state_dict, target_modules = _align_krea2_lora_state_dict_to_transformer(
             state_dict,
             target_modules,
@@ -344,9 +459,6 @@ class Krea2LoraLoaderMixin(LoraBaseMixin):
                 lora_config_kwargs.pop("use_dora")
         lora_config = LoraConfig(**lora_config_kwargs)
 
-        if adapter_name is None:
-            adapter_name = get_adapter_name(transformer)
-
         logger.info(
             f"Loading {cls.transformer_name} LoRA adapter '{adapter_name}' "
             f"from {source_prefix or 'unprefixed'} keys with {len(target_modules)} target module(s)."
@@ -367,6 +479,7 @@ class Krea2LoraLoaderMixin(LoraBaseMixin):
             incompatible_keys = set_peft_model_state_dict(transformer, state_dict, adapter_name, **peft_kwargs)
             if incompatible_keys is not None:
                 logger.info(f"Loaded KREA2 LoRA with incompatible keys: {incompatible_keys}")
+            _register_krea2_parameter_lora_deltas(transformer, adapter_name, parameter_lora_deltas)
         finally:
             restore_offload_state(_pipeline, is_model_cpu_offload, is_sequential_cpu_offload)
 

--- a/simpletuner/helpers/models/krea2/transformer.py
+++ b/simpletuner/helpers/models/krea2/transformer.py
@@ -441,9 +441,66 @@ class Krea2FinalLayer(nn.Module):
         self.scale_shift_table = nn.Parameter(torch.zeros(2, hidden_size))
         self.norm = Krea2RMSNorm(hidden_size, eps=eps)
         self.linear = nn.Linear(hidden_size, out_channels, bias=True)
+        self._parameter_lora_deltas: dict[str, torch.Tensor] = {}
+        self._parameter_lora_active_adapters: list[str] = []
+        self._parameter_lora_adapter_weights: dict[str, float] = {}
+        self._parameter_lora_enabled = True
+
+    def register_parameter_lora_delta(self, parameter_name: str, adapter_name: str, delta: torch.Tensor) -> None:
+        if parameter_name != "scale_shift_table":
+            raise ValueError(f"Krea2FinalLayer does not support parameter LoRA target `{parameter_name}`.")
+        if tuple(delta.shape) != tuple(self.scale_shift_table.shape):
+            raise ValueError(
+                f"Krea2FinalLayer LoRA delta for `{parameter_name}` has shape {tuple(delta.shape)}, "
+                f"expected {tuple(self.scale_shift_table.shape)}."
+            )
+        self._parameter_lora_deltas[adapter_name] = delta.detach().cpu()
+        if adapter_name not in self._parameter_lora_active_adapters:
+            self._parameter_lora_active_adapters.append(adapter_name)
+        self._parameter_lora_adapter_weights.setdefault(adapter_name, 1.0)
+
+    def set_parameter_lora_adapters(self, adapter_names: list[str], adapter_weights: list[float]) -> None:
+        self._parameter_lora_active_adapters = [
+            adapter_name for adapter_name in adapter_names if adapter_name in self._parameter_lora_deltas
+        ]
+        self._parameter_lora_adapter_weights = {
+            adapter_name: float(weight)
+            for adapter_name, weight in zip(adapter_names, adapter_weights)
+            if adapter_name in self._parameter_lora_deltas
+        }
+
+    def delete_parameter_lora_adapters(self, adapter_names: list[str]) -> None:
+        for adapter_name in adapter_names:
+            self._parameter_lora_deltas.pop(adapter_name, None)
+            self._parameter_lora_adapter_weights.pop(adapter_name, None)
+        self._parameter_lora_active_adapters = [
+            adapter_name for adapter_name in self._parameter_lora_active_adapters if adapter_name not in adapter_names
+        ]
+
+    def enable_parameter_lora(self, enabled: bool) -> None:
+        self._parameter_lora_enabled = enabled
+
+    def _scale_shift_table_with_parameter_lora(self) -> torch.Tensor:
+        scale_shift_table = self.scale_shift_table
+        if not self._parameter_lora_enabled:
+            return scale_shift_table
+        for adapter_name in self._parameter_lora_active_adapters:
+            delta = self._parameter_lora_deltas.get(adapter_name)
+            if delta is None:
+                continue
+            weight = self._parameter_lora_adapter_weights.get(adapter_name, 1.0)
+            scale_shift_table = (
+                scale_shift_table
+                + delta.to(
+                    device=scale_shift_table.device,
+                    dtype=scale_shift_table.dtype,
+                )
+                * weight
+            )
+        return scale_shift_table
 
     def forward(self, hidden_states: torch.Tensor, temb: torch.Tensor) -> torch.Tensor:
-        modulation = temb + self.scale_shift_table
+        modulation = temb + self._scale_shift_table_with_parameter_lora()
         scale, shift = modulation.chunk(2, dim=1)
         hidden_states = (1.0 + scale) * self.norm(hidden_states) + shift
         return self.linear(hidden_states)
@@ -635,6 +692,66 @@ class Krea2Transformer2DModel(ModelMixin, ConfigMixin, AttentionMixin, PeftAdapt
     def set_router(self, router: TREADRouter, routes: list[dict[str, Any]] | None = None) -> None:
         self._tread_router = router
         self._tread_routes = routes
+
+    @staticmethod
+    def _parameter_lora_weight_value(weight: Any) -> float:
+        if weight is None:
+            return 1.0
+        if isinstance(weight, dict):
+            for key in ("final_layer.scale_shift_table", "scale_shift_table", "final_layer"):
+                if key in weight:
+                    return float(weight[key])
+            return 1.0
+        return float(weight)
+
+    @classmethod
+    def _normalize_parameter_lora_adapter_weights(
+        cls,
+        adapter_names: list[str] | str,
+        weights: float | dict | list[float] | list[dict] | list[None] | None = None,
+    ) -> tuple[list[str], list[float]]:
+        adapter_names = [adapter_names] if isinstance(adapter_names, str) else list(adapter_names)
+        if not isinstance(weights, list):
+            weights = [weights] * len(adapter_names)
+        if len(adapter_names) != len(weights):
+            raise ValueError(
+                f"Length of adapter names {len(adapter_names)} is not equal to the length of their weights {len(weights)}."
+            )
+        return adapter_names, [cls._parameter_lora_weight_value(weight) for weight in weights]
+
+    def set_adapters(
+        self,
+        adapter_names: list[str] | str,
+        weights: float | dict | list[float] | list[dict] | list[None] | None = None,
+    ):
+        super().set_adapters(adapter_names, weights)
+        adapter_names, weights = self._normalize_parameter_lora_adapter_weights(adapter_names, weights)
+        for module in self.modules():
+            set_parameter_lora_adapters = getattr(module, "set_parameter_lora_adapters", None)
+            if set_parameter_lora_adapters is not None:
+                set_parameter_lora_adapters(adapter_names, weights)
+
+    def delete_adapters(self, adapter_names: list[str] | str):
+        super().delete_adapters(adapter_names)
+        adapter_names = [adapter_names] if isinstance(adapter_names, str) else list(adapter_names)
+        for module in self.modules():
+            delete_parameter_lora_adapters = getattr(module, "delete_parameter_lora_adapters", None)
+            if delete_parameter_lora_adapters is not None:
+                delete_parameter_lora_adapters(adapter_names)
+
+    def enable_lora(self):
+        super().enable_lora()
+        for module in self.modules():
+            enable_parameter_lora = getattr(module, "enable_parameter_lora", None)
+            if enable_parameter_lora is not None:
+                enable_parameter_lora(True)
+
+    def disable_lora(self):
+        super().disable_lora()
+        for module in self.modules():
+            enable_parameter_lora = getattr(module, "enable_parameter_lora", None)
+            if enable_parameter_lora is not None:
+                enable_parameter_lora(False)
 
     def enable_flowmap_time_conditioning(self, gate_value: float = 0.25, deltatime_type: str = "r") -> None:
         self.time_embed.enable_flowmap_time_conditioning(gate_value=gate_value, deltatime_type=deltatime_type)

--- a/tests/test_krea2_model.py
+++ b/tests/test_krea2_model.py
@@ -164,6 +164,49 @@ class Krea2VendoredModelTests(unittest.TestCase):
         )
         self.assertEqual(_infer_krea2_lora_target_modules(normalized), ["transformer_blocks.1.attn.to_v"])
 
+    def test_lora_loader_normalizes_krea2_turbo_distill_targets(self):
+        state_dict = {
+            "diffusion_model.first.lora_A.weight": torch.ones(2, 4),
+            "diffusion_model.first.lora_B.weight": torch.ones(6, 2),
+            "diffusion_model.tmlp.0.lora_A.weight": torch.ones(2, 8),
+            "diffusion_model.tmlp.0.lora_B.weight": torch.ones(6, 2),
+            "diffusion_model.tmlp.2.lora_A.weight": torch.ones(2, 6),
+            "diffusion_model.tmlp.2.lora_B.weight": torch.ones(6, 2),
+            "diffusion_model.tproj.1.lora_A.weight": torch.ones(2, 6),
+            "diffusion_model.tproj.1.lora_B.weight": torch.ones(36, 2),
+            "diffusion_model.txtfusion.layerwise_blocks.0.attn.to_q.lora_A.weight": torch.ones(2, 6),
+            "diffusion_model.txtfusion.layerwise_blocks.0.attn.to_q.lora_B.weight": torch.ones(6, 2),
+            "diffusion_model.txtfusion.projector.lora_A.weight": torch.ones(1, 2),
+            "diffusion_model.txtfusion.projector.lora_B.weight": torch.ones(1, 1),
+            "diffusion_model.txtmlp.1.lora_A.weight": torch.ones(2, 6),
+            "diffusion_model.txtmlp.1.lora_B.weight": torch.ones(6, 2),
+            "diffusion_model.txtmlp.3.lora_A.weight": torch.ones(2, 6),
+            "diffusion_model.txtmlp.3.lora_B.weight": torch.ones(6, 2),
+            "diffusion_model.last.linear.lora_A.weight": torch.ones(2, 6),
+            "diffusion_model.last.linear.lora_B.weight": torch.ones(4, 2),
+            "diffusion_model.last.modulation.lin.lora_A.weight": torch.ones(2, 6),
+            "diffusion_model.last.modulation.lin.lora_B.weight": torch.ones(2, 2),
+        }
+
+        normalized, prefix = _normalize_krea2_lora_state_dict(state_dict)
+
+        self.assertEqual(prefix, "diffusion_model")
+        self.assertEqual(
+            _infer_krea2_lora_target_modules(normalized),
+            [
+                "img_in",
+                "time_embed.linear_1",
+                "time_embed.linear_2",
+                "time_mod_proj",
+                "text_fusion.layerwise_blocks.0.attn.to_q",
+                "text_fusion.projector",
+                "txt_in.linear_1",
+                "txt_in.linear_2",
+                "final_layer.linear",
+                "final_layer.scale_shift_table",
+            ],
+        )
+
     def test_lora_loader_injects_external_krea2_adapter_with_requested_name(self):
         transformer = Krea2Transformer2DModel(
             in_channels=4,
@@ -195,6 +238,91 @@ class Krea2VendoredModelTests(unittest.TestCase):
 
         self.assertIn("krea2_turbo", transformer.peft_config)
         self.assertIn("transformer_blocks.0.attn.to_q", transformer.peft_config["krea2_turbo"].target_modules)
+
+    def test_lora_loader_applies_krea2_turbo_distill_parameter_target(self):
+        transformer = Krea2Transformer2DModel(
+            in_channels=4,
+            num_layers=1,
+            attention_head_dim=6,
+            num_attention_heads=1,
+            num_key_value_heads=1,
+            intermediate_size=8,
+            timestep_embed_dim=8,
+            text_hidden_dim=6,
+            num_text_layers=2,
+            text_num_attention_heads=1,
+            text_num_key_value_heads=1,
+            text_intermediate_size=8,
+            num_layerwise_text_blocks=1,
+            num_refiner_text_blocks=0,
+            axes_dims_rope=(2, 2, 2),
+        )
+        state_dict = {
+            "diffusion_model.first.lora_A.weight": torch.ones(2, 4),
+            "diffusion_model.first.lora_B.weight": torch.ones(6, 2),
+            "diffusion_model.tmlp.0.lora_A.weight": torch.ones(2, 8),
+            "diffusion_model.tmlp.0.lora_B.weight": torch.ones(6, 2),
+            "diffusion_model.tmlp.2.lora_A.weight": torch.ones(2, 6),
+            "diffusion_model.tmlp.2.lora_B.weight": torch.ones(6, 2),
+            "diffusion_model.tproj.1.lora_A.weight": torch.ones(2, 6),
+            "diffusion_model.tproj.1.lora_B.weight": torch.ones(36, 2),
+            "diffusion_model.txtfusion.layerwise_blocks.0.attn.to_q.lora_A.weight": torch.ones(2, 6),
+            "diffusion_model.txtfusion.layerwise_blocks.0.attn.to_q.lora_B.weight": torch.ones(6, 2),
+            "diffusion_model.txtfusion.projector.lora_A.weight": torch.ones(1, 2),
+            "diffusion_model.txtfusion.projector.lora_B.weight": torch.ones(1, 1),
+            "diffusion_model.txtmlp.1.lora_A.weight": torch.ones(2, 6),
+            "diffusion_model.txtmlp.1.lora_B.weight": torch.ones(6, 2),
+            "diffusion_model.txtmlp.3.lora_A.weight": torch.ones(2, 6),
+            "diffusion_model.txtmlp.3.lora_B.weight": torch.ones(6, 2),
+            "diffusion_model.last.linear.lora_A.weight": torch.ones(2, 6),
+            "diffusion_model.last.linear.lora_B.weight": torch.ones(4, 2),
+            "diffusion_model.last.modulation.lin.lora_A.weight": torch.ones(2, 6),
+            "diffusion_model.last.modulation.lin.lora_B.weight": torch.ones(2, 2),
+        }
+
+        Krea2LoraLoaderMixin.load_lora_into_transformer(
+            state_dict,
+            transformer=transformer,
+            adapter_name="krea2_turbo_distill",
+            metadata={"ss_network_alpha": "2"},
+        )
+
+        targets = transformer.peft_config["krea2_turbo_distill"].target_modules
+        self.assertIn("img_in", targets)
+        self.assertIn("time_embed.linear_1", targets)
+        self.assertIn("time_embed.linear_2", targets)
+        self.assertIn("time_mod_proj", targets)
+        self.assertIn("text_fusion.layerwise_blocks.0.attn.to_q", targets)
+        self.assertIn("text_fusion.projector", targets)
+        self.assertIn("txt_in.linear_1", targets)
+        self.assertIn("txt_in.linear_2", targets)
+        self.assertIn("final_layer.linear", targets)
+        self.assertNotIn("final_layer.scale_shift_table", targets)
+        self.assertTrue(
+            torch.equal(
+                transformer.final_layer._scale_shift_table_with_parameter_lora(),
+                torch.full_like(transformer.final_layer.scale_shift_table, 2.0),
+            )
+        )
+
+        transformer.set_adapters("krea2_turbo_distill", 0.5)
+
+        self.assertTrue(
+            torch.equal(
+                transformer.final_layer._scale_shift_table_with_parameter_lora(),
+                torch.full_like(transformer.final_layer.scale_shift_table, 1.0),
+            )
+        )
+
+        transformer.delete_adapters("krea2_turbo_distill")
+
+        self.assertEqual(transformer.final_layer._parameter_lora_deltas, {})
+        self.assertTrue(
+            torch.equal(
+                transformer.final_layer._scale_shift_table_with_parameter_lora(),
+                transformer.final_layer.scale_shift_table,
+            )
+        )
 
     def test_lora_loader_injects_without_state_dict_argument(self):
         transformer = Krea2Transformer2DModel(


### PR DESCRIPTION
This pull request introduces support for parameter-based LoRA deltas in the Krea2 model pipeline, enabling more flexible and robust LoRA adapter injection, especially for Krea2 Turbo/Distill variants. The main changes include new logic for handling LoRA targets that are parameters (not just modules), utilities for adapter management, and comprehensive tests for these features.

**LoRA Parameter Support and Loader Enhancements:**

* Added logic to extract, map, and apply LoRA deltas directly to parameters (not only modules) in Krea2 models, including shape validation and error handling. (`simpletuner/helpers/models/krea2/lora_pipeline.py`)
* Implemented `_register_krea2_parameter_lora_deltas` to register parameter LoRA deltas with the transformer, and integrated this into the LoRA loading process. (`simpletuner/helpers/models/krea2/lora_pipeline.py`) (F77e7e94L247R247, F77e7e94L479R479)
* Updated the LoRA loader to normalize new Krea2 Turbo/Distill LoRA target names, supporting additional mapping prefixes. (`simpletuner/helpers/models/krea2/lora_pipeline.py`) [[1]](diffhunk://#diff-327991aa7f06cb41d062fade84f61156fb9c4091a5f93700673cce49d7f33c2fR37-R45) [[2]](diffhunk://#diff-8cd355d2945f47c18c4c6d5eef6b35d7bfa6fa94efa34343b946673d19fab3bbR167-R209)

**Krea2FinalLayer Parameter LoRA Management:**

* Added methods to `Krea2FinalLayer` for registering, enabling/disabling, weighting, and deleting parameter LoRA deltas, and updated the forward pass to apply these deltas. (`simpletuner/helpers/models/krea2/transformer.py`)
* Extended the model class to propagate adapter management calls (set, delete, enable, disable) to all modules supporting parameter LoRA. (`simpletuner/helpers/models/krea2/transformer.py`) (Fbda723aL693R693)

**Testing and Validation:**

* Added tests to verify normalization of Krea2 Turbo/Distill LoRA targets and correct application/removal of parameter-based LoRA deltas, including shape and value checks. (`tests/test_krea2_model.py`) [[1]](diffhunk://#diff-8cd355d2945f47c18c4c6d5eef6b35d7bfa6fa94efa34343b946673d19fab3bbR167-R209) [[2]](diffhunk://#diff-8cd355d2945f47c18c4c6d5eef6b35d7bfa6fa94efa34343b946673d19fab3bbR242-R326)

These changes make the Krea2 pipeline more robust and compatible with a wider range of LoRA adapters, especially those using parameter-based injection.