### PR TITLE
Fix adapter-only validation adapter runs

### DIFF
--- a/simpletuner/helpers/training/validation_adapters.py
+++ b/simpletuner/helpers/training/validation_adapters.py
@@ -235,20 +235,19 @@ def build_validation_adapter_runs(
             is_base=False,
         )
 
-    if adapter_path and mode != "none":
+    if mode != "none" and adapter_path:
         specs = [_build_adapter_spec(adapter_path, adapter_strength, adapter_name)]
         preferred_label = adapter_name or _stem_from_path(adapter_path)
         runs.append(_make_run(preferred_label, specs))
 
-    for entry in _iter_config_entries(adapter_config):
-        label, specs = _normalize_run_entry(entry)
-        if not specs:
-            continue
-        runs.append(_make_run(label, specs))
+    if mode != "none":
+        for entry in _iter_config_entries(adapter_config):
+            label, specs = _normalize_run_entry(entry)
+            if not specs:
+                continue
+            runs.append(_make_run(label, specs))
 
-    include_base = True
-    if adapter_path and mode == "adapter_only" and adapter_config in (None, [], {}):
-        include_base = False
+    include_base = mode == "comparison" or not runs
 
     ordered_runs: List[ValidationAdapterRun] = []
     if include_base:

--- a/tests/test_validation_adapters.py
+++ b/tests/test_validation_adapters.py
@@ -48,22 +48,20 @@ class ValidationAdapterBuilderTests(unittest.TestCase):
             },
         ]
         runs = build_validation_adapter_runs(None, config)
-        self.assertEqual(3, len(runs))
+        self.assertEqual(2, len(runs))
 
         first = runs[0]
-        self.assertTrue(first.is_base)
+        self.assertFalse(first.is_base)
+        self.assertEqual("base_adapter", first.slug)
+        self.assertEqual("org/base_adapter", first.adapters[0].repo_id)
 
         second = runs[1]
-        self.assertEqual("base_adapter", second.slug)
-        self.assertEqual("org/base_adapter", second.adapters[0].repo_id)
-
-        third = runs[2]
-        self.assertEqual("combo", third.label)
-        self.assertEqual(2, len(third.adapters))
-        strengths = [adapter.strength for adapter in third.adapters]
+        self.assertEqual("combo", second.label)
+        self.assertEqual(2, len(second.adapters))
+        strengths = [adapter.strength for adapter in second.adapters]
         self.assertEqual([0.5, 1.0], strengths)
-        self.assertEqual("repo/style", third.adapters[1].repo_id)
-        self.assertEqual("style.safetensors", third.adapters[1].weight_name)
+        self.assertEqual("repo/style", second.adapters[1].repo_id)
+        self.assertEqual("style.safetensors", second.adapters[1].weight_name)
 
     def test_adapter_mode_comparison_includes_base(self):
         runs = build_validation_adapter_runs(
@@ -76,8 +74,37 @@ class ValidationAdapterBuilderTests(unittest.TestCase):
         self.assertEqual("sample", second.adapters[0].adapter_name)
         self.assertEqual(0.8, second.adapters[0].strength)
 
+    def test_adapter_mode_comparison_with_config_includes_base(self):
+        runs = build_validation_adapter_runs(
+            None,
+            [{"label": "custom", "path": "repo/hero"}],
+            adapter_mode="comparison",
+        )
+        self.assertEqual(2, len(runs))
+        self.assertTrue(runs[0].is_base)
+        self.assertEqual("custom", runs[1].slug)
+
+    def test_adapter_mode_adapter_only_with_config_excludes_base(self):
+        runs = build_validation_adapter_runs(
+            None,
+            [{"label": "custom", "path": "repo/hero"}],
+            adapter_mode="adapter_only",
+        )
+        self.assertEqual(1, len(runs))
+        self.assertFalse(runs[0].is_base)
+        self.assertEqual("custom", runs[0].slug)
+
     def test_adapter_mode_none_skips_loading(self):
         runs = build_validation_adapter_runs("foo/bar", None, adapter_mode="none")
+        self.assertEqual(1, len(runs))
+        self.assertTrue(runs[0].is_base)
+
+    def test_adapter_mode_none_skips_config_loading(self):
+        runs = build_validation_adapter_runs(
+            None,
+            [{"label": "custom", "path": "repo/hero"}],
+            adapter_mode="none",
+        )
         self.assertEqual(1, len(runs))
         self.assertTrue(runs[0].is_base)
 
@@ -91,8 +118,8 @@ class ValidationAdapterBuilderTests(unittest.TestCase):
             }
         ]
         runs = build_validation_adapter_runs(None, config)
