### PR TITLE
Fix Krea2 eval dynamic shift patch sizing

### DIFF
--- a/simpletuner/helpers/models/common.py
+++ b/simpletuner/helpers/models/common.py
@@ -9,6 +9,7 @@ import random
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from enum import Enum
+from numbers import Integral
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Protocol, Sequence
 
 if TYPE_CHECKING:
@@ -4612,24 +4613,55 @@ class ModelFoundation(ExplorativeModelingMixin, ABC):
         return batch
 
     def _get_patch_size_for_dynamic_shift(self, noise_scheduler):
-        component = None
-        try:
-            component = self.get_trained_component()
-        except Exception:
-            component = None
-
+        component = self.get_trained_component()
         if component is not None:
-            patch_size = getattr(getattr(component, "config", None), "patch_size", None)
+            component_config = getattr(component, "config", None)
+            patch_size = getattr(component_config, "patch_size", None)
             if patch_size is not None:
+                patch_size_t = getattr(component_config, "patch_size_t", None)
+                if patch_size_t is not None and isinstance(patch_size, Integral):
+                    return (patch_size_t, patch_size, patch_size)
                 return patch_size
 
         scheduler_config = getattr(noise_scheduler, "config", None)
         if scheduler_config is not None:
             patch_size = getattr(scheduler_config, "patch_size", None)
             if patch_size is not None:
+                patch_size_t = getattr(scheduler_config, "patch_size_t", None)
+                if patch_size_t is not None and isinstance(patch_size, Integral):
+                    return (patch_size_t, patch_size, patch_size)
                 return patch_size
 
