### PR TITLE
Add local metrics galleries and timestep charts

### DIFF
--- a/documentation/webui/LOCAL_METRICS.es.md
+++ b/documentation/webui/LOCAL_METRICS.es.md
@@ -15,6 +15,7 @@ El directorio de salida contiene:
 - `training_metrics.jsonl`: escalares por paso, en formato append-only.
 - `training_metrics.json`: manifiesto atómico, estado y nombres de métricas.
 - `validation_media.jsonl`: índice de imágenes, vídeo y audio de validación.
+- `timestep_distribution.jsonl`: muestras de timestep agrupadas por paso global.
 - `training_report.html`: informe autónomo que abre sin servidor.
 
 Una reanudación añade registros. Archiva el informe HTML junto con el directorio de salida porque usa rutas relativas para los medios.
@@ -23,7 +24,7 @@ Cuando un tracker no recopila telemetría del sistema de forma nativa, SimpleTun
 
 ## WebUI y API
 
-Abre **Metrics** y **Training Runs** para elegir escalares, comparar validaciones por prompt/paso y abrir el informe. **System** conserva salud de GPU y Prometheus.
+Abre **Metrics** y **Training Runs** para elegir escalares por paso o minutos, ver la distribución de timesteps, revisar galerías de validación por paso y abrir el informe. **System** conserva salud de GPU y Prometheus.
 
 ```text
 GET /api/metrics/training/runs

--- a/documentation/webui/LOCAL_METRICS.hi.md
+++ b/documentation/webui/LOCAL_METRICS.hi.md
@@ -13,6 +13,7 @@ SimpleTuner बाहरी सेवा के बिना प्रशिक�
 - `training_metrics.jsonl`: हर step के append-only scalar records।
 - `training_metrics.json`: atomic run manifest, status और metric names।
 - `validation_media.jsonl`: validation image, video और audio index।
+- `timestep_distribution.jsonl`: global step के अनुसार grouped timestep samples।
 - `training_report.html`: बिना server के खुलने वाली self-contained report।
 
 Resume पर records जोड़े जाते हैं। HTML relative media paths उपयोग करता है, इसलिए इसे output directory के साथ archive करें।
@@ -21,7 +22,7 @@ Resume पर records जोड़े जाते हैं। HTML relative me
 
 ## WebUI और API
 
-**Metrics** में **Training Runs** खोलें। यहाँ scalar चुन सकते हैं, prompt/step के अनुसार validation तुलना कर सकते हैं और offline report खोल सकते हैं। **System** में GPU health और Prometheus configuration रहती है।
+**Metrics** में **Training Runs** खोलें। यहाँ step या minutes पर scalar, timestep distribution, हर step की validation gallery और offline report देख सकते हैं। **System** में GPU health और Prometheus configuration रहती है।
 
 ```text
 GET /api/metrics/training/runs

--- a/documentation/webui/LOCAL_METRICS.ja.md
+++ b/documentation/webui/LOCAL_METRICS.ja.md
@@ -13,6 +13,7 @@
 - `training_metrics.jsonl`: step ごとの追記専用スカラー記録
 - `training_metrics.json`: 状態、メトリクス名、設定を含むアトミックなマニフェスト
 - `validation_media.jsonl`: 検証画像・動画・音声のインデックス
+- `timestep_distribution.jsonl`: global step ごとにまとめた timestep サンプル
 - `training_report.html`: サーバーなしで開ける自己完結レポート
 
 再開時は既存履歴へ追記します。HTML は相対メディアパスを使うため、出力ディレクトリと一緒に保存してください。
@@ -21,7 +22,7 @@ tracker が system telemetry を標準で収集しない場合、SimpleTuner は
 
 ## WebUI と API
 
-**Metrics** の **Training Runs** でスカラーを選択し、prompt と step ごとに検証結果を比較できます。**System** には GPU health と Prometheus 設定があります。
+**Metrics** の **Training Runs** で step または分単位のスカラー、timestep 分布、step ごとの検証ギャラリー、オフラインレポートを確認できます。**System** には GPU health と Prometheus 設定があります。
 
 ```text
 GET /api/metrics/training/runs

--- a/documentation/webui/LOCAL_METRICS.md
+++ b/documentation/webui/LOCAL_METRICS.md
@@ -19,6 +19,7 @@ The training output directory contains:
 | `training_metrics.jsonl` | Append-only scalar records with step and UTC timestamp |
 | `training_metrics.json` | Atomic run manifest, metric names, status, and selected configuration values |
 | `validation_media.jsonl` | Indexed validation image, video, and audio paths |
+| `timestep_distribution.jsonl` | Timestep samples grouped by global step |
 | `training_report.html` | Self-contained report that opens without a server |
 
 The JSONL files are the raw interface for analysis tools. A resumed run appends records instead of replacing them. Under DDP, only the main process writes these files.
@@ -32,8 +33,9 @@ When a tracker does not collect system telemetry natively, SimpleTuner records n
 Open **Metrics**, then **Training Runs**. Runs are discovered from saved WebUI environments. The page provides:
 
 - dynamic scalar selection, up to eight series
-- latest values and step history
-- validation comparison by prompt and training step
+- latest values over step or elapsed minutes
+- timestep distribution over global step
+- validation galleries grouped by prompt for each training step
 - a link to the offline report
 
 The **System** section retains GPU health and Prometheus configuration.

--- a/documentation/webui/LOCAL_METRICS.pt-BR.md
+++ b/documentation/webui/LOCAL_METRICS.pt-BR.md
@@ -13,6 +13,7 @@ Use valores separados por virgula, como `report_to=simpletuner,wandb`, para ativ
 - `training_metrics.jsonl`: escalares por etapa, somente anexados.
 - `training_metrics.json`: manifesto atômico, status e nomes das métricas.
 - `validation_media.jsonl`: índice de imagens, vídeos e áudios de validação.
+- `timestep_distribution.jsonl`: amostras de timestep agrupadas por etapa global.
 - `training_report.html`: relatório autônomo que abre sem servidor.
 
 Ao retomar, novos registros são anexados. Arquive o HTML com o diretório de saída, pois os caminhos de mídia são relativos.
@@ -21,7 +22,7 @@ Quando um tracker não coleta telemetria do sistema nativamente, o SimpleTuner r
 
 ## WebUI e API
 
-Abra **Metrics** e **Training Runs** para selecionar escalares, comparar validações por prompt/etapa e abrir o relatório. **System** mantém a saúde das GPUs e a configuração do Prometheus.
+Abra **Metrics** e **Training Runs** para selecionar escalares por etapa ou minutos, ver a distribuição de timesteps, revisar galerias de validação por etapa e abrir o relatório. **System** mantém a saúde das GPUs e a configuração do Prometheus.
 
 ```text
 GET /api/metrics/training/runs

--- a/documentation/webui/LOCAL_METRICS.zh.md
+++ b/documentation/webui/LOCAL_METRICS.zh.md
@@ -13,6 +13,7 @@ SimpleTuner 可以在不使用外部服务的情况下记录训练指标：
 - `training_metrics.jsonl`：按 step 追加的标量记录。
 - `training_metrics.json`：原子写入的运行清单、状态和指标名称。
 - `validation_media.jsonl`：验证图像、视频和音频索引。
+- `timestep_distribution.jsonl`：按 global step 分组的 timestep 样本。
 - `training_report.html`：无需服务器即可打开的独立报告。
 
 恢复训练时会追加记录。HTML 使用相对媒体路径，因此应与输出目录一起归档。
@@ -21,7 +22,7 @@ SimpleTuner 可以在不使用外部服务的情况下记录训练指标：
 
 ## WebUI 与 API
 
