### PR TITLE
Round training metrics display precision

### DIFF
--- a/simpletuner/static/js/training_metrics_chart.js
+++ b/simpletuner/static/js/training_metrics_chart.js
@@ -65,8 +65,8 @@
     function formatMetricValue(value) {
         if (typeof value !== 'number' || !Number.isFinite(value)) return '—';
         const absolute = Math.abs(value);
-        if (absolute !== 0 && (absolute >= 10000 || absolute < 0.001)) return value.toExponential(3);
-        return value.toLocaleString(undefined, { maximumFractionDigits: 6 });
+        if (absolute !== 0 && (absolute >= 10000 || absolute < 0.001)) return value.toExponential(2);
+        return value.toLocaleString(undefined, { maximumFractionDigits: 2 });
     }
 
     function timestampMs(record) {

--- a/tests/js/training_metrics_component.test.js
+++ b/tests/js/training_metrics_component.test.js
@@ -117,6 +117,15 @@ describe('training metrics component', () => {
         expect(selected).toEqual(['train_loss']);
     });
 
+    test('formats scalar metric values with two decimal places at most', () => {
+        const charts = window.TrainingMetricsCharts;
+
+        expect(charts.formatMetricValue(1.23456)).toBe('1.23');
+        expect(charts.formatMetricValue(1.2)).toBe('1.2');
+        expect(charts.formatMetricValue(0.0001234)).toBe('1.23e-4');
+        expect(charts.formatMetricValue(Number.NaN)).toBe('—');
+    });
+
     test('limits the chart to eight selected metrics', () => {
         state.trainingCharts = [{ id: 'chart-a', kind: 'scalar', name: 'Loss', metrics: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'], metricSearch: '' }];
         state.selectedTrainingMetrics = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];


### PR DESCRIPTION
## Summary
- Limit training metric display values to 2 decimal places.
- Use 2 decimal places in scientific notation for very small or large metric values.
- Add JS coverage for the shared metrics formatter.

## Testing
- `npm test -- --runTestsByPath tests/js/training_metrics_component.test.js`