-        return getattr(self.config, "patch_size", None)
+        config = getattr(self, "config", None)
+        patch_size = getattr(config, "patch_size", None)
+        if patch_size is not None:
+            patch_size_t = getattr(config, "patch_size_t", None)
+            if patch_size_t is not None and isinstance(patch_size, Integral):
+                return (patch_size_t, patch_size, patch_size)
+        return patch_size
+
+    @staticmethod
+    def _coerce_dynamic_shift_patch_dimension(value) -> int:
+        if isinstance(value, bool) or not isinstance(value, Integral):
+            raise ValueError(f"Dynamic timestep shift patch dimensions must be positive integers, got {value!r}.")
+        dimension = int(value)
+        if dimension <= 0:
+            raise ValueError(f"Dynamic timestep shift patch dimensions must be positive integers, got {value!r}.")
+        return dimension
+
+    def _dynamic_shift_patch_dimensions(self, patch_size) -> tuple[int, int, int]:
+        if isinstance(patch_size, Integral) and not isinstance(patch_size, bool):
+            spatial_patch_size = self._coerce_dynamic_shift_patch_dimension(patch_size)
+            return (1, spatial_patch_size, spatial_patch_size)
+        if isinstance(patch_size, Sequence) and not isinstance(patch_size, (str, bytes)):
+            if len(patch_size) == 2:
+                patch_dimensions = (1, patch_size[0], patch_size[1])
+            elif len(patch_size) == 3:
+                patch_dimensions = tuple(patch_size)
+            else:
+                raise ValueError("Dynamic timestep shift patch size must be an integer or a 2D/3D patch-size sequence.")
+            return tuple(self._coerce_dynamic_shift_patch_dimension(value) for value in patch_dimensions)
+        raise ValueError("Cannot compute dynamic timestep shift because no valid `patch_size` was found.")
 
     def calculate_dynamic_shift_mu(self, noise_scheduler, latents: torch.Tensor | None):
         """
@@ -4657,19 +4689,30 @@ class ModelFoundation(ExplorativeModelingMixin, ABC):
                 f"Cannot compute dynamic timestep shift; scheduler is missing config values: {', '.join(missing_fields)}"
             )
 
-        patch_size = self._get_patch_size_for_dynamic_shift(noise_scheduler)
-        if patch_size is None or patch_size <= 0:
-            raise ValueError("Cannot compute dynamic timestep shift because no valid `patch_size` was found.")
-
-        # Handle video latents [B, C, F, H, W] vs image latents [B, C, H, W]
-        if latents.ndim == 5:
-            num_frames, height, width = latents.shape[-3:]
+        latent_sequence_length = getattr(self, "_latent_sequence_length", None)
+        if callable(latent_sequence_length):
+            seq_len = int(latent_sequence_length(latents))
         else:
-            num_frames = 1
-            height, width = latents.shape[-2:]
+            patch_size = self._get_patch_size_for_dynamic_shift(noise_scheduler)
+            if patch_size is None:
+                raise ValueError("Cannot compute dynamic timestep shift because no valid `patch_size` was found.")
+            temporal_patch_size, height_patch_size, width_patch_size = self._dynamic_shift_patch_dimensions(patch_size)
 
-        # Compute sequence length (spatiotemporal for video, spatial for images)
-        seq_len = num_frames * (int(height) // int(patch_size)) * (int(width) // int(patch_size))
+            # Handle video latents [B, C, F, H, W] vs image latents [B, C, H, W]
+            if latents.ndim == 5:
+                num_frames, height, width = latents.shape[-3:]
+            else:
+                num_frames = 1
+                height, width = latents.shape[-2:]
+
+            seq_len = (
+                (int(num_frames) // temporal_patch_size)
+                * (int(height) // height_patch_size)
+                * (int(width) // width_patch_size)
+            )
+        if seq_len <= 0:
+            raise ValueError(f"Cannot compute dynamic timestep shift from non-positive sequence length {seq_len}.")
+
         from simpletuner.helpers.models.sd3.pipeline import calculate_shift
 
         return calculate_shift(

--- a/simpletuner/helpers/models/flux2/model.py
+++ b/simpletuner/helpers/models/flux2/model.py
@@ -87,6 +87,7 @@ class Flux2(ImageModelFoundation):
     ENABLED_IN_WIZARD = True
     PREDICTION_TYPE = PredictionTypes.FLOW_MATCHING
     MODEL_TYPE = ModelTypes.TRANSFORMER
+    USES_DYNAMIC_SHIFT = True
     AUTO_LORA_FORMAT_DETECTION = True
     NATIVE_COMFYUI_LORA_SUPPORT = True  # Flux2 has native ComfyUI LoRA support, no conversion needed
     COMFYUI_LORA_PRESERVE_COMPONENT_PREFIXES = {"transformer"}

--- a/simpletuner/helpers/models/krea2/model.py
+++ b/simpletuner/helpers/models/krea2/model.py
@@ -403,6 +403,13 @@ class Krea2(ImageModelFoundation):
         config = getattr(transformer, "config", None)
         return int(max(getattr(config, "patch_size", 2), 1))
 
+    def _latent_sequence_length(self, latent_tensor: torch.Tensor) -> int:
+        if latent_tensor.dim() != 4:
+            raise ValueError(f"Krea 2 expected image latents with shape (B, C, H, W), got {tuple(latent_tensor.shape)}.")
+        _, _, height, width = latent_tensor.shape
+        patch_size = self._patch_size()
+        return max((height // patch_size) * (width // patch_size), 1)
+
     def _pack_latents(self, latents: torch.Tensor) -> tuple[torch.Tensor, int, int]:
         patch_size = self._patch_size()
         batch_size, channels, height, width = latents.shape

--- a/tests/test_krea2_model.py
+++ b/tests/test_krea2_model.py
@@ -81,6 +81,24 @@ class Krea2VendoredModelTests(unittest.TestCase):
         self.assertEqual(_krea2_rope_freqs_dtype(torch.device("cuda")), torch.float64)
         self.assertEqual(_krea2_rope_freqs_dtype(torch.device("mps")), torch.float32)
 
+    def test_dynamic_shift_mu_uses_krea2_patch_size_without_transformer_config_field(self):
+        model = Krea2.__new__(Krea2)
+        model.config = SimpleNamespace()
+        model.model = SimpleNamespace(config=SimpleNamespace())
+        model.unwrap_model = lambda model: model
+        scheduler = FlowMatchEulerDiscreteScheduler(
+            use_dynamic_shifting=True,
+            base_image_seq_len=256,
+            max_image_seq_len=512,
+            base_shift=0.5,
+            max_shift=1.0,
+        )
+
+        mu = model.calculate_dynamic_shift_mu(scheduler, torch.zeros(1, 16, 8, 8))
+
+        expected = 0.5 / (512 - 256) * 16  # (8 / 2) * (8 / 2)
+        self.assertAlmostEqual(mu, expected)
+
     def test_lora_loader_targets_transformer(self):
         self.assertEqual(Krea2LoraLoaderMixin._lora_loadable_modules, ["transformer"])
         self.assertEqual(Krea2LoraLoaderMixin.transformer_name, "transformer")

--- a/tests/test_validation_dynamic_shift.py
+++ b/tests/test_validation_dynamic_shift.py
@@ -1,3 +1,5 @@
+import inspect
+import math
 import types
 import unittest
 from unittest.mock import MagicMock, patch
@@ -5,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import torch
 
 from simpletuner.helpers.models.common import ModelFoundation
+from simpletuner.helpers.models.registry import ModelRegistry
 from simpletuner.helpers.training.validation import Evaluation
 
 
@@ -163,6 +166,70 @@ class DynamicShiftTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             eval_helper.get_timestep_schedule(scheduler, latents=torch.zeros(1, 4, 4, 4))
+
+    def _dynamic_shift_model_classes(self):
+        dynamic_shift_model_classes = {}
+        for family, registry_entry in ModelRegistry.model_families().items():
+            if hasattr(registry_entry, "get_real_class"):
+                model_cls = registry_entry.get_real_class()
+            else:
+                model_cls = registry_entry
+            if getattr(model_cls, "USES_DYNAMIC_SHIFT", False):
+                dynamic_shift_model_classes[family] = model_cls
+        return dynamic_shift_model_classes
+
+    def _model_class_declares_patch_size(self, model_cls):
+        component_cls = getattr(model_cls, "MODEL_CLASS", None)
+        self.assertIsNotNone(component_cls, f"{model_cls.__name__} must define MODEL_CLASS")
+        init_method = getattr(component_cls, "__init__", None)
+        try:
+            parameters = inspect.signature(init_method).parameters
+        except (TypeError, ValueError):
+            return False
+        return "patch_size" in parameters
+
+    def test_dynamic_shift_models_expose_patch_geometry_or_sequence_length(self):
+        model_classes = self._dynamic_shift_model_classes()
+        self.assertGreater(len(model_classes), 0)
+
+        for family, model_cls in model_classes.items():
+            with self.subTest(family=family):
+                has_model_sequence_length = "_latent_sequence_length" in model_cls.__dict__
+                has_component_patch_size = self._model_class_declares_patch_size(model_cls)
+                self.assertTrue(
+                    has_model_sequence_length or has_component_patch_size,
+                    f"{model_cls.__name__} uses dynamic shift but does not expose patch geometry",
+                )
+
+                model = model_cls.__new__(model_cls)
+                model.config = types.SimpleNamespace(controlnet=False)
+                model.accelerator = None
+                model.model = types.SimpleNamespace(config=types.SimpleNamespace())
+                if not has_model_sequence_length:
+                    model.model.config.patch_size = 2
+                    model.model.config.patch_size_t = 1
+
+                latent_channels = getattr(model_cls, "LATENT_CHANNEL_COUNT", 4)
+                latents = torch.zeros(1, latent_channels, 8, 8)
+                mu = model.calculate_dynamic_shift_mu(self.scheduler, latents)
+
+                self.assertTrue(math.isfinite(mu), f"{model_cls.__name__} produced non-finite dynamic shift mu")
+
+    def test_dynamic_scheduler_configs_declare_dynamic_shift_flag(self):
+        for family, registry_entry in ModelRegistry.model_families().items():
+            if hasattr(registry_entry, "get_real_class"):
+                model_cls = registry_entry.get_real_class()
+            else:
+                model_cls = registry_entry
+            scheduler_config = getattr(inspect.getmodule(model_cls), "SCHEDULER_CONFIG", None)
+            if not isinstance(scheduler_config, dict) or not scheduler_config.get("use_dynamic_shifting"):
+                continue
+
+            with self.subTest(family=family):
+                self.assertTrue(
+                    getattr(model_cls, "USES_DYNAMIC_SHIFT", False),
+                    f"{model_cls.__name__} scheduler config enables dynamic shift without USES_DYNAMIC_SHIFT",
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_validation_dynamic_shift.py
+++ b/tests/test_validation_dynamic_shift.py
@@ -33,6 +33,28 @@ class _DummyModel(ModelFoundation):
         return getattr(self, "_test_patch_size", None)
 
 
+class _DefaultPatchModel(ModelFoundation):
+    # Bypass abstract __init__ by using __new__ in tests.
+    PREDICTION_TYPE = None
+    MODEL_TYPE = None
+    NAME = "DefaultPatch"
+    DEFAULT_PIPELINE_TYPE = None
+    PIPELINE_CLASSES = {}
+    VALIDATION_USES_NEGATIVE_PROMPT = False
+
+    def model_predict(self, prepared_batch, custom_timesteps: list = None):
+        raise NotImplementedError
+
+    def _encode_prompts(self, prompts: list, is_negative_prompt: bool = False):
+        raise NotImplementedError
+
+    def convert_text_embed_for_pipeline(self, text_embedding: torch.Tensor) -> dict:
+        raise NotImplementedError
+
+    def convert_negative_text_embed_for_pipeline(self, text_embedding: torch.Tensor) -> dict:
+        raise NotImplementedError
+
+
 class DynamicShiftTests(unittest.TestCase):
     def setUp(self):
         self.scheduler = MagicMock()
@@ -52,6 +74,29 @@ class DynamicShiftTests(unittest.TestCase):
         mu = model.calculate_dynamic_shift_mu(self.scheduler, latents)
 
         expected = 0.5 / (512 - 256) * 4  # linear shift per seq len
+        self.assertAlmostEqual(mu, expected)
+
+    def test_calculate_dynamic_shift_mu_uses_temporal_patch_size_for_video_latents(self):
+        model = _DummyModel.__new__(_DummyModel)
+        model._test_patch_size = (4, 2, 2)
+        model.config = types.SimpleNamespace()
+
+        latents = torch.zeros(1, 4, 8, 4, 4)
+        mu = model.calculate_dynamic_shift_mu(self.scheduler, latents)
+
+        expected = 0.5 / (512 - 256) * 8  # (8 / 4) * (4 / 2) * (4 / 2)
+        self.assertAlmostEqual(mu, expected)
+
+    def test_calculate_dynamic_shift_mu_uses_component_patch_size_t(self):
+        model = _DefaultPatchModel.__new__(_DefaultPatchModel)
+        model.config = types.SimpleNamespace(controlnet=False)
+        model.accelerator = None
+        model.model = types.SimpleNamespace(config=types.SimpleNamespace(patch_size=2, patch_size_t=4))
+
+        latents = torch.zeros(1, 4, 8, 4, 4)
+        mu = model.calculate_dynamic_shift_mu(self.scheduler, latents)
+
+        expected = 0.5 / (512 - 256) * 8  # (8 / 4) * (4 / 2) * (4 / 2)
         self.assertAlmostEqual(mu, expected)
 
     def test_calculate_dynamic_shift_mu_errors_when_config_missing(self):


### PR DESCRIPTION
## Summary
- derive validation dynamic-shift sequence length from model-specific latent sequence helpers when available
- preserve temporal patch geometry from `patch_size_t` for dynamic-shift models
- add registry-wide dynamic-shift invariants so new auto-shift model families must expose patch geometry or model-local sequence length
- mark Flux2 as dynamic-shift so validation follows its scheduler config

## Tests
- `.venv/bin/python -m unittest -v -f tests.test_validation_dynamic_shift tests.test_krea2_model tests.test_ltxvideo2_dynamic_shift tests.test_flux2_model`
- `.venv/bin/python -m unittest -v -f`