-打开 **Metrics** 和 **Training Runs**，可选择标量、按 prompt/step 比较验证结果并打开离线报告。**System** 保留 GPU 健康和 Prometheus 设置。
+打开 **Metrics** 和 **Training Runs**，可按 step 或分钟查看标量、查看 timestep 分布、按 step 浏览验证图库并打开离线报告。**System** 保留 GPU 健康和 Prometheus 设置。
 
 ```text
 GET /api/metrics/training/runs

--- a/simpletuner/helpers/training/local_metrics.py
+++ b/simpletuner/helpers/training/local_metrics.py
@@ -15,6 +15,7 @@ SCHEMA_VERSION = 1
 METRICS_FILENAME = "training_metrics.jsonl"
 MANIFEST_FILENAME = "training_metrics.json"
 MEDIA_FILENAME = "validation_media.jsonl"
+TIMESTEP_DISTRIBUTION_FILENAME = "timestep_distribution.jsonl"
 REPORT_FILENAME = "training_report.html"
 REPORT_REFRESH_INTERVAL = 100
 
@@ -96,6 +97,10 @@ def read_media_records(output_dir: str | os.PathLike[str]) -> list[dict[str, Any
     return read_jsonl(Path(output_dir) / MEDIA_FILENAME)
 
 
+def read_timestep_distribution_records(output_dir: str | os.PathLike[str]) -> list[dict[str, Any]]:
+    return read_jsonl(Path(output_dir) / TIMESTEP_DISTRIBUTION_FILENAME)
+
+
 def downsample_records(records: list[dict[str, Any]], max_points: int) -> list[dict[str, Any]]:
     if max_points < 2:
         raise ValueError("max_points must be at least 2.")
@@ -165,6 +170,7 @@ def render_static_report(output_dir: str | os.PathLike[str], max_points: int = 5
         "run": read_manifest(output_path),
         "records": records,
         "media": _media_for_report(output_path),
+        "timesteps": read_timestep_distribution_records(output_path),
     }
     html = template_path.read_text(encoding="utf-8")
     html = html.replace("__SIMPLETUNER_REPORT_CSS__", chart_style_path.read_text(encoding="utf-8"))
@@ -206,6 +212,35 @@ def record_validation_media(
             "path": path.relative_to(output_dir).as_posix(),
         },
     )
+
+
+def record_timestep_distribution(config: Any, samples: list[tuple[int | float, int | float]]) -> None:
+    if config is None or not is_local_metrics_enabled(getattr(config, "report_to", None)) or not samples:
+        return
+
+    grouped: dict[int, list[float]] = {}
+    for step, timestep in samples:
+        try:
+            step_value = int(step)
+            timestep_value = float(timestep)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(timestep_value):
+            grouped.setdefault(step_value, []).append(timestep_value)
+    if not grouped:
+        return
+
+    output_dir = Path(getattr(config, "output_dir")).expanduser().resolve()
+    for step, timesteps in sorted(grouped.items()):
+        _append_json_line(
+            output_dir / TIMESTEP_DISTRIBUTION_FILENAME,
+            {
+                "schema_version": SCHEMA_VERSION,
+                "timestamp": _utc_now(),
+                "step": step,
+                "timesteps": timesteps,
+            },
+        )
 
 
 def _state_tracker_step() -> int:

--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -80,7 +80,7 @@ from simpletuner.helpers.training.evaluation import ModelEvaluator
 from simpletuner.helpers.training.exceptions import GPUHealthError
 from simpletuner.helpers.training.gpu_circuit_breaker import get_current_gpu_index, get_gpu_circuit_breaker, is_cuda_error
 from simpletuner.helpers.training.iteration_tracker import IterationTracker
-from simpletuner.helpers.training.local_metrics import LocalMetricsTracker
+from simpletuner.helpers.training.local_metrics import LocalMetricsTracker, record_timestep_distribution
 from simpletuner.helpers.training.min_snr_gamma import compute_snr
 from simpletuner.helpers.training.multi_process import _get_rank as get_rank
 from simpletuner.helpers.training.multi_process import broadcast_object_from_main, should_log
@@ -7409,6 +7409,7 @@ class Trainer:
                     current_epoch_step += 1
                     StateTracker.set_global_step(self.state["global_step"])
                     self.iteration_tracker.record_step(self.state["global_step"])
+                    wandb_logs.update(self.iteration_tracker.iteration_metrics())
                     self._export_dynamo_cache_after_first_step()
                     if ramtorch_profile.profile_enabled():
                         ramtorch_profile.record_train_step(
@@ -7461,6 +7462,9 @@ class Trainer:
                                 self._twinflow_traj_logged = True
                             else:
                                 wandb_logs["twinflow_traj_table"] = self._twinflow_traj_table
+
+                    if report_to_contains(self.config.report_to, "simpletuner") and self.accelerator.is_main_process:
+                        record_timestep_distribution(self.config, self.timesteps_buffer)
 
                     # Clear buffers
                     self.timesteps_buffer = []

--- a/simpletuner/simpletuner_sdk/server/services/training_metrics_service.py
+++ b/simpletuner/simpletuner_sdk/server/services/training_metrics_service.py
@@ -12,10 +12,12 @@ from simpletuner.helpers.training.local_metrics import (
     MEDIA_FILENAME,
     METRICS_FILENAME,
     REPORT_FILENAME,
+    TIMESTEP_DISTRIBUTION_FILENAME,
     downsample_records,
     read_manifest,
     read_media_records,
     read_metric_records,
+    read_timestep_distribution_records,
 )
 from simpletuner.simpletuner_sdk.server.services.config_store import ConfigStore
 from simpletuner.simpletuner_sdk.server.services.webui_state import WebUIStateStore
@@ -139,11 +141,13 @@ class TrainingMetricsService:
             },
             "records": records,
             "media": media,
+            "timesteps": read_timestep_distribution_records(output_dir),
             "available_metrics": sorted(manifest.get("metric_names", [])),
             "raw_files": {
                 "metrics": METRICS_FILENAME,
                 "manifest": MANIFEST_FILENAME,
                 "media": MEDIA_FILENAME,
+                "timesteps": TIMESTEP_DISTRIBUTION_FILENAME,
                 "report": REPORT_FILENAME,
             },
         }

--- a/simpletuner/static/css/metrics.css
+++ b/simpletuner/static/css/metrics.css
@@ -1035,6 +1035,34 @@
     max-width: 13rem;
 }
 
+.training-axis-toggle {
+    display: inline-flex;
+    flex: 0 0 auto;
+    gap: 0.25rem;
+    padding: 0.2rem;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    border-radius: 0.3rem;
+    background: rgba(2, 6, 23, 0.32);
+}
+
+.training-axis-toggle button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    min-height: 1.8rem;
+    padding: 0.25rem 0.45rem;
+    border: 0;
+    border-radius: 0.2rem;
+    color: #94a3b8;
+    background: transparent;
+    font-size: 0.7rem;
+}
+
+.training-axis-toggle button.active {
+    color: #e0f2fe;
+    background: rgba(14, 165, 233, 0.18);
+}
+
 .training-metric-picker {
     display: flex;
     justify-content: flex-end;
@@ -1110,6 +1138,11 @@
     height: 24rem;
 }
 
+.training-timestep-canvas-wrap {
+    height: 16rem;
+    margin-top: 1rem;
+}
+
 .training-chart-canvas-wrap canvas {
     display: block;
     width: 100%;
@@ -1144,9 +1177,37 @@
     gap: 0.6rem;
 }
 
+.training-media-gallery {
+    display: grid;
+    gap: 0.85rem;
+}
+
+.training-media-group {
+    min-width: 0;
+}
+
+.training-media-group h4 {
+    overflow: hidden;
+    margin: 0 0 0.45rem;
+    color: #e2e8f0;
+    font-size: 0.78rem;
+    font-weight: 650;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .training-media-grid figure {
     min-width: 0;
     margin: 0;
+}
+
+.training-media-image-button {
+    display: block;
+    width: 100%;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    cursor: zoom-in;
 }
 
 .training-media-grid img,
@@ -1180,6 +1241,77 @@
     text-align: center;
 }
 
+.training-media-lightbox {
+    position: fixed;
+    inset: 0;
+    z-index: 1090;
+    display: grid;
+    grid-template-rows: minmax(0, 1fr) auto auto;
+    gap: 0.75rem;
+    padding: 1rem;
+    background: rgba(2, 6, 23, 0.94);
+}
+
+.training-media-lightbox-body {
+    min-width: 0;
+    min-height: 0;
+    overflow: auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.training-media-lightbox-body img {
+    display: block;
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+}
+
+.training-media-lightbox-body img.actual-size {
+    max-width: none;
+    max-height: none;
+}
+
+.training-media-lightbox-toolbar {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+}
+
+.training-media-lightbox-toolbar button {
+    width: 2.25rem;
+    height: 2.25rem;
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    border-radius: 0.25rem;
+    color: #e2e8f0;
+    background: rgba(15, 23, 42, 0.85);
+}
+
+.training-media-lightbox-toolbar button:disabled {
+    opacity: 0.45;
+}
+
+.training-media-lightbox-toolbar span {
+    min-width: 4rem;
+    color: #cbd5e1;
+    font-size: 0.8rem;
+    text-align: center;
+}
+
+.training-media-lightbox-caption {
+    overflow: hidden;
+    color: #cbd5e1;
+    font-size: 0.82rem;
+    pointer-events: none;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 @media (max-width: 1100px) {
     .training-metrics-layout {
         grid-template-columns: 1fr;
@@ -1200,9 +1332,15 @@
 
     .training-run-actions .form-select,
     .training-tool-header .form-select,
-    .training-metric-picker {
+    .training-metric-picker,
+    .training-axis-toggle {
         width: 100%;
         max-width: none;
+    }
+
+    .training-axis-toggle button {
+        flex: 1 1 0;
+        justify-content: center;
     }
 
     .training-run-summary {
@@ -1219,6 +1357,10 @@
 
     .training-chart-canvas-wrap {
         height: 18rem;
+    }
+
+    .training-media-grid {
+        grid-template-columns: 1fr;
     }
 
     .gpu-stats-grid {

--- a/simpletuner/static/css/training_metrics_report.css
+++ b/simpletuner/static/css/training_metrics_report.css
@@ -107,6 +107,29 @@ input {
     font-size: 17px;
 }
 
+.axis-toggle {
+    display: inline-flex;
+    gap: 4px;
+    padding: 3px;
+    border: 1px solid var(--report-border);
+    background: #05070b;
+}
+
+.axis-toggle button {
+    min-height: 30px;
+    padding: 4px 9px;
+    border: 0;
+    background: transparent;
+    color: var(--report-muted);
+    cursor: pointer;
+    font-size: 12px;
+}
+
+.axis-toggle button.active {
+    background: rgba(56, 189, 248, 0.14);
+    color: var(--report-text);
+}
+
 .metric-picker {
     display: flex;
     flex-wrap: wrap;
@@ -145,6 +168,10 @@ input {
     background: var(--report-panel);
 }
 
+.timestep-chart-frame {
+    height: 310px;
+}
+
 .chart-frame canvas {
     width: 100%;
     height: 100%;
@@ -173,20 +200,6 @@ input {
     margin-top: 4px;
 }
 
-.media-controls {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-}
-
-.media-controls select {
-    min-width: 180px;
-    padding: 7px 28px 7px 9px;
-    border: 1px solid var(--report-border);
-    background: var(--report-panel);
-    color: var(--report-text);
-}
-
 .media-timeline {
     display: flex;
     gap: 6px;
@@ -212,6 +225,24 @@ input {
 
 .media-grid {
     display: grid;
+    gap: 18px;
+}
+
+.media-group {
+    min-width: 0;
+}
+
+.media-group h3 {
+    overflow: hidden;
+    margin: 0 0 8px;
+    color: var(--report-text);
+    font-size: 14px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.media-group-grid {
+    display: grid;
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     gap: 12px;
 }
@@ -220,6 +251,15 @@ input {
     min-width: 0;
     border: 1px solid var(--report-border);
     background: var(--report-panel);
+}
+
+.media-image-button {
+    display: block;
+    width: 100%;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    cursor: zoom-in;
 }
 
 .media-item img,
@@ -241,6 +281,78 @@ input {
     padding: 8px 10px;
     color: var(--report-muted);
     font-size: 12px;
+}
+
+.media-lightbox {
+    position: fixed;
+    inset: 0;
+    z-index: 10;
+    display: grid;
+    grid-template-rows: minmax(0, 1fr) auto auto;
+    gap: 12px;
+    padding: 16px;
+    background: rgba(5, 7, 11, 0.95);
+}
+
+.media-lightbox[hidden] {
+    display: none;
+}
+
+.media-lightbox-body {
+    min-width: 0;
+    min-height: 0;
+    overflow: auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.media-lightbox-body img {
+    display: block;
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+}
+
+.media-lightbox-body img.actual-size {
+    max-width: none;
+    max-height: none;
+}
+
+.media-lightbox-toolbar {
+    display: flex;
+    justify-content: center;
+    gap: 6px;
+}
+
+.media-lightbox-toolbar button {
+    min-width: 36px;
+    min-height: 36px;
+    border: 1px solid var(--report-border);
+    background: var(--report-panel);
+    color: var(--report-text);
+    cursor: pointer;
+}
+
+.media-lightbox-toolbar button:disabled {
+    color: var(--report-muted);
+    cursor: default;
+}
+
+.media-lightbox-toolbar span {
+    min-width: 64px;
+    align-self: center;
+    color: var(--report-muted);
+    text-align: center;
+}
+
+.media-lightbox-caption {
+    overflow: hidden;
+    color: var(--report-muted);
+    font-size: 13px;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 @media (max-width: 720px) {

--- a/simpletuner/static/js/metrics_component.js
+++ b/simpletuner/static/js/metrics_component.js
@@ -81,6 +81,7 @@ function metricsComponent(initialSettings = {}) {
             }
 
             this.startGpuHealthPolling();
+            this.startTrainingMetricsPolling();
         },
 
         destroy() {

--- a/simpletuner/static/js/training_metrics_chart.js
+++ b/simpletuner/static/js/training_metrics_chart.js
@@ -6,7 +6,10 @@
         'train_loss',
         'optimization_loss',
         'diffusion_loss',
-        'eval_loss',
+        'loss/val/pooled',
+        'loss/val',
+        'iteration_step_time_seconds',
+        'seconds_per_step',
         'learning_rate',
     ];
 
@@ -19,7 +22,14 @@
     }
 
     function defaultMetricNames(names, limit = 4) {
-        const selected = PREFERRED_METRICS.filter((name) => names.includes(name));
+        const selected = [];
+        PREFERRED_METRICS.forEach((preferred) => {
+            names.forEach((name) => {
+                if (selected.length >= limit) return;
+                if (selected.includes(name)) return;
+                if (name === preferred || name.startsWith(`${preferred}/`)) selected.push(name);
+            });
+        });
         for (const name of names) {
             if (selected.length >= limit) break;
             if (!selected.includes(name) && !name.includes('learning_rate')) selected.push(name);
@@ -44,11 +54,29 @@
         return value.toLocaleString(undefined, { maximumFractionDigits: 6 });
     }
 
+    function timestampMs(record) {
+        if (!record || typeof record.timestamp !== 'string') return null;
+        const timestamp = Date.parse(record.timestamp);
+        return Number.isFinite(timestamp) ? timestamp : null;
+    }
+
+    function elapsedMinutes(record, startTimestamp) {
+        const timestamp = timestampMs(record);
+        if (timestamp === null || startTimestamp === null) return null;
+        return (timestamp - startTimestamp) / 60000;
+    }
+
+    function formatXAxisValue(value, mode) {
+        if (mode === 'minutes') return `${formatMetricValue(value)} min`;
+        return Math.round(value).toLocaleString();
+    }
+
     class TrainingMetricsChart {
         constructor(canvas, options = {}) {
             this.canvas = canvas;
             this.records = [];
             this.metrics = [];
+            this.xAxisMode = options.xAxisMode === 'minutes' ? 'minutes' : 'step';
             this.options = options;
             this.geometry = null;
             this.hoverIndex = null;
@@ -64,9 +92,10 @@
             canvas.addEventListener('pointerleave', this._leaveHandler);
         }
 
-        setData(records, metrics) {
+        setData(records, metrics, options = {}) {
             this.records = Array.isArray(records) ? records : [];
             this.metrics = Array.isArray(metrics) ? metrics.slice(0, COLORS.length) : [];
+            if (options.xAxisMode) this.xAxisMode = options.xAxisMode === 'minutes' ? 'minutes' : 'step';
             this.hoverIndex = null;
             this.draw();
         }
@@ -92,11 +121,21 @@
             context.setTransform(dpr, 0, 0, dpr, 0, 0);
             context.clearRect(0, 0, width, height);
 
-            const points = this.records.filter((record) => Number.isFinite(Number(record.step)));
+            const timestampValues = this.records.map(timestampMs).filter((value) => value !== null);
+            const startTimestamp = timestampValues.length ? Math.min(...timestampValues) : null;
+            const activeXAxisMode = this.xAxisMode === 'minutes' && startTimestamp !== null ? 'minutes' : 'step';
+            const points = this.records
+                .map((record) => ({
+                    record,
+                    xValue: activeXAxisMode === 'minutes'
+                        ? elapsedMinutes(record, startTimestamp)
+                        : Number(record.step),
+                }))
+                .filter((point) => Number.isFinite(point.xValue));
             const values = [];
-            points.forEach((record) => {
+            points.forEach((point) => {
                 this.metrics.forEach((name) => {
-                    const value = record.metrics && record.metrics[name];
+                    const value = point.record.metrics && point.record.metrics[name];
                     if (typeof value === 'number' && Number.isFinite(value)) values.push(value);
                 });
             });
@@ -109,12 +148,12 @@
             const padding = { left: 64, right: 20, top: 20, bottom: 42 };
             const plotWidth = width - padding.left - padding.right;
             const plotHeight = height - padding.top - padding.bottom;
-            const steps = points.map((record) => Number(record.step));
-            let minStep = Math.min(...steps);
-            let maxStep = Math.max(...steps);
+            const xValues = points.map((point) => point.xValue);
+            let minX = Math.min(...xValues);
+            let maxX = Math.max(...xValues);
             let minValue = Math.min(...values);
             let maxValue = Math.max(...values);
-            if (minStep === maxStep) maxStep = minStep + 1;
+            if (minX === maxX) maxX = minX + 1;
             if (minValue === maxValue) {
                 const offset = Math.abs(minValue) * 0.05 || 1;
                 minValue -= offset;
@@ -124,9 +163,9 @@
             minValue -= valuePadding;
             maxValue += valuePadding;
 
-            const xForStep = (step) => padding.left + ((step - minStep) / (maxStep - minStep)) * plotWidth;
+            const xForValue = (xValue) => padding.left + ((xValue - minX) / (maxX - minX)) * plotWidth;
             const yForValue = (value) => padding.top + (1 - (value - minValue) / (maxValue - minValue)) * plotHeight;
-            this.geometry = { points, padding, plotWidth, plotHeight, minStep, maxStep, minValue, maxValue, xForStep, yForValue };
+            this.geometry = { points, padding, plotWidth, plotHeight, minX, maxX, minValue, maxValue, xForValue, yForValue, xAxisMode: activeXAxisMode };
 
             this._drawGrid(context, width, height, this.geometry);
             this.metrics.forEach((name, metricIndex) => {
@@ -135,13 +174,13 @@
                 context.lineJoin = 'round';
                 context.beginPath();
                 let started = false;
-                points.forEach((record) => {
-                    const value = record.metrics && record.metrics[name];
+                points.forEach((point) => {
+                    const value = point.record.metrics && point.record.metrics[name];
                     if (typeof value !== 'number' || !Number.isFinite(value)) {
                         started = false;
                         return;
                     }
-                    const x = xForStep(Number(record.step));
+                    const x = xForValue(point.xValue);
                     const y = yForValue(value);
                     if (!started) {
                         context.moveTo(x, y);
@@ -154,8 +193,8 @@
             });
 
             if (this.hoverIndex !== null && points[this.hoverIndex]) {
-                const record = points[this.hoverIndex];
-                const x = xForStep(Number(record.step));
+                const point = points[this.hoverIndex];
+                const x = xForValue(point.xValue);
                 context.strokeStyle = 'rgba(148, 163, 184, 0.65)';
                 context.lineWidth = 1;
                 context.beginPath();
@@ -163,7 +202,7 @@
                 context.lineTo(x, padding.top + plotHeight);
                 context.stroke();
                 this.metrics.forEach((name, metricIndex) => {
-                    const value = record.metrics && record.metrics[name];
+                    const value = point.record.metrics && point.record.metrics[name];
                     if (typeof value !== 'number' || !Number.isFinite(value)) return;
                     context.fillStyle = COLORS[metricIndex % COLORS.length];
                     context.beginPath();
@@ -181,7 +220,7 @@
         }
 
         _drawGrid(context, width, height, geometry) {
-            const { padding, plotWidth, plotHeight, minStep, maxStep, minValue, maxValue } = geometry;
+            const { padding, plotWidth, plotHeight, minX, maxX, minValue, maxValue, xAxisMode } = geometry;
             context.font = '12px system-ui, sans-serif';
             context.fillStyle = '#94a3b8';
             context.strokeStyle = 'rgba(148, 163, 184, 0.18)';
@@ -204,8 +243,8 @@
             for (let index = 0; index <= 4; index += 1) {
                 const ratio = index / 4;
                 const x = padding.left + ratio * plotWidth;
-                const step = Math.round(minStep + ratio * (maxStep - minStep));
-                context.fillText(step.toLocaleString(), x, height - padding.bottom + 12);
+                const value = minX + ratio * (maxX - minX);
+                context.fillText(formatXAxisValue(value, xAxisMode), x, height - padding.bottom + 12);
             }
         }
 
@@ -213,11 +252,11 @@
             if (!this.geometry) return;
             const rect = this.canvas.getBoundingClientRect();
             const x = event.clientX - rect.left;
-            const { points, xForStep } = this.geometry;
+            const { points, xForValue } = this.geometry;
             let nearestIndex = 0;
             let nearestDistance = Number.POSITIVE_INFINITY;
             points.forEach((record, index) => {
-                const distance = Math.abs(xForStep(Number(record.step)) - x);
+                const distance = Math.abs(xForValue(record.xValue) - x);
                 if (distance < nearestDistance) {
                     nearestDistance = distance;
                     nearestIndex = index;
@@ -230,11 +269,13 @@
             if (this.options.onHover) {
                 const record = points[nearestIndex];
                 this.options.onHover({
-                    record,
-                    x: xForStep(Number(record.step)),
+                    record: record.record,
+                    x: xForValue(record.xValue),
+                    xValue: record.xValue,
+                    xAxisMode: this.geometry.xAxisMode,
                     metrics: this.metrics.map((name, index) => ({
                         name,
-                        value: record.metrics ? record.metrics[name] : undefined,
+                        value: record.record.metrics ? record.record.metrics[name] : undefined,
                         color: COLORS[index % COLORS.length],
                     })),
                 });
@@ -242,10 +283,104 @@
         }
     }
 
+    class TimestepDistributionChart {
+        constructor(canvas) {
+            this.canvas = canvas;
+            this.records = [];
+            this._resizeHandler = () => this.draw();
+            global.addEventListener('resize', this._resizeHandler);
+        }
+
+        setData(records) {
+            this.records = Array.isArray(records) ? records : [];
+            this.draw();
+        }
+
+        destroy() {
+            global.removeEventListener('resize', this._resizeHandler);
+        }
+
+        draw() {
+            const context = this.canvas.getContext('2d');
+            if (!context) return;
+            const width = Math.max(320, this.canvas.clientWidth || 800);
+            const height = Math.max(220, this.canvas.clientHeight || 320);
+            const dpr = global.devicePixelRatio || 1;
+            this.canvas.width = Math.round(width * dpr);
+            this.canvas.height = Math.round(height * dpr);
+            context.setTransform(dpr, 0, 0, dpr, 0, 0);
+            context.clearRect(0, 0, width, height);
+
+            const points = [];
+            this.records.forEach((record) => {
+                const step = Number(record.step);
+                if (!Number.isFinite(step) || !Array.isArray(record.timesteps)) return;
+                record.timesteps.forEach((timestep) => {
+                    const value = Number(timestep);
+                    if (Number.isFinite(value)) points.push({ step, timestep: value });
+                });
+            });
+            if (!points.length) {
+                context.fillStyle = '#94a3b8';
+                context.font = '14px system-ui, sans-serif';
+                context.textAlign = 'center';
+                context.fillText('No timestep samples recorded', width / 2, height / 2);
+                return;
+            }
+
+            const padding = { left: 64, right: 20, top: 20, bottom: 42 };
+            const plotWidth = width - padding.left - padding.right;
+            const plotHeight = height - padding.top - padding.bottom;
+            let minStep = Math.min(...points.map((point) => point.step));
+            let maxStep = Math.max(...points.map((point) => point.step));
+            let minTimestep = Math.min(...points.map((point) => point.timestep));
+            let maxTimestep = Math.max(...points.map((point) => point.timestep));
+            if (minStep === maxStep) maxStep = minStep + 1;
+            if (minTimestep === maxTimestep) maxTimestep = minTimestep + 1;
+            const xForStep = (step) => padding.left + ((step - minStep) / (maxStep - minStep)) * plotWidth;
+            const yForTimestep = (timestep) =>
+                padding.top + (1 - (timestep - minTimestep) / (maxTimestep - minTimestep)) * plotHeight;
+
+            context.strokeStyle = 'rgba(148, 163, 184, 0.18)';
+            context.lineWidth = 1;
+            context.font = '12px system-ui, sans-serif';
+            context.fillStyle = '#94a3b8';
+            context.textAlign = 'right';
+            context.textBaseline = 'middle';
+            for (let index = 0; index <= 4; index += 1) {
+                const ratio = index / 4;
+                const y = padding.top + ratio * plotHeight;
+                const value = maxTimestep - ratio * (maxTimestep - minTimestep);
+                context.beginPath();
+                context.moveTo(padding.left, y);
+                context.lineTo(padding.left + plotWidth, y);
+                context.stroke();
+                context.fillText(formatMetricValue(value), padding.left - 10, y);
+            }
+            context.textAlign = 'center';
+            context.textBaseline = 'top';
+            for (let index = 0; index <= 4; index += 1) {
+                const ratio = index / 4;
+                const x = padding.left + ratio * plotWidth;
+                const step = Math.round(minStep + ratio * (maxStep - minStep));
+                context.fillText(step.toLocaleString(), x, height - padding.bottom + 12);
+            }
+
+            context.fillStyle = 'rgba(56, 189, 248, 0.45)';
+            points.forEach((point) => {
+                context.beginPath();
+                context.arc(xForStep(point.step), yForTimestep(point.timestep), 2, 0, Math.PI * 2);
+                context.fill();
+            });
+        }
+    }
+
     global.TrainingMetricsCharts = {
         COLORS,
+        TimestepDistributionChart,
         TrainingMetricsChart,
         defaultMetricNames,
+        formatXAxisValue,
         formatMetricValue,
         latestMetricValues,
         metricNames,

--- a/simpletuner/static/js/training_metrics_component.js
+++ b/simpletuner/static/js/training_metrics_component.js
@@ -10,14 +10,23 @@
             trainingMetricsLoading: false,
             trainingMetricsError: null,
             selectedTrainingMetrics: [],
-            selectedTrainingMediaLabel: '',
             selectedTrainingMediaStep: null,
+            selectedTrainingXAxis: 'step',
+            trainingMediaLightbox: null,
             trainingChartHover: null,
             _trainingMetricsChart: null,
+            _trainingTimestepChart: null,
+            _trainingMetricsTimer: null,
+            trainingMetricsPollMs: 5000,
 
-            async loadTrainingRuns() {
-                this.trainingMetricsLoading = true;
-                this.trainingMetricsError = null;
+            async loadTrainingRuns(options = {}) {
+                const { silent = false } = options;
+                if (!silent) {
+                    this.trainingMetricsLoading = true;
+                    this.trainingMetricsError = null;
+                } else if (this.trainingMetricsLoading) {
+                    return;
+                }
                 try {
                     const response = await fetch('/api/metrics/training/runs');
                     if (!response.ok) throw new Error(`Unable to load training runs (HTTP ${response.status})`);
@@ -32,11 +41,11 @@
                         (run) => run.environment === this.selectedTrainingEnvironment,
                     );
                     if (!selectedStillExists) this.selectedTrainingEnvironment = this.trainingRuns[0].environment;
-                    await this.loadTrainingRun();
+                    await this.loadTrainingRun({ silent, preserveSelections: silent });
                 } catch (error) {
                     this.trainingMetricsError = error.message || 'Unable to load training runs';
                 } finally {
-                    this.trainingMetricsLoading = false;
+                    if (!silent) this.trainingMetricsLoading = false;
                 }
             },
 
@@ -46,31 +55,63 @@
                 await this.loadTrainingRun();
             },
 
-            async loadTrainingRun() {
+            async loadTrainingRun(options = {}) {
                 if (!this.selectedTrainingEnvironment) return;
-                this.trainingMetricsLoading = true;
-                this.trainingMetricsError = null;
+                const { silent = false, preserveSelections = false } = options;
+                if (!silent) {
+                    this.trainingMetricsLoading = true;
+                    this.trainingMetricsError = null;
+                } else if (this.trainingMetricsLoading) {
+                    return;
+                }
                 try {
                     const environment = encodeURIComponent(this.selectedTrainingEnvironment);
                     const response = await fetch(`/api/metrics/training/runs/${environment}?max_points=4000`);
                     if (!response.ok) throw new Error(`Unable to load run metrics (HTTP ${response.status})`);
                     this.trainingRunData = await response.json();
                     const available = this.trainingRunData.available_metrics || [];
-                    this.selectedTrainingMetrics = global.TrainingMetricsCharts.defaultMetricNames(available);
-                    this.selectDefaultTrainingMedia();
-                    this.$nextTick(() => this.renderTrainingMetricsChart());
+                    this.syncSelectedTrainingMetrics(available, preserveSelections);
+                    this.selectDefaultTrainingMedia({ preserveSelection: preserveSelections });
+                    this.$nextTick(() => {
+                        this.renderTrainingMetricsChart();
+                        this.renderTimestepDistributionChart();
+                    });
                 } catch (error) {
                     this.trainingMetricsError = error.message || 'Unable to load run metrics';
                     this.trainingRunData = null;
                 } finally {
-                    this.trainingMetricsLoading = false;
+                    if (!silent) this.trainingMetricsLoading = false;
                 }
             },
 
             setMetricsSection(section) {
                 this.activeMetricsSection = section;
-                if (section === 'training') this.$nextTick(() => this.renderTrainingMetricsChart());
+                if (section === 'training') {
+                    this.startTrainingMetricsPolling();
+                    this.$nextTick(() => {
+                        this.renderTrainingMetricsChart();
+                        this.renderTimestepDistributionChart();
+                    });
+                } else {
+                    this.stopTrainingMetricsPolling();
+                }
                 if (section === 'system') this.$nextTick(() => this.renderActiveGpuCharts());
+            },
+
+            syncSelectedTrainingMetrics(available, preserveSelections = false) {
+                if (preserveSelections) {
+                    const retained = this.selectedTrainingMetrics.filter((metric) => available.includes(metric));
+                    if (retained.length) {
+                        this.selectedTrainingMetrics = retained.slice(0, 8);
+                        return;
+                    }
+                }
+                this.selectedTrainingMetrics = global.TrainingMetricsCharts.defaultMetricNames(available);
+            },
+
+            setTrainingXAxis(mode) {
+                this.selectedTrainingXAxis = mode === 'minutes' ? 'minutes' : 'step';
+                this.renderTrainingMetricsChart();
             },
 
             toggleTrainingMetric(metric) {
@@ -96,7 +137,17 @@
                 this._trainingMetricsChart.setData(
                     this.trainingRunData.records || [],
                     this.selectedTrainingMetrics,
+                    { xAxisMode: this.selectedTrainingXAxis },
                 );
+            },
+
+            renderTimestepDistributionChart() {
+                const canvas = this.$refs.timestepDistributionCanvas;
+                if (!canvas || !this.trainingRunData || !global.TrainingMetricsCharts) return;
+                if (!this._trainingTimestepChart) {
+                    this._trainingTimestepChart = new global.TrainingMetricsCharts.TimestepDistributionChart(canvas);
+                }
+                this._trainingTimestepChart.setData(this.trainingRunData.timesteps || []);
             },
 
             latestTrainingMetrics() {
@@ -109,43 +160,75 @@
                 return global.TrainingMetricsCharts.formatMetricValue(value);
             },
 
-            trainingMediaLabels() {
-                if (!this.trainingRunData) return [];
-                return Array.from(new Set((this.trainingRunData.media || []).map((item) => item.label))).sort();
-            },
-
             trainingMediaSteps() {
-                if (!this.trainingRunData || !this.selectedTrainingMediaLabel) return [];
+                if (!this.trainingRunData) return [];
                 return Array.from(
-                    new Set(
-                        (this.trainingRunData.media || [])
-                            .filter((item) => item.label === this.selectedTrainingMediaLabel)
-                            .map((item) => item.step),
-                    ),
+                    new Set((this.trainingRunData.media || []).map((item) => item.step)),
                 ).sort((left, right) => left - right);
             },
 
-            selectDefaultTrainingMedia() {
-                const labels = this.trainingMediaLabels();
-                this.selectedTrainingMediaLabel = labels[0] || '';
+            selectDefaultTrainingMedia(options = {}) {
+                const { preserveSelection = false } = options;
                 const steps = this.trainingMediaSteps();
-                this.selectedTrainingMediaStep = steps.length ? steps[steps.length - 1] : null;
-            },
-
-            selectTrainingMediaLabel(label) {
-                this.selectedTrainingMediaLabel = label;
-                const steps = this.trainingMediaSteps();
+                if (preserveSelection && steps.includes(this.selectedTrainingMediaStep)) return;
                 this.selectedTrainingMediaStep = steps.length ? steps[steps.length - 1] : null;
             },
 
             selectedTrainingMedia() {
                 if (!this.trainingRunData) return [];
                 return (this.trainingRunData.media || [])
-                    .filter(
-                        (item) =>
-                            item.label === this.selectedTrainingMediaLabel && item.step === this.selectedTrainingMediaStep,
-                    )
-                    .sort((left, right) => left.index - right.index);
+                    .filter((item) => item.step === this.selectedTrainingMediaStep)
+                    .sort((left, right) => {
+                        const labelOrder = String(left.label || '').localeCompare(String(right.label || ''));
+                        return labelOrder || Number(left.index || 0) - Number(right.index || 0);
+                    });
+            },
+
+            selectedTrainingMediaGroups() {
+                const groups = new Map();
+                this.selectedTrainingMedia().forEach((item) => {
+                    const label = item.label || 'Validation';
+                    if (!groups.has(label)) groups.set(label, []);
+                    groups.get(label).push(item);
+                });
+                return Array.from(groups, ([label, items]) => ({ label, items }));
+            },
+
+            selectedTrainingImages() {
+                return this.selectedTrainingMedia()
+                    .filter((item) => item.type === 'image' && item.url)
+                    .map((item) => ({
+                        item,
+                        src: item.url,
+                        caption: [
+                            item.label,
+                            `step ${Number(item.step).toLocaleString()}`,
+                            item.resolution,
+                            `output ${Number(item.index || 0) + 1}`,
+                        ].filter(Boolean).join(' · '),
+                    }));
+            },
+
+            openTrainingMediaLightbox(item) {
+                if (!item || item.type !== 'image') return;
+                const images = this.selectedTrainingImages();
+                const index = Math.max(0, images.findIndex((image) => image.item.path === item.path));
+                this.trainingMediaLightbox = { images, index, actualSize: false };
+            },
+
+            closeTrainingMediaLightbox() {
+                this.trainingMediaLightbox = null;
+            },
+
+            setTrainingLightboxIndex(index) {
+                if (!this.trainingMediaLightbox) return;
+                const maxIndex = this.trainingMediaLightbox.images.length - 1;
+                this.trainingMediaLightbox.index = Math.max(0, Math.min(maxIndex, index));
+            },
+
+            toggleTrainingLightboxSize() {
+                if (!this.trainingMediaLightbox) return;
+                this.trainingMediaLightbox.actualSize = !this.trainingMediaLightbox.actualSize;
             },
 
             trainingReportUrl() {
@@ -154,10 +237,32 @@
             },
 
             destroyTrainingMetrics() {
+                this.stopTrainingMetricsPolling();
                 if (this._trainingMetricsChart) {
                     this._trainingMetricsChart.destroy();
                     this._trainingMetricsChart = null;
                 }
+                if (this._trainingTimestepChart) {
+                    this._trainingTimestepChart.destroy();
+                    this._trainingTimestepChart = null;
+                }
+            },
+
+            startTrainingMetricsPolling() {
+                if (this._trainingMetricsTimer) return;
+                this._trainingMetricsTimer = window.setInterval(() => {
+                    if (this.activeMetricsSection !== 'training') return;
+                    if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
+                    const status = this.trainingRunData && this.trainingRunData.run && this.trainingRunData.run.status;
+                    if (status !== 'running') return;
+                    this.loadTrainingRuns({ silent: true });
+                }, this.trainingMetricsPollMs);
+            },
+
+            stopTrainingMetricsPolling() {
+                if (!this._trainingMetricsTimer) return;
+                window.clearInterval(this._trainingMetricsTimer);
+                this._trainingMetricsTimer = null;
             },
         };
     }

--- a/simpletuner/templates/metrics_tab.html
+++ b/simpletuner/templates/metrics_tab.html
@@ -109,12 +109,28 @@
                 <div class="training-metrics-layout">
                     <section class="training-chart-tool" aria-label="Scalar chart">
                         <div class="training-tool-header">
-                            <div>
-                                <h3>Scalars</h3>
-                                <span x-show="trainingChartHover"
-                                      x-text="trainingChartHover ? 'Step ' + trainingChartHover.record.step.toLocaleString() : ''"></span>
-                            </div>
-                            <div class="training-metric-picker" aria-label="Chart metrics">
+	                            <div>
+	                                <h3>Scalars</h3>
+	                                <span x-show="trainingChartHover"
+	                                      x-text="trainingChartHover ? (trainingChartHover.xAxisMode === 'minutes' ? TrainingMetricsCharts.formatXAxisValue(trainingChartHover.xValue, 'minutes') : 'Step ' + trainingChartHover.record.step.toLocaleString()) : ''"></span>
+	                            </div>
+	                            <div class="training-axis-toggle" role="group" aria-label="Chart x-axis">
+	                                <button type="button"
+	                                        :class="{ 'active': selectedTrainingXAxis === 'step' }"
+	                                        @click="setTrainingXAxis('step')"
+	                                        title="Show values by global step">
+	                                    <i class="fas fa-shoe-prints"></i>
+	                                    <span>Step</span>
+	                                </button>
+	                                <button type="button"
+	                                        :class="{ 'active': selectedTrainingXAxis === 'minutes' }"
+	                                        @click="setTrainingXAxis('minutes')"
+	                                        title="Show values by elapsed minutes">
+	                                    <i class="fas fa-clock"></i>
+	                                    <span>Minutes</span>
+	                                </button>
+	                            </div>
+	                            <div class="training-metric-picker" aria-label="Chart metrics">
                                 <template x-for="metric in trainingRunData.available_metrics" :key="metric">
                                     <label :class="{ 'selected': selectedTrainingMetrics.includes(metric) }">
                                         <input type="checkbox"
@@ -134,27 +150,25 @@
                                 </div>
                             </template>
                         </div>
-                        <div class="training-chart-canvas-wrap">
-                            <canvas x-ref="trainingMetricsCanvas" data-testid="training-metrics-canvas"></canvas>
-                        </div>
-                    </section>
+	                        <div class="training-chart-canvas-wrap">
+	                            <canvas x-ref="trainingMetricsCanvas" data-testid="training-metrics-canvas"></canvas>
+	                        </div>
+	                        <template x-if="(trainingRunData.timesteps || []).length">
+	                            <div class="training-chart-canvas-wrap training-timestep-canvas-wrap">
+	                                <canvas x-ref="timestepDistributionCanvas"
+	                                        data-testid="training-timestep-distribution-canvas"
+	                                        aria-label="Timestep distribution"></canvas>
+	                            </div>
+	                        </template>
+	                    </section>
 
                     <section class="training-media-tool" aria-label="Validation media">
-                        <div class="training-tool-header">
-                            <div>
-                                <h3>Validation</h3>
-                                <span>Compare saved outputs by prompt and step.</span>
-                            </div>
-                            <select class="form-select form-select-sm"
-                                    :value="selectedTrainingMediaLabel"
-                                    @change="selectTrainingMediaLabel($event.target.value)"
-                                    :disabled="!trainingMediaLabels().length"
-                                    aria-label="Validation prompt">
-                                <template x-for="label in trainingMediaLabels()" :key="label">
-                                    <option :value="label" x-text="label"></option>
-                                </template>
-                            </select>
-                        </div>
+	                        <div class="training-tool-header">
+	                            <div>
+	                                <h3>Validation</h3>
+	                                <span>Saved outputs grouped by prompt and step.</span>
+	                            </div>
+	                        </div>
                         <div class="training-media-steps" role="group" aria-label="Validation steps">
                             <template x-for="step in trainingMediaSteps()" :key="step">
                                 <button type="button"
@@ -166,32 +180,89 @@
                         <template x-if="!selectedTrainingMedia().length">
                             <div class="training-media-empty">No validation media was recorded for this run.</div>
                         </template>
-                        <div class="training-media-grid">
-                            <template x-for="item in selectedTrainingMedia()" :key="item.path">
-                                <figure>
-                                    <img x-show="item.type === 'image'"
-                                         :src="item.type === 'image' ? item.url : null"
-                                         :alt="item.label + ' at step ' + item.step">
-                                    <video x-show="item.type === 'video'"
-                                           :src="item.type === 'video' ? item.url : null"
-                                           controls
-                                           preload="metadata"></video>
-                                    <audio x-show="item.type === 'audio'"
-                                           :src="item.type === 'audio' ? item.url : null"
-                                           controls
-                                           preload="metadata"></audio>
-                                    <figcaption>
-                                        <span x-text="'Output ' + (item.index + 1)"></span>
-                                        <span x-text="item.resolution || item.type"></span>
-                                    </figcaption>
-                                </figure>
-                            </template>
-                        </div>
-                    </section>
-                </div>
-            </div>
-        </template>
-    </section>
+	                        <div class="training-media-gallery">
+	                            <template x-for="group in selectedTrainingMediaGroups()" :key="group.label">
+	                                <section class="training-media-group">
+	                                    <h4 x-text="group.label"></h4>
+	                                    <div class="training-media-grid">
+	                                        <template x-for="item in group.items" :key="item.path">
+	                                            <figure>
+	                                                <button type="button"
+	                                                        class="training-media-image-button"
+	                                                        x-show="item.type === 'image'"
+	                                                        @click="openTrainingMediaLightbox(item)"
+	                                                        title="Open validation image">
+	                                                    <img :src="item.type === 'image' ? item.url : null"
+	                                                         :alt="item.label + ' at step ' + item.step">
+	                                                </button>
+	                                                <video x-show="item.type === 'video'"
+	                                                       :src="item.type === 'video' ? item.url : null"
+	                                                       controls
+	                                                       preload="metadata"></video>
+	                                                <audio x-show="item.type === 'audio'"
+	                                                       :src="item.type === 'audio' ? item.url : null"
+	                                                       controls
+	                                                       preload="metadata"></audio>
+	                                                <figcaption>
+	                                                    <span x-text="'Output ' + (item.index + 1)"></span>
+	                                                    <span x-text="item.resolution || item.type"></span>
+	                                                </figcaption>
+	                                            </figure>
+	                                        </template>
+	                                    </div>
+	                                </section>
+	                            </template>
+	                        </div>
+	                    </section>
+	                </div>
+	            </div>
+	        </template>
+	        <template x-teleport="body">
+	            <template x-if="trainingMediaLightbox">
+	                <div class="training-media-lightbox"
+	                     role="dialog"
+	                     aria-modal="true"
+	                     tabindex="-1"
+	                     @click.self="closeTrainingMediaLightbox()"
+	                     @keydown.escape.window="closeTrainingMediaLightbox()"
+	                     @keydown.arrow-left.window="setTrainingLightboxIndex(trainingMediaLightbox.index - 1)"
+	                     @keydown.arrow-right.window="setTrainingLightboxIndex(trainingMediaLightbox.index + 1)">
+	                    <div class="training-media-lightbox-body">
+	                        <img :class="{ 'actual-size': trainingMediaLightbox.actualSize }"
+	                             :src="trainingMediaLightbox.images[trainingMediaLightbox.index]?.src"
+	                             :alt="trainingMediaLightbox.images[trainingMediaLightbox.index]?.caption">
+	                    </div>
+	                    <div class="training-media-lightbox-toolbar">
+	                        <button type="button"
+	                                @click="setTrainingLightboxIndex(trainingMediaLightbox.index - 1)"
+	                                :disabled="trainingMediaLightbox.index === 0"
+	                                title="Previous image">
+	                            <i class="fas fa-chevron-left"></i>
+	                        </button>
+	                        <span x-text="`${trainingMediaLightbox.index + 1} / ${trainingMediaLightbox.images.length}`"></span>
+	                        <button type="button"
+	                                @click="setTrainingLightboxIndex(trainingMediaLightbox.index + 1)"
+	                                :disabled="trainingMediaLightbox.index >= trainingMediaLightbox.images.length - 1"
+	                                title="Next image">
+	                            <i class="fas fa-chevron-right"></i>
+	                        </button>
+	                        <button type="button"
+	                                @click="toggleTrainingLightboxSize()"
+	                                :title="trainingMediaLightbox.actualSize ? 'Fit to screen' : 'Show at 1:1 size'">
+	                            <i class="fas" :class="trainingMediaLightbox.actualSize ? 'fa-compress' : 'fa-expand'"></i>
+	                        </button>
+	                        <button type="button"
+	                                @click="closeTrainingMediaLightbox()"
+	                                title="Close image">
+	                            <i class="fas fa-times"></i>
+	                        </button>
+	                    </div>
+	                    <div class="training-media-lightbox-caption"
+	                         x-text="trainingMediaLightbox.images[trainingMediaLightbox.index]?.caption"></div>
+	                </div>
+	            </template>
+	        </template>
+	    </section>
 
     <div x-show="activeMetricsSection === 'system'" x-cloak>
 

--- a/simpletuner/templates/training_metrics_report.html
+++ b/simpletuner/templates/training_metrics_report.html
@@ -18,30 +18,49 @@
 
         <section class="report-summary" id="run-summary"></section>
 
-        <section class="report-section">
-            <div class="report-section-header">
-                <h2>Scalar metrics</h2>
-                <div class="report-meta" id="chart-step"></div>
-            </div>
+	        <section class="report-section">
+	            <div class="report-section-header">
+	                <h2>Scalar metrics</h2>
+	                <div class="axis-toggle" role="group" aria-label="Chart x-axis">
+	                    <button type="button" class="active" data-axis-mode="step">Step</button>
+	                    <button type="button" data-axis-mode="minutes">Minutes</button>
+	                </div>
+	            </div>
             <div class="metric-picker" id="metric-picker"></div>
             <div class="chart-frame">
                 <canvas id="metrics-chart"></canvas>
-                <div class="chart-tooltip" id="chart-tooltip" hidden></div>
-            </div>
-        </section>
+	                <div class="chart-tooltip" id="chart-tooltip" hidden></div>
+	            </div>
+	        </section>
 
-        <section class="report-section">
-            <div class="report-section-header">
-                <h2>Validation media</h2>
-                <div class="media-controls">
-                    <label class="report-meta" for="media-label">Prompt</label>
-                    <select id="media-label"></select>
-                </div>
-            </div>
-            <div class="media-timeline" id="media-timeline"></div>
-            <div class="media-grid" id="media-grid"></div>
-        </section>
-    </main>
+	        <section class="report-section" id="timestep-section" hidden>
+	            <div class="report-section-header">
+	                <h2>Timestep distribution</h2>
+	            </div>
+	            <div class="chart-frame timestep-chart-frame">
+	                <canvas id="timestep-chart"></canvas>
+	            </div>
+	        </section>
+
+	        <section class="report-section">
+	            <div class="report-section-header">
+	                <h2>Validation media</h2>
+	            </div>
+	            <div class="media-timeline" id="media-timeline"></div>
+	            <div class="media-grid" id="media-grid"></div>
+	        </section>
+	    </main>
+	    <div class="media-lightbox" id="media-lightbox" hidden>
+	        <div class="media-lightbox-body" id="media-lightbox-body"></div>
+	        <div class="media-lightbox-toolbar">
+	            <button type="button" id="media-lightbox-prev" title="Previous image">‹</button>
+	            <span id="media-lightbox-count"></span>
+	            <button type="button" id="media-lightbox-next" title="Next image">›</button>
+	            <button type="button" id="media-lightbox-size" title="Show at 1:1 size">1:1</button>
+	            <button type="button" id="media-lightbox-close" title="Close image">×</button>
+	        </div>
+	        <div class="media-lightbox-caption" id="media-lightbox-caption"></div>
+	    </div>
 
     <script id="training-metrics-data" type="application/json">__SIMPLETUNER_REPORT_DATA__</script>
     <script>__SIMPLETUNER_CHART_JS__</script>
@@ -50,12 +69,16 @@
             const payload = JSON.parse(document.getElementById('training-metrics-data').textContent);
             const charts = window.TrainingMetricsCharts;
             const run = payload.run || {};
-            const records = payload.records || [];
-            const media = payload.media || [];
-            const names = charts.metricNames(records);
-            let selectedMetrics = charts.defaultMetricNames(names);
-            let selectedLabel = null;
-            let selectedStep = null;
+	            const records = payload.records || [];
+	            const media = payload.media || [];
+	            const timesteps = payload.timesteps || [];
+	            const names = charts.metricNames(records);
+	            let selectedMetrics = charts.defaultMetricNames(names);
+	            let selectedStep = null;
+	            let selectedAxisMode = 'step';
+	            let lightboxImages = [];
+	            let lightboxIndex = 0;
+	            let lightboxActualSize = false;
 
             function escapeHtml(value) {
                 return String(value)
@@ -89,7 +112,10 @@
                     const rows = info.metrics.filter((metric) => typeof metric.value === 'number').map((metric) =>
                         `<div class="chart-tooltip-row"><span style="color:${metric.color}">${escapeHtml(metric.name)}</span><strong>${escapeHtml(charts.formatMetricValue(metric.value))}</strong></div>`
                     ).join('');
-                    tooltip.innerHTML = `<strong>Step ${escapeHtml(info.record.step)}</strong>${rows}`;
+	                    const xLabel = info.xAxisMode === 'minutes'
+	                        ? charts.formatXAxisValue(info.xValue, 'minutes')
+	                        : `Step ${Number(info.record.step).toLocaleString()}`;
+	                    tooltip.innerHTML = `<strong>${escapeHtml(xLabel)}</strong>${rows}`;
                     tooltip.style.left = `${Math.min(info.x + 12, tooltip.parentElement.clientWidth - 200)}px`;
                     tooltip.style.top = '12px';
                     tooltip.hidden = false;
@@ -107,43 +133,94 @@
                     const input = document.createElement('input');
                     input.type = 'checkbox';
                     input.checked = index >= 0;
-                    input.addEventListener('change', () => {
-                        if (input.checked && !selectedMetrics.includes(name)) selectedMetrics.push(name);
-                        if (!input.checked) selectedMetrics = selectedMetrics.filter((entry) => entry !== name);
-                        selectedMetrics = selectedMetrics.slice(-charts.COLORS.length);
-                        renderMetricPicker();
-                        chart.setData(records, selectedMetrics);
-                    });
+	                    input.addEventListener('change', () => {
+	                        if (input.checked && !selectedMetrics.includes(name)) selectedMetrics.push(name);
+	                        if (!input.checked) selectedMetrics = selectedMetrics.filter((entry) => entry !== name);
+	                        selectedMetrics = selectedMetrics.slice(-charts.COLORS.length);
+	                        renderMetricPicker();
+	                        chart.setData(records, selectedMetrics, { xAxisMode: selectedAxisMode });
+	                    });
                     label.append(input, document.createTextNode(name));
                     picker.appendChild(label);
                 });
             }
 
-            function mediaForSelection() {
-                return media.filter((item) => item.label === selectedLabel && Number(item.step) === Number(selectedStep));
-            }
+	            function mediaForSelectedStep() {
+	                return media
+	                    .filter((item) => Number(item.step) === Number(selectedStep))
+	                    .sort((left, right) => {
+	                        const labelOrder = String(left.label || '').localeCompare(String(right.label || ''));
+	                        return labelOrder || Number(left.index || 0) - Number(right.index || 0);
+	                    });
+	            }
 
-            function renderMedia() {
-                const labels = Array.from(new Set(media.map((item) => item.label))).sort();
-                const select = document.getElementById('media-label');
-                select.innerHTML = '';
-                labels.forEach((label) => {
-                    const option = document.createElement('option');
-                    option.value = label;
-                    option.textContent = label;
-                    select.appendChild(option);
-                });
-                if (!selectedLabel || !labels.includes(selectedLabel)) selectedLabel = labels[0] || null;
-                select.value = selectedLabel || '';
-                select.onchange = () => {
-                    selectedLabel = select.value;
-                    selectedStep = null;
-                    renderMedia();
-                };
+	            function mediaGroupsForSelectedStep() {
+	                const groups = new Map();
+	                mediaForSelectedStep().forEach((item) => {
+	                    const label = item.label || 'Validation';
+	                    if (!groups.has(label)) groups.set(label, []);
+	                    groups.get(label).push(item);
+	                });
+	                return Array.from(groups, ([label, items]) => ({ label, items }));
+	            }
 
-                const steps = Array.from(new Set(media.filter((item) => item.label === selectedLabel).map((item) => Number(item.step)))).sort((a, b) => a - b);
-                if (selectedStep === null || !steps.includes(selectedStep)) selectedStep = steps[steps.length - 1] ?? null;
-                const timeline = document.getElementById('media-timeline');
+	            function selectedImages() {
+	                return mediaForSelectedStep()
+	                    .filter((item) => item.type === 'image')
+	                    .map((item) => ({
+	                        item,
+	                        src: item.path,
+	                        caption: [
+	                            item.label,
+	                            `step ${Number(item.step).toLocaleString()}`,
+	                            item.resolution,
+	                            `sample ${Number(item.index) + 1}`,
+	                        ].filter(Boolean).join(' · '),
+	                    }));
+	            }
+
+	            function closeLightbox() {
+	                document.getElementById('media-lightbox').hidden = true;
+	            }
+
+	            function renderLightbox() {
+	                const lightbox = document.getElementById('media-lightbox');
+	                const body = document.getElementById('media-lightbox-body');
+	                const caption = document.getElementById('media-lightbox-caption');
+	                const count = document.getElementById('media-lightbox-count');
+	                const previous = document.getElementById('media-lightbox-prev');
+	                const next = document.getElementById('media-lightbox-next');
+	                const size = document.getElementById('media-lightbox-size');
+	                const image = lightboxImages[lightboxIndex];
+	                if (!image) {
+	                    closeLightbox();
+	                    return;
+	                }
+	                body.innerHTML = '';
+	                const element = document.createElement('img');
+	                element.src = image.src;
+	                element.alt = image.caption;
+	                if (lightboxActualSize) element.className = 'actual-size';
+	                body.appendChild(element);
+	                caption.textContent = image.caption;
+	                count.textContent = `${lightboxIndex + 1} / ${lightboxImages.length}`;
+	                previous.disabled = lightboxIndex === 0;
+	                next.disabled = lightboxIndex >= lightboxImages.length - 1;
+	                size.textContent = lightboxActualSize ? 'Fit' : '1:1';
+	                lightbox.hidden = false;
+	            }
+
+	            function openLightbox(item) {
+	                lightboxImages = selectedImages();
+	                lightboxIndex = Math.max(0, lightboxImages.findIndex((image) => image.item.path === item.path));
+	                lightboxActualSize = false;
+	                renderLightbox();
+	            }
+
+	            function renderMedia() {
+	                const steps = Array.from(new Set(media.map((item) => Number(item.step)))).sort((a, b) => a - b);
+	                if (selectedStep === null || !steps.includes(selectedStep)) selectedStep = steps[steps.length - 1] ?? null;
+	                const timeline = document.getElementById('media-timeline');
                 timeline.innerHTML = '';
                 steps.forEach((step) => {
                     const button = document.createElement('button');
@@ -157,41 +234,103 @@
                     timeline.appendChild(button);
                 });
 
-                const grid = document.getElementById('media-grid');
-                grid.innerHTML = '';
-                const selected = mediaForSelection();
-                if (!selected.length) {
-                    grid.innerHTML = '<div class="report-empty">No validation media</div>';
-                    return;
-                }
-                selected.forEach((item) => {
-                    const wrapper = document.createElement('article');
-                    wrapper.className = 'media-item';
-                    let element;
-                    if (item.type === 'video') {
-                        element = document.createElement('video');
-                        element.controls = true;
-                    } else if (item.type === 'audio') {
-                        element = document.createElement('audio');
-                        element.controls = true;
-                    } else {
-                        element = document.createElement('img');
-                        element.loading = 'lazy';
-                        element.alt = `${item.label} at step ${item.step}`;
-                    }
-                    element.src = item.path;
-                    const caption = document.createElement('div');
-                    caption.className = 'media-caption';
-                    caption.textContent = [item.resolution, `sample ${Number(item.index) + 1}`].filter(Boolean).join(' · ');
-                    wrapper.append(element, caption);
-                    grid.appendChild(wrapper);
-                });
-            }
+	                const grid = document.getElementById('media-grid');
+	                grid.innerHTML = '';
+	                const groups = mediaGroupsForSelectedStep();
+	                if (!groups.length) {
+	                    grid.innerHTML = '<div class="report-empty">No validation media</div>';
+	                    return;
+	                }
+	                groups.forEach((group) => {
+	                    const section = document.createElement('section');
+	                    section.className = 'media-group';
+	                    const heading = document.createElement('h3');
+	                    heading.textContent = group.label;
+	                    const groupGrid = document.createElement('div');
+	                    groupGrid.className = 'media-group-grid';
+	                    group.items.forEach((item) => {
+	                        const wrapper = document.createElement('article');
+	                        wrapper.className = 'media-item';
+	                        let element;
+	                        if (item.type === 'video') {
+	                            element = document.createElement('video');
+	                            element.controls = true;
+	                            element.src = item.path;
+	                        } else if (item.type === 'audio') {
+	                            element = document.createElement('audio');
+	                            element.controls = true;
+	                            element.src = item.path;
+	                        } else {
+	                            const button = document.createElement('button');
+	                            button.type = 'button';
+	                            button.className = 'media-image-button';
+	                            button.onclick = () => openLightbox(item);
+	                            element = document.createElement('img');
+	                            element.loading = 'lazy';
+	                            element.alt = `${item.label} at step ${item.step}`;
+	                            element.src = item.path;
+	                            button.appendChild(element);
+	                            element = button;
+	                        }
+	                        const caption = document.createElement('div');
+	                        caption.className = 'media-caption';
+	                        caption.textContent = [item.resolution, `sample ${Number(item.index) + 1}`].filter(Boolean).join(' · ');
+	                        wrapper.append(element, caption);
+	                        groupGrid.appendChild(wrapper);
+	                    });
+	                    section.append(heading, groupGrid);
+	                    grid.appendChild(section);
+	                });
+	            }
 
-            renderMetricPicker();
-            chart.setData(records, selectedMetrics);
-            renderMedia();
-        })();
+	            document.querySelectorAll('[data-axis-mode]').forEach((button) => {
+	                button.addEventListener('click', () => {
+	                    selectedAxisMode = button.dataset.axisMode === 'minutes' ? 'minutes' : 'step';
+	                    document.querySelectorAll('[data-axis-mode]').forEach((entry) =>
+	                        entry.classList.toggle('active', entry === button)
+	                    );
+	                    chart.setData(records, selectedMetrics, { xAxisMode: selectedAxisMode });
+	                });
+	            });
+
+	            document.getElementById('media-lightbox').addEventListener('click', (event) => {
+	                if (event.target.id === 'media-lightbox') closeLightbox();
+	            });
+	            document.getElementById('media-lightbox-close').onclick = closeLightbox;
+	            document.getElementById('media-lightbox-prev').onclick = () => {
+	                lightboxIndex = Math.max(0, lightboxIndex - 1);
+	                renderLightbox();
+	            };
+	            document.getElementById('media-lightbox-next').onclick = () => {
+	                lightboxIndex = Math.min(lightboxImages.length - 1, lightboxIndex + 1);
+	                renderLightbox();
+	            };
+	            document.getElementById('media-lightbox-size').onclick = () => {
+	                lightboxActualSize = !lightboxActualSize;
+	                renderLightbox();
+	            };
+	            document.addEventListener('keydown', (event) => {
+	                if (document.getElementById('media-lightbox').hidden) return;
+	                if (event.key === 'Escape') closeLightbox();
+	                if (event.key === 'ArrowLeft') {
+	                    lightboxIndex = Math.max(0, lightboxIndex - 1);
+	                    renderLightbox();
+	                }
+	                if (event.key === 'ArrowRight') {
+	                    lightboxIndex = Math.min(lightboxImages.length - 1, lightboxIndex + 1);
+	                    renderLightbox();
+	                }
+	            });
+
+	            renderMetricPicker();
+	            chart.setData(records, selectedMetrics, { xAxisMode: selectedAxisMode });
+	            if (timesteps.length) {
+	                document.getElementById('timestep-section').hidden = false;
+	                const timestepChart = new charts.TimestepDistributionChart(document.getElementById('timestep-chart'));
+	                timestepChart.setData(timesteps);
+	            }
+	            renderMedia();
+	        })();
     </script>
 </body>
 </html>

--- a/tests/js/training_metrics_component.test.js
+++ b/tests/js/training_metrics_component.test.js
@@ -9,8 +9,10 @@ describe('training metrics component', () => {
     beforeEach(() => {
         fetch.mockReset();
         state = window.trainingMetricsState();
+        state.$refs = {};
         state.$nextTick = (callback) => callback();
         state.renderTrainingMetricsChart = jest.fn();
+        state.renderTimestepDistributionChart = jest.fn();
     });
 
     test('loads run summaries and selects the newest run', async () => {
@@ -43,7 +45,7 @@ describe('training metrics component', () => {
         expect(fetch).toHaveBeenNthCalledWith(2, '/api/metrics/training/runs/anima?max_points=4000');
     });
 
-    test('filters validation media by prompt and step', () => {
+    test('groups validation media by prompt for the selected step', () => {
         state.trainingRunData = {
             media: [
                 { label: 'portrait', step: 10, index: 0, path: 'a.webp' },
@@ -55,11 +57,59 @@ describe('training metrics component', () => {
 
         state.selectDefaultTrainingMedia();
 
-        expect(state.selectedTrainingMediaLabel).toBe('landscape');
         expect(state.selectedTrainingMediaStep).toBe(20);
-        state.selectTrainingMediaLabel('portrait');
         expect(state.trainingMediaSteps()).toEqual([10, 20]);
-        expect(state.selectedTrainingMedia().map((item) => item.path)).toEqual(['b.webp', 'c.webp']);
+        expect(state.selectedTrainingMedia().map((item) => item.path)).toEqual(['d.webp', 'b.webp', 'c.webp']);
+        expect(state.selectedTrainingMediaGroups()).toEqual([
+            { label: 'landscape', items: [{ label: 'landscape', step: 20, index: 0, path: 'd.webp' }] },
+            {
+                label: 'portrait',
+                items: [
+                    { label: 'portrait', step: 20, index: 0, path: 'b.webp' },
+                    { label: 'portrait', step: 20, index: 1, path: 'c.webp' },
+                ],
+            },
+        ]);
+    });
+
+    test('preserves metric selection while silently refreshing a running run', async () => {
+        state.selectedTrainingEnvironment = 'anima';
+        state.selectedTrainingMetrics = ['train_loss'];
+        fetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                run: { environment: 'anima', status: 'running', last_step: 21 },
+                available_metrics: ['learning_rate', 'train_loss', 'seconds_per_step'],
+                records: [{ step: 21, metrics: { train_loss: 0.4, seconds_per_step: 1.2 } }],
+                media: [],
+            }),
+        });
+
+        await state.loadTrainingRun({ silent: true, preserveSelections: true });
+
+        expect(state.selectedTrainingMetrics).toEqual(['train_loss']);
+        expect(state.trainingMetricsLoading).toBe(false);
+    });
+
+    test('sets chart x-axis mode when rendering', () => {
+        state.renderTrainingMetricsChart.mockClear();
+
+        state.setTrainingXAxis('minutes');
+
+        expect(state.selectedTrainingXAxis).toBe('minutes');
+        expect(state.renderTrainingMetricsChart).toHaveBeenCalledTimes(1);
+    });
+
+    test('prefers validation loss and timing metrics by default', () => {
+        const selected = window.TrainingMetricsCharts.defaultMetricNames([
+            'learning_rate',
+            'loss/val/pooled',
+            'seconds_per_step',
+            'train_loss',
+            'z_metric',
+        ]);
+
+        expect(selected).toEqual(['train_loss', 'loss/val/pooled', 'seconds_per_step', 'learning_rate']);
     });
 
     test('limits the chart to eight selected metrics', () => {

--- a/tests/selenium_support.py
+++ b/tests/selenium_support.py
@@ -32,6 +32,15 @@ if hasattr(multiprocessing, "set_start_method"):
 TEST_HOST = "127.0.0.1"
 
 
+def _server_process_context() -> multiprocessing.context.BaseContext:
+    if sys.platform == "darwin":
+        methods = multiprocessing.get_all_start_methods()
+        if "forkserver" in methods:
+            return multiprocessing.get_context("forkserver")
+        return multiprocessing.get_context("spawn")
+    return multiprocessing.get_context()
+
+
 def _run_test_server(port: int, home_path: str, webui_config_path: str) -> None:
     import logging
 
@@ -87,7 +96,8 @@ class _TestServerManager:
         self.home_path = home_path
         webui_config_path = str(Path(home_path) / ".simpletuner" / "webui")
         self.port = self._find_free_port()
-        self._process = multiprocessing.Process(target=_run_test_server, args=(self.port, home_path, webui_config_path))
+        process_context = _server_process_context()
+        self._process = process_context.Process(target=_run_test_server, args=(self.port, home_path, webui_config_path))
         self._process.daemon = True
         self._process.start()
         timeout = os.environ.get("SELENIUM_SERVER_START_TIMEOUT")

--- a/tests/test_local_metrics.py
+++ b/tests/test_local_metrics.py
@@ -14,11 +14,14 @@ from simpletuner.helpers.training.local_metrics import (
     MEDIA_FILENAME,
     METRICS_FILENAME,
     REPORT_FILENAME,
+    TIMESTEP_DISTRIBUTION_FILENAME,
     LocalMetricsTracker,
     downsample_records,
     is_local_metrics_enabled,
     read_media_records,
     read_metric_records,
+    read_timestep_distribution_records,
+    record_timestep_distribution,
 )
 from simpletuner.helpers.training.state_tracker import StateTracker
 from simpletuner.helpers.training.validation_images import save_validation_image
@@ -93,6 +96,18 @@ class LocalMetricsTrackerTests(unittest.TestCase):
         self.assertTrue(is_local_metrics_enabled(["wandb", "simpletuner"]))
         self.assertFalse(is_local_metrics_enabled("all"))
         self.assertFalse(is_local_metrics_enabled("wandb"))
+
+    def test_timestep_distribution_records_grouped_samples(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config = SimpleNamespace(output_dir=directory, report_to="simpletuner")
+
+            record_timestep_distribution(config, [(4, 10), (4, 12.5), (5, 22), (5, float("nan"))])
+
+            records = read_timestep_distribution_records(directory)
+            self.assertEqual([record["step"] for record in records], [4, 5])
+            self.assertEqual(records[0]["timesteps"], [10.0, 12.5])
+            self.assertEqual(records[1]["timesteps"], [22.0])
+            self.assertTrue((Path(directory) / TIMESTEP_DISTRIBUTION_FILENAME).is_file())
 
 
 class ValidationMediaManifestTests(unittest.TestCase):

--- a/tests/test_training_metrics_service.py
+++ b/tests/test_training_metrics_service.py
@@ -3,7 +3,13 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from simpletuner.helpers.training.local_metrics import MANIFEST_FILENAME, MEDIA_FILENAME, METRICS_FILENAME, REPORT_FILENAME
+from simpletuner.helpers.training.local_metrics import (
+    MANIFEST_FILENAME,
+    MEDIA_FILENAME,
+    METRICS_FILENAME,
+    REPORT_FILENAME,
+    TIMESTEP_DISTRIBUTION_FILENAME,
+)
 from simpletuner.simpletuner_sdk.server.services.training_metrics_service import (
     TrainingMetricsService,
     TrainingMetricsServiceError,
@@ -57,6 +63,7 @@ class TrainingMetricsServiceTests(unittest.TestCase):
             METRICS_FILENAME,
             [{"step": step, "metrics": {"loss": 10.0 - step, "lr": step / 1000, "epoch": step / 10}} for step in range(10)],
         )
+        self._write_jsonl(TIMESTEP_DISTRIBUTION_FILENAME, [{"step": 9, "timesteps": [10.0, 20.0]}])
         validation_dir = self.output_dir / "validation_images"
         validation_dir.mkdir()
         (validation_dir / "step_9_prompt_0.webp").write_bytes(b"RIFF")
@@ -104,6 +111,8 @@ class TrainingMetricsServiceTests(unittest.TestCase):
         self.assertEqual([record["step"] for record in result["records"]], [2, 5, 8])
         self.assertEqual([set(record["metrics"]) for record in result["records"]], [{"loss"}] * 3)
         self.assertEqual(result["available_metrics"], ["loss", "lr"])
+        self.assertEqual(result["timesteps"], [{"step": 9, "timesteps": [10.0, 20.0]}])
+        self.assertEqual(result["raw_files"]["timesteps"], TIMESTEP_DISTRIBUTION_FILENAME)
         self.assertEqual(len(result["media"]), 1)
         self.assertIn("/api/metrics/training/runs/anima/media/validation_images/", result["media"][0]["url"])
 

--- a/tests/test_webui_e2e.py
+++ b/tests/test_webui_e2e.py
@@ -779,16 +779,31 @@ class TrainingMetricsDashboardTestCase(_TrainerPageMixin, WebUITestCase):
             encoding="utf-8",
         )
         image_path = validation_dir / "step_20_prompt_0_64x64.png"
+        second_image_path = validation_dir / "step_20_second_0_64x64.png"
         Image.new("RGB", (64, 64), color=(32, 160, 120)).save(image_path, format="PNG")
-        media = {
-            "step": 20,
-            "type": "image",
-            "label": "A green square",
-            "index": 0,
-            "resolution": "64x64",
-            "path": image_path.relative_to(output_dir).as_posix(),
-        }
-        (output_dir / "validation_media.jsonl").write_text(f"{json.dumps(media)}\n", encoding="utf-8")
+        Image.new("RGB", (64, 64), color=(120, 80, 220)).save(second_image_path, format="PNG")
+        media_records = [
+            {
+                "step": 20,
+                "type": "image",
+                "label": "A green square",
+                "index": 0,
+                "resolution": "64x64",
+                "path": image_path.relative_to(output_dir).as_posix(),
+            },
+            {
+                "step": 20,
+                "type": "image",
+                "label": "A violet square",
+                "index": 0,
+                "resolution": "64x64",
+                "path": second_image_path.relative_to(output_dir).as_posix(),
+            },
+        ]
+        (output_dir / "validation_media.jsonl").write_text(
+            "".join(f"{json.dumps(media)}\n" for media in media_records),
+            encoding="utf-8",
+        )
         (output_dir / "training_report.html").write_text("<html>report</html>", encoding="utf-8")
 
         def scenario(driver, _browser):
@@ -810,13 +825,28 @@ class TrainingMetricsDashboardTestCase(_TrainerPageMixin, WebUITestCase):
             self.assertGreater(canvas.size["width"], 300)
             self.assertGreater(canvas.size["height"], 200)
 
-            image = WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located((By.CSS_SELECTOR, ".training-media-grid > figure img"))
+            images = WebDriverWait(driver, 10).until(
+                lambda _driver: driver.find_elements(By.CSS_SELECTOR, ".training-media-grid figure img")
             )
+            self.assertEqual(len(images), 2)
+            image = images[0]
             media_response = requests.get(image.get_attribute("src"), timeout=5)
             self.assertEqual(media_response.status_code, 200, media_response.text)
             self.assertEqual(media_response.headers["content-type"], "image/png")
             self.assertEqual(Image.open(BytesIO(media_response.content)).size, (64, 64))
+            image.click()
+            lightbox = WebDriverWait(driver, 10).until(
+                EC.visibility_of_element_located((By.CSS_SELECTOR, ".training-media-lightbox"))
+            )
+            self.assertTrue(lightbox.is_displayed())
+            actual_size_button = lightbox.find_element(
+                By.CSS_SELECTOR, ".training-media-lightbox-toolbar button[title='Show at 1:1 size']"
+            )
+            actual_size_button.click()
+            lightbox_image = driver.find_element(By.CSS_SELECTOR, ".training-media-lightbox-body img")
+            self.assertIn("actual-size", lightbox_image.get_attribute("class"))
+            lightbox.find_element(By.CSS_SELECTOR, ".training-media-lightbox-toolbar button[title='Close image']").click()
+            WebDriverWait(driver, 5).until(EC.invisibility_of_element_located((By.CSS_SELECTOR, ".training-media-lightbox")))
 
             loss_toggle = driver.find_element(
                 By.XPATH,


### PR DESCRIPTION
## Summary

- add step/minutes x-axis support for local scalar charts and prefer validation loss plus step timing metrics
- render validation media as grouped galleries with an image lightbox in the WebUI and offline report
- persist local timestep samples in `timestep_distribution.jsonl`, expose them through the training metrics API, and render a distribution chart
- auto-refresh running local metrics runs while the Metrics tab is open

Refs #3167.

## Validation

- `npm test -- --runInBand tests/js/training_metrics_component.test.js`
- `.venv/bin/python -m unittest tests.test_local_metrics tests.test_training_metrics_service tests.test_iteration_tracker -v -f`
- `.venv/bin/python -m py_compile simpletuner/helpers/training/trainer.py simpletuner/helpers/training/local_metrics.py simpletuner/simpletuner_sdk/server/services/training_metrics_service.py`
- `git diff --check`

Selenium E2E was attempted with `SIMPLETUNER_SELENIUM_TESTS=1` and `SELENIUM_SERVER_START_TIMEOUT=120`, but the harness failed in `setUpClass` before the test body because the test server did not become healthy within the timeout.
