### PR TITLE
Fix conditioning masks in nested dataset directories

### DIFF
--- a/simpletuner/helpers/multiaspect/sampler.py
+++ b/simpletuner/helpers/multiaspect/sampler.py
@@ -860,7 +860,7 @@ class MultiAspectSampler(torch.utils.data.Sampler):
             for sample in samples:
                 sample_path: str = sample["image_path"]
                 if self.metadata_backend.instance_data_dir is not None and self.metadata_backend.instance_data_dir != "":
-                    sample_path = sample_path.split(self.metadata_backend.instance_data_dir)[-1]
+                    sample_path = sample_path.split(self.metadata_backend.instance_data_dir)[-1].lstrip("/")
 
                 # Deterministic selection based on hash of image path and current epoch
                 # This ensures the same image gets the same conditioning dataset within an epoch
@@ -916,7 +916,7 @@ class MultiAspectSampler(torch.utils.data.Sampler):
                 for sample in samples:
                     sample_path: str = sample["image_path"]
                     if self.metadata_backend.instance_data_dir is not None and self.metadata_backend.instance_data_dir != "":
-                        sample_path = sample_path.split(self.metadata_backend.instance_data_dir)[-1]
+                        sample_path = sample_path.split(self.metadata_backend.instance_data_dir)[-1].lstrip("/")
 
                     conditioning_sample = sampler.get_conditioning_sample(sample_path)
                     if conditioning_sample is not None:

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -23,6 +23,7 @@ from accelerate import PartialState
 from PIL import Image
 
 from simpletuner.helpers.data_backend.dataset_types import DatasetType
+from simpletuner.helpers.data_backend.local import LocalDataBackend
 from simpletuner.helpers.metadata.backends.base import MetadataBackend
 from simpletuner.helpers.metadata.backends.discovery import DiscoveryMetadataBackend
 from simpletuner.helpers.multiaspect.sampler import MultiAspectSampler
@@ -269,6 +270,79 @@ class TestMultiAspectSampler(unittest.TestCase):
         self.assertIsNotNone(conditioning_sample)
         self.assertEqual(conditioning_sample.image_path(), "/conditioning/11.png")
         self.assertEqual(conditioning_sample.caption, "caption")
+
+    def test_connect_conditioning_samples_preserves_nested_mask_paths(self):
+        relative_paths = ["white.deriv/shared.png", "c2s_over/shared.png"]
+        metadata = {
+            "original_size": (8, 8),
+            "target_size": (8, 8),
+            "intermediary_size": (8, 8),
+            "crop_coordinates": (0, 0),
+            "aspect_ratio": 1.0,
+        }
+        backend_config = {"crop": False, "resolution": 8, "resolution_type": "pixel"}
+
+        with tempfile.TemporaryDirectory() as dataset_dir:
+            source_dir = os.path.join(dataset_dir, "images")
+            samples = tuple({"image_path": os.path.join(source_dir, path)} for path in relative_paths)
+            self.metadata_backend.instance_data_dir = source_dir
+            self.sampler.logger = MagicMock()
+            conditioning_datasets = []
+            for dataset_idx in range(2):
+                conditioning_id = f"masks-{dataset_idx}"
+                conditioning_dir = os.path.join(dataset_dir, conditioning_id)
+                for image_idx, relative_path in enumerate(relative_paths):
+                    mask_path = os.path.join(conditioning_dir, relative_path)
+                    os.makedirs(os.path.dirname(mask_path), exist_ok=True)
+                    Image.new("RGB", (8, 8), color=(image_idx * 255,) * 3).save(mask_path)
+
+                conditioning_metadata = Mock(spec=DiscoveryMetadataBackend)
+                conditioning_metadata.id = conditioning_id
+                conditioning_metadata.instance_data_dir = conditioning_dir
+                conditioning_metadata.aspect_ratio_bucket_indices = {}
+                conditioning_metadata.get_metadata_by_filepath.return_value = metadata
+                conditioning_sampler = MultiAspectSampler(
+                    id=conditioning_id,
+                    metadata_backend=conditioning_metadata,
+                    data_backend=LocalDataBackend(self.accelerator, conditioning_id),
+                    accelerator=self.accelerator,
+                    batch_size=2,
+                    model=None,
+                    conditioning_type="mask",
+                )
+                conditioning_datasets.append({"id": conditioning_id, "sampler": conditioning_sampler})
+
+            for sampling_mode in ("random", "combined"):
+                for dataset_count in (1, 2):
+                    with (
+                        self.subTest(sampling_mode=sampling_mode, dataset_count=dataset_count),
+                        patch.object(
+                            StateTracker, "get_conditioning_datasets", return_value=conditioning_datasets[:dataset_count]
+                        ),
+                        patch.object(
+                            StateTracker,
+                            "get_args",
+                            return_value=SimpleNamespace(conditioning_multidataset_sampling=sampling_mode),
+                        ),
+                        patch.object(StateTracker, "get_data_backend_config", return_value=backend_config),
+                        patch.object(StateTracker, "get_model", return_value=None),
+                        patch("simpletuner.helpers.multiaspect.sampler.PromptHandler.magic_prompt", return_value="caption"),
+                    ):
+                        self.sampler.logger.reset_mock()
+                        output = self.sampler.connect_conditioning_samples(samples)
+
+                        expected_count = len(samples) * (1 if sampling_mode == "random" else dataset_count)
+                        self.assertEqual(output[: len(samples)], samples)
+                        masks = output[len(samples) :]
+                        self.assertEqual(len(masks), expected_count)
+                        for mask_idx, mask in enumerate(masks):
+                            relative_path = relative_paths[mask_idx % len(samples)]
+                            self.assertEqual(
+                                mask.image_path(), os.path.join(dataset_dir, mask.data_backend_id, relative_path)
+                            )
+                            self.assertEqual(mask.image.getpixel((0, 0)), (mask_idx % len(samples) * 255,) * 3)
+                            self.assertEqual(mask.conditioning_type, "mask")
+                        self.sampler.logger.warning.assert_not_called()
 
     def test_load_states_with_matching_batch_size_restores_schedule_before_normalizing_legacy_seen_flags(self):
         self.sampler.state_manager.load_state.return_value = {


### PR DESCRIPTION
Removing the source dataset directory left a leading slash in conditioning sample paths. The conditioning sampler interpreted these as absolute paths and discarded their subdirectories, so masks such as `masks/white.deriv/shared.png` were looked up as `masks/shared.png`.

Normalize the source-relative path in both random and combined sampling before retrieving masks. The regression reads real mask files with identical basenames in separate subdirectories and covers both sampling modes with one or two conditioning datasets. A two-image batch correctly receives two masks when one conditioning dataset is configured.

Validation:
- Red: `.venv/bin/python -m unittest -v -f tests.test_sampler.TestMultiAspectSampler.test_connect_conditioning_samples_preserves_nested_mask_paths` failed before the fix with zero masks instead of two, then passed after the fix.
- Green: `.venv/bin/python -m unittest -v -f tests.test_sampler tests.test_conditioning_split_alignment tests.test_validation_dataset_selection` passed all 45 tests.
- Black checks and `git diff --cached --check` passed.

Closes #3198.
