### PR TITLE
Fix W&B tracker initialization handling

### DIFF
--- a/simpletuner/helpers/training/trainer.py
+++ b/simpletuner/helpers/training/trainer.py
@@ -22,6 +22,7 @@ except Exception:
 import sys
 import threading
 import time
+import uuid
 from collections import deque
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager
@@ -31,11 +32,11 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
 from unittest import mock as unittest_mock
 
 import huggingface_hub
-import wandb
 from torch.distributed.fsdp.api import ShardedOptimStateDictConfig, ShardedStateDictConfig
 from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
 from torch.distributed.tensor import DTensor
 
+import wandb
 from simpletuner.helpers import log_format  # noqa
 from simpletuner.helpers.caching.memory import reclaim_memory
 from simpletuner.helpers.caching.text_embeds import TextEmbeddingCache
@@ -178,6 +179,8 @@ filelock_logger = _setup_logger("filelock", default_level="WARNING")
 connection_logger = _setup_logger("urllib3.connectionpool", default_level="WARNING")
 training_logger = _setup_logger("training-loop", env_var="SIMPLETUNER_TRAINING_LOOP_LOG_LEVEL")
 
+WANDB_RUN_ID_FILENAME = ".wandb_run_id"
+
 
 import accelerate
 import diffusers
@@ -280,6 +283,7 @@ class Trainer:
     publishing_manager = None
     dynamo_cache_manager = None
     _cleanup_invoked = False
+    _trackers_initialized = False
 
     def __init__(
         self,
@@ -311,6 +315,7 @@ class Trainer:
         self.lr = 0.0
         self.job_id = job_id
         self._cleanup_invoked = False
+        self._trackers_initialized = False
         self.sidecar_optimizer = None
         self.sidecar_lr_scheduler = None
         self.sidecar_lr = None
@@ -5241,6 +5246,23 @@ class Trainer:
 
         return lr_scheduler
 
+    def _resolve_wandb_run_id(self, public_args_hash: str) -> str:
+        resume_from_checkpoint = getattr(self.config, "resume_from_checkpoint", None)
+        output_dir = Path(getattr(self.config, "output_dir")).expanduser()
+        run_id_path = output_dir / WANDB_RUN_ID_FILENAME
+        if resume_from_checkpoint:
+            if run_id_path.is_file():
+                run_id = run_id_path.read_text(encoding="utf-8").strip()
+                if not run_id:
+                    raise ValueError(f"{WANDB_RUN_ID_FILENAME} is empty.")
+                return run_id
+            return public_args_hash
+
+        run_id = uuid.uuid4().hex
+        output_dir.mkdir(parents=True, exist_ok=True)
+        run_id_path.write_text(f"{run_id}\n", encoding="utf-8")
+        return run_id
+
     def _build_init_tracker_kwargs(self, tracker_run_name: str, public_args_hash: str) -> Dict[str, Dict[str, object]]:
         """Prepare tracker-specific init kwargs for the active logging backends."""
         loggers = getattr(self.accelerator, "log_with", None)
@@ -5270,7 +5292,7 @@ class Trainer:
         if "wandb" in tracker_names:
             init_kwargs["wandb"] = {
                 "name": tracker_run_name,
-                "id": f"{public_args_hash}",
+                "id": self._resolve_wandb_run_id(public_args_hash),
                 "resume": "allow",
                 "allow_val_change": True,
             }
@@ -5338,6 +5360,9 @@ class Trainer:
         raise TypeError(f"Object of type {payload.__class__.__name__} is not JSON serializable")
 
     def init_trackers(self):
+        if getattr(self, "_trackers_initialized", False):
+            return
+
         # We need to initialize the trackers we use, and also store our configuration.
         # The trackers initializes automatically on the main process.
         self.guidance_values_table = None
@@ -5368,16 +5393,13 @@ class Trainer:
                     init_kwargs=init_kwargs,
                 )
             except Exception as e:
-                if "Object has no attribute 'disabled'" in repr(e):
-                    logger.warning("WandB is disabled, and Accelerate was not quite happy about it.")
-                    self.accelerator.trackers = []
-                else:
-                    logger.error(f"Could not initialize trackers: {e}")
-                    event = error_event(
-                        message=f"Could not initialize trackers. Continuing without. {e}",
-                        job_id=self.job_id,
-                    )
-                    self._emit_event(event)
+                logger.error(f"Could not initialize trackers: {e}")
+                event = error_event(
+                    message=f"Could not initialize trackers: {e}",
+                    job_id=self.job_id,
+                )
+                self._emit_event(event)
+                raise RuntimeError(f"Could not initialize trackers: {e}") from e
             event = notification_event(
                 message="Training configuration initialized",
                 title="Training Config",
@@ -5385,6 +5407,7 @@ class Trainer:
                 data=public_args_payload,
             )
             self._emit_event(event)
+        self._trackers_initialized = True
 
     def resume_and_prepare(self):
         self.init_optimizer()

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -3564,17 +3564,50 @@ class TestTrainer(unittest.TestCase):
         mock_trained_model.set_requires_gradient_sync.assert_any_call(False)
 
     def test_build_init_tracker_kwargs_filters_to_active_trackers(self):
-        trainer = object.__new__(Trainer)
-        trainer.accelerator = SimpleNamespace(log_with=["tensorboard", "wandb"])
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trainer = object.__new__(Trainer)
+            trainer.accelerator = SimpleNamespace(log_with=["tensorboard", "wandb"])
+            trainer.config = SimpleNamespace(output_dir=tmpdir, resume_from_checkpoint=None)
 
