### PR TITLE
Improve training metrics dashboard layout

### DIFF
--- a/simpletuner/simpletuner_sdk/server/routes/webui_state.py
+++ b/simpletuner/simpletuner_sdk/server/routes/webui_state.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from simpletuner.simpletuner_sdk.server.services.cloud.auth.middleware import get_current_user
 from simpletuner.simpletuner_sdk.server.services.cloud.auth.models import User
@@ -574,6 +574,39 @@ class CheckpointInferenceSettingsPayload(BaseModel):
     streaming_preview: bool = False
 
 
+class TrainingMetricChartPayload(BaseModel):
+    """One scalar chart in the training metrics workspace."""
+
+    kind: Literal["scalar"] = "scalar"
+    name: str = "Training metrics"
+    metrics: List[str] = Field(default_factory=list)
+    smoothing: float = Field(default=0, ge=0, le=0.99)
+
+
+class TrainingMetricTemplatePayload(BaseModel):
+    """A named training metrics chart layout."""
+
+    name: str
+    charts: List[TrainingMetricChartPayload] = Field(default_factory=list)
+
+
+class TrainingMetricEnvironmentPayload(BaseModel):
+    """Per-environment active training metrics layout."""
+
+    template: str = "Default"
+    xAxis: Literal["step", "minutes"] = "step"
+    showTimestepChart: bool = False
+    mediaPanelCollapsed: bool = False
+    charts: List[TrainingMetricChartPayload] = Field(default_factory=list)
+
+
+class TrainingMetricLayoutsPayload(BaseModel):
+    """Persisted training metrics layout state."""
+
+    templates: List[TrainingMetricTemplatePayload] = Field(default_factory=list)
+    environments: Dict[str, TrainingMetricEnvironmentPayload] = Field(default_factory=dict)
+
+
 @router.get("/ui-state/checkpoint-inference")
 async def get_checkpoint_inference_settings(
     _user: User = Depends(get_current_user),
@@ -597,6 +630,34 @@ async def save_checkpoint_inference_settings(
     try:
         settings = payload.model_dump()
         store.save_checkpoint_inference_settings(settings)
+        return payload
+    except ValueError as error:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error
+
+
+@router.get("/ui-state/training-metrics")
+async def get_training_metrics_layouts(
+    _user: User = Depends(get_current_user),
+) -> TrainingMetricLayoutsPayload:
+    """Get training metrics chart layouts."""
+    store = WebUIStateStore()
+    try:
+        settings = store.get_training_metrics_layouts()
+        return TrainingMetricLayoutsPayload.model_validate(settings)
+    except ValueError as error:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error
+
+
+@router.post("/ui-state/training-metrics")
+async def save_training_metrics_layouts(
+    payload: TrainingMetricLayoutsPayload,
+    _user: User = Depends(get_current_user),
+) -> TrainingMetricLayoutsPayload:
+    """Save training metrics chart layouts."""
+    store = WebUIStateStore()
+    try:
+        settings = payload.model_dump()
+        store.save_training_metrics_layouts(settings)
         return payload
     except ValueError as error:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error

--- a/simpletuner/simpletuner_sdk/server/services/webui_state.py
+++ b/simpletuner/simpletuner_sdk/server/services/webui_state.py
@@ -785,6 +785,18 @@ class WebUIStateStore:
         ui_state["checkpoint_inference"] = settings
         self.save_ui_state(ui_state)
 
+    def get_training_metrics_layouts(self) -> Dict[str, Any]:
+        """Get persisted training metrics chart layouts."""
+        ui_state = self.load_ui_state()
+        settings = ui_state.get("training_metrics")
+        return settings if isinstance(settings, dict) else {}
+
+    def save_training_metrics_layouts(self, settings: Dict[str, Any]) -> None:
+        """Save training metrics chart layouts without replacing unrelated UI state."""
+        ui_state = self.load_ui_state()
+        ui_state["training_metrics"] = settings
+        self.save_ui_state(ui_state)
+
     def get_collapsed_sections(self, tab_name: str) -> Dict[str, bool]:
         """Get collapsed state for sections in a specific tab."""
         ui_state = self.load_ui_state()

--- a/simpletuner/static/css/metrics.css
+++ b/simpletuner/static/css/metrics.css
@@ -907,7 +907,10 @@
 .training-tool-header,
 .training-run-actions,
 .training-latest-values,
-.training-media-steps {
+.training-chart-legend,
+.training-chart-layout-toolbar,
+.training-chart-layout-controls,
+.training-chart-actions {
     display: flex;
     align-items: center;
 }
@@ -1012,13 +1015,83 @@
     gap: 1rem;
 }
 
-.training-chart-tool,
+.training-metrics-layout.validation-collapsed {
+    grid-template-columns: minmax(0, 1fr) 2.75rem;
+}
+
+.training-chart-workspace,
 .training-media-tool {
     min-width: 0;
     padding: 1rem;
     border: 1px solid rgba(148, 163, 184, 0.2);
     border-radius: 0.5rem;
     background: rgba(15, 23, 42, 0.38);
+}
+
+.training-chart-workspace {
+    display: grid;
+    gap: 0.8rem;
+}
+
+.training-media-tool.collapsed {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 0.45rem;
+}
+
+.training-media-tool.collapsed .training-tool-header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+}
+
+.training-media-tool.collapsed .training-tool-header > div,
+.training-media-tool.collapsed .training-media-panel-body {
+    display: none !important;
+}
+
+.training-media-collapse-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    min-width: 2rem;
+    height: 2rem;
+    padding: 0;
+}
+
+.training-chart-layout-toolbar {
+    justify-content: space-between;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+}
+
+.training-chart-layout-controls {
+    gap: 0.45rem;
+    min-width: min(100%, 30rem);
+}
+
+.training-chart-layout-controls .form-select {
+    width: 9rem;
+}
+
+.training-chart-layout-controls .form-control {
+    width: 12rem;
+}
+
+.training-chart-stack {
+    display: grid;
+    gap: 0.8rem;
+}
+
+.training-chart-tool {
+    min-width: 0;
+    padding: 0.8rem;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    border-radius: 0.4rem;
+    background: rgba(2, 6, 23, 0.18);
 }
 
 .training-tool-header {
@@ -1033,6 +1106,44 @@
 
 .training-tool-header .form-select {
     max-width: 13rem;
+}
+
+.training-chart-title {
+    display: grid;
+    gap: 0.25rem;
+    min-width: min(100%, 16rem);
+}
+
+.training-chart-title > span {
+    display: block;
+    height: 1rem;
+    overflow: hidden;
+    line-height: 1rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.training-chart-title .form-control {
+    min-height: 1.9rem;
+    border-color: rgba(148, 163, 184, 0.22);
+    color: #f8fafc;
+    background: rgba(15, 23, 42, 0.5);
+    font-size: 0.85rem;
+    font-weight: 650;
+}
+
+.training-chart-actions {
+    gap: 0.35rem;
+}
+
+.training-chart-actions .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    min-width: 2rem;
+    height: 2rem;
+    padding: 0;
 }
 
 .training-axis-toggle {
@@ -1063,19 +1174,57 @@
     background: rgba(14, 165, 233, 0.18);
 }
 
-.training-metric-picker {
+.training-chart-selector {
+    display: grid;
+    gap: 0.55rem;
+    margin-top: 0.75rem;
+    padding: 0.65rem;
+    border: 1px solid rgba(148, 163, 184, 0.16);
+    border-radius: 0.35rem;
+    background: rgba(15, 23, 42, 0.68);
+}
+
+.training-chart-smoothing {
+    display: grid;
+    grid-template-columns: minmax(8rem, 1fr) minmax(10rem, 2fr);
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.training-chart-smoothing label {
     display: flex;
-    justify-content: flex-end;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin: 0;
+    color: #cbd5e1;
+    font-size: 0.75rem;
+}
+
+.training-chart-smoothing strong {
+    color: #f8fafc;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-weight: 650;
+}
+
+.training-chart-smoothing input[type="range"] {
+    width: 100%;
+    accent-color: #38bdf8;
+}
+
+.training-metric-picker {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
     gap: 0.35rem;
-    max-width: 70%;
-    flex-wrap: wrap;
+    max-height: 13rem;
+    overflow: auto;
 }
 
 .training-metric-picker label {
     display: inline-flex;
     align-items: center;
     gap: 0.3rem;
-    max-width: 14rem;
+    min-width: 0;
     padding: 0.25rem 0.45rem;
     border: 1px solid rgba(148, 163, 184, 0.2);
     border-radius: 0.25rem;
@@ -1110,6 +1259,32 @@
     overflow-x: auto;
 }
 
+.training-chart-legend {
+    gap: 0.6rem;
+    min-height: 1.55rem;
+    margin-top: 0.6rem;
+    overflow-x: auto;
+    flex-wrap: wrap;
+}
+
+.training-chart-legend > div {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    min-width: 0;
+    color: #cbd5e1;
+    font-size: 0.75rem;
+    white-space: nowrap;
+}
+
+.training-chart-swatch {
+    flex: 0 0 auto;
+    width: 0.55rem;
+    height: 0.55rem;
+    border-radius: 999px;
+}
+
 .training-latest-values > div {
     min-width: 7rem;
 }
@@ -1138,9 +1313,54 @@
     height: 24rem;
 }
 
+.training-chart-tooltip {
+    position: absolute;
+    z-index: 2;
+    display: grid;
+    gap: 0.25rem;
+    width: min(15rem, calc(100% - 1rem));
+    padding: 0.5rem 0.6rem;
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    border-radius: 0.35rem;
+    color: #e2e8f0;
+    background: rgba(2, 6, 23, 0.9);
+    box-shadow: 0 0.6rem 1.5rem rgba(2, 6, 23, 0.35);
+    pointer-events: none;
+}
+
+.training-chart-tooltip-title {
+    color: #94a3b8;
+    font-size: 0.7rem;
+}
+
+.training-chart-tooltip-row {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.35rem;
+    min-width: 0;
+    font-size: 0.72rem;
+}
+
+.training-chart-tooltip-row span:not(.training-chart-swatch) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.training-chart-tooltip-row strong {
+    color: #f8fafc;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-weight: 650;
+}
+
 .training-timestep-canvas-wrap {
     height: 16rem;
     margin-top: 1rem;
+}
+
+.training-timestep-panel {
+    margin-top: 0.25rem;
 }
 
 .training-chart-canvas-wrap canvas {
@@ -1149,26 +1369,34 @@
     height: 100%;
 }
 
-.training-media-steps {
-    gap: 0.25rem;
+.training-media-step-slider {
+    display: grid;
+    gap: 0.45rem;
     margin: 0.8rem 0;
-    overflow-x: auto;
 }
 
-.training-media-steps button {
-    min-width: 2.5rem;
-    padding: 0.25rem 0.45rem;
-    border: 1px solid rgba(148, 163, 184, 0.2);
-    border-radius: 0.25rem;
+.training-media-step-slider label,
+.training-media-lightbox-step-slider label {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin: 0;
     color: #94a3b8;
-    background: transparent;
-    font-size: 0.7rem;
+    font-size: 0.75rem;
 }
 
-.training-media-steps button.active {
-    border-color: #38bdf8;
-    color: #e0f2fe;
-    background: rgba(14, 165, 233, 0.14);
+.training-media-step-slider strong,
+.training-media-lightbox-step-slider strong {
+    color: #f8fafc;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-weight: 650;
+}
+
+.training-media-step-slider input[type="range"],
+.training-media-lightbox-step-slider input[type="range"] {
+    width: 100%;
+    accent-color: #38bdf8;
 }
 
 .training-media-grid {
@@ -1246,7 +1474,7 @@
     inset: 0;
     z-index: 1090;
     display: grid;
-    grid-template-rows: minmax(0, 1fr) auto auto;
+    grid-template-rows: minmax(0, 1fr) auto auto auto;
     gap: 0.75rem;
     padding: 1rem;
     background: rgba(2, 6, 23, 0.94);
@@ -1302,6 +1530,13 @@
     text-align: center;
 }
 
+.training-media-lightbox-step-slider {
+    width: min(34rem, 100%);
+    justify-self: center;
+    display: grid;
+    gap: 0.45rem;
+}
+
 .training-media-lightbox-caption {
     overflow: hidden;
     color: #cbd5e1;
@@ -1315,6 +1550,14 @@
 @media (max-width: 1100px) {
     .training-metrics-layout {
         grid-template-columns: 1fr;
+    }
+
+    .training-metrics-layout.validation-collapsed {
+        grid-template-columns: 1fr;
+    }
+
+    .training-media-tool.collapsed {
+        min-height: 2.9rem;
     }
 }
 
@@ -1332,10 +1575,26 @@
 
     .training-run-actions .form-select,
     .training-tool-header .form-select,
-    .training-metric-picker,
+    .training-chart-layout-controls,
+    .training-chart-layout-controls .form-select,
+    .training-chart-layout-controls .form-control,
     .training-axis-toggle {
         width: 100%;
         max-width: none;
+    }
+
+    .training-chart-layout-controls {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .training-chart-layout-controls .btn {
+        justify-content: center;
+    }
+
+    .training-chart-smoothing {
+        grid-template-columns: 1fr;
+        gap: 0.4rem;
     }
 
     .training-axis-toggle button {

--- a/simpletuner/static/css/trainer-core.css
+++ b/simpletuner/static/css/trainer-core.css
@@ -100,6 +100,15 @@
     color: var(--text-soft);
 }
 
+.tab-fragment .form-select {
+    appearance: none;
+    padding-right: 2rem;
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23cbd5e1' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m4 6 4 4 4-4'/%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 0.65rem center;
+    background-size: 0.75rem 0.75rem;
+}
+
 .danger-mode-locked {
     opacity: 0.6;
     position: relative;

--- a/simpletuner/static/js/metrics_component.js
+++ b/simpletuner/static/js/metrics_component.js
@@ -67,6 +67,8 @@ function metricsComponent(initialSettings = {}) {
             // Check if hero should be shown
             this.heroDismissed = this.dismissedHints.includes('hero');
 
+            await this.loadTrainingMetricLayouts();
+
             // Load categories, templates, circuit breaker status, and GPU health
             await Promise.all([
                 this.loadTrainingRuns(),

--- a/simpletuner/static/js/training_metrics_chart.js
+++ b/simpletuner/static/js/training_metrics_chart.js
@@ -186,7 +186,7 @@
                 return;
             }
 
-            const padding = { left: 64, right: 20, top: 20, bottom: 42 };
+            const padding = { left: 56, right: 20, top: 20, bottom: 42 };
             const plotWidth = width - padding.left - padding.right;
             const plotHeight = height - padding.top - padding.bottom;
             const xValues = points.map((point) => point.xValue);
@@ -295,13 +295,6 @@
                 context.fillText(formatXAxisValue(value, xAxisMode), x, height - padding.bottom + 12);
             }
             context.fillText(xAxisMode === 'minutes' ? 'Elapsed minutes' : 'Global step', padding.left + plotWidth / 2, height - 14);
-
-            context.save();
-            context.translate(16, padding.top + plotHeight / 2);
-            context.rotate(-Math.PI / 2);
-            context.textBaseline = 'top';
-            context.fillText('Metric value', 0, 0);
-            context.restore();
         }
 
         _handlePointer(event) {

--- a/simpletuner/static/js/training_metrics_chart.js
+++ b/simpletuner/static/js/training_metrics_chart.js
@@ -12,6 +12,12 @@
         'seconds_per_step',
         'learning_rate',
     ];
+    const LOSS_METRIC_PATTERNS = [
+        /^train_loss$/,
+        /^loss$/,
+        /^loss\//,
+        /(^|[/_.-])loss([/_.-]|$)/,
+    ];
 
     function metricNames(records) {
         const names = new Set();
@@ -21,15 +27,24 @@
         return Array.from(names).sort((left, right) => left.localeCompare(right));
     }
 
-    function defaultMetricNames(names, limit = 4) {
+    function isLossMetric(name) {
+        return LOSS_METRIC_PATTERNS.some((pattern) => pattern.test(name));
+    }
+
+    function defaultMetricNames(names, limit = 1) {
         const selected = [];
         PREFERRED_METRICS.forEach((preferred) => {
             names.forEach((name) => {
                 if (selected.length >= limit) return;
                 if (selected.includes(name)) return;
+                if (!isLossMetric(name)) return;
                 if (name === preferred || name.startsWith(`${preferred}/`)) selected.push(name);
             });
         });
+        for (const name of names) {
+            if (selected.length >= limit) break;
+            if (!selected.includes(name) && isLossMetric(name)) selected.push(name);
+        }
         for (const name of names) {
             if (selected.length >= limit) break;
             if (!selected.includes(name) && !name.includes('learning_rate')) selected.push(name);
@@ -71,12 +86,30 @@
         return Math.round(value).toLocaleString();
     }
 
+    function normalizeSmoothing(value) {
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed)) return 0;
+        return Math.max(0, Math.min(0.99, parsed));
+    }
+
+    function smoothSeries(points, smoothing) {
+        const factor = normalizeSmoothing(smoothing);
+        if (!factor || !Array.isArray(points) || points.length < 2) return points;
+        let smoothedValue = points[0].value;
+        return points.map((point, index) => {
+            if (index === 0) return { ...point, rawValue: point.value };
+            smoothedValue = smoothedValue * factor + point.value * (1 - factor);
+            return { ...point, rawValue: point.value, value: smoothedValue };
+        });
+    }
+
     class TrainingMetricsChart {
         constructor(canvas, options = {}) {
             this.canvas = canvas;
             this.records = [];
             this.metrics = [];
             this.xAxisMode = options.xAxisMode === 'minutes' ? 'minutes' : 'step';
+            this.smoothing = normalizeSmoothing(options.smoothing);
             this.options = options;
             this.geometry = null;
             this.hoverIndex = null;
@@ -96,6 +129,7 @@
             this.records = Array.isArray(records) ? records : [];
             this.metrics = Array.isArray(metrics) ? metrics.slice(0, COLORS.length) : [];
             if (options.xAxisMode) this.xAxisMode = options.xAxisMode === 'minutes' ? 'minutes' : 'step';
+            this.smoothing = normalizeSmoothing(options.smoothing);
             this.hoverIndex = null;
             this.draw();
         }
@@ -132,13 +166,20 @@
                         : Number(record.step),
                 }))
                 .filter((point) => Number.isFinite(point.xValue));
-            const values = [];
-            points.forEach((point) => {
-                this.metrics.forEach((name) => {
+            const series = this.metrics.map((name, metricIndex) => ({
+                name,
+                color: COLORS[metricIndex % COLORS.length],
+                points: smoothSeries(points.filter((point) => {
                     const value = point.record.metrics && point.record.metrics[name];
-                    if (typeof value === 'number' && Number.isFinite(value)) values.push(value);
-                });
-            });
+                    return typeof value === 'number' && Number.isFinite(value);
+                }).map((point) => ({
+                    ...point,
+                    value: point.record.metrics[name],
+                    rawValue: point.record.metrics[name],
+                })), this.smoothing),
+            }));
+            const drawableSeries = series.filter((entry) => entry.points.length);
+            const values = drawableSeries.flatMap((entry) => entry.points.map((point) => point.value));
             if (!points.length || !values.length || !this.metrics.length) {
                 this._drawEmpty(context, width, height);
                 this.geometry = null;
@@ -165,26 +206,33 @@
 
             const xForValue = (xValue) => padding.left + ((xValue - minX) / (maxX - minX)) * plotWidth;
             const yForValue = (value) => padding.top + (1 - (value - minValue) / (maxValue - minValue)) * plotHeight;
-            this.geometry = { points, padding, plotWidth, plotHeight, minX, maxX, minValue, maxValue, xForValue, yForValue, xAxisMode: activeXAxisMode };
+            this.geometry = {
+                points,
+                series,
+                padding,
+                plotWidth,
+                plotHeight,
+                minX,
+                maxX,
+                minValue,
+                maxValue,
+                xForValue,
+                yForValue,
+                xAxisMode: activeXAxisMode,
+            };
 
             this._drawGrid(context, width, height, this.geometry);
-            this.metrics.forEach((name, metricIndex) => {
-                context.strokeStyle = COLORS[metricIndex % COLORS.length];
+            drawableSeries.forEach((entry) => {
+                context.strokeStyle = entry.color;
                 context.lineWidth = 2;
+                context.lineCap = 'round';
                 context.lineJoin = 'round';
                 context.beginPath();
-                let started = false;
-                points.forEach((point) => {
-                    const value = point.record.metrics && point.record.metrics[name];
-                    if (typeof value !== 'number' || !Number.isFinite(value)) {
-                        started = false;
-                        return;
-                    }
+                entry.points.forEach((point, index) => {
                     const x = xForValue(point.xValue);
-                    const y = yForValue(value);
-                    if (!started) {
+                    const y = yForValue(point.value);
+                    if (index === 0) {
                         context.moveTo(x, y);
-                        started = true;
                     } else {
                         context.lineTo(x, y);
                     }
@@ -201,12 +249,12 @@
                 context.moveTo(x, padding.top);
                 context.lineTo(x, padding.top + plotHeight);
                 context.stroke();
-                this.metrics.forEach((name, metricIndex) => {
-                    const value = point.record.metrics && point.record.metrics[name];
-                    if (typeof value !== 'number' || !Number.isFinite(value)) return;
-                    context.fillStyle = COLORS[metricIndex % COLORS.length];
+                series.forEach((entry) => {
+                    const nearest = this._nearestSeriesPoint(entry.points, point.xValue);
+                    if (!nearest) return;
+                    context.fillStyle = entry.color;
                     context.beginPath();
-                    context.arc(x, yForValue(value), 4, 0, Math.PI * 2);
+                    context.arc(xForValue(nearest.xValue), yForValue(nearest.value), 4, 0, Math.PI * 2);
                     context.fill();
                 });
             }
@@ -246,13 +294,21 @@
                 const value = minX + ratio * (maxX - minX);
                 context.fillText(formatXAxisValue(value, xAxisMode), x, height - padding.bottom + 12);
             }
+            context.fillText(xAxisMode === 'minutes' ? 'Elapsed minutes' : 'Global step', padding.left + plotWidth / 2, height - 14);
+
+            context.save();
+            context.translate(16, padding.top + plotHeight / 2);
+            context.rotate(-Math.PI / 2);
+            context.textBaseline = 'top';
+            context.fillText('Metric value', 0, 0);
+            context.restore();
         }
 
         _handlePointer(event) {
             if (!this.geometry) return;
             const rect = this.canvas.getBoundingClientRect();
             const x = event.clientX - rect.left;
-            const { points, xForValue } = this.geometry;
+            const { points, series, xForValue } = this.geometry;
             let nearestIndex = 0;
             let nearestDistance = Number.POSITIVE_INFINITY;
             points.forEach((record, index) => {
@@ -268,18 +324,40 @@
             }
             if (this.options.onHover) {
                 const record = points[nearestIndex];
+                const metrics = series.map((entry) => {
+                    const nearest = this._nearestSeriesPoint(entry.points, record.xValue);
+                    return {
+                        name: entry.name,
+                        value: nearest?.value,
+                        rawValue: nearest?.rawValue,
+                        y: nearest ? this.geometry.yForValue(nearest.value) : undefined,
+                        color: entry.color,
+                    };
+                });
                 this.options.onHover({
                     record: record.record,
                     x: xForValue(record.xValue),
                     xValue: record.xValue,
                     xAxisMode: this.geometry.xAxisMode,
-                    metrics: this.metrics.map((name, index) => ({
-                        name,
-                        value: record.record.metrics ? record.record.metrics[name] : undefined,
-                        color: COLORS[index % COLORS.length],
-                    })),
+                    width: rect.width || this.canvas.clientWidth || 0,
+                    height: rect.height || this.canvas.clientHeight || 0,
+                    metrics,
                 });
             }
+        }
+
+        _nearestSeriesPoint(points, xValue) {
+            if (!Array.isArray(points) || !points.length) return null;
+            let nearest = points[0];
+            let nearestDistance = Math.abs(nearest.xValue - xValue);
+            points.slice(1).forEach((point) => {
+                const distance = Math.abs(point.xValue - xValue);
+                if (distance < nearestDistance) {
+                    nearest = point;
+                    nearestDistance = distance;
+                }
+            });
+            return nearest;
         }
     }
 
@@ -365,6 +443,13 @@
                 const step = Math.round(minStep + ratio * (maxStep - minStep));
                 context.fillText(step.toLocaleString(), x, height - padding.bottom + 12);
             }
+            context.fillText('Global step', padding.left + plotWidth / 2, height - 14);
+            context.save();
+            context.translate(16, padding.top + plotHeight / 2);
+            context.rotate(-Math.PI / 2);
+            context.textBaseline = 'top';
+            context.fillText('Timestep', 0, 0);
+            context.restore();
 
             context.fillStyle = 'rgba(56, 189, 248, 0.45)';
             points.forEach((point) => {
@@ -384,5 +469,6 @@
         formatMetricValue,
         latestMetricValues,
         metricNames,
+        normalizeSmoothing,
     };
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/simpletuner/static/js/training_metrics_component.js
+++ b/simpletuner/static/js/training_metrics_component.js
@@ -1,6 +1,80 @@
 (function (global) {
     'use strict';
 
+    const MAX_CHART_METRICS = 8;
+
+    function chartId() {
+        if (global.crypto && typeof global.crypto.randomUUID === 'function') {
+            return global.crypto.randomUUID();
+        }
+        return `chart-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    }
+
+    function cleanLayoutName(name) {
+        const value = String(name || '').trim();
+        return value || 'Default';
+    }
+
+    function uniqueMetrics(metrics, available) {
+        const allowed = new Set(available || []);
+        const selected = [];
+        (metrics || []).forEach((metric) => {
+            if (typeof metric !== 'string') return;
+            if (allowed.size && !allowed.has(metric)) return;
+            if (!selected.includes(metric)) selected.push(metric);
+        });
+        return selected.slice(0, MAX_CHART_METRICS);
+    }
+
+    function normalizeSmoothing(value) {
+        if (global.TrainingMetricsCharts && typeof global.TrainingMetricsCharts.normalizeSmoothing === 'function') {
+            return global.TrainingMetricsCharts.normalizeSmoothing(value);
+        }
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed)) return 0;
+        return Math.max(0, Math.min(0.99, parsed));
+    }
+
+    function makeScalarChart(name, metrics, id = null, metricSearch = '', smoothing = 0) {
+        return {
+            id: id || chartId(),
+            kind: 'scalar',
+            name: String(name || 'Training metrics').trim() || 'Training metrics',
+            metrics: Array.isArray(metrics) ? metrics.slice(0, MAX_CHART_METRICS) : [],
+            metricSearch,
+            smoothing: normalizeSmoothing(smoothing),
+        };
+    }
+
+    function normalizeCharts(charts, available) {
+        const normalized = [];
+        (charts || []).forEach((chart, index) => {
+            if (!chart || chart.kind === 'timestep') return;
+            normalized.push(makeScalarChart(
+                chart.name || `Chart ${index + 1}`,
+                uniqueMetrics(chart.metrics, available),
+                typeof chart.id === 'string' && chart.id.trim() ? chart.id : null,
+                typeof chart.metricSearch === 'string' ? chart.metricSearch : '',
+                chart.smoothing,
+            ));
+        });
+        return normalized;
+    }
+
+    function defaultCharts(available) {
+        const metrics = global.TrainingMetricsCharts
+            ? global.TrainingMetricsCharts.defaultMetricNames(available || [], 1)
+            : [];
+        return [makeScalarChart('Training metrics', metrics)];
+    }
+
+    function defaultLayoutState() {
+        return {
+            templates: [],
+            environments: {},
+        };
+    }
+
     function trainingMetricsState() {
         return {
             activeMetricsSection: 'training',
@@ -12,12 +86,135 @@
             selectedTrainingMetrics: [],
             selectedTrainingMediaStep: null,
             selectedTrainingXAxis: 'step',
+            selectedTrainingLayoutName: 'Default',
+            trainingLayoutNameInput: 'Default',
+            trainingLayoutModalOpen: false,
+            trainingLayoutSaving: false,
+            trainingLayoutError: null,
+            trainingMetricLayouts: defaultLayoutState(),
+            trainingMetricLayoutsLoaded: false,
+            trainingCharts: [],
+            showTrainingTimestepChart: false,
+            trainingMediaPanelCollapsed: false,
+            trainingChartHover: {},
+            trainingChartSelectorOpen: null,
             trainingMediaLightbox: null,
-            trainingChartHover: null,
-            _trainingMetricsChart: null,
+            _trainingMetricsCharts: {},
             _trainingTimestepChart: null,
             _trainingMetricsTimer: null,
+            _trainingLayoutSaveTimer: null,
             trainingMetricsPollMs: 5000,
+
+            async loadTrainingMetricLayouts() {
+                try {
+                    const response = await fetch('/api/webui/ui-state/training-metrics');
+                    if (!response.ok) throw new Error(`Unable to load training metrics layouts (HTTP ${response.status})`);
+                    const payload = await response.json();
+                    this.trainingMetricLayouts = this.normalizeTrainingMetricLayoutState(payload);
+                } catch (error) {
+                    console.warn('Failed to load training metrics layouts:', error);
+                    this.trainingMetricLayouts = defaultLayoutState();
+                } finally {
+                    this.trainingMetricLayoutsLoaded = true;
+                }
+            },
+
+            normalizeTrainingMetricLayoutState(payload) {
+                const state = defaultLayoutState();
+                if (!payload || typeof payload !== 'object') return state;
+                if (Array.isArray(payload.templates)) {
+                    payload.templates.forEach((template) => {
+                        if (!template || typeof template !== 'object') return;
+                        const name = cleanLayoutName(template.name);
+                        const charts = normalizeCharts(template.charts || [], []);
+                        state.templates.push({ name, charts });
+                    });
+                }
+                if (payload.environments && typeof payload.environments === 'object') {
+                    Object.entries(payload.environments).forEach(([environment, layout]) => {
+                        if (!layout || typeof layout !== 'object') return;
+                        state.environments[environment] = {
+                            template: cleanLayoutName(layout.template),
+                            charts: normalizeCharts(layout.charts || [], []),
+                            xAxis: layout.xAxis === 'minutes' ? 'minutes' : 'step',
+                            showTimestepChart: Boolean(layout.showTimestepChart),
+                            mediaPanelCollapsed: Boolean(layout.mediaPanelCollapsed),
+                        };
+                    });
+                }
+                return state;
+            },
+
+            serializeTrainingMetricLayoutState() {
+                return {
+                    templates: (this.trainingMetricLayouts.templates || []).map((template) => ({
+                        name: cleanLayoutName(template.name),
+                        charts: normalizeCharts(template.charts || [], []).map((chart) => ({
+                            kind: 'scalar',
+                            name: chart.name,
+                            metrics: chart.metrics,
+                            smoothing: chart.smoothing,
+                        })),
+                    })),
+                    environments: Object.fromEntries(
+                        Object.entries(this.trainingMetricLayouts.environments || {}).map(([environment, layout]) => [
+                            environment,
+                            {
+                                template: cleanLayoutName(layout.template),
+                                xAxis: layout.xAxis === 'minutes' ? 'minutes' : 'step',
+                                showTimestepChart: Boolean(layout.showTimestepChart),
+                                mediaPanelCollapsed: Boolean(layout.mediaPanelCollapsed),
+                                charts: normalizeCharts(layout.charts || [], []).map((chart) => ({
+                                    kind: 'scalar',
+                                    name: chart.name,
+                                    metrics: chart.metrics,
+                                    smoothing: chart.smoothing,
+                                })),
+                            },
+                        ]),
+                    ),
+                };
+            },
+
+            async saveTrainingMetricLayoutState() {
+                if (!this.trainingMetricLayoutsLoaded) return;
+                this.trainingLayoutSaving = true;
+                this.trainingLayoutError = null;
+                try {
+                    const response = await fetch('/api/webui/ui-state/training-metrics', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(this.serializeTrainingMetricLayoutState()),
+                    });
+                    if (!response.ok) throw new Error(`Unable to save training metrics layout (HTTP ${response.status})`);
+                    this.trainingMetricLayouts = this.normalizeTrainingMetricLayoutState(await response.json());
+                } catch (error) {
+                    this.trainingLayoutError = error.message || 'Unable to save training metrics layout';
+                } finally {
+                    this.trainingLayoutSaving = false;
+                }
+            },
+
+            queueTrainingMetricLayoutSave() {
+                if (!this.trainingMetricLayoutsLoaded || !this.selectedTrainingEnvironment) return;
+                this.rememberTrainingEnvironmentLayout();
+                if (this._trainingLayoutSaveTimer) window.clearTimeout(this._trainingLayoutSaveTimer);
+                this._trainingLayoutSaveTimer = window.setTimeout(() => {
+                    this._trainingLayoutSaveTimer = null;
+                    this.saveTrainingMetricLayoutState();
+                }, 400);
+            },
+
+            rememberTrainingEnvironmentLayout() {
+                if (!this.selectedTrainingEnvironment) return;
+                this.trainingMetricLayouts.environments[this.selectedTrainingEnvironment] = {
+                    template: cleanLayoutName(this.selectedTrainingLayoutName),
+                    xAxis: this.selectedTrainingXAxis,
+                    showTimestepChart: Boolean(this.showTrainingTimestepChart),
+                    mediaPanelCollapsed: Boolean(this.trainingMediaPanelCollapsed),
+                    charts: normalizeCharts(this.trainingCharts, this.trainingRunData?.available_metrics || []),
+                };
+            },
 
             async loadTrainingRuns(options = {}) {
                 const { silent = false } = options;
@@ -70,10 +267,10 @@
                     if (!response.ok) throw new Error(`Unable to load run metrics (HTTP ${response.status})`);
                     this.trainingRunData = await response.json();
                     const available = this.trainingRunData.available_metrics || [];
-                    this.syncSelectedTrainingMetrics(available, preserveSelections);
+                    this.syncTrainingCharts(available, preserveSelections);
                     this.selectDefaultTrainingMedia({ preserveSelection: preserveSelections });
                     this.$nextTick(() => {
-                        this.renderTrainingMetricsChart();
+                        this.renderTrainingMetricsCharts();
                         this.renderTimestepDistributionChart();
                     });
                 } catch (error) {
@@ -89,7 +286,7 @@
                 if (section === 'training') {
                     this.startTrainingMetricsPolling();
                     this.$nextTick(() => {
-                        this.renderTrainingMetricsChart();
+                        this.renderTrainingMetricsCharts();
                         this.renderTimestepDistributionChart();
                     });
                 } else {
@@ -98,47 +295,241 @@
                 if (section === 'system') this.$nextTick(() => this.renderActiveGpuCharts());
             },
 
-            syncSelectedTrainingMetrics(available, preserveSelections = false) {
-                if (preserveSelections) {
-                    const retained = this.selectedTrainingMetrics.filter((metric) => available.includes(metric));
-                    if (retained.length) {
-                        this.selectedTrainingMetrics = retained.slice(0, 8);
-                        return;
-                    }
+            trainingSavedLayouts() {
+                const names = ['Default'];
+                (this.trainingMetricLayouts.templates || []).forEach((template) => {
+                    const name = cleanLayoutName(template.name);
+                    if (!names.includes(name)) names.push(name);
+                });
+                return names;
+            },
+
+            getTrainingTemplate(name) {
+                const normalized = cleanLayoutName(name);
+                return (this.trainingMetricLayouts.templates || []).find(
+                    (template) => cleanLayoutName(template.name) === normalized,
+                );
+            },
+
+            syncTrainingCharts(available, preserveSelections = false) {
+                if (preserveSelections && this.trainingCharts.length) {
+                    this.trainingCharts = normalizeCharts(this.trainingCharts, available);
+                    if (!this.trainingCharts.length) this.trainingCharts = defaultCharts(available);
+                    this.syncLegacySelectedTrainingMetrics();
+                    return;
                 }
-                this.selectedTrainingMetrics = global.TrainingMetricsCharts.defaultMetricNames(available);
+
+                const environmentLayout = this.trainingMetricLayouts.environments[this.selectedTrainingEnvironment];
+                if (environmentLayout && Array.isArray(environmentLayout.charts) && environmentLayout.charts.length) {
+                    this.selectedTrainingLayoutName = cleanLayoutName(environmentLayout.template);
+                    this.trainingLayoutNameInput = this.selectedTrainingLayoutName;
+                    this.selectedTrainingXAxis = environmentLayout.xAxis === 'minutes' ? 'minutes' : 'step';
+                    this.showTrainingTimestepChart = Boolean(environmentLayout.showTimestepChart);
+                    this.trainingMediaPanelCollapsed = Boolean(environmentLayout.mediaPanelCollapsed);
+                    this.trainingCharts = normalizeCharts(environmentLayout.charts, available);
+                    if (!this.trainingCharts.length) this.trainingCharts = defaultCharts(available);
+                    this.syncLegacySelectedTrainingMetrics();
+                    return;
+                }
+
+                const templateName = environmentLayout ? cleanLayoutName(environmentLayout.template) : 'Default';
+                const template = this.getTrainingTemplate(templateName);
+                this.selectedTrainingLayoutName = template ? template.name : 'Default';
+                this.trainingLayoutNameInput = this.selectedTrainingLayoutName;
+                this.selectedTrainingXAxis = environmentLayout?.xAxis === 'minutes' ? 'minutes' : 'step';
+                this.showTrainingTimestepChart = Boolean(environmentLayout?.showTimestepChart);
+                this.trainingMediaPanelCollapsed = Boolean(environmentLayout?.mediaPanelCollapsed);
+                this.trainingCharts = template ? normalizeCharts(template.charts, available) : defaultCharts(available);
+                if (!this.trainingCharts.length) this.trainingCharts = defaultCharts(available);
+                this.syncLegacySelectedTrainingMetrics();
+            },
+
+            syncSelectedTrainingMetrics(available, preserveSelections = false) {
+                this.syncTrainingCharts(available, preserveSelections);
+            },
+
+            syncLegacySelectedTrainingMetrics() {
+                const firstChart = this.trainingCharts.find((chart) => chart.kind === 'scalar');
+                this.selectedTrainingMetrics = firstChart ? firstChart.metrics.slice() : [];
+            },
+
+            selectTrainingLayout(name) {
+                const layoutName = cleanLayoutName(name);
+                const available = this.trainingRunData?.available_metrics || [];
+                const template = this.getTrainingTemplate(layoutName);
+                this.selectedTrainingLayoutName = template ? template.name : 'Default';
+                this.trainingLayoutNameInput = this.selectedTrainingLayoutName;
+                this.trainingCharts = template ? normalizeCharts(template.charts, available) : defaultCharts(available);
+                if (!this.trainingCharts.length) this.trainingCharts = defaultCharts(available);
+                this.syncLegacySelectedTrainingMetrics();
+                this.trainingChartSelectorOpen = null;
+                this.$nextTick(() => this.renderTrainingMetricsCharts());
+                this.queueTrainingMetricLayoutSave();
+            },
+
+            async saveTrainingChartLayout(name) {
+                const layoutName = cleanLayoutName(name || this.trainingLayoutNameInput || this.selectedTrainingLayoutName);
+                const charts = normalizeCharts(this.trainingCharts, this.trainingRunData?.available_metrics || []);
+                const existingIndex = (this.trainingMetricLayouts.templates || []).findIndex(
+                    (template) => cleanLayoutName(template.name) === layoutName,
+                );
+                const template = { name: layoutName, charts };
+                if (existingIndex >= 0) {
+                    this.trainingMetricLayouts.templates.splice(existingIndex, 1, template);
+                } else {
+                    this.trainingMetricLayouts.templates.push(template);
+                }
+                this.selectedTrainingLayoutName = layoutName;
+                this.trainingLayoutNameInput = layoutName;
+                this.rememberTrainingEnvironmentLayout();
+                await this.saveTrainingMetricLayoutState();
+            },
+
+            openTrainingLayoutModal() {
+                this.trainingLayoutNameInput = cleanLayoutName(this.selectedTrainingLayoutName);
+                this.trainingLayoutModalOpen = true;
+            },
+
+            closeTrainingLayoutModal() {
+                if (this.trainingLayoutSaving) return;
+                this.trainingLayoutModalOpen = false;
+            },
+
+            async confirmTrainingLayoutSave() {
+                await this.saveTrainingChartLayout(this.trainingLayoutNameInput);
+                if (!this.trainingLayoutError) this.trainingLayoutModalOpen = false;
             },
 
             setTrainingXAxis(mode) {
                 this.selectedTrainingXAxis = mode === 'minutes' ? 'minutes' : 'step';
-                this.renderTrainingMetricsChart();
+                this.renderTrainingMetricsCharts();
+                this.queueTrainingMetricLayoutSave();
             },
 
-            toggleTrainingMetric(metric) {
-                const index = this.selectedTrainingMetrics.indexOf(metric);
-                if (index >= 0) {
-                    this.selectedTrainingMetrics.splice(index, 1);
-                } else if (this.selectedTrainingMetrics.length < 8) {
-                    this.selectedTrainingMetrics.push(metric);
+            async toggleTrainingTimestepChart() {
+                this.showTrainingTimestepChart = !this.showTrainingTimestepChart;
+                this.$nextTick(() => this.renderTimestepDistributionChart());
+                this.rememberTrainingEnvironmentLayout();
+                if (this._trainingLayoutSaveTimer) {
+                    window.clearTimeout(this._trainingLayoutSaveTimer);
+                    this._trainingLayoutSaveTimer = null;
                 }
-                this.renderTrainingMetricsChart();
+                await this.saveTrainingMetricLayoutState();
+            },
+
+            async toggleTrainingMediaPanel() {
+                this.trainingMediaPanelCollapsed = !this.trainingMediaPanelCollapsed;
+                this.$nextTick(() => {
+                    this.renderTrainingMetricsCharts();
+                    this.renderTimestepDistributionChart();
+                });
+                this.rememberTrainingEnvironmentLayout();
+                if (this._trainingLayoutSaveTimer) {
+                    window.clearTimeout(this._trainingLayoutSaveTimer);
+                    this._trainingLayoutSaveTimer = null;
+                }
+                await this.saveTrainingMetricLayoutState();
+            },
+
+            addTrainingChart() {
+                this.trainingCharts.push(makeScalarChart(`Chart ${this.trainingCharts.length + 1}`, []));
+                this.trainingChartSelectorOpen = this.trainingCharts[this.trainingCharts.length - 1].id;
+                this.syncLegacySelectedTrainingMetrics();
+                this.$nextTick(() => this.renderTrainingMetricsCharts());
+                this.queueTrainingMetricLayoutSave();
+            },
+
+            removeTrainingChart(chartIdValue) {
+                if (this.trainingCharts.length <= 1) return;
+                this.trainingCharts = this.trainingCharts.filter((chart) => chart.id !== chartIdValue);
+                if (this.trainingChartSelectorOpen === chartIdValue) this.trainingChartSelectorOpen = null;
+                if (this._trainingMetricsCharts[chartIdValue]) {
+                    this._trainingMetricsCharts[chartIdValue].destroy();
+                    delete this._trainingMetricsCharts[chartIdValue];
+                }
+                this.syncLegacySelectedTrainingMetrics();
+                this.$nextTick(() => this.renderTrainingMetricsCharts());
+                this.queueTrainingMetricLayoutSave();
+            },
+
+            toggleTrainingChartSelector(chartIdValue) {
+                this.trainingChartSelectorOpen = this.trainingChartSelectorOpen === chartIdValue ? null : chartIdValue;
+            },
+
+            filteredTrainingMetrics(chart) {
+                const available = this.trainingRunData?.available_metrics || [];
+                const query = String(chart.metricSearch || '').trim().toLowerCase();
+                if (!query) return available;
+                return available.filter((metric) => metric.toLowerCase().includes(query));
+            },
+
+            toggleTrainingMetric(metric, chartIdValue = null) {
+                const chart = chartIdValue
+                    ? this.trainingCharts.find((candidate) => candidate.id === chartIdValue)
+                    : this.trainingCharts[0];
+                if (!chart) return;
+                const index = chart.metrics.indexOf(metric);
+                if (index >= 0) {
+                    chart.metrics.splice(index, 1);
+                } else if (chart.metrics.length < MAX_CHART_METRICS) {
+                    chart.metrics.push(metric);
+                }
+                this.syncLegacySelectedTrainingMetrics();
+                this.renderTrainingMetricsCharts();
+                this.queueTrainingMetricLayoutSave();
+            },
+
+            setTrainingChartSmoothing(chart, value) {
+                if (!chart) return;
+                chart.smoothing = normalizeSmoothing(value);
+                this.renderTrainingMetricsCharts();
+                this.queueTrainingMetricLayoutSave();
+            },
+
+            formatTrainingSmoothing(value) {
+                const smoothing = normalizeSmoothing(value);
+                if (!smoothing) return 'Off';
+                return `${Math.round(smoothing * 100)}%`;
             },
 
             renderTrainingMetricsChart() {
-                const canvas = this.$refs.trainingMetricsCanvas;
-                if (!canvas || !this.trainingRunData || !global.TrainingMetricsCharts) return;
-                if (!this._trainingMetricsChart) {
-                    this._trainingMetricsChart = new global.TrainingMetricsCharts.TrainingMetricsChart(canvas, {
-                        onHover: (value) => {
-                            this.trainingChartHover = value;
-                        },
-                    });
-                }
-                this._trainingMetricsChart.setData(
-                    this.trainingRunData.records || [],
-                    this.selectedTrainingMetrics,
-                    { xAxisMode: this.selectedTrainingXAxis },
-                );
+                this.renderTrainingMetricsCharts();
+            },
+
+            renderTrainingMetricsCharts() {
+                if (!this.trainingRunData || !global.TrainingMetricsCharts) return;
+                const root = document.getElementById('metrics-tab-content') || document;
+                const canvases = root.querySelectorAll('canvas[data-training-chart-id]');
+                const liveChartIds = new Set();
+                canvases.forEach((canvas) => {
+                    const chartIdValue = canvas.dataset.trainingChartId;
+                    const chart = this.trainingCharts.find((candidate) => candidate.id === chartIdValue);
+                    if (!chart) return;
+                    liveChartIds.add(chartIdValue);
+                    if (!this._trainingMetricsCharts[chartIdValue]) {
+                        this._trainingMetricsCharts[chartIdValue] = new global.TrainingMetricsCharts.TrainingMetricsChart(canvas, {
+                            onHover: (value) => {
+                                if (value) {
+                                    this.trainingChartHover = { ...this.trainingChartHover, [chartIdValue]: value };
+                                } else {
+                                    const nextHover = { ...this.trainingChartHover };
+                                    delete nextHover[chartIdValue];
+                                    this.trainingChartHover = nextHover;
+                                }
+                            },
+                        });
+                    }
+                    this._trainingMetricsCharts[chartIdValue].setData(
+                        this.trainingRunData.records || [],
+                        chart.metrics,
+                        { xAxisMode: this.selectedTrainingXAxis, smoothing: chart.smoothing },
+                    );
+                });
+                Object.keys(this._trainingMetricsCharts).forEach((chartIdValue) => {
+                    if (liveChartIds.has(chartIdValue)) return;
+                    this._trainingMetricsCharts[chartIdValue].destroy();
+                    delete this._trainingMetricsCharts[chartIdValue];
+                });
             },
 
             renderTimestepDistributionChart() {
@@ -150,10 +541,59 @@
                 this._trainingTimestepChart.setData(this.trainingRunData.timesteps || []);
             },
 
-            latestTrainingMetrics() {
+            trainingChartHoverLabel(chart) {
+                const hover = this.trainingChartHover[chart.id];
+                if (!hover) return '';
+                if (hover.xAxisMode === 'minutes') {
+                    return global.TrainingMetricsCharts.formatXAxisValue(hover.xValue, 'minutes');
+                }
+                return `Step ${Number(hover.record.step || 0).toLocaleString()}`;
+            },
+
+            trainingChartHoverValues(chart) {
+                const hover = this.trainingChartHover[chart.id];
+                if (!hover || !Array.isArray(hover.metrics)) return [];
+                return hover.metrics
+                    .filter((metric) => typeof metric.value === 'number' && Number.isFinite(metric.value))
+                    .map((metric) => ({
+                        ...metric,
+                        formatted: this.formatTrainingMetric(metric.value),
+                    }));
+            },
+
+            trainingChartLegend(chart) {
+                const colors = global.TrainingMetricsCharts?.COLORS || [];
+                return (chart?.metrics || []).map((metric, index) => ({
+                    name: metric,
+                    color: colors[index % colors.length] || '#38bdf8',
+                }));
+            },
+
+            trainingChartTooltipStyle(chart) {
+                const hover = this.trainingChartHover[chart.id];
+                if (!hover) return '';
+                const plottedValues = this.trainingChartHoverValues(chart);
+                if (!plottedValues.length) return '';
+                const tooltipWidth = 240;
+                const chartWidth = Number(hover.width || 0);
+                const minLeft = tooltipWidth / 2 + 8;
+                const maxLeft = Math.max(minLeft, chartWidth - tooltipWidth / 2 - 8);
+                const left = chartWidth
+                    ? Math.min(Math.max(Number(hover.x || 0), minLeft), maxLeft)
+                    : Number(hover.x || 0);
+                const yValues = plottedValues
+                    .map((metric) => Number(metric.y))
+                    .filter((value) => Number.isFinite(value));
+                const top = yValues.length ? Math.max(12, Math.min(...yValues)) : 24;
+                const transform = top < 96 ? 'translate(-50%, 0.75rem)' : 'translate(-50%, calc(-100% - 0.75rem))';
+                return `left: ${left}px; top: ${top}px; transform: ${transform};`;
+            },
+
+            latestTrainingMetrics(chart = null) {
                 if (!this.trainingRunData) return [];
+                const targetChart = chart || this.trainingCharts[0];
                 const latest = global.TrainingMetricsCharts.latestMetricValues(this.trainingRunData.records || []);
-                return this.selectedTrainingMetrics.map((name) => ({ name, value: latest[name] }));
+                return (targetChart?.metrics || []).map((name) => ({ name, value: latest[name] }));
             },
 
             formatTrainingMetric(value) {
@@ -165,6 +605,29 @@
                 return Array.from(
                     new Set((this.trainingRunData.media || []).map((item) => item.step)),
                 ).sort((left, right) => left - right);
+            },
+
+            trainingMediaStepIndex() {
+                const steps = this.trainingMediaSteps();
+                const index = steps.indexOf(this.selectedTrainingMediaStep);
+                return index >= 0 ? index : Math.max(0, steps.length - 1);
+            },
+
+            setTrainingMediaStepIndex(index) {
+                const steps = this.trainingMediaSteps();
+                if (!steps.length) return;
+                const parsed = Number.parseInt(index, 10);
+                const clamped = Number.isFinite(parsed)
+                    ? Math.max(0, Math.min(steps.length - 1, parsed))
+                    : steps.length - 1;
+                this.selectedTrainingMediaStep = steps[clamped];
+            },
+
+            selectedTrainingMediaStepLabel() {
+                if (this.selectedTrainingMediaStep === null || typeof this.selectedTrainingMediaStep === 'undefined') {
+                    return 'No step';
+                }
+                return `Step ${Number(this.selectedTrainingMediaStep).toLocaleString()}`;
             },
 
             selectDefaultTrainingMedia(options = {}) {
@@ -194,36 +657,122 @@
                 return Array.from(groups, ([label, items]) => ({ label, items }));
             },
 
+            trainingImageCaption(item) {
+                if (!item) return '';
+                return [
+                    item.label,
+                    `step ${Number(item.step).toLocaleString()}`,
+                    item.resolution,
+                    `output ${Number(item.index || 0) + 1}`,
+                ].filter(Boolean).join(' · ');
+            },
+
+            trainingImageEntry(item) {
+                return {
+                    item,
+                    src: item.url,
+                    caption: this.trainingImageCaption(item),
+                };
+            },
+
             selectedTrainingImages() {
                 return this.selectedTrainingMedia()
                     .filter((item) => item.type === 'image' && item.url)
-                    .map((item) => ({
-                        item,
-                        src: item.url,
-                        caption: [
-                            item.label,
-                            `step ${Number(item.step).toLocaleString()}`,
-                            item.resolution,
-                            `output ${Number(item.index || 0) + 1}`,
-                        ].filter(Boolean).join(' · '),
-                    }));
+                    .map((item) => this.trainingImageEntry(item));
+            },
+
+            allTrainingImages() {
+                if (!this.trainingRunData) return [];
+                return (this.trainingRunData.media || [])
+                    .filter((item) => item.type === 'image' && item.url)
+                    .sort((left, right) => {
+                        const stepOrder = Number(left.step || 0) - Number(right.step || 0);
+                        if (stepOrder) return stepOrder;
+                        const labelOrder = String(left.label || '').localeCompare(String(right.label || ''));
+                        return labelOrder || Number(left.index || 0) - Number(right.index || 0);
+                    })
+                    .map((item) => this.trainingImageEntry(item));
             },
 
             openTrainingMediaLightbox(item) {
                 if (!item || item.type !== 'image') return;
-                const images = this.selectedTrainingImages();
-                const index = Math.max(0, images.findIndex((image) => image.item.path === item.path));
-                this.trainingMediaLightbox = { images, index, actualSize: false };
+                this.trainingMediaLightbox = { path: item.path, actualSize: false };
             },
 
             closeTrainingMediaLightbox() {
                 this.trainingMediaLightbox = null;
             },
 
-            setTrainingLightboxIndex(index) {
+            currentTrainingLightboxImage() {
+                if (!this.trainingMediaLightbox) return null;
+                return this.allTrainingImages().find(
+                    (image) => image.item.path === this.trainingMediaLightbox.path,
+                ) || null;
+            },
+
+            trainingLightboxSameStepImages() {
+                const current = this.currentTrainingLightboxImage();
+                if (!current) return [];
+                return this.allTrainingImages().filter((image) => image.item.step === current.item.step);
+            },
+
+            trainingLightboxSameOutputImages() {
+                const current = this.currentTrainingLightboxImage();
+                if (!current) return [];
+                return this.allTrainingImages().filter((image) => (
+                    String(image.item.label || '') === String(current.item.label || '')
+                    && Number(image.item.index || 0) === Number(current.item.index || 0)
+                ));
+            },
+
+            trainingLightboxSameStepIndex() {
+                const current = this.currentTrainingLightboxImage();
+                if (!current) return -1;
+                return this.trainingLightboxSameStepImages().findIndex((image) => image.item.path === current.item.path);
+            },
+
+            trainingLightboxSameOutputIndex() {
+                const current = this.currentTrainingLightboxImage();
+                if (!current) return -1;
+                return this.trainingLightboxSameOutputImages().findIndex((image) => image.item.path === current.item.path);
+            },
+
+            trainingLightboxStepLabel() {
+                const current = this.currentTrainingLightboxImage();
+                if (!current) return 'No step';
+                return `Step ${Number(current.item.step).toLocaleString()}`;
+            },
+
+            setTrainingLightboxImageOffset(offset) {
                 if (!this.trainingMediaLightbox) return;
-                const maxIndex = this.trainingMediaLightbox.images.length - 1;
-                this.trainingMediaLightbox.index = Math.max(0, Math.min(maxIndex, index));
+                const images = this.trainingLightboxSameStepImages();
+                const currentIndex = this.trainingLightboxSameStepIndex();
+                const next = images[currentIndex + offset];
+                if (next) this.trainingMediaLightbox.path = next.item.path;
+            },
+
+            setTrainingLightboxStepIndex(index) {
+                if (!this.trainingMediaLightbox) return;
+                const images = this.trainingLightboxSameOutputImages();
+                if (!images.length) return;
+                const parsed = Number.parseInt(index, 10);
+                const clamped = Number.isFinite(parsed)
+                    ? Math.max(0, Math.min(images.length - 1, parsed))
+                    : images.length - 1;
+                const next = images[clamped];
+                this.trainingMediaLightbox.path = next.item.path;
+                this.selectedTrainingMediaStep = next.item.step;
+            },
+
+            setTrainingLightboxStepOffset(offset) {
+                if (!this.trainingMediaLightbox) return;
+                const images = this.trainingLightboxSameOutputImages();
+                const currentIndex = this.trainingLightboxSameOutputIndex();
+                const next = images[currentIndex + offset];
+                if (next) {
+                    this.trainingMediaLightbox.path = next.item.path;
+                    this.selectedTrainingMediaStep = next.item.step;
+                }
             },
 
             toggleTrainingLightboxSize() {
@@ -238,10 +787,12 @@
 
             destroyTrainingMetrics() {
                 this.stopTrainingMetricsPolling();
-                if (this._trainingMetricsChart) {
-                    this._trainingMetricsChart.destroy();
-                    this._trainingMetricsChart = null;
+                if (this._trainingLayoutSaveTimer) {
+                    window.clearTimeout(this._trainingLayoutSaveTimer);
+                    this._trainingLayoutSaveTimer = null;
                 }
+                Object.values(this._trainingMetricsCharts).forEach((chart) => chart.destroy());
+                this._trainingMetricsCharts = {};
                 if (this._trainingTimestepChart) {
                     this._trainingTimestepChart.destroy();
                     this._trainingTimestepChart = null;

--- a/simpletuner/templates/metrics_tab.html
+++ b/simpletuner/templates/metrics_tab.html
@@ -106,114 +106,250 @@
                     </div>
                 </div>
 
-                <div class="training-metrics-layout">
-                    <section class="training-chart-tool" aria-label="Scalar chart">
+                <div class="training-metrics-layout"
+                     :class="{ 'validation-collapsed': trainingMediaPanelCollapsed }">
+                    <section class="training-chart-workspace" aria-label="Scalar charts">
+                        <div class="training-chart-layout-toolbar">
+                            <div class="training-chart-layout-controls">
+                                <select class="form-select form-select-sm"
+                                        x-model="selectedTrainingLayoutName"
+                                        @change="selectTrainingLayout(selectedTrainingLayoutName)"
+                                        aria-label="Saved chart layout">
+                                    <template x-for="layout in trainingSavedLayouts()" :key="layout">
+                                        <option :value="layout" x-text="layout"></option>
+                                    </template>
+                                </select>
+                                <button type="button"
+                                        class="btn btn-sm btn-secondary"
+                                        @click="openTrainingLayoutModal()"
+                                        :disabled="trainingLayoutSaving">
+                                    <i class="fas" :class="trainingLayoutSaving ? 'fa-spinner fa-spin' : 'fa-save'"></i>
+                                    <span>Save layout</span>
+                                </button>
+                            </div>
+                            <div class="training-axis-toggle" role="group" aria-label="Chart x-axis">
+                                <button type="button"
+                                        :class="{ 'active': selectedTrainingXAxis === 'step' }"
+                                        @click="setTrainingXAxis('step')"
+                                        title="Show values by global step">
+                                    <i class="fas fa-shoe-prints"></i>
+                                    <span>Step</span>
+                                </button>
+                                <button type="button"
+                                        :class="{ 'active': selectedTrainingXAxis === 'minutes' }"
+                                        @click="setTrainingXAxis('minutes')"
+                                        title="Show values by elapsed minutes">
+                                    <i class="fas fa-clock"></i>
+                                    <span>Minutes</span>
+                                </button>
+                            </div>
+                            <button type="button"
+                                    class="btn btn-sm btn-primary"
+                                    @click="addTrainingChart()">
+                                <i class="fas fa-plus"></i>
+                                <span>New chart</span>
+                            </button>
+                        </div>
+                        <template x-if="trainingLayoutError">
+                            <div class="alert alert-warning py-2" x-text="trainingLayoutError"></div>
+                        </template>
+                        <div class="training-chart-stack">
+                            <template x-for="chart in trainingCharts" :key="chart.id">
+                                <section class="training-chart-tool" :aria-label="chart.name">
+                                    <div class="training-tool-header">
+                                        <div class="training-chart-title">
+                                            <input type="text"
+                                                   class="form-control form-control-sm"
+                                                   x-model="chart.name"
+                                                   @input="queueTrainingMetricLayoutSave()"
+                                                   aria-label="Chart name">
+                                            <span x-text="trainingChartHoverLabel(chart)"></span>
+                                        </div>
+                                        <div class="training-chart-actions">
+                                            <button type="button"
+                                                    class="btn btn-sm btn-secondary"
+                                                    @click="toggleTrainingChartSelector(chart.id)"
+                                                    title="Select metrics">
+                                                <i class="fas fa-cog"></i>
+                                            </button>
+                                            <button type="button"
+                                                    class="btn btn-sm btn-secondary"
+                                                    @click="removeTrainingChart(chart.id)"
+                                                    :disabled="trainingCharts.length <= 1"
+                                                    title="Remove chart">
+                                                <i class="fas fa-trash"></i>
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div class="training-chart-selector"
+                                         x-show="trainingChartSelectorOpen === chart.id"
+                                         @click.outside="trainingChartSelectorOpen = null"
+                                         x-cloak>
+                                        <div class="training-chart-smoothing">
+                                            <label :for="'training-chart-smoothing-' + chart.id">
+                                                <span>Smoothing</span>
+                                                <strong x-text="formatTrainingSmoothing(chart.smoothing)"></strong>
+                                            </label>
+                                            <input type="range"
+                                                   :id="'training-chart-smoothing-' + chart.id"
+                                                   min="0"
+                                                   max="0.99"
+                                                   step="0.01"
+                                                   :value="chart.smoothing"
+                                                   @input="setTrainingChartSmoothing(chart, $event.target.value)"
+                                                   aria-label="Chart smoothing">
+                                        </div>
+                                        <input type="search"
+                                               class="form-control form-control-sm"
+                                               x-model="chart.metricSearch"
+                                               placeholder="Search metrics"
+                                               aria-label="Search metrics">
+                                        <div class="training-metric-picker" aria-label="Chart metrics">
+                                            <template x-for="metric in filteredTrainingMetrics(chart)" :key="metric">
+                                                <label :class="{ 'selected': chart.metrics.includes(metric) }">
+                                                    <input type="checkbox"
+                                                           :checked="chart.metrics.includes(metric)"
+                                                           @change="toggleTrainingMetric(metric, chart.id)"
+                                                           :disabled="!chart.metrics.includes(metric) && chart.metrics.length >= 8">
+                                                    <span x-text="metric"></span>
+                                                </label>
+                                            </template>
+                                        </div>
+                                    </div>
+                                    <div class="training-chart-legend" aria-label="Chart legend">
+                                        <template x-for="metric in trainingChartLegend(chart)" :key="metric.name">
+                                            <div>
+                                                <span class="training-chart-swatch" :style="'background: ' + metric.color"></span>
+                                                <span x-text="metric.name"></span>
+                                            </div>
+                                        </template>
+                                    </div>
+                                    <div class="training-latest-values">
+                                        <template x-for="metric in latestTrainingMetrics(chart)" :key="metric.name">
+                                            <div>
+                                                <span x-text="metric.name"></span>
+                                                <strong x-text="formatTrainingMetric(metric.value)"></strong>
+                                            </div>
+                                        </template>
+                                    </div>
+                                    <div class="training-chart-canvas-wrap">
+                                        <canvas :data-training-chart-id="chart.id"
+                                                data-testid="training-metrics-canvas"
+                                                x-init="$nextTick(() => renderTrainingMetricsCharts())"
+                                                :aria-label="chart.name"></canvas>
+                                        <div class="training-chart-tooltip"
+                                             x-show="trainingChartHoverValues(chart).length"
+                                             :style="trainingChartTooltipStyle(chart)"
+                                             x-cloak>
+                                            <div class="training-chart-tooltip-title"
+                                                 x-text="trainingChartHoverLabel(chart)"></div>
+                                            <template x-for="metric in trainingChartHoverValues(chart)" :key="metric.name">
+                                                <div class="training-chart-tooltip-row">
+                                                    <span class="training-chart-swatch" :style="'background: ' + metric.color"></span>
+                                                    <span x-text="metric.name"></span>
+                                                    <strong x-text="metric.formatted"></strong>
+                                                </div>
+                                            </template>
+                                        </div>
+                                    </div>
+                                </section>
+                            </template>
+                        </div>
+                        <template x-if="(trainingRunData.timesteps || []).length">
+                            <section class="training-chart-tool training-timestep-panel" aria-label="Timestep distribution">
+                                <div class="training-tool-header">
+                                    <div>
+                                        <h3>Timestep distribution</h3>
+                                        <span>Samples by global step.</span>
+                                    </div>
+                                    <button type="button"
+                                            class="btn btn-sm btn-secondary"
+                                            @click="toggleTrainingTimestepChart()">
+                                        <i class="fas" :class="showTrainingTimestepChart ? 'fa-eye-slash' : 'fa-eye'"></i>
+                                        <span x-text="showTrainingTimestepChart ? 'Hide' : 'Show'"></span>
+                                    </button>
+                                </div>
+                                <div class="training-chart-canvas-wrap training-timestep-canvas-wrap" x-show="showTrainingTimestepChart" x-cloak>
+                                    <canvas x-ref="timestepDistributionCanvas"
+                                            data-testid="training-timestep-distribution-canvas"
+                                            aria-label="Timestep distribution"></canvas>
+                                </div>
+                            </section>
+                        </template>
+                    </section>
+
+                    <section class="training-media-tool"
+                             :class="{ 'collapsed': trainingMediaPanelCollapsed }"
+                             aria-label="Validation media">
                         <div class="training-tool-header">
-	                            <div>
-	                                <h3>Scalars</h3>
-	                                <span x-show="trainingChartHover"
-	                                      x-text="trainingChartHover ? (trainingChartHover.xAxisMode === 'minutes' ? TrainingMetricsCharts.formatXAxisValue(trainingChartHover.xValue, 'minutes') : 'Step ' + trainingChartHover.record.step.toLocaleString()) : ''"></span>
-	                            </div>
-	                            <div class="training-axis-toggle" role="group" aria-label="Chart x-axis">
-	                                <button type="button"
-	                                        :class="{ 'active': selectedTrainingXAxis === 'step' }"
-	                                        @click="setTrainingXAxis('step')"
-	                                        title="Show values by global step">
-	                                    <i class="fas fa-shoe-prints"></i>
-	                                    <span>Step</span>
-	                                </button>
-	                                <button type="button"
-	                                        :class="{ 'active': selectedTrainingXAxis === 'minutes' }"
-	                                        @click="setTrainingXAxis('minutes')"
-	                                        title="Show values by elapsed minutes">
-	                                    <i class="fas fa-clock"></i>
-	                                    <span>Minutes</span>
-	                                </button>
-	                            </div>
-	                            <div class="training-metric-picker" aria-label="Chart metrics">
-                                <template x-for="metric in trainingRunData.available_metrics" :key="metric">
-                                    <label :class="{ 'selected': selectedTrainingMetrics.includes(metric) }">
-                                        <input type="checkbox"
-                                               :checked="selectedTrainingMetrics.includes(metric)"
-                                               @change="toggleTrainingMetric(metric)"
-                                               :disabled="!selectedTrainingMetrics.includes(metric) && selectedTrainingMetrics.length >= 8">
-                                        <span x-text="metric"></span>
-                                    </label>
+                            <div>
+                                <h3>Validation</h3>
+                                <span>Saved outputs grouped by prompt and step.</span>
+                            </div>
+                            <button type="button"
+                                    class="btn btn-sm btn-secondary training-media-collapse-button"
+                                    @click="toggleTrainingMediaPanel()"
+                                    :title="trainingMediaPanelCollapsed ? 'Show validation media' : 'Collapse validation media'"
+                                    :aria-label="trainingMediaPanelCollapsed ? 'Show validation media' : 'Collapse validation media'">
+                                <i class="fas" :class="trainingMediaPanelCollapsed ? 'fa-chevron-left' : 'fa-chevron-right'"></i>
+                            </button>
+                        </div>
+                        <div class="training-media-panel-body"
+                             x-show="!trainingMediaPanelCollapsed"
+                             x-cloak>
+                            <div class="training-media-step-slider">
+                                <label for="training-media-step-range">
+                                    <span>Checkpoint</span>
+                                    <strong x-text="selectedTrainingMediaStepLabel()"></strong>
+                                </label>
+                                <input id="training-media-step-range"
+                                       type="range"
+                                       min="0"
+                                       :max="Math.max(0, trainingMediaSteps().length - 1)"
+                                       step="1"
+                                       :value="trainingMediaStepIndex()"
+                                       :disabled="trainingMediaSteps().length <= 1"
+                                       @input="setTrainingMediaStepIndex($event.target.value)"
+                                       aria-label="Validation checkpoint step">
+                            </div>
+                            <template x-if="!selectedTrainingMedia().length">
+                                <div class="training-media-empty">No validation media was recorded for this run.</div>
+                            </template>
+                            <div class="training-media-gallery">
+                                <template x-for="group in selectedTrainingMediaGroups()" :key="group.label">
+                                    <section class="training-media-group">
+                                        <h4 x-text="group.label"></h4>
+                                        <div class="training-media-grid">
+                                            <template x-for="item in group.items" :key="item.path">
+                                                <figure>
+                                                    <button type="button"
+                                                            class="training-media-image-button"
+                                                            x-show="item.type === 'image'"
+                                                            @click="openTrainingMediaLightbox(item)"
+                                                            title="Open validation image">
+                                                        <img :src="item.type === 'image' ? item.url : null"
+                                                             :alt="item.label + ' at step ' + item.step">
+                                                    </button>
+                                                    <video x-show="item.type === 'video'"
+                                                           :src="item.type === 'video' ? item.url : null"
+                                                           controls
+                                                           preload="metadata"></video>
+                                                    <audio x-show="item.type === 'audio'"
+                                                           :src="item.type === 'audio' ? item.url : null"
+                                                           controls
+                                                           preload="metadata"></audio>
+                                                    <figcaption>
+                                                        <span x-text="'Output ' + (item.index + 1)"></span>
+                                                        <span x-text="item.resolution || item.type"></span>
+                                                    </figcaption>
+                                                </figure>
+                                            </template>
+                                        </div>
+                                    </section>
                                 </template>
                             </div>
                         </div>
-                        <div class="training-latest-values">
-                            <template x-for="metric in latestTrainingMetrics()" :key="metric.name">
-                                <div>
-                                    <span x-text="metric.name"></span>
-                                    <strong x-text="formatTrainingMetric(metric.value)"></strong>
-                                </div>
-                            </template>
-                        </div>
-	                        <div class="training-chart-canvas-wrap">
-	                            <canvas x-ref="trainingMetricsCanvas" data-testid="training-metrics-canvas"></canvas>
-	                        </div>
-	                        <template x-if="(trainingRunData.timesteps || []).length">
-	                            <div class="training-chart-canvas-wrap training-timestep-canvas-wrap">
-	                                <canvas x-ref="timestepDistributionCanvas"
-	                                        data-testid="training-timestep-distribution-canvas"
-	                                        aria-label="Timestep distribution"></canvas>
-	                            </div>
-	                        </template>
-	                    </section>
-
-                    <section class="training-media-tool" aria-label="Validation media">
-	                        <div class="training-tool-header">
-	                            <div>
-	                                <h3>Validation</h3>
-	                                <span>Saved outputs grouped by prompt and step.</span>
-	                            </div>
-	                        </div>
-                        <div class="training-media-steps" role="group" aria-label="Validation steps">
-                            <template x-for="step in trainingMediaSteps()" :key="step">
-                                <button type="button"
-                                        :class="{ 'active': selectedTrainingMediaStep === step }"
-                                        @click="selectedTrainingMediaStep = step"
-                                        x-text="step.toLocaleString()"></button>
-                            </template>
-                        </div>
-                        <template x-if="!selectedTrainingMedia().length">
-                            <div class="training-media-empty">No validation media was recorded for this run.</div>
-                        </template>
-	                        <div class="training-media-gallery">
-	                            <template x-for="group in selectedTrainingMediaGroups()" :key="group.label">
-	                                <section class="training-media-group">
-	                                    <h4 x-text="group.label"></h4>
-	                                    <div class="training-media-grid">
-	                                        <template x-for="item in group.items" :key="item.path">
-	                                            <figure>
-	                                                <button type="button"
-	                                                        class="training-media-image-button"
-	                                                        x-show="item.type === 'image'"
-	                                                        @click="openTrainingMediaLightbox(item)"
-	                                                        title="Open validation image">
-	                                                    <img :src="item.type === 'image' ? item.url : null"
-	                                                         :alt="item.label + ' at step ' + item.step">
-	                                                </button>
-	                                                <video x-show="item.type === 'video'"
-	                                                       :src="item.type === 'video' ? item.url : null"
-	                                                       controls
-	                                                       preload="metadata"></video>
-	                                                <audio x-show="item.type === 'audio'"
-	                                                       :src="item.type === 'audio' ? item.url : null"
-	                                                       controls
-	                                                       preload="metadata"></audio>
-	                                                <figcaption>
-	                                                    <span x-text="'Output ' + (item.index + 1)"></span>
-	                                                    <span x-text="item.resolution || item.type"></span>
-	                                                </figcaption>
-	                                            </figure>
-	                                        </template>
-	                                    </div>
-	                                </section>
-	                            </template>
-	                        </div>
-	                    </section>
+                    </section>
 	                </div>
 	            </div>
 	        </template>
@@ -225,26 +361,40 @@
 	                     tabindex="-1"
 	                     @click.self="closeTrainingMediaLightbox()"
 	                     @keydown.escape.window="closeTrainingMediaLightbox()"
-	                     @keydown.arrow-left.window="setTrainingLightboxIndex(trainingMediaLightbox.index - 1)"
-	                     @keydown.arrow-right.window="setTrainingLightboxIndex(trainingMediaLightbox.index + 1)">
+	                     @keydown.arrow-left.window="setTrainingLightboxImageOffset(-1)"
+	                     @keydown.arrow-right.window="setTrainingLightboxImageOffset(1)"
+	                     @keydown.arrow-up.window.prevent="setTrainingLightboxStepOffset(-1)"
+	                     @keydown.arrow-down.window.prevent="setTrainingLightboxStepOffset(1)">
 	                    <div class="training-media-lightbox-body">
 	                        <img :class="{ 'actual-size': trainingMediaLightbox.actualSize }"
-	                             :src="trainingMediaLightbox.images[trainingMediaLightbox.index]?.src"
-	                             :alt="trainingMediaLightbox.images[trainingMediaLightbox.index]?.caption">
+	                             :src="currentTrainingLightboxImage()?.src"
+	                             :alt="currentTrainingLightboxImage()?.caption">
 	                    </div>
 	                    <div class="training-media-lightbox-toolbar">
 	                        <button type="button"
-	                                @click="setTrainingLightboxIndex(trainingMediaLightbox.index - 1)"
-	                                :disabled="trainingMediaLightbox.index === 0"
-	                                title="Previous image">
+	                                @click="setTrainingLightboxStepOffset(-1)"
+	                                :disabled="trainingLightboxSameOutputIndex() <= 0"
+	                                title="Previous step">
+	                            <i class="fas fa-step-backward"></i>
+	                        </button>
+	                        <button type="button"
+	                                @click="setTrainingLightboxImageOffset(-1)"
+	                                :disabled="trainingLightboxSameStepIndex() <= 0"
+	                                title="Previous image in step">
 	                            <i class="fas fa-chevron-left"></i>
 	                        </button>
-	                        <span x-text="`${trainingMediaLightbox.index + 1} / ${trainingMediaLightbox.images.length}`"></span>
+	                        <span x-text="`${trainingLightboxSameStepIndex() + 1} / ${trainingLightboxSameStepImages().length}`"></span>
 	                        <button type="button"
-	                                @click="setTrainingLightboxIndex(trainingMediaLightbox.index + 1)"
-	                                :disabled="trainingMediaLightbox.index >= trainingMediaLightbox.images.length - 1"
-	                                title="Next image">
+	                                @click="setTrainingLightboxImageOffset(1)"
+	                                :disabled="trainingLightboxSameStepIndex() >= trainingLightboxSameStepImages().length - 1"
+	                                title="Next image in step">
 	                            <i class="fas fa-chevron-right"></i>
+	                        </button>
+	                        <button type="button"
+	                                @click="setTrainingLightboxStepOffset(1)"
+	                                :disabled="trainingLightboxSameOutputIndex() >= trainingLightboxSameOutputImages().length - 1"
+	                                title="Next step">
+	                            <i class="fas fa-step-forward"></i>
 	                        </button>
 	                        <button type="button"
 	                                @click="toggleTrainingLightboxSize()"
@@ -257,8 +407,69 @@
 	                            <i class="fas fa-times"></i>
 	                        </button>
 	                    </div>
+	                    <div class="training-media-lightbox-step-slider">
+	                        <label for="training-media-lightbox-step-range">
+	                            <span>Checkpoint</span>
+	                            <strong x-text="trainingLightboxStepLabel()"></strong>
+	                        </label>
+	                        <input id="training-media-lightbox-step-range"
+	                               type="range"
+	                               min="0"
+	                               :max="Math.max(0, trainingLightboxSameOutputImages().length - 1)"
+	                               step="1"
+	                               :value="Math.max(0, trainingLightboxSameOutputIndex())"
+	                               :disabled="trainingLightboxSameOutputImages().length <= 1"
+	                               @input="setTrainingLightboxStepIndex($event.target.value)"
+	                               aria-label="Validation lightbox checkpoint step">
+	                    </div>
 	                    <div class="training-media-lightbox-caption"
-	                         x-text="trainingMediaLightbox.images[trainingMediaLightbox.index]?.caption"></div>
+	                         x-text="currentTrainingLightboxImage()?.caption"></div>
+	                </div>
+	            </template>
+	        </template>
+	        <template x-teleport="body">
+	            <template x-if="trainingLayoutModalOpen">
+	                <div>
+	                    <div class="modal fade show d-block training-layout-modal"
+	                         tabindex="-1"
+	                         role="dialog"
+	                         aria-modal="true"
+	                         @keydown.escape.window="closeTrainingLayoutModal()">
+	                        <div class="modal-dialog modal-dialog-centered">
+	                            <form class="modal-content bg-dark"
+	                                  @submit.prevent="confirmTrainingLayoutSave()"
+	                                  x-init="$nextTick(() => $refs.trainingLayoutNameInput?.focus())">
+	                                <div class="modal-header border-secondary py-2">
+	                                    <h6 class="modal-title">Save Chart Layout</h6>
+	                                    <button type="button"
+	                                            class="btn-close btn-close-white"
+	                                            aria-label="Close"
+	                                            @click="closeTrainingLayoutModal()"></button>
+	                                </div>
+	                                <div class="modal-body">
+	                                    <label class="form-label" for="training-layout-name">Layout name</label>
+	                                    <input id="training-layout-name"
+	                                           type="text"
+	                                           class="form-control"
+	                                           x-ref="trainingLayoutNameInput"
+	                                           x-model="trainingLayoutNameInput"
+	                                           required>
+	                                </div>
+	                                <div class="modal-footer border-secondary py-2">
+	                                    <button type="button"
+	                                            class="btn btn-outline-secondary"
+	                                            @click="closeTrainingLayoutModal()">Cancel</button>
+	                                    <button type="submit"
+	                                            class="btn btn-primary"
+	                                            :disabled="trainingLayoutSaving">
+	                                        <i class="fas" :class="trainingLayoutSaving ? 'fa-spinner fa-spin' : 'fa-save'"></i>
+	                                        <span>Save</span>
+	                                    </button>
+	                                </div>
+	                            </form>
+	                        </div>
+	                    </div>
+	                    <div class="modal-backdrop fade show" @click="closeTrainingLayoutModal()"></div>
 	                </div>
 	            </template>
 	        </template>

--- a/tests/js/training_metrics_component.test.js
+++ b/tests/js/training_metrics_component.test.js
@@ -12,6 +12,7 @@ describe('training metrics component', () => {
         state.$refs = {};
         state.$nextTick = (callback) => callback();
         state.renderTrainingMetricsChart = jest.fn();
+        state.renderTrainingMetricsCharts = jest.fn();
         state.renderTimestepDistributionChart = jest.fn();
     });
 
@@ -40,7 +41,9 @@ describe('training metrics component', () => {
 
         expect(state.selectedTrainingEnvironment).toBe('anima');
         expect(state.trainingRunData.run.last_step).toBe(20);
-        expect(state.selectedTrainingMetrics).toEqual(['learning_rate', 'loss']);
+        expect(state.trainingCharts).toHaveLength(1);
+        expect(state.trainingCharts[0].name).toBe('Training metrics');
+        expect(state.selectedTrainingMetrics).toEqual(['loss']);
         expect(fetch).toHaveBeenNthCalledWith(1, '/api/metrics/training/runs');
         expect(fetch).toHaveBeenNthCalledWith(2, '/api/metrics/training/runs/anima?max_points=4000');
     });
@@ -74,6 +77,7 @@ describe('training metrics component', () => {
 
     test('preserves metric selection while silently refreshing a running run', async () => {
         state.selectedTrainingEnvironment = 'anima';
+        state.trainingCharts = [{ id: 'chart-a', kind: 'scalar', name: 'Loss', metrics: ['train_loss'], metricSearch: '', smoothing: 0 }];
         state.selectedTrainingMetrics = ['train_loss'];
         fetch.mockResolvedValueOnce({
             ok: true,
@@ -87,20 +91,21 @@ describe('training metrics component', () => {
 
         await state.loadTrainingRun({ silent: true, preserveSelections: true });
 
+        expect(state.trainingCharts[0].metrics).toEqual(['train_loss']);
         expect(state.selectedTrainingMetrics).toEqual(['train_loss']);
         expect(state.trainingMetricsLoading).toBe(false);
     });
 
     test('sets chart x-axis mode when rendering', () => {
-        state.renderTrainingMetricsChart.mockClear();
+        state.renderTrainingMetricsCharts.mockClear();
 
         state.setTrainingXAxis('minutes');
 
         expect(state.selectedTrainingXAxis).toBe('minutes');
-        expect(state.renderTrainingMetricsChart).toHaveBeenCalledTimes(1);
+        expect(state.renderTrainingMetricsCharts).toHaveBeenCalledTimes(1);
     });
 
-    test('prefers validation loss and timing metrics by default', () => {
+    test('prefers one loss metric by default', () => {
         const selected = window.TrainingMetricsCharts.defaultMetricNames([
             'learning_rate',
             'loss/val/pooled',
@@ -109,10 +114,11 @@ describe('training metrics component', () => {
             'z_metric',
         ]);
 
-        expect(selected).toEqual(['train_loss', 'loss/val/pooled', 'seconds_per_step', 'learning_rate']);
+        expect(selected).toEqual(['train_loss']);
     });
 
     test('limits the chart to eight selected metrics', () => {
+        state.trainingCharts = [{ id: 'chart-a', kind: 'scalar', name: 'Loss', metrics: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'], metricSearch: '' }];
         state.selectedTrainingMetrics = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
 
         state.toggleTrainingMetric('i');
@@ -121,7 +127,188 @@ describe('training metrics component', () => {
         state.toggleTrainingMetric('a');
         state.toggleTrainingMetric('i');
         expect(state.selectedTrainingMetrics).toContain('i');
-        expect(state.renderTrainingMetricsChart).toHaveBeenCalledTimes(3);
+        expect(state.renderTrainingMetricsCharts).toHaveBeenCalledTimes(3);
+    });
+
+    test('applies saved environment chart layout', async () => {
+        state.selectedTrainingEnvironment = 'anima';
+        state.trainingMetricLayouts = {
+            templates: [],
+            environments: {
+                anima: {
+                    template: 'Loss detail',
+                    xAxis: 'minutes',
+                    showTimestepChart: true,
+                    mediaPanelCollapsed: true,
+                    charts: [
+                        { kind: 'scalar', name: 'Loss', metrics: ['train_loss', 'loss/val'], smoothing: 0.25 },
+                        { kind: 'scalar', name: 'GPU', metrics: ['system/gpu/0/memory_used_gb'], smoothing: 0.5 },
+                    ],
+                },
+            },
+        };
+        fetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                run: { environment: 'anima', status: 'running', last_step: 21 },
+                available_metrics: ['train_loss', 'loss/val', 'system/gpu/0/memory_used_gb'],
+                records: [{ step: 21, metrics: { train_loss: 0.4 } }],
+                media: [],
+            }),
+        });
+
+        await state.loadTrainingRun();
+
+        expect(state.selectedTrainingLayoutName).toBe('Loss detail');
+        expect(state.selectedTrainingXAxis).toBe('minutes');
+        expect(state.showTrainingTimestepChart).toBe(true);
+        expect(state.trainingMediaPanelCollapsed).toBe(true);
+        expect(state.trainingCharts.map((chart) => chart.metrics)).toEqual([
+            ['train_loss', 'loss/val'],
+            ['system/gpu/0/memory_used_gb'],
+        ]);
+        expect(state.trainingCharts.map((chart) => chart.smoothing)).toEqual([0.25, 0.5]);
+    });
+
+    test('timestep chart expanded state is saved with the environment layout', () => {
+        state.selectedTrainingEnvironment = 'anima';
+        state.trainingMetricLayoutsLoaded = true;
+        state.trainingRunData = { available_metrics: ['train_loss'] };
+        state.trainingCharts = [{ id: 'chart-a', kind: 'scalar', name: 'Loss', metrics: ['train_loss'], metricSearch: '', smoothing: 0 }];
+        state.$nextTick = (callback) => callback();
+
+        state.toggleTrainingTimestepChart();
+
+        expect(state.showTrainingTimestepChart).toBe(true);
+        expect(state.trainingMetricLayouts.environments.anima.showTimestepChart).toBe(true);
+        expect(state.renderTimestepDistributionChart).toHaveBeenCalled();
+    });
+
+    test('validation media collapsed state is saved with the environment layout', async () => {
+        state.selectedTrainingEnvironment = 'anima';
+        state.trainingMetricLayoutsLoaded = true;
+        state.trainingRunData = { available_metrics: ['train_loss'] };
+        state.trainingCharts = [{ id: 'chart-a', kind: 'scalar', name: 'Loss', metrics: ['train_loss'], metricSearch: '', smoothing: 0 }];
+        fetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                templates: [],
+                environments: {
+                    anima: {
+                        template: 'Default',
+                        xAxis: 'step',
+                        showTimestepChart: false,
+                        mediaPanelCollapsed: true,
+                        charts: [{ kind: 'scalar', name: 'Loss', metrics: ['train_loss'], smoothing: 0 }],
+                    },
+                },
+            }),
+        });
+
+        await state.toggleTrainingMediaPanel();
+
+        expect(state.trainingMediaPanelCollapsed).toBe(true);
+        expect(state.trainingMetricLayouts.environments.anima.mediaPanelCollapsed).toBe(true);
+        expect(state.renderTrainingMetricsCharts).toHaveBeenCalled();
+        expect(fetch).toHaveBeenCalledWith(
+            '/api/webui/ui-state/training-metrics',
+            expect.objectContaining({
+                method: 'POST',
+                body: expect.stringContaining('"mediaPanelCollapsed":true'),
+            }),
+        );
+    });
+
+    test('lightbox can switch between steps for the same validation output', () => {
+        state.trainingRunData = {
+            media: [
+                { type: 'image', label: 'portrait', step: 10, index: 0, path: 'step-10-a.webp', url: '/a.webp' },
+                { type: 'image', label: 'portrait', step: 10, index: 1, path: 'step-10-b.webp', url: '/b.webp' },
+                { type: 'image', label: 'portrait', step: 20, index: 0, path: 'step-20-a.webp', url: '/c.webp' },
+            ],
+        };
+        state.openTrainingMediaLightbox(state.trainingRunData.media[0]);
+
+        state.setTrainingLightboxImageOffset(1);
+        expect(state.currentTrainingLightboxImage().item.path).toBe('step-10-b.webp');
+
+        state.setTrainingLightboxImageOffset(-1);
+        state.setTrainingLightboxStepOffset(1);
+        expect(state.currentTrainingLightboxImage().item.path).toBe('step-20-a.webp');
+        expect(state.selectedTrainingMediaStep).toBe(20);
+
+        state.setTrainingLightboxStepIndex(0);
+        expect(state.currentTrainingLightboxImage().item.path).toBe('step-10-a.webp');
+        expect(state.trainingLightboxStepLabel()).toBe('Step 10');
+    });
+
+    test('validation media step slider maps indices to recorded checkpoint steps', () => {
+        state.trainingRunData = {
+            media: [
+                { type: 'image', step: 5, path: 'step-5.webp' },
+                { type: 'image', step: 20, path: 'step-20.webp' },
+                { type: 'image', step: 125, path: 'step-125.webp' },
+            ],
+        };
+        state.selectDefaultTrainingMedia();
+
+        expect(state.trainingMediaStepIndex()).toBe(2);
+        expect(state.selectedTrainingMediaStepLabel()).toBe('Step 125');
+
+        state.setTrainingMediaStepIndex(1);
+        expect(state.selectedTrainingMediaStep).toBe(20);
+
+        state.setTrainingMediaStepIndex(99);
+        expect(state.selectedTrainingMediaStep).toBe(125);
+    });
+
+    test('save layout modal prompts for a layout name', async () => {
+        state.selectedTrainingLayoutName = 'Loss detail';
+        state.trainingCharts = [{ id: 'chart-a', kind: 'scalar', name: 'Loss', metrics: ['train_loss'], metricSearch: '', smoothing: 0 }];
+        state.trainingRunData = { available_metrics: ['train_loss'] };
+        state.trainingMetricLayoutsLoaded = true;
+        fetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                templates: [{ name: 'Loss detail', charts: [{ kind: 'scalar', name: 'Loss', metrics: ['train_loss'], smoothing: 0 }] }],
+                environments: {},
+            }),
+        });
+
+        state.openTrainingLayoutModal();
+        expect(state.trainingLayoutModalOpen).toBe(true);
+        expect(state.trainingLayoutNameInput).toBe('Loss detail');
+
+        await state.confirmTrainingLayoutSave();
+        expect(state.trainingLayoutModalOpen).toBe(false);
+        expect(fetch).toHaveBeenCalledWith(
+            '/api/webui/ui-state/training-metrics',
+            expect.objectContaining({ method: 'POST' }),
+        );
+    });
+
+    test('chart smoothing is clamped and rendered as a chart option', () => {
+        state.trainingRunData = {
+            records: [{ step: 1, metrics: { train_loss: 1 } }],
+            available_metrics: ['train_loss'],
+        };
+        state.trainingCharts = [{ id: 'chart-a', kind: 'scalar', name: 'Loss', metrics: ['train_loss'], metricSearch: '', smoothing: 0 }];
+        state.renderTrainingMetricsCharts.mockClear();
+
+        state.setTrainingChartSmoothing(state.trainingCharts[0], 1.5);
+
+        expect(state.trainingCharts[0].smoothing).toBe(0.99);
+        expect(state.formatTrainingSmoothing(state.trainingCharts[0].smoothing)).toBe('99%');
+        expect(state.renderTrainingMetricsCharts).toHaveBeenCalledTimes(1);
+    });
+
+    test('builds per-chart legend entries from selected metrics', () => {
+        const chart = { metrics: ['train_loss', 'loss/val'] };
+
+        expect(state.trainingChartLegend(chart)).toEqual([
+            { name: 'train_loss', color: '#38bdf8' },
+            { name: 'loss/val', color: '#f59e0b' },
+        ]);
     });
 
     test('surfaces API failures without retaining stale run data', async () => {

--- a/tests/test_webui_api.py
+++ b/tests/test_webui_api.py
@@ -435,6 +435,51 @@ class WebUICollapsedSectionsAPITestCase(_WebUIBaseTestCase):
 
         self.assertEqual(response.status_code, 422)
 
+    def test_training_metrics_layout_settings_persist(self) -> None:
+        response = self.client.get("/api/webui/ui-state/training-metrics")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"templates": [], "environments": {}})
+
+        payload = {
+            "templates": [
+                {
+                    "name": "Loss",
+                    "charts": [
+                        {
+                            "kind": "scalar",
+                            "name": "Training metrics",
+                            "metrics": ["train_loss"],
+                            "smoothing": 0.25,
+                        }
+                    ],
+                }
+            ],
+            "environments": {
+                "sdxl-test": {
+                    "template": "Loss",
+                    "xAxis": "minutes",
+                    "showTimestepChart": True,
+                    "mediaPanelCollapsed": True,
+                    "charts": [
+                        {
+                            "kind": "scalar",
+                            "name": "Training metrics",
+                            "metrics": ["train_loss", "loss/val"],
+                            "smoothing": 0.5,
+                        }
+                    ],
+                }
+            },
+        }
+
+        response = self.client.post("/api/webui/ui-state/training-metrics", json=payload)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), payload)
+
+        response = self.client.get("/api/webui/ui-state/training-metrics")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), payload)
+
     def test_save_and_get_collapsed_sections(self) -> None:
         """Test POST saves sections and GET retrieves them."""
         sections = {"section1": True, "section2": False, "section3": True}

--- a/tests/test_webui_e2e.py
+++ b/tests/test_webui_e2e.py
@@ -778,11 +778,29 @@ class TrainingMetricsDashboardTestCase(_TrainerPageMixin, WebUITestCase):
             "".join(f"{json.dumps(record)}\n" for record in records),
             encoding="utf-8",
         )
+        timestep_records = [
+            {"step": 10, "timesteps": [100.0, 300.0, 700.0]},
+            {"step": 20, "timesteps": [120.0, 340.0, 760.0]},
+        ]
+        (output_dir / "timestep_distribution.jsonl").write_text(
+            "".join(f"{json.dumps(record)}\n" for record in timestep_records),
+            encoding="utf-8",
+        )
+        first_step_image_path = validation_dir / "step_10_prompt_0_64x64.png"
         image_path = validation_dir / "step_20_prompt_0_64x64.png"
         second_image_path = validation_dir / "step_20_second_0_64x64.png"
+        Image.new("RGB", (64, 64), color=(16, 96, 180)).save(first_step_image_path, format="PNG")
         Image.new("RGB", (64, 64), color=(32, 160, 120)).save(image_path, format="PNG")
         Image.new("RGB", (64, 64), color=(120, 80, 220)).save(second_image_path, format="PNG")
         media_records = [
+            {
+                "step": 10,
+                "type": "image",
+                "label": "A green square",
+                "index": 0,
+                "resolution": "64x64",
+                "path": first_step_image_path.relative_to(output_dir).as_posix(),
+            },
             {
                 "step": 20,
                 "type": "image",
@@ -824,11 +842,84 @@ class TrainingMetricsDashboardTestCase(_TrainerPageMixin, WebUITestCase):
             )
             self.assertGreater(canvas.size["width"], 300)
             self.assertGreater(canvas.size["height"], 200)
+            legend_text = driver.find_element(By.CSS_SELECTOR, ".training-chart-legend").text
+            self.assertIn("train_loss", legend_text)
+            before_hover_top = driver.execute_script(
+                "return arguments[0].getBoundingClientRect().top;",
+                canvas,
+            )
+            driver.execute_script(
+                """
+                const canvas = arguments[0];
+                const rect = canvas.getBoundingClientRect();
+                const EventClass = window.PointerEvent || window.MouseEvent;
+                canvas.dispatchEvent(new EventClass('pointermove', {
+                    bubbles: true,
+                    clientX: rect.left + rect.width / 2,
+                    clientY: rect.top + rect.height / 2
+                }));
+                """,
+                canvas,
+            )
+            hover_result = WebDriverWait(driver, 5).until(
+                lambda _driver: driver.execute_script(
+                    """
+                    const canvas = arguments[0];
+                    const wrapper = canvas.closest('.training-chart-canvas-wrap');
+                    const tooltip = wrapper.querySelector('.training-chart-tooltip');
+                    const hoverRows = Array.from(wrapper.querySelectorAll('.training-chart-tooltip-row'));
+                    const labels = hoverRows.map((row) => row.textContent.trim()).filter(Boolean);
+                    if (!labels.length || !tooltip) return null;
+                    const tooltipRect = tooltip.getBoundingClientRect();
+                    const wrapperRect = wrapper.getBoundingClientRect();
+                    return {
+                        top: canvas.getBoundingClientRect().top,
+                        labels,
+                        tooltipInsideChart:
+                            tooltipRect.left >= wrapperRect.left
+                            && tooltipRect.right <= wrapperRect.right
+                            && tooltipRect.top >= wrapperRect.top
+                            && tooltipRect.bottom <= wrapperRect.bottom
+                    };
+                    """,
+                    canvas,
+                )
+            )
+            self.assertAlmostEqual(before_hover_top, hover_result["top"], delta=1)
+            self.assertTrue(any("train_loss" in label for label in hover_result["labels"]), hover_result)
+            self.assertTrue(hover_result["tooltipInsideChart"], hover_result)
 
             images = WebDriverWait(driver, 10).until(
                 lambda _driver: driver.find_elements(By.CSS_SELECTOR, ".training-media-grid figure img")
             )
             self.assertEqual(len(images), 2)
+            media_step_slider = driver.find_element(By.CSS_SELECTOR, "input[aria-label='Validation checkpoint step']")
+            self.assertEqual(media_step_slider.get_attribute("max"), "1")
+            self.assertEqual(media_step_slider.get_attribute("value"), "1")
+            driver.execute_script(
+                """
+                arguments[0].value = '0';
+                arguments[0].dispatchEvent(new Event('input', { bubbles: true }));
+                """,
+                media_step_slider,
+            )
+            WebDriverWait(driver, 5).until(
+                lambda _driver: len(driver.find_elements(By.CSS_SELECTOR, ".training-media-grid figure img")) == 1
+            )
+            driver.execute_script(
+                """
+                arguments[0].value = '1';
+                arguments[0].dispatchEvent(new Event('input', { bubbles: true }));
+                """,
+                media_step_slider,
+            )
+            images = WebDriverWait(driver, 5).until(
+                lambda _driver: (
+                    driver.find_elements(By.CSS_SELECTOR, ".training-media-grid figure img")
+                    if len(driver.find_elements(By.CSS_SELECTOR, ".training-media-grid figure img")) == 2
+                    else False
+                )
+            )
             image = images[0]
             media_response = requests.get(image.get_attribute("src"), timeout=5)
             self.assertEqual(media_response.status_code, 200, media_response.text)
@@ -845,15 +936,102 @@ class TrainingMetricsDashboardTestCase(_TrainerPageMixin, WebUITestCase):
             actual_size_button.click()
             lightbox_image = driver.find_element(By.CSS_SELECTOR, ".training-media-lightbox-body img")
             self.assertIn("actual-size", lightbox_image.get_attribute("class"))
+            lightbox_step_slider = lightbox.find_element(
+                By.CSS_SELECTOR, "input[aria-label='Validation lightbox checkpoint step']"
+            )
+            self.assertEqual(lightbox_step_slider.get_attribute("max"), "1")
+            driver.execute_script(
+                """
+                arguments[0].value = '0';
+                arguments[0].dispatchEvent(new Event('input', { bubbles: true }));
+                """,
+                lightbox_step_slider,
+            )
+            WebDriverWait(driver, 5).until(lambda _driver: "step 10" in lightbox.text)
             lightbox.find_element(By.CSS_SELECTOR, ".training-media-lightbox-toolbar button[title='Close image']").click()
             WebDriverWait(driver, 5).until(EC.invisibility_of_element_located((By.CSS_SELECTOR, ".training-media-lightbox")))
 
+            driver.find_element(By.CSS_SELECTOR, ".training-chart-actions button[title='Select metrics']").click()
+            smoothing_slider = WebDriverWait(driver, 5).until(
+                EC.presence_of_element_located((By.CSS_SELECTOR, "input[aria-label='Chart smoothing']"))
+            )
+            driver.execute_script(
+                """
+                arguments[0].value = '0.5';
+                arguments[0].dispatchEvent(new Event('input', { bubbles: true }));
+                """,
+                smoothing_slider,
+            )
+            WebDriverWait(driver, 5).until(
+                lambda _driver: driver.execute_script(
+                    "return Alpine.$data(document.getElementById('metrics-tab-content')).trainingCharts[0].smoothing;"
+                )
+                == 0.5
+            )
             loss_toggle = driver.find_element(
                 By.XPATH,
                 "//div[contains(@class, 'training-metric-picker')]//label[span[text()='train_loss']]/input",
             )
             loss_toggle.click()
             WebDriverWait(driver, 5).until(lambda _driver: not loss_toggle.is_selected())
+
+            timestep_toggle = driver.find_element(
+                By.XPATH,
+                "//section[contains(@class, 'training-timestep-panel')]//button[.//span[text()='Show']]",
+            )
+            driver.execute_script("arguments[0].click();", timestep_toggle)
+            WebDriverWait(driver, 5).until(
+                EC.visibility_of_element_located((By.CSS_SELECTOR, "[data-testid='training-timestep-distribution-canvas']"))
+            )
+            WebDriverWait(driver, 5).until(
+                lambda _driver: requests.get(
+                    f"{self.base_url}/api/webui/ui-state/training-metrics",
+                    timeout=5,
+                ).json()[
+                    "environments"
+                ]["test-config"]["showTimestepChart"]
+            )
+            trainer_page.switch_to_basic_tab()
+            trainer_page.switch_to_metrics_tab()
+            WebDriverWait(driver, 10).until(
+                EC.visibility_of_element_located((By.CSS_SELECTOR, "[data-testid='training-timestep-distribution-canvas']"))
+            )
+
+            driver.set_window_size(1280, 900)
+            canvas = WebDriverWait(driver, 10).until(
+                EC.visibility_of_element_located((By.CSS_SELECTOR, "[data-testid='training-metrics-canvas']"))
+            )
+            chart_width_before_collapse = driver.execute_script(
+                "return arguments[0].getBoundingClientRect().width;",
+                canvas,
+            )
+            collapse_button = driver.find_element(By.CSS_SELECTOR, "button[title='Collapse validation media']")
+            driver.execute_script("arguments[0].click();", collapse_button)
+            WebDriverWait(driver, 5).until(
+                EC.presence_of_element_located((By.CSS_SELECTOR, ".training-metrics-layout.validation-collapsed"))
+            )
+            WebDriverWait(driver, 5).until(
+                lambda _driver: driver.execute_script(
+                    "return arguments[0].getBoundingClientRect().width;",
+                    driver.find_element(By.CSS_SELECTOR, "[data-testid='training-metrics-canvas']"),
+                )
+                > chart_width_before_collapse
+            )
+            self.assertFalse(driver.find_element(By.CSS_SELECTOR, ".training-media-panel-body").is_displayed())
+            WebDriverWait(driver, 5).until(
+                lambda _driver: requests.get(
+                    f"{self.base_url}/api/webui/ui-state/training-metrics",
+                    timeout=5,
+                ).json()[
+                    "environments"
+                ]["test-config"]["mediaPanelCollapsed"]
+            )
+            trainer_page.switch_to_basic_tab()
+            trainer_page.switch_to_metrics_tab()
+            layout = WebDriverWait(driver, 10).until(
+                EC.presence_of_element_located((By.CSS_SELECTOR, ".training-metrics-layout.validation-collapsed"))
+            )
+            self.assertIn("validation-collapsed", layout.get_attribute("class"))
 
             driver.set_window_size(430, 900)
             workspace = driver.find_element(By.CSS_SELECTOR, ".training-metrics-workspace")


### PR DESCRIPTION
## Summary
- add configurable training metrics chart layouts with per-environment persistence, smoothing, legends, and in-chart hover tooltips
- add validation checkpoint sliders, lightbox step navigation, and a collapsible validation panel so charts can use the freed width
- persist timestep and validation panel visibility with the training metrics layout state

## Tests
- `npm test -- --runInBand tests/js/training_metrics_component.test.js`
- `.venv/bin/python -m unittest tests.test_webui_api.WebUICollapsedSectionsAPITestCase.test_training_metrics_layout_settings_persist -v`
- `SIMPLETUNER_SELENIUM_TESTS=1 .venv/bin/python -m unittest tests.test_webui_e2e.TrainingMetricsDashboardTestCase -v`
- `git diff --check`