### PR TITLE
fix(quantisation): QuantoLoraConv2d cannot be constructed (update_layer missing use_dora)

### DIFF
--- a/simpletuner/helpers/training/quantisation/peft_workarounds.py
+++ b/simpletuner/helpers/training/quantisation/peft_workarounds.py
@@ -184,7 +184,7 @@ class QuantoLoraConv2d(torch.nn.Module, LoraLayer):
         LoraLayer.__init__(self, base_layer)
 
         self._active_adapter = adapter_name
-        self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights, use_rslora)
+        self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights, use_rslora, use_dora)
 
     def update_layer(
         self,


### PR DESCRIPTION
## Problem

`QuantoLoraConv2d` cannot be constructed. It defines its own `update_layer` with `use_dora` as a **required** positional parameter:

```python
def update_layer(
    self, adapter_name, r, lora_alpha, lora_dropout, init_lora_weights, use_rslora, use_dora,
):
```

but `__init__` calls it with six arguments ([`peft_workarounds.py:187`](https://github.com/bghira/SimpleTuner/blob/main/simpletuner/helpers/training/quantisation/peft_workarounds.py#L187)):

```python
self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights, use_rslora)
```

```
TypeError: update_layer() missing 1 required positional argument: 'use_dora'
```

This is not a dead path: `QuantoLoraConv2d` is the `QConv2d` entry in `custom_module_mapping` and is instantiated by `dispatch_default`, so quanto LoRA on any model with `Conv2d` layers fails during module replacement.

## Why `use_dora`, specifically

Its sibling `QuantoLoraLinear` calls `update_layer` with the same six arguments and is fine, because it does **not** define its own `update_layer` — it inherits peft's `LoraLayer.update_layer`, where `use_dora` has a default. `QuantoLoraConv2d` overrides the method without a default, so the same six-argument call no longer binds. That asymmetry is the whole bug.

`use_dora` is already a parameter of `QuantoLoraConv2d.__init__` (and is guarded to `False` two lines above), and `update_layer` genuinely consumes it:

```python
if use_dora:
    self.dora_init(adapter_name)
    self.use_dora[adapter_name] = True
else:
    self.use_dora[adapter_name] = False
```

so today the `self.use_dora[adapter_name] = False` bookkeeping never runs either. Passing the parameter through is what the method was written to receive.

## Verification

Both `self.update_layer(...)` call sites in the file were replayed against the `update_layer` resolved for their own class, using `ast` + `inspect.Signature.bind` (parse only — nothing imported, no torch or quanto needed):

```
                                                                     BEFORE
QuantoLoraLinear  line  69  self.update_layer(6 args)  [inherited from peft LoraLayer]
    -> skipped: callee is peft's LoraLayer.update_layer

QuantoLoraConv2d  line 187  self.update_layer(6 args)  [own def in QuantoLoraConv2d]
    def update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights, use_rslora, use_dora)
    -> TypeError: missing a required argument: 'use_dora'

                                                                     AFTER
QuantoLoraConv2d  line 187  self.update_layer(7 args)  [own def in QuantoLoraConv2d]
    -> OK   adapter_name=adapter_name, r=r, lora_alpha=lora_alpha, lora_dropout=lora_dropout,
            init_lora_weights=init_lora_weights, use_rslora=use_rslora, use_dora=use_dora
```

Formatting checked with the repo's pinned hook — `black 24.8.0 --line-length=125` (from `.pre-commit-config.yaml`) reports the file unchanged both before and after. The new line is 109 characters, within the 125 limit, and `flake8` runs with `E501` in `--extend-ignore` regardless.

Net diff: **+1 / −1**.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