-        init_kwargs = trainer._build_init_tracker_kwargs("run-name", "abc123")
+            with patch(
+                "simpletuner.helpers.training.trainer.uuid.uuid4",
+                return_value=SimpleNamespace(hex="generated-id"),
+            ):
+                init_kwargs = trainer._build_init_tracker_kwargs("run-name", "abc123")
 
-        self.assertIn("wandb", init_kwargs)
-        self.assertEqual(init_kwargs["wandb"]["name"], "run-name")
-        self.assertEqual(init_kwargs["wandb"]["id"], "abc123")
-        self.assertEqual(init_kwargs["wandb"]["resume"], "allow")
-        self.assertTrue(init_kwargs["wandb"]["allow_val_change"])
-        self.assertNotIn("tensorboard", init_kwargs)
+            self.assertIn("wandb", init_kwargs)
+            self.assertEqual(init_kwargs["wandb"]["name"], "run-name")
+            self.assertEqual(init_kwargs["wandb"]["id"], "generated-id")
+            self.assertEqual(init_kwargs["wandb"]["resume"], "allow")
+            self.assertTrue(init_kwargs["wandb"]["allow_val_change"])
+            self.assertNotIn("tensorboard", init_kwargs)
+            self.assertEqual(Path(tmpdir, ".wandb_run_id").read_text(encoding="utf-8").strip(), "generated-id")
+
+    def test_build_init_tracker_kwargs_reuses_persisted_wandb_id_on_resume(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, ".wandb_run_id").write_text("existing-id\n", encoding="utf-8")
+            trainer = object.__new__(Trainer)
+            trainer.accelerator = SimpleNamespace(log_with=["wandb"])
+            trainer.config = SimpleNamespace(output_dir=tmpdir, resume_from_checkpoint="checkpoint-100")
+
+            with patch("simpletuner.helpers.training.trainer.uuid.uuid4") as generate_id:
+                init_kwargs = trainer._build_init_tracker_kwargs("run-name", "abc123")
+
+            self.assertEqual(init_kwargs["wandb"]["id"], "existing-id")
+            generate_id.assert_not_called()
+
+    def test_build_init_tracker_kwargs_uses_legacy_hash_for_resume_without_persisted_wandb_id(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trainer = object.__new__(Trainer)
+            trainer.accelerator = SimpleNamespace(log_with=["wandb"])
+            trainer.config = SimpleNamespace(output_dir=tmpdir, resume_from_checkpoint="checkpoint-100")
+
+            with patch("simpletuner.helpers.training.trainer.uuid.uuid4") as generate_id:
+                init_kwargs = trainer._build_init_tracker_kwargs("run-name", "abc123")
+
+            self.assertEqual(init_kwargs["wandb"]["id"], "abc123")
+            self.assertFalse(Path(tmpdir, ".wandb_run_id").exists())
+            generate_id.assert_not_called()
 
     def test_build_init_tracker_kwargs_supports_swanlab(self):
         tracker_enum_like = SimpleNamespace(value="swanlab")
@@ -3592,6 +3625,52 @@ class TestTrainer(unittest.TestCase):
                 "resume": "allow",
             },
         )
+
+    def test_init_trackers_is_idempotent(self):
+        trainer = object.__new__(Trainer)
+        trainer.accelerator = Mock(is_main_process=True)
+        trainer.config = SimpleNamespace(
+            accelerator_project_config=object(),
+            process_group_kwargs=object(),
+            webhook_config={},
+            weight_dtype=torch.float32,
+            base_weight_dtype=torch.float32,
+            tracker_project_name="project",
+            tracker_run_name="run",
+            report_to=["simpletuner", "wandb"],
+        )
+        trainer.job_id = "job-123"
+        trainer._emit_event = Mock()
+        trainer._build_init_tracker_kwargs = Mock(return_value={})
+
+        trainer.init_trackers()
+        trainer.init_trackers()
+
+        trainer.accelerator.init_trackers.assert_called_once()
+        trainer._build_init_tracker_kwargs.assert_called_once()
+
+    def test_init_trackers_raises_when_requested_tracker_fails_to_initialize(self):
+        trainer = object.__new__(Trainer)
+        trainer.accelerator = Mock(is_main_process=True)
+        trainer.accelerator.init_trackers.side_effect = ValueError("wandb auth failed")
+        trainer.config = SimpleNamespace(
+            accelerator_project_config=object(),
+            process_group_kwargs=object(),
+            webhook_config={},
+            weight_dtype=torch.float32,
+            base_weight_dtype=torch.float32,
+            tracker_project_name="project",
+            tracker_run_name="run",
+            report_to=["simpletuner", "wandb"],
+        )
+        trainer.job_id = "job-123"
+        trainer._emit_event = Mock()
+        trainer._build_init_tracker_kwargs = Mock(return_value={})
+
+        with self.assertRaisesRegex(RuntimeError, "Could not initialize trackers"):
+            trainer.init_trackers()
+
+        self.assertFalse(getattr(trainer, "_trackers_initialized", False))
 
     def test_disable_dynamo_lru_cache_for_checkpointing_calls_private_api(self):
         from simpletuner.helpers.training import trainer as trainer_module


### PR DESCRIPTION
## Summary
- make tracker initialization idempotent so repeated entrypoints do not register duplicate trackers
- surface tracker initialization failures instead of continuing with only SimpleTuner metrics
- use a fresh persisted W&B run id for new runs and reuse it on checkpoint resume

## Tests
- `.venv/bin/python -m unittest tests.test_trainer tests.test_report_to tests.test_local_metrics -v -f`
- `.venv/bin/python -m unittest -v -f`