### PR TITLE
Treat blank publishing config as disabled

### DIFF
--- a/simpletuner/helpers/configuration/cli_utils.py
+++ b/simpletuner/helpers/configuration/cli_utils.py
@@ -279,6 +279,8 @@ def mapping_to_cli_args(
 
         value_str = str(value).strip()
         if not value_str:
+            if canonical_key in {"webhook_config", "publishing_config", "peft_lora_target_modules"}:
+                continue
             if isinstance(value, str) and field is not None and getattr(field, "allow_empty", False):
                 cli_args.append(_format_key_value(key, ""))
             continue

--- a/simpletuner/helpers/configuration/cmd_args.py
+++ b/simpletuner/helpers/configuration/cmd_args.py
@@ -250,6 +250,8 @@ def _normalize_structured_config_option(raw_value, option_name: str):
         import os
 
         config_str = os.path.expanduser(str(raw_value))
+        if config_str.strip() in ("", "None"):
+            return None
         if config_str.startswith("{") or config_str.startswith("["):
             if _contains_ast_markers(config_str):
                 raise ValueError(f"{option_name} contains AST object patterns instead of valid JSON. Received: {config_str}")

--- a/tests/test_allow_empty_fields.py
+++ b/tests/test_allow_empty_fields.py
@@ -30,6 +30,12 @@ class TestAllowEmptyFields(unittest.TestCase):
 
         self.assertIn("--validation_negative_prompt=", result)
 
+    def test_blank_optional_structured_config_skipped_when_mapping_to_cli_args(self):
+        result = mapping_to_cli_args({"publishing_config": "", "validation_negative_prompt": ""})
+
+        self.assertNotIn("--publishing_config=", result)
+        self.assertIn("--validation_negative_prompt=", result)
+
     def test_empty_string_preserved_in_form_submission(self):
         """Test that empty strings are preserved during form normalization."""
         # Simulate form data with empty negative prompt

--- a/tests/test_publishing_config_parsing.py
+++ b/tests/test_publishing_config_parsing.py
@@ -36,6 +36,14 @@ class _StubProvider(PublishingProvider):
 
 
 class TestPublishingConfigParsing(unittest.TestCase):
+    def test_blank_publishing_config_is_disabled(self):
+        args_list = _base_args() + ["--publishing_config="]
+
+        args = parse_cmdline_args(input_args=args_list, exit_on_error=False)
+
+        self.assertIsNotNone(args)
+        self.assertIsNone(args.publishing_config)
+
     def test_inline_publishing_config_json(self):
         config_json = json.dumps([{"provider": "s3", "bucket": "demo"}])
         args_list = _base_args() + [f"--publishing_config={config_json}"]


### PR DESCRIPTION
## Summary
- skip blank optional structured config values when building CLI args
- normalize blank `publishing_config` CLI values to disabled instead of treating them as file paths
- add coverage proving regular allow-empty text fields still preserve empty values

## Validation
- `.venv/bin/python -m unittest tests.test_publishing_config_parsing tests.test_allow_empty_fields -v -f`
- `git diff --check`