### PR TITLE
Add manual system telemetry metrics logging

### DIFF
--- a/documentation/webui/LOCAL_METRICS.es.md
+++ b/documentation/webui/LOCAL_METRICS.es.md
@@ -19,6 +19,8 @@ El directorio de salida contiene:
 
 Una reanudación añade registros. Archiva el informe HTML junto con el directorio de salida porque usa rutas relativas para los medios.
 
+Cuando un tracker no recopila telemetría del sistema de forma nativa, SimpleTuner registra métricas numéricas de CPU, memoria, disco, red y GPU para ese tracker. WandB se omite porque su cliente ya informa métricas del host.
+
 ## WebUI y API
 
 Abre **Metrics** y **Training Runs** para elegir escalares, comparar validaciones por prompt/paso y abrir el informe. **System** conserva salud de GPU y Prometheus.

--- a/documentation/webui/LOCAL_METRICS.hi.md
+++ b/documentation/webui/LOCAL_METRICS.hi.md
@@ -17,6 +17,8 @@ SimpleTuner बाहरी सेवा के बिना प्रशिक�
 
 Resume पर records जोड़े जाते हैं। HTML relative media paths उपयोग करता है, इसलिए इसे output directory के साथ archive करें।
 
+जब कोई tracker system telemetry native रूप से collect नहीं करता, SimpleTuner उस tracker के लिए CPU, memory, disk, network और GPU की numeric metrics लिखता है। WandB को छोड़ा जाता है क्योंकि उसका client host metrics पहले से report करता है।
+
 ## WebUI और API
 
 **Metrics** में **Training Runs** खोलें। यहाँ scalar चुन सकते हैं, prompt/step के अनुसार validation तुलना कर सकते हैं और offline report खोल सकते हैं। **System** में GPU health और Prometheus configuration रहती है।

--- a/documentation/webui/LOCAL_METRICS.ja.md
+++ b/documentation/webui/LOCAL_METRICS.ja.md
@@ -17,6 +17,8 @@
 
 再開時は既存履歴へ追記します。HTML は相対メディアパスを使うため、出力ディレクトリと一緒に保存してください。
 
+tracker が system telemetry を標準で収集しない場合、SimpleTuner は CPU、メモリ、ディスク、ネットワーク、GPU の数値メトリクスをその tracker に記録します。WandB はクライアント側で host metrics を収集するため、手動記録の対象外です。
+
 ## WebUI と API
 
 **Metrics** の **Training Runs** でスカラーを選択し、prompt と step ごとに検証結果を比較できます。**System** には GPU health と Prometheus 設定があります。

--- a/documentation/webui/LOCAL_METRICS.md
+++ b/documentation/webui/LOCAL_METRICS.md
@@ -25,6 +25,8 @@ The JSONL files are the raw interface for analysis tools. A resumed run appends 
 
 The HTML report embeds a bounded copy of the scalar history and uses relative paths for validation media. Archive it with the output directory.
 
+When a tracker does not collect system telemetry natively, SimpleTuner records numeric CPU, memory, disk, network, and GPU telemetry for that tracker. WandB is skipped for manual system telemetry because its client already reports host metrics.
+
 ## WebUI
 
 Open **Metrics**, then **Training Runs**. Runs are discovered from saved WebUI environments. The page provides:

--- a/documentation/webui/LOCAL_METRICS.pt-BR.md
+++ b/documentation/webui/LOCAL_METRICS.pt-BR.md
@@ -17,6 +17,8 @@ Use valores separados por virgula, como `report_to=simpletuner,wandb`, para ativ
 
 Ao retomar, novos registros são anexados. Arquive o HTML com o diretório de saída, pois os caminhos de mídia são relativos.
 
