### PR TITLE
Fix WebUI save dirty state tracking

### DIFF
--- a/simpletuner/templates/partials/form_field_htmx.html
+++ b/simpletuner/templates/partials/form_field_htmx.html
@@ -1298,7 +1298,17 @@ window.handleFieldValidation = window.handleFieldValidation || function(event, e
             const relatedEl = document.getElementById(relatedId);
             if (relatedEl && window.htmx && typeof window.htmx.trigger === 'function') {
                 relatedState[relatedId] = true;
-                window.htmx.trigger(relatedEl, 'change');
+                const wasSuppressed = trainerStore ? trainerStore._suppressDirtyTracking : false;
+                if (trainerStore) {
+                    trainerStore._suppressDirtyTracking = true;
+                }
+                try {
+                    window.htmx.trigger(relatedEl, 'change');
+                } finally {
+                    if (trainerStore) {
+                        trainerStore._suppressDirtyTracking = wasSuppressed;
+                    }
+                }
             }
         }
     }

--- a/simpletuner/templates/trainer_htmx.html
+++ b/simpletuner/templates/trainer_htmx.html
@@ -36,20 +36,26 @@
 
 {% block body %}
 <script>
+function trainerNextTick(callback) {
+    if (window.Alpine && typeof window.Alpine.nextTick === 'function') {
+        return window.Alpine.nextTick(callback);
+    }
+    return Promise.resolve().then(callback);
+}
+
+function trainerNextFrame() {
+    return new Promise(resolve => {
+        trainerNextTick(() => {
+            trainerNextTick(() => {
+                requestAnimationFrame(resolve);
+            });
+        });
+    });
+}
+
 // Initialize Alpine store early to prevent race conditions
 document.addEventListener('alpine:init', () => {
-    Alpine.store('trainer', {
-        formDirty: false,
-        showConfigSaveDialog: false,
-        createConfigBackupOption: false,
-        preserveDefaultsOption: false,
-        saveConfig: () => {
-            console.warn('Trainer component not fully initialized yet');
-            window.showToast('Please wait for the page to fully load', 'warning');
-        },
-        cancelSaveConfig: () => {},
-        confirmSaveConfig: () => {}
-    });
+    Alpine.store('trainer', trainerComponent());
 
     // Shared dataloader configs store
     Alpine.store('dataloaderConfigs', {
@@ -606,7 +612,7 @@ function trainerComponent() {
             }
 
             // Ensure tab button gets active class
-            this.$nextTick(() => {
+            trainerNextTick(() => {
                 const allTabButtons = document.querySelectorAll('.tab-btn');
                 allTabButtons.forEach(button => {
                     button.classList.remove('active');
@@ -1089,7 +1095,7 @@ function trainerComponent() {
             this.formValueStore = {};
             this.configValues = { ...normalized };
             this.seedFormValueStoreFromConfig(normalized);
-            await this.$nextTick();
+            await trainerNextTick();
             this.applyStoredValues();
             this.captureFormValues();
             this.markFormDirty();
@@ -4373,7 +4379,7 @@ function trainerComponent() {
                 }
                 this.overlayVisible = true;
                 this.overlayError = '';
-                this.$nextTick(async () => {
+                trainerNextTick(async () => {
                     if (this.$refs.onboardingInput && nextStep.input_type === 'directory') {
                         this.$refs.onboardingInput.focus();
                         this.$refs.onboardingInput.select();
@@ -5672,16 +5678,7 @@ function trainerComponent() {
                             // updating baseline and clearing suppression. Without this, Alpine may
                             // update form inputs AFTER we clear _suppressDirtyTracking, causing
                             // input/change events to flip formDirty back to true.
-                            await new Promise(resolve => {
-                                this.$nextTick(() => {
-                                    // Double nextTick to ensure all reactive effects have settled
-                                    this.$nextTick(() => {
-                                        requestAnimationFrame(() => {
-                                            resolve();
-                                        });
-                                    });
-                                });
-                            });
+                            await trainerNextFrame();
                             // Update baseline to match refreshed values so checkFormDirty() sees no changes
                             this.updateBaselineFormData();
                             // Ensure form is still clean after refresh
@@ -5825,13 +5822,10 @@ function trainerComponent() {
 
 <!-- Main App - shown when auth check complete and login not required -->
 <div class="dashboard-wrapper"
-     x-data="trainerComponent()"
+     x-data="$store.trainer"
      x-show="$store.cloudAuth.shouldShowApp"
      x-cloak
      x-init="(async () => {
-         // Store reference to Alpine component for external access
-         Alpine.store('trainer', $data);
-
          // Wait for auth before loading tab content
          const canProceed = await window.waitForAuthReady();
          if (!canProceed) {


### PR DESCRIPTION
## Summary
- use the trainer Alpine store as the dashboard state source of truth instead of re-registering the live component proxy
- replace shared trainer methods' component-only nextTick calls with a helper that works from store calls
- suppress dirty tracking for synthetic cross-field validation change events

## Validation
- `SIMPLETUNER_SELENIUM_TESTS=1 SELENIUM_SERVER_START_TIMEOUT=180 .venv/bin/python -m unittest tests.test_webui_e2e.FormDirtyStateFlowTestCase tests.test_webui_e2e.EasyModeFormDirtyTestCase tests.test_webui_e2e.TrainingEpochsStepsValidationTestCase -v -f`
- `git diff --check`