### PR TITLE
Fix validation image labels in Hugging Face model cards

### DIFF
--- a/simpletuner/helpers/publishing/metadata.py
+++ b/simpletuner/helpers/publishing/metadata.py
@@ -736,6 +736,7 @@ def save_model_card(
     if base_model.count("/") > 1:
         base_model = f"{model_family}/unknown-model"
     validation_prompts = _normalize_validation_prompts(validation_prompts)
+    prompts_by_shortname = dict(zip(validation_shortnames or [], validation_prompts or []))
     logger.debug(f"Validating from prompts: {validation_prompts}")
     assets_folder = os.path.join(repo_folder, "assets")
     optimizer_config = StateTracker.get_args().optimizer_config
@@ -751,7 +752,6 @@ def save_model_card(
             datasets_str += _dataset_overview_for_model(model, dataset_id, dataset_backend)
     widget_str = ""
     idx = 0
-    shortname_idx = 0
     args = StateTracker.get_args()
     negative_prompt_text = str(args.validation_negative_prompt)
     if negative_prompt_text == "":
@@ -762,10 +762,23 @@ def save_model_card(
     audio_sample_rate = model.validation_audio_sample_rate() or 44100
 
     def _add_widget_entries(media, asset_prefix: str):
-        nonlocal widget_str, idx, shortname_idx, has_video, has_audio
-        for media_list in media.values() if isinstance(media, dict) else media:
+        nonlocal widget_str, idx, has_video, has_audio
+        media_items = media.items() if isinstance(media, dict) else enumerate(media)
+        for shortname_idx, (shortname, media_list) in enumerate(media_items):
             if not isinstance(media_list, list):
                 media_list = [media_list]
+            validation_prompt = "no prompt available"
+            if validation_prompts is not None:
+                if isinstance(media, dict) and validation_shortnames is not None:
+                    validation_prompt = prompts_by_shortname.get(shortname, f"prompt not found ({shortname})")
+                elif shortname_idx < len(validation_prompts):
+                    validation_prompt = validation_prompts[shortname_idx]
+                else:
+                    validation_prompt = f"prompt not found ({shortname_idx})"
+            if validation_prompt == "":
+                validation_prompt = "unconditional (blank prompt)"
+            else:
+                validation_prompt = validation_prompt.replace("'", "''")
             sub_idx = 0
             for media_sample in media_list:
                 output_path, media_extension = save_metadata_sample(
@@ -779,16 +792,6 @@ def save_model_card(
                     has_video = True
                 if media_extension in {"wav", "flac", "mp3", "ogg", "m4a"}:
                     has_audio = True
-                validation_prompt = "no prompt available"
-                if validation_prompts is not None:
-                    try:
-                        validation_prompt = validation_prompts[shortname_idx]
-                    except IndexError:
-                        validation_prompt = f"prompt not found ({validation_shortnames[shortname_idx] if validation_shortnames is not None and shortname_idx in validation_shortnames else shortname_idx})"
-                if validation_prompt == "":
-                    validation_prompt = "unconditional (blank prompt)"
-                else:
-                    validation_prompt = validation_prompt.replace("'", "''")
                 widget_str += f"\n- text: '{validation_prompt}'"
                 widget_str += "\n  parameters:"
                 widget_str += f"\n    negative_prompt: '{negative_prompt_text}'"
@@ -797,8 +800,6 @@ def save_model_card(
                 widget_str += f"\n    url: {widget_url}"
                 idx += 1
                 sub_idx += 1
-
-            shortname_idx += 1
 
     if has_media:
         widget_str = "widget:"

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
+import yaml
 from PIL import Image
 
 from simpletuner.helpers.publishing.huggingface import HubManager
@@ -643,6 +644,68 @@ class TestMetadataFunctions(unittest.TestCase):
                 {key: [Path(path).name for path in paths] for key, paths in audios.items()},
                 {"prompt": ["step_50_prompt_0.wav"]},
             )
+
+    def test_model_card_matches_checkpoint_media_to_prompt_shortnames(self):
+        self.args.controlnet = False
+        self.args.control = False
+        model = MagicMock(
+            MODEL_LICENSE="other",
+            PREDICTION_TYPE=SimpleNamespace(value="epsilon"),
+            MODEL_TYPE=SimpleNamespace(value="unet"),
+            gligen=False,
+        )
+        model.validation_audio_sample_rate.return_value = 44100
+        model.custom_model_card_schedule_info.return_value = ""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            validation_dir = Path(tmpdir, "validation_images")
+            validation_dir.mkdir()
+            for name, color in [("unconditional", "black"), ("portrait", "red"), ("landscape", "blue")]:
+                Image.new("RGB", (8, 8), color=color).save(validation_dir / f"step_50_{name}_0_8x8.png")
+            manager = object.__new__(HubManager)
+            manager.config = SimpleNamespace(output_dir=tmpdir)
+            images, _ = manager._filter_checkpoint_validation_media(
+                50,
+                {"unconditional": [], "portrait": [], "landscape": []},
+                None,
+            )
+            images["portrait"] *= 2
+            with (
+                patch("simpletuner.helpers.publishing.metadata.StateTracker.get_model_family", return_value="sdxl"),
+                patch("simpletuner.helpers.publishing.metadata.StateTracker.get_data_backends", return_value={}),
+                patch("simpletuner.helpers.publishing.metadata.StateTracker.get_weight_dtype", return_value=torch.bfloat16),
+                patch(
+                    "simpletuner.helpers.publishing.metadata.StateTracker.get_accelerator",
+                    return_value=MagicMock(num_processes=1),
+                ),
+                patch("simpletuner.helpers.publishing.metadata.StateTracker.get_args", return_value=self.args),
+                patch("simpletuner.helpers.publishing.metadata.StateTracker.get_model", return_value=model),
+            ):
+                save_model_card(
+                    model=model,
+                    repo_id="test-repo",
+                    images=images,
+                    audios={"portrait": [torch.zeros(1, 160)]},
+                    base_model="test-base-model",
+                    validation_prompts=["", "A person's portrait", "A landscape"],
+                    validation_shortnames=["unconditional", "portrait", "landscape"],
+                    repo_folder=tmpdir,
+                    global_step=50,
+                    epoch=1,
+                )
+            readme = Path(tmpdir, "README.md").read_text(encoding="utf-8")
+            widgets = yaml.safe_load(readme.split("---", 2)[1])["widget"]
+            self.assertEqual(len(widgets), 5)
+            expected = {
+                (0, 0, 0): "unconditional (blank prompt)",
+                (255, 0, 0): "A person's portrait",
+                (0, 0, 255): "A landscape",
+            }
+            for widget in widgets:
+                if widget["output"]["url"].endswith(".wav"):
+                    self.assertEqual(widget["text"], "A person's portrait")
+                    continue
+                with Image.open(Path(tmpdir, widget["output"]["url"])) as asset:
+                    self.assertEqual(widget["text"], expected[asset.getpixel((0, 0))])
 
     def test_save_training_config_sanitizes_public_export(self):
         config = SimpleNamespace(


### PR DESCRIPTION
Checkpoint validation media is sorted by filename, while prompts retain their configured order. The model-card writer paired them by position, which shifted labels when the unconditional sample sorted last or samples were filtered out.

Match named media to validation shortnames and keep each image/audio group attached to its prompt. Prompt lookup is shared by all samples in a group; unnamed media retains positional handling.

Closes #3201.

Validation:

- The regression failed before the fix: a landscape image was labeled as an unconditional sample.
- `.venv/bin/python -m unittest -v -f tests.test_model_card tests.test_model_card_scheduler` — 42 tests passed, including reordered checkpoint media, repeated images, matching audio labels, blank prompts, and quoted prompt text.