+Quando um tracker não coleta telemetria do sistema nativamente, o SimpleTuner registra métricas numéricas de CPU, memória, disco, rede e GPU para esse tracker. O WandB é ignorado porque seu cliente já relata métricas do host.
+
 ## WebUI e API
 
 Abra **Metrics** e **Training Runs** para selecionar escalares, comparar validações por prompt/etapa e abrir o relatório. **System** mantém a saúde das GPUs e a configuração do Prometheus.

--- a/documentation/webui/LOCAL_METRICS.zh.md
+++ b/documentation/webui/LOCAL_METRICS.zh.md
@@ -17,6 +17,8 @@ SimpleTuner 可以在不使用外部服务的情况下记录训练指标：
 
 恢复训练时会追加记录。HTML 使用相对媒体路径，因此应与输出目录一起归档。
 
+当 tracker 本身不收集系统遥测时，SimpleTuner 会为该 tracker 记录 CPU、内存、磁盘、网络和 GPU 的数值指标。WandB 会被跳过，因为它的客户端已经报告主机指标。
+
 ## WebUI 与 API
 
 打开 **Metrics** 和 **Training Runs**，可选择标量、按 prompt/step 比较验证结果并打开离线报告。**System** 保留 GPU 健康和 Prometheus 设置。

--- a/simpletuner/helpers/training/system_metrics.py
+++ b/simpletuner/helpers/training/system_metrics.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import plistlib
+import re
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+import psutil
+
+from simpletuner.helpers.training.reporting import report_to_tokens
+
+logger = logging.getLogger(__name__)
+
+NATIVE_SYSTEM_METRIC_TRACKERS = {"wandb"}
+
+
+def should_collect_manual_system_metrics(report_to: Any) -> bool:
+    return any(token not in NATIVE_SYSTEM_METRIC_TRACKERS and token != "none" for token in report_to_tokens(report_to))
+
+
+def _coerce_number(value: Any) -> Optional[float]:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        match = re.search(r"-?\d+(?:\.\d+)?", value)
+        if not match:
+            return None
+        try:
+            return float(match.group(0))
+        except ValueError:
+            return None
+    return None
+
+
+def _gib(value: Optional[float]) -> Optional[float]:
+    if value is None:
+        return None
+    return round(float(value) / (1024**3), 3)
+
+
+def _put_metric(metrics: dict[str, float], name: str, value: Any, *, digits: int = 3) -> None:
+    number = _coerce_number(value)
+    if number is None:
+        return
+    metrics[name] = round(number, digits)
+
+
+def _first_key_value(entry: dict[str, Any], key_fragments: Iterable[tuple[str, ...]]) -> Optional[float]:
+    lowered = [(key.lower(), value) for key, value in entry.items()]
+    for fragments in key_fragments:
+        for key, value in lowered:
+            if all(fragment in key for fragment in fragments):
+                return _coerce_number(value)
+    return None
+
+
+class SystemMetricsSampler:
+    def __init__(
+        self,
+        *,
+        output_dir: str | os.PathLike[str],
+        min_interval_seconds: float = 5.0,
+        time_source: Any = None,
+    ) -> None:
+        self.output_dir = Path(output_dir).expanduser()
+        self.min_interval_seconds = float(min_interval_seconds)
+        self._time_source = time_source or time.monotonic
+        self._last_sample_time: Optional[float] = None
+        self._last_net_counters: Optional[Any] = None
+        self._last_net_time: Optional[float] = None
+
+    def sample(self, *, force: bool = False) -> dict[str, float]:
+        now = float(self._time_source())
+        if not force and self._last_sample_time is not None and now - self._last_sample_time < self.min_interval_seconds:
+            return {}
+        self._last_sample_time = now
+
+        metrics: dict[str, float] = {}
+        self._sample_system(metrics, now)
+        self._sample_gpu(metrics)
+        return metrics
+
+    def _sample_system(self, metrics: dict[str, float], now: float) -> None:
+        cpu_percent = psutil.cpu_percent(interval=None)
+        _put_metric(metrics, "system/cpu_percent", cpu_percent, digits=1)
+
+        memory = psutil.virtual_memory()
+        _put_metric(metrics, "system/memory_percent", memory.percent, digits=1)
+        _put_metric(metrics, "system/memory_available_gb", _gib(float(memory.available)), digits=3)
+
+        disk = shutil.disk_usage(self.output_dir)
+        _put_metric(metrics, "system/disk_free_gb", _gib(float(disk.free)), digits=3)
+        if disk.total > 0:
+            _put_metric(metrics, "system/disk_percent", (disk.used / disk.total) * 100.0, digits=1)
+
+        counters = psutil.net_io_counters()
+        if self._last_net_counters is not None and self._last_net_time is not None:
+            elapsed = now - self._last_net_time
+            if elapsed > 0:
+                sent_delta = max(0, counters.bytes_sent - self._last_net_counters.bytes_sent)
+                recv_delta = max(0, counters.bytes_recv - self._last_net_counters.bytes_recv)
+                _put_metric(metrics, "system/network_sent_mbps", (sent_delta * 8) / elapsed / 1_000_000, digits=3)
+                _put_metric(metrics, "system/network_recv_mbps", (recv_delta * 8) / elapsed / 1_000_000, digits=3)
+        self._last_net_counters = counters
+        self._last_net_time = now
+
+    def _sample_gpu(self, metrics: dict[str, float]) -> None:
+        try:
+            import torch
+        except ImportError:
+            return
+
+        if torch.cuda.is_available():
+            if bool(getattr(torch.version, "hip", None)):
+                self._sample_rocm(metrics)
+            else:
+                self._sample_cuda(metrics)
+            return
+
+        mps_backend = getattr(torch.backends, "mps", None)
+        if mps_backend is not None and mps_backend.is_available():
+            self._sample_mps(metrics, torch)
+
+    def _sample_cuda(self, metrics: dict[str, float]) -> None:
+        if self._sample_nvml(metrics):
+            return
+        self._sample_nvidia_smi(metrics)
+
+    def _sample_nvml(self, metrics: dict[str, float]) -> bool:
+        try:
+            import pynvml
+        except ImportError:
+            return False
+
+        initialized_here = False
+        try:
+            pynvml.nvmlInit()
+            initialized_here = True
+        except Exception as exc:
+            already_initialized = getattr(pynvml, "NVMLError_AlreadyInitialized", None)
+            if already_initialized is None or not isinstance(exc, already_initialized):
+                logger.debug("Unable to initialise NVML for system metrics: %s", exc, exc_info=True)
+                return False
+
+        initial_metric_count = len(metrics)
+        try:
+            device_count = pynvml.nvmlDeviceGetCount()
+            for index in range(device_count):
+                handle = pynvml.nvmlDeviceGetHandleByIndex(index)
+                prefix = f"system/gpu/{index}"
+                try:
+                    util = pynvml.nvmlDeviceGetUtilizationRates(handle)
+                    _put_metric(metrics, f"{prefix}/utilization_percent", getattr(util, "gpu", None), digits=1)
+                    _put_metric(metrics, f"{prefix}/memory_utilization_percent", getattr(util, "memory", None), digits=1)
+                except Exception:
+                    logger.debug("Unable to read NVML utilisation for GPU %s", index, exc_info=True)
+                try:
+                    mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
+                    _put_metric(metrics, f"{prefix}/memory_used_gb", _gib(float(mem.used)), digits=3)
+                    _put_metric(metrics, f"{prefix}/memory_total_gb", _gib(float(mem.total)), digits=3)
+                    if mem.total:
+                        _put_metric(metrics, f"{prefix}/memory_percent", (mem.used / mem.total) * 100.0, digits=1)
+                except Exception:
+                    logger.debug("Unable to read NVML memory for GPU %s", index, exc_info=True)
+                try:
+                    _put_metric(
+                        metrics,
+                        f"{prefix}/temperature_celsius",
+                        pynvml.nvmlDeviceGetTemperature(handle, pynvml.NVML_TEMPERATURE_GPU),
+                        digits=1,
+                    )
+                except Exception:
+                    logger.debug("Unable to read NVML temperature for GPU %s", index, exc_info=True)
+                try:
+                    _put_metric(metrics, f"{prefix}/fan_speed_percent", pynvml.nvmlDeviceGetFanSpeed(handle), digits=1)
+                except Exception:
+                    logger.debug("Unable to read NVML fan speed for GPU %s", index, exc_info=True)
+                try:
+                    _put_metric(metrics, f"{prefix}/power_usage_watts", pynvml.nvmlDeviceGetPowerUsage(handle) / 1000.0)
+                except Exception:
+                    logger.debug("Unable to read NVML power usage for GPU %s", index, exc_info=True)
+            return len(metrics) > initial_metric_count
+        finally:
+            if initialized_here:
+                try:
+                    pynvml.nvmlShutdown()
+                except Exception:
+                    logger.debug("Unable to shutdown NVML after system metrics sampling", exc_info=True)
+
+    def _sample_nvidia_smi(self, metrics: dict[str, float]) -> None:
+        try:
+            completed = subprocess.run(
+                [
+                    "nvidia-smi",
+                    "--query-gpu=utilization.gpu,memory.used,memory.total,temperature.gpu,fan.speed,power.draw",
+                    "--format=csv,noheader,nounits",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+        except (FileNotFoundError, subprocess.SubprocessError) as exc:
+            logger.debug("Unable to query nvidia-smi for system metrics: %s", exc, exc_info=True)
+            return
+
+        for index, line in enumerate(completed.stdout.strip().splitlines()):
+            values = [value.strip() for value in line.split(",")]
+            if len(values) < 6:
+                continue
+            util, mem_used_mib, mem_total_mib, temperature, fan_speed, power = values[:6]
+            prefix = f"system/gpu/{index}"
+            _put_metric(metrics, f"{prefix}/utilization_percent", util, digits=1)
+            mem_used = _coerce_number(mem_used_mib)
+            mem_total = _coerce_number(mem_total_mib)
+            if mem_used is not None:
+                _put_metric(metrics, f"{prefix}/memory_used_gb", mem_used / 1024.0, digits=3)
+            if mem_total is not None:
+                _put_metric(metrics, f"{prefix}/memory_total_gb", mem_total / 1024.0, digits=3)
+            if mem_used is not None and mem_total:
+                _put_metric(metrics, f"{prefix}/memory_percent", (mem_used / mem_total) * 100.0, digits=1)
+            _put_metric(metrics, f"{prefix}/temperature_celsius", temperature, digits=1)
+            _put_metric(metrics, f"{prefix}/fan_speed_percent", fan_speed, digits=1)
+            _put_metric(metrics, f"{prefix}/power_usage_watts", power)
+
+    def _sample_rocm(self, metrics: dict[str, float]) -> None:
+        rocm_smi = shutil.which("rocm-smi")
+        if not rocm_smi:
+            return
+        try:
+            completed = subprocess.run(
+                [rocm_smi, "--showuse", "--showmemuse", "--showtemp", "--showfan", "--showpower", "--json"],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+        except (FileNotFoundError, subprocess.SubprocessError) as exc:
+            logger.debug("Unable to query rocm-smi for system metrics: %s", exc, exc_info=True)
+            return
+
+        try:
+            payload = json.loads(completed.stdout or "{}")
+        except json.JSONDecodeError as exc:
+            logger.debug("Unable to parse rocm-smi JSON for system metrics: %s", exc, exc_info=True)
+            return
+        if not isinstance(payload, dict):
+            return
+
+        for position, entry in enumerate(payload.values()):
+            if not isinstance(entry, dict):
+                continue
+            prefix = f"system/gpu/{position}"
+            _put_metric(metrics, f"{prefix}/utilization_percent", _first_key_value(entry, [("gpu", "use")]), digits=1)
+            memory_percent = _first_key_value(entry, [("vram", "%"), ("memory", "%"), ("mem", "%")])
+            _put_metric(metrics, f"{prefix}/memory_percent", memory_percent, digits=1)
+            _put_metric(
+                metrics, f"{prefix}/temperature_celsius", _first_key_value(entry, [("temperature",), ("temp",)]), digits=1
+            )
+            _put_metric(
+                metrics, f"{prefix}/fan_speed_percent", _first_key_value(entry, [("fan", "%"), ("fan", "speed")]), digits=1
+            )
+            _put_metric(metrics, f"{prefix}/power_usage_watts", _first_key_value(entry, [("power",), ("watt",)]))
+
+    def _sample_mps(self, metrics: dict[str, float], torch: Any) -> None:
+        prefix = "system/gpu/0"
+        utilization = self._mps_utilization()
+        _put_metric(metrics, f"{prefix}/utilization_percent", utilization, digits=1)
+
+        driver_alloc = getattr(torch.mps, "driver_allocated_memory", None)
+        driver_total = getattr(torch.mps, "driver_total_memory", None)
+        if callable(driver_alloc) and callable(driver_total):
+            try:
+                allocated = float(driver_alloc())
+                total = float(driver_total())
+            except Exception:
+                logger.debug("Unable to query MPS memory statistics for system metrics", exc_info=True)
+            else:
+                _put_metric(metrics, f"{prefix}/memory_used_gb", _gib(allocated), digits=3)
+                _put_metric(metrics, f"{prefix}/memory_total_gb", _gib(total), digits=3)
+                if total > 0:
+                    _put_metric(metrics, f"{prefix}/memory_percent", (allocated / total) * 100.0, digits=1)
+
+    def _mps_utilization(self) -> Optional[float]:
+        if platform.system() != "Darwin":
+            return None
+        try:
+            completed = subprocess.run(
+                ["ioreg", "-r", "-k", "PerformanceStatistics", "-d", "1", "-a"],
+                check=True,
+                capture_output=True,
+                text=False,
+                timeout=2,
+            )
+            data = plistlib.loads(completed.stdout)
+        except (FileNotFoundError, subprocess.SubprocessError, plistlib.InvalidFileException, ValueError) as exc:
+            logger.debug("Unable to query MPS utilisation for system metrics: %s", exc, exc_info=True)
+            return None
+        if not isinstance(data, list):
+            return None
+        for entry in data:
+            if not isinstance(entry, dict):
+                continue
+            perf = entry.get("PerformanceStatistics")
+            if not isinstance(perf, dict):
+                continue
+            value = _coerce_number(perf.get("Device Utilization %"))
+            if value is not None:
+                return value
+        return None
+
+
+def log_system_metrics_to_trackers(trackers: Iterable[Any], metrics: dict[str, float], *, step: int) -> None:
+    if not metrics:
+        return
+    for tracker in trackers:
+        name = str(getattr(tracker, "name", "") or "").strip().lower()
+        if not name or name in NATIVE_SYSTEM_METRIC_TRACKERS:
+            continue
+        log = getattr(tracker, "log", None)
+        if not callable(log):
+            logger.warning("Tracker '%s' cannot receive manual system metrics because it has no log method.", name)
+            continue
+        try:
+            log(metrics, step=step)
+        except Exception as exc:
+            logger.warning("Failed to log manual system metrics to tracker '%s': %s", name, exc)

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -109,6 +109,11 @@ from simpletuner.helpers.training.reporting import normalize_report_to, report_t
 from simpletuner.helpers.training.script_runner import run_hook_script
 from simpletuner.helpers.training.sdnq_compile import configure_sdnq_compile_mode
 from simpletuner.helpers.training.state_tracker import StateTracker
+from simpletuner.helpers.training.system_metrics import (
+    SystemMetricsSampler,
+    log_system_metrics_to_trackers,
+    should_collect_manual_system_metrics,
+)
 from simpletuner.helpers.training.validation import Validation, prepare_validation_prompt_list
 from simpletuner.helpers.training.wrappers import rebind_prepared_forward, unwrap_model
 from simpletuner.helpers.utils import ramtorch as ramtorch_utils
@@ -2485,6 +2490,7 @@ class Trainer:
         self.grad_norm = None
         self.extra_lr_scheduler_kwargs = {}
         self.iteration_tracker = IterationTracker()
+        self.system_metrics_sampler = None
         StateTracker.set_global_step(self.state["global_step"])
         StateTracker.set_global_resume_step(self.state["global_resume_step"])
         self._init_publishing_manager()
@@ -5848,6 +5854,21 @@ class Trainer:
                 metrics[key] = value
         return metrics
 
+    def _log_manual_system_metrics(self) -> None:
+        if not self.accelerator.is_main_process:
+            return
+        trackers = list(getattr(self.accelerator, "trackers", []) or [])
+        if not trackers:
+            return
+        tracker_names = [str(getattr(tracker, "name", "") or "").strip().lower() for tracker in trackers]
+        if not should_collect_manual_system_metrics(tracker_names):
+            return
+        if self.system_metrics_sampler is None:
+            self.system_metrics_sampler = SystemMetricsSampler(output_dir=self.config.output_dir)
+        metrics = self.system_metrics_sampler.sample()
+        if metrics:
+            log_system_metrics_to_trackers(trackers, metrics, step=int(self.state["global_step"]))
+
     def _prepare_training_progress_payload(
         self,
         *,
@@ -7549,6 +7570,7 @@ class Trainer:
                         )
                     except Exception as e:
                         logger.error(f"Failed to log to accelerator; ignoring error: {e}")
+                    self._log_manual_system_metrics()
 
                     # Reset some values for the next go.
                     self.train_loss = 0.0

--- a/tests/test_system_metrics.py
+++ b/tests/test_system_metrics.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from simpletuner.helpers.training.system_metrics import (
+    SystemMetricsSampler,
+    log_system_metrics_to_trackers,
+    should_collect_manual_system_metrics,
+)
+
+
+class SystemMetricsSamplerTests(unittest.TestCase):
+    def test_should_collect_manual_system_metrics_skips_native_wandb_only(self):
+        self.assertFalse(should_collect_manual_system_metrics("wandb"))
+        self.assertFalse(should_collect_manual_system_metrics(["none"]))
+        self.assertTrue(should_collect_manual_system_metrics("simpletuner"))
+        self.assertTrue(should_collect_manual_system_metrics(["wandb", "simpletuner"]))
+        self.assertTrue(should_collect_manual_system_metrics(["tensorboard"]))
+
+    def test_samples_system_metrics_and_network_rates(self):
+        times = iter([10.0, 15.0])
+        counters = [
+            SimpleNamespace(bytes_sent=1_000, bytes_recv=2_000),
+            SimpleNamespace(bytes_sent=2_000, bytes_recv=4_500),
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            sampler = SystemMetricsSampler(output_dir=directory, min_interval_seconds=0, time_source=lambda: next(times))
+            sampler._sample_gpu = lambda metrics: metrics.update({"system/gpu/0/utilization_percent": 42.0})
+            with (
+                mock.patch("simpletuner.helpers.training.system_metrics.psutil.cpu_percent", return_value=25.5),
+                mock.patch(
+                    "simpletuner.helpers.training.system_metrics.psutil.virtual_memory",
+                    return_value=SimpleNamespace(percent=63.2, available=4 * 1024**3),
+                ),
+                mock.patch(
+                    "simpletuner.helpers.training.system_metrics.psutil.net_io_counters",
+                    side_effect=counters,
+                ),
+                mock.patch(
+                    "simpletuner.helpers.training.system_metrics.shutil.disk_usage",
+                    return_value=SimpleNamespace(total=100, used=25, free=75),
+                ),
+            ):
+                first = sampler.sample(force=True)
+                second = sampler.sample(force=True)
+
+        self.assertEqual(first["system/cpu_percent"], 25.5)
+        self.assertEqual(first["system/memory_percent"], 63.2)
+        self.assertEqual(first["system/disk_percent"], 25.0)
+        self.assertEqual(first["system/gpu/0/utilization_percent"], 42.0)
+        self.assertNotIn("system/network_sent_mbps", first)
+        self.assertEqual(second["system/network_sent_mbps"], 0.002)
+        self.assertEqual(second["system/network_recv_mbps"], 0.004)
+
+    def test_sampler_throttles_between_intervals(self):
+        times = iter([10.0, 11.0])
+        with tempfile.TemporaryDirectory() as directory:
+            sampler = SystemMetricsSampler(output_dir=directory, min_interval_seconds=5, time_source=lambda: next(times))
+            sampler._sample_system = lambda metrics, _now: metrics.update({"system/cpu_percent": 1.0})
+            sampler._sample_gpu = lambda _metrics: None
+
+            self.assertEqual(sampler.sample(), {"system/cpu_percent": 1.0})
+            self.assertEqual(sampler.sample(), {})
+
+    def test_rocm_json_metrics_are_flattened(self):
+        payload = {
+            "card0": {
+                "GPU use (%)": "76%",
+                "GPU Memory Allocated (VRAM%)": "41%",
+                "Temperature (Sensor edge) (C)": "62.5c",
+                "Fan Speed (%)": "35%",
+                "Average Graphics Package Power (W)": "180.5 W",
+            }
+        }
+        completed = SimpleNamespace(stdout=json.dumps(payload))
+        sampler = SystemMetricsSampler(output_dir=".", min_interval_seconds=0)
+        metrics: dict[str, float] = {}
+        with (
+            mock.patch("simpletuner.helpers.training.system_metrics.shutil.which", return_value="/usr/bin/rocm-smi"),
+            mock.patch("simpletuner.helpers.training.system_metrics.subprocess.run", return_value=completed),
+        ):
+            sampler._sample_rocm(metrics)
+
+        self.assertEqual(metrics["system/gpu/0/utilization_percent"], 76.0)
+        self.assertEqual(metrics["system/gpu/0/memory_percent"], 41.0)
+        self.assertEqual(metrics["system/gpu/0/temperature_celsius"], 62.5)
+        self.assertEqual(metrics["system/gpu/0/fan_speed_percent"], 35.0)
+        self.assertEqual(metrics["system/gpu/0/power_usage_watts"], 180.5)
+
+
+class SystemMetricsTrackerRoutingTests(unittest.TestCase):
+    def test_logs_to_non_native_trackers_only(self):
+        wandb = SimpleNamespace(name="wandb", log=mock.Mock())
+        simpletuner = SimpleNamespace(name="simpletuner", log=mock.Mock())
+        tensorboard = SimpleNamespace(name="tensorboard", log=mock.Mock())
+
+        log_system_metrics_to_trackers(
+            [wandb, simpletuner, tensorboard],
+            {"system/cpu_percent": 33.0},
+            step=12,
+        )
+
+        wandb.log.assert_not_called()
+        simpletuner.log.assert_called_once_with({"system/cpu_percent": 33.0}, step=12)
+        tensorboard.log.assert_called_once_with({"system/cpu_percent": 33.0}, step=12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a training-side system telemetry sampler for trackers without native host metrics
- collect CPU, memory, output disk, network rate, and GPU metrics
- support NVIDIA/CUDA, AMD/ROCm, and Apple/MPS telemetry sources where available
- skip manual telemetry for WandB to avoid duplicating its native host metrics

Refs #3167.

## Validation

- `.venv/bin/python -m unittest tests.test_system_metrics -v -f`
- `.venv/bin/python -m py_compile simpletuner/helpers/training/system_metrics.py simpletuner/helpers/training/trainer.py`
- `git diff --check`
