### PR TITLE
Honor native attention backend selection in direct SDPA calls

### DIFF
--- a/simpletuner/helpers/training/attention_backend.py
+++ b/simpletuner/helpers/training/attention_backend.py
@@ -5,6 +5,7 @@ import inspect
 import os
 import subprocess
 import sys
+from contextlib import ExitStack
 from dataclasses import dataclass
 from enum import Enum
 from functools import lru_cache
@@ -190,6 +191,13 @@ if AttentionBackendName is not None:
             _DIFFUSERS_BACKEND_ALIASES[alias] = AttentionBackendName(target)
         except Exception:
             continue
+
+_TORCH_SDPA_BACKENDS = {
+    "_native_math": torch.nn.attention.SDPBackend.MATH,
+    "_native_flash": torch.nn.attention.SDPBackend.FLASH_ATTENTION,
+    "_native_efficient": torch.nn.attention.SDPBackend.EFFICIENT_ATTENTION,
+    "_native_cudnn": torch.nn.attention.SDPBackend.CUDNN_ATTENTION,
+}
 
 
 class AttentionBackendMode(str, Enum):
@@ -1460,8 +1468,13 @@ class AttentionBackendController:
 
             cls._disable_diffusers_backend()
             try:
-                context = diffusers_attention_backend(backend_enum)
-                context.__enter__()
+                with ExitStack() as contexts:
+                    contexts.enter_context(diffusers_attention_backend(backend_enum))
+                    sdpa_backend = _TORCH_SDPA_BACKENDS.get(_DIFFUSERS_BACKEND_TARGETS.get(backend_key))
+                    if sdpa_backend is not None:
+                        # Legacy UNet processors call PyTorch SDPA directly, bypassing Diffusers dispatch.
+                        contexts.enter_context(torch.nn.attention.sdpa_kernel(sdpa_backend))
+                    context = contexts.pop_all()
             except Exception as exc:
                 message = f"Failed to enable attention backend '{backend_key}': {exc}"
                 logger.error(message)

--- a/tests/test_attention_backend.py
+++ b/tests/test_attention_backend.py
@@ -630,6 +630,52 @@ class TestAttentionBackendPersistence(unittest.TestCase):
         AttentionBackendController.restore_default()
         self.assertIsNone(AttentionBackendController._diffusers_backend_name)
 
+    def test_native_math_controls_legacy_diffusers_processor(self):
+        from diffusers.models.attention_processor import Attention, AttnProcessor2_0
+
+        attention = Attention(query_dim=32, heads=4, dim_head=8, processor=AttnProcessor2_0())
+        hidden_states = torch.randn(1, 8, 32, requires_grad=True)
+        config = SimpleNamespace(attention_mechanism="native-math")
+        AttentionBackendController.apply(config, AttentionPhase.TRAIN)
+
+        with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU]) as profile:
+            attention(hidden_states).sum().backward()
+
+        operators = {event.key for event in profile.key_averages()}
+        self.assertIn("aten::_scaled_dot_product_attention_math", operators)
+        self.assertFalse(any("flash_attention" in operator for operator in operators))
+        self.assertTrue(torch.isfinite(hidden_states.grad).all())
+
+    def test_native_math_restores_sdpa_selection_on_backend_switch(self):
+        with torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.FLASH_ATTENTION):
+            AttentionBackendController.apply(SimpleNamespace(attention_mechanism="native-math"), AttentionPhase.TRAIN)
+            self.assertTrue(torch.backends.cuda.math_sdp_enabled())
+            self.assertFalse(torch.backends.cuda.flash_sdp_enabled())
+            AttentionBackendController.apply(SimpleNamespace(attention_mechanism="native"), AttentionPhase.TRAIN)
+            self.assertFalse(torch.backends.cuda.math_sdp_enabled())
+            self.assertTrue(torch.backends.cuda.flash_sdp_enabled())
+            AttentionBackendController.restore_default()
+
+    def test_native_sdpa_variants_restore_selection_across_phases(self):
+        enabled = {
+            "native-math": torch.backends.cuda.math_sdp_enabled,
+            "native-flash": torch.backends.cuda.flash_sdp_enabled,
+            "native-efficient": torch.backends.cuda.mem_efficient_sdp_enabled,
+            "native-cudnn": torch.backends.cuda.cudnn_sdp_enabled,
+        }
+        original = {name: check() for name, check in enabled.items()}
+        for backend in (*enabled, "cudnn"):
+            with self.subTest(backend=backend):
+                config = SimpleNamespace(attention_mechanism=backend)
+                for phase in (AttentionPhase.TRAIN, AttentionPhase.EVAL, AttentionPhase.TRAIN):
+                    AttentionBackendController.apply(config, phase)
+                    expected = "native-cudnn" if backend == "cudnn" else backend
+                    self.assertEqual(
+                        {name: check() for name, check in enabled.items()}, {name: name == expected for name in enabled}
+                    )
+                AttentionBackendController.restore_default()
+                self.assertEqual({name: check() for name, check in enabled.items()}, original)
+
     def test_hub_backend_omits_empty_kernel_user_agent(self):
         if not attention_backend_module._DIFFUSERS_BACKEND_ALIASES:
             self.skipTest("Diffusers attention backend helpers unavailable in this environment.")


### PR DESCRIPTION
Selecting `native-math` previously changed only Diffusers' dispatch registry. SDXL's `AttnProcessor2_0` calls PyTorch SDPA directly, so it could still select flash attention. Scope PyTorch's SDPA selection alongside the existing Diffusers context for explicit native backends, restoring both when the backend changes.

The real CPU profiler regression previously observed `aten::_scaled_dot_product_flash_attention_for_cpu` and its backward despite selecting `native-math`. It now observes `aten::_scaled_dot_product_attention_math` with finite gradients. Additional tests cover backend switching and train/evaluation restoration for all explicit native SDPA choices.

Validation: `.venv/bin/python -m unittest -v -f tests.test_attention_backend` — 34 passed. Both the processor dispatch and backend-switch regressions failed before the fix and passed afterward.

Supplemental investigation: a tiny SDXL-shaped UNet with BF16 LoRA, math attention, gradient checkpointing, and SimpleTuner's AdamWBF16 completed three steps each on CPU and MPS. Convolution hooks observed recomputation during the first backward and every subsequent backward. This checks the control flow at reduced scale; it is not a full SDXL or RDNA2 hardware reproduction.

Related to #3195. This corrects the ineffective native-math diagnostic; resolution of the reported RDNA2 SIGSEGV requires testing on affected hardware.
