### PR TITLE
fix(server): five audit_log calls omit the required action argument

### DIFF
--- a/simpletuner/simpletuner_sdk/server/routes/approvals.py
+++ b/simpletuner/simpletuner_sdk/server/routes/approvals.py
@@ -419,7 +419,8 @@ async def approve_request(
     # Audit log
     if request:
         await audit_log(
-            event_type=AuditEventType.JOB_APPROVED,
+            AuditEventType.JOB_APPROVED,
+            f"Job {request.job_id} approved by '{user.username}'",
             actor_id=user.id,
             target_type="approval_request",
             target_id=str(request_id),
@@ -484,7 +485,8 @@ async def reject_request(
     # Audit log
     if request:
         await audit_log(
-            event_type=AuditEventType.JOB_REJECTED,
+            AuditEventType.JOB_REJECTED,
+            f"Job {request.job_id} rejected by '{user.username}'",
             actor_id=user.id,
             target_type="approval_request",
             target_id=str(request_id),
@@ -570,7 +572,8 @@ async def bulk_approve_requests(
 
                     # Audit log
                     await audit_log(
-                        event_type=AuditEventType.JOB_APPROVED,
+                        AuditEventType.JOB_APPROVED,
+                        f"Job {request.job_id} approved by '{user.username}' (bulk)",
                         actor_id=user.id,
                         target_type="approval_request",
                         target_id=str(request_id),
@@ -634,7 +637,8 @@ async def bulk_reject_requests(
 
                     # Audit log
                     await audit_log(
-                        event_type=AuditEventType.JOB_REJECTED,
+                        AuditEventType.JOB_REJECTED,
+                        f"Job {request.job_id} rejected by '{user.username}' (bulk)",
                         actor_id=user.id,
                         target_type="approval_request",
                         target_id=str(request_id),

--- a/simpletuner/simpletuner_sdk/server/services/cloud/credential_resolver.py
+++ b/simpletuner/simpletuner_sdk/server/services/cloud/credential_resolver.py
@@ -124,7 +124,8 @@ class CredentialResolver:
                         from .audit import AuditEventType, audit_log
 
                         await audit_log(
-                            event_type=AuditEventType.CREDENTIAL_USED,
+                            AuditEventType.CREDENTIAL_USED,
+                            f"Credential '{provider}/{credential_name}' used",
                             actor_id=user_id,
                             target_type="credential",
                             target_id=f"{provider}/{credential_name}",


### PR DESCRIPTION
## Problem

`audit_log` takes `action` as a **required positional** parameter:

```python
# simpletuner_sdk/server/services/cloud/audit.py:638
async def audit_log(
    event_type: AuditEventType,
    action: str,
    **kwargs,
) -> int:
    store = get_audit_store()
    return await store.log(event_type, action, **kwargs)
```

Five call sites pass `event_type` as a *keyword* and never pass `action` at all, so each
raises:

```
TypeError: audit_log() missing 1 required positional argument: 'action'
```

| file | lines |
|---|---|
| `server/routes/approvals.py` | 421, 486, 572, 636 |
| `server/services/cloud/credential_resolver.py` | 126 |

## Impact differs by site

**`routes/approvals.py` — unguarded, fires after the state change.** At L421 the approval
has already been committed and the job already unblocked in the queue before the audit
call runs:

```python
    if scheduler:
        await scheduler.approve_job(request.job_id, request_id)   # state already mutated
...
    # Audit log
    if request:
        await audit_log(                       # <-- raises here
            event_type=AuditEventType.JOB_APPROVED,
```

So the endpoint returns 500 for an approval that actually *succeeded*, and no audit record
is written. Same for reject (L486) and the bulk paths (L572, L636).

**`credential_resolver.py` — swallowed.** That call sits inside a `try/except Exception`
that logs at debug level, so credential-use auditing has silently never recorded anything.

## The correct shape is already in the codebase

`routes/auth.py` calls it correctly throughout — positional `event_type`, then a
human-readable `action` string:

```python
await audit_log(
    AuditEventType.AUTH_LOGIN_SUCCESS,
    f"User '{user.username}' logged in",
    actor_id=user.id,
    ...
)
```

`approvals.py` is the only module that consistently disagrees.

## Verification

Binding each call against the real signature, with a working `auth.py` call as control:

```
audit_log signature: (event_type, action, **kwargs)

UNPATCHED  approvals.py:421   -> TypeError: missing a required argument: 'action'
CONTROL    auth.py:211        -> bound OK
PATCHED    approvals.py:421   -> bound OK
```

## Change

Passes `action` positionally at all five sites, matching `auth.py`'s phrasing. Every value
interpolated (`request.job_id`, `user.username`, `provider`, `credential_name`) is already
in scope and already used in the adjacent `details` dict. No behaviour changes beyond the
audit records now actually being written.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