-        self.assertEqual(2, len(runs))
-        run = runs[1]
+        self.assertEqual(1, len(runs))
+        run = runs[0]
         self.assertEqual("custom", run.label)
         adapter = run.adapters[0]
         self.assertEqual("hero_adapter", adapter.adapter_name)
@@ -111,7 +138,7 @@ class ValidationAdapterBuilderTests(unittest.TestCase):
         ]
         runs = build_validation_adapter_runs(None, config)
 
-        run = runs[1]
+        run = runs[0]
         self.assertEqual("repo/detail", run.adapters[0].repo_id)
         self.assertEqual("two", run.adapters[0].target_stage)
         self.assertEqual("one", run.adapters[1].target_stage)
@@ -246,7 +273,7 @@ class ValidationAdapterStageLoadingTests(unittest.TestCase):
         run = build_validation_adapter_runs(
             None,
             [{"label": "refiner", "path": "repo/refiner", "target_stage": "two", "strength": 0.4}],
-        )[1]
+        )[0]
 
         with validator._temporary_validation_adapters(run):
             self.assertEqual([], base_pipeline.load_calls)
@@ -266,7 +293,7 @@ class ValidationAdapterStageLoadingTests(unittest.TestCase):
         run = build_validation_adapter_runs(
             None,
             [{"label": "low-noise", "path": "repo/low", "target_stage": "low", "strength": 0.6}],
-        )[1]
+        )[0]
 
         with validator._temporary_validation_adapters(run):
             with validator._temporary_validation_stage_adapters(pipeline, ("high", "low")):
@@ -291,7 +318,7 @@ class ValidationAdapterStageLoadingTests(unittest.TestCase):
                     ],
                 }
             ],
-        )[1]
+        )[0]
 
         with validator._temporary_validation_adapters(run):
             self.assertEqual(("combo", 0.25), pipeline.set_calls[0])
@@ -314,7 +341,7 @@ class ValidationAdapterStageLoadingTests(unittest.TestCase):
         run = build_validation_adapter_runs(
             None,
             [{"label": "Krea2 Turbo adapter", "path": "repo/krea2", "adapter_name": "krea2_turbo_adapter"}],
-        )[1]
+        )[0]
 
         with validator._temporary_validation_adapters(run):
             self.assertEqual("repo/krea2", pipeline.load_calls[0][0])
@@ -332,7 +359,7 @@ class ValidationAdapterStageLoadingTests(unittest.TestCase):
         run = build_validation_adapter_runs(
             None,
             [{"label": "Krea2 Turbo adapter", "path": "repo/krea2", "adapter_name": "krea2_turbo_adapter"}],
-        )[1]
+        )[0]
 
         with validator._temporary_validation_adapters(run):
             self.assertEqual(


### PR DESCRIPTION
## Summary
- honor validation_adapter_mode for validation_adapter_config runs
- only add a base validation run for comparison mode or when no adapter runs are configured
- ignore adapter config entries when adapter mode is none

## Tests
- .venv/bin/python -m unittest tests.test_validation_adapters -v
- .venv/bin/python -m unittest -v -f

Fixes #3184