### PR TITLE
Refresh training reports before post-upload scripts

### DIFF
--- a/simpletuner/helpers/training/local_metrics.py
+++ b/simpletuner/helpers/training/local_metrics.py
@@ -5,6 +5,7 @@ import math
 import os
 from datetime import datetime, timezone
 from pathlib import Path
+from threading import Lock
 from typing import Any, Optional
 
 from accelerate.tracking import GeneralTracker
@@ -18,6 +19,7 @@ MEDIA_FILENAME = "validation_media.jsonl"
 TIMESTEP_DISTRIBUTION_FILENAME = "timestep_distribution.jsonl"
 REPORT_FILENAME = "training_report.html"
 REPORT_REFRESH_INTERVAL = 100
+_REPORT_LOCK = Lock()
 
 _CONFIG_KEYS = (
     "model_family",
@@ -159,28 +161,29 @@ def _json_for_html(payload: Any) -> str:
 
 
 def render_static_report(output_dir: str | os.PathLike[str], max_points: int = 5000) -> Path:
-    output_path = Path(output_dir).resolve()
-    package_root = Path(__file__).resolve().parents[2]
-    template_path = package_root / "templates" / "training_metrics_report.html"
-    chart_script_path = package_root / "static" / "js" / "training_metrics_chart.js"
-    chart_style_path = package_root / "static" / "css" / "training_metrics_report.css"
+    with _REPORT_LOCK:
+        output_path = Path(output_dir).resolve()
+        package_root = Path(__file__).resolve().parents[2]
+        template_path = package_root / "templates" / "training_metrics_report.html"
+        chart_script_path = package_root / "static" / "js" / "training_metrics_chart.js"
+        chart_style_path = package_root / "static" / "css" / "training_metrics_report.css"
 
-    records = downsample_records(read_metric_records(output_path), max_points=max_points)
-    payload = {
-        "run": read_manifest(output_path),
-        "records": records,
-        "media": _media_for_report(output_path),
-        "timesteps": read_timestep_distribution_records(output_path),
-    }
-    html = template_path.read_text(encoding="utf-8")
-    html = html.replace("__SIMPLETUNER_REPORT_CSS__", chart_style_path.read_text(encoding="utf-8"))
-    html = html.replace("__SIMPLETUNER_REPORT_DATA__", _json_for_html(payload))
-    html = html.replace("__SIMPLETUNER_CHART_JS__", chart_script_path.read_text(encoding="utf-8"))
-    report_path = output_path / REPORT_FILENAME
-    temporary = report_path.with_suffix(".html.tmp")
-    temporary.write_text(html, encoding="utf-8")
-    os.replace(temporary, report_path)
-    return report_path
+        records = downsample_records(read_metric_records(output_path), max_points=max_points)
+        payload = {
+            "run": read_manifest(output_path),
+            "records": records,
+            "media": _media_for_report(output_path),
+            "timesteps": read_timestep_distribution_records(output_path),
+        }
+        html = template_path.read_text(encoding="utf-8")
+        html = html.replace("__SIMPLETUNER_REPORT_CSS__", chart_style_path.read_text(encoding="utf-8"))
+        html = html.replace("__SIMPLETUNER_REPORT_DATA__", _json_for_html(payload))
+        html = html.replace("__SIMPLETUNER_CHART_JS__", chart_script_path.read_text(encoding="utf-8"))
+        report_path = output_path / REPORT_FILENAME
+        temporary = report_path.with_suffix(".html.tmp")
+        temporary.write_text(html, encoding="utf-8")
+        os.replace(temporary, report_path)
+        return report_path
 
 
 def record_validation_media(

--- a/simpletuner/helpers/training/script_runner.py
+++ b/simpletuner/helpers/training/script_runner.py
@@ -6,6 +6,7 @@ import subprocess
 from concurrent.futures import ThreadPoolExecutor
 from typing import Callable
 
+from simpletuner.helpers.training.local_metrics import is_local_metrics_enabled, render_static_report
 from simpletuner.helpers.training.state_tracker import StateTracker
 from simpletuner.helpers.utils.checkpoint_manager import CheckpointManager
 
@@ -123,4 +124,6 @@ def run_hook_script(
     except ValueError as exc:
         logger.error("Failed to format external script command: %s", exc)
         return
+    if is_local_metrics_enabled(getattr(config, "report_to", None)):
+        render_static_report(output_dir)
     submit_script(command)

--- a/tests/test_local_metrics.py
+++ b/tests/test_local_metrics.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import json
 import tempfile
+import threading
 import unittest
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 from PIL import Image
@@ -22,12 +25,53 @@ from simpletuner.helpers.training.local_metrics import (
     read_metric_records,
     read_timestep_distribution_records,
     record_timestep_distribution,
+    render_static_report,
 )
 from simpletuner.helpers.training.state_tracker import StateTracker
 from simpletuner.helpers.training.validation_images import save_validation_image
 
 
 class LocalMetricsTrackerTests(unittest.TestCase):
+    def test_concurrent_report_refresh_preserves_latest_snapshot(self):
+        with tempfile.TemporaryDirectory() as directory:
+            tracker = LocalMetricsTracker("concurrent-report", directory, "tests")
+            tracker.store_init_configuration({"model_family": "flux"})
+            tracker.log({"train_loss": 1.0}, step=1)
+            first_snapshot_read = threading.Event()
+            release_first_render = threading.Event()
+
+            def read_snapshot(output_dir):
+                records = read_metric_records(output_dir)
+                if not first_snapshot_read.is_set():
+                    first_snapshot_read.set()
+                    if not release_first_render.wait(timeout=10):
+                        raise TimeoutError("The first report render was not released.")
+                return records
+
+            with (
+                patch("simpletuner.helpers.training.local_metrics.read_metric_records", side_effect=read_snapshot),
+                ThreadPoolExecutor(max_workers=2) as executor,
+            ):
+                first_render = executor.submit(render_static_report, directory)
+                try:
+                    self.assertTrue(first_snapshot_read.wait(timeout=5))
+                    tracker.log({"train_loss": 0.5}, step=2)
+                    second_render = executor.submit(render_static_report, directory)
+                    try:
+                        second_render.result(timeout=1)
+                    except TimeoutError:
+                        pass
+                finally:
+                    release_first_render.set()
+                first_render.result(timeout=5)
+                second_render.result(timeout=5)
+
+            html = (Path(directory) / REPORT_FILENAME).read_text(encoding="utf-8")
+            payload = json.loads(
+                html.split('<script id="training-metrics-data" type="application/json">')[1].split("</script>")[0]
+            )
+            self.assertEqual([record["step"] for record in payload["records"]], [1, 2])
+
     def test_tracker_writes_scalars_manifest_and_self_contained_report(self):
         with tempfile.TemporaryDirectory() as directory:
             tracker = LocalMetricsTracker("anima-smoke", directory, "local-tests")

--- a/tests/test_script_runner.py
+++ b/tests/test_script_runner.py
@@ -1,13 +1,77 @@
+import json
 import os
 import tempfile
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from PIL import Image
+
 from simpletuner.helpers.training import script_runner
+from simpletuner.helpers.training.local_metrics import REPORT_FILENAME, LocalMetricsTracker, record_timestep_distribution
+from simpletuner.helpers.training.validation_images import save_validation_image
 
 
 class ScriptRunnerTests(unittest.TestCase):
+    def test_hook_refreshes_report_before_script_submission(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output_dir = Path(directory)
+            config = SimpleNamespace(output_dir=directory, report_to="simpletuner")
+            tracker = LocalMetricsTracker("upload-report", directory, "tests")
+            tracker.store_init_configuration({"model_family": "flux"})
+            tracker.log({"train_loss": 1.0}, step=943)
+            tracker.log({"train_loss": 0.5}, step=1000)
+            validation_dir = output_dir / "validation_images"
+            validation_dir.mkdir()
+            with patch("simpletuner.helpers.training.local_metrics._state_tracker_step", return_value=1000):
+                save_validation_image(
+                    Image.new("RGB", (8, 8)),
+                    validation_dir,
+                    "step_1000_sample",
+                    config,
+                    label="sample",
+                    index=0,
+                    resolution="8x8",
+                )
+            tracker.log({"train_loss": 0.4}, step=1002)
+            record_timestep_distribution(config, [(1002, 250)])
+
+            def report_payload():
+                html = (output_dir / REPORT_FILENAME).read_text(encoding="utf-8")
+                return json.loads(
+                    html.split('<script id="training-metrics-data" type="application/json">')[1].split("</script>")[0]
+                )
+
+            self.assertEqual(report_payload()["run"]["last_step"], 943)
+            submitted_reports = []
+            with patch.object(
+                script_runner, "submit_script", side_effect=lambda command: submitted_reports.append(report_payload())
+            ) as submit:
+                script_runner.run_hook_script(
+                    "sync-report {global_step}",
+                    config=config,
+                    local_path=str(output_dir / "checkpoint-1000"),
+                    global_step=1002,
+                )
+
+            submit.assert_called_once_with(["sync-report", "1002"])
+            payload = submitted_reports[0]
+            self.assertEqual(payload["run"]["last_step"], 1002)
+            self.assertEqual([record["step"] for record in payload["records"]], [943, 1000, 1002])
+            self.assertEqual(payload["media"][0]["path"], "validation_images/step_1000_sample.png")
+            self.assertEqual(payload["media"][0]["step"], 1000)
+            self.assertEqual(payload["timesteps"][0]["step"], 1002)
+
+    def test_hook_does_not_create_report_when_local_metrics_are_disabled(self):
+        for report_to in (None, "none", "wandb", "all"):
+            with self.subTest(report_to=report_to), tempfile.TemporaryDirectory() as directory:
+                config = SimpleNamespace(output_dir=directory, report_to=report_to)
+                with patch.object(script_runner, "submit_script") as submit:
+                    script_runner.run_hook_script("sync-report", config=config)
+                submit.assert_called_once_with(["sync-report"])
+                self.assertFalse((Path(directory) / REPORT_FILENAME).exists())
+
     def test_build_script_command_requires_nonempty(self):
         with self.assertRaises(ValueError):
             script_runner.build_script_command("", lambda _: "")


### PR DESCRIPTION
The static report embeds a snapshot refreshed every 100 metric records. Post-upload scripts could therefore copy an HTML report from step 943 even after metrics and validation images for checkpoint 1000 had been written.

Refresh the enabled local report before submitting an external hook. This reuses the shared path used by trainer uploads, validation publishing, and checkpoint hooks, so the report includes the latest recorded metrics, validation media, and timestep samples. Serialize report renders to prevent periodic and background upload refreshes from sharing a temporary file or overwriting a newer snapshot with an older one. Runs without the local tracker do not create reports.

Validation:
- The new hook regression failed before the fix with report step 943 instead of 1002, then passed with checkpoint-1000 validation media included. The hook's current-step placeholder remains 1002.
- The concurrent-render regression failed before the fix with an older snapshot replacing the latest, then passed after serializing renders.
- `.venv/bin/python -m unittest -v -f tests.test_script_runner tests.test_local_metrics` passed all 14 tests.
- `.venv/bin/python -m unittest -v -f tests.test_trainer tests.test_validation_external tests.test_training_metrics_service tests.test_training_metrics_routes` passed all 132 tests.
- `git diff --cached --check` passed.

Closes #3207